### PR TITLE
#482 Objects' saving fix.

### DIFF
--- a/bedita-app/app_model.php
+++ b/bedita-app/app_model.php
@@ -1111,11 +1111,12 @@ class BeditaObjectModel extends BeditaSimpleObjectModel {
 		}
 
 		$beObject->create();
-        if ($res = $beObject->save($data, $validate, $fieldList)) {
+        if (!$res = $beObject->save($data, $validate, $fieldList)) {
 			return $res;
 		}
 
 		$data2["id"] = $beObject->id;
+		$this->create(null);
 		$res = parent::save($data2, $validate, $fieldList);
 		//$res = Model::save($data, $validate, $fieldList) ;
 		//$res = ClassRegistry::init("Model")->save($data2, $validate, $fieldList);

--- a/bedita-app/app_model.php
+++ b/bedita-app/app_model.php
@@ -1111,7 +1111,7 @@ class BeditaObjectModel extends BeditaSimpleObjectModel {
 		}
 
 		$beObject->create();
-		if (!$res = $beObject->save($data, $validate, $fieldList)) {
+        if ($res = $beObject->save($data, $validate, $fieldList)) {
 			return $res;
 		}
 

--- a/bedita-app/app_model.php
+++ b/bedita-app/app_model.php
@@ -1110,7 +1110,11 @@ class BeditaObjectModel extends BeditaSimpleObjectModel {
 			}
 		}
 
-		$beObject->create();
+        if (empty($data['id']) && empty($data['BEObject']['id']) && empty($data[$this->name]['id'])) {
+            $beObject->create();
+        } else {
+            $beObject->create(null);
+        }
         if (!$res = $beObject->save($data, $validate, $fieldList)) {
 			return $res;
 		}

--- a/bedita-app/models/behaviors/foreign_dependence_save.php
+++ b/bedita-app/models/behaviors/foreign_dependence_save.php
@@ -68,7 +68,7 @@ class ForeignDependenceSaveBehavior extends ModelBehavior {
 				
 			// save parent/s
 			$run = true ;
-            if (empty($data['id'])) {
+            if (empty($model->data[$model->name]['id'])) {
                 $model->$name->create();
             } else {
                 // Avoid default values.

--- a/bedita-app/models/behaviors/foreign_dependence_save.php
+++ b/bedita-app/models/behaviors/foreign_dependence_save.php
@@ -68,7 +68,12 @@ class ForeignDependenceSaveBehavior extends ModelBehavior {
 				
 			// save parent/s
 			$run = true ;
-			$model->$name->create();
+            if (empty($data['id'])) {
+                $model->$name->create();
+            } else {
+                // Avoid default values.
+                $model->$name->create(null);
+            }
 			if(!$res = $model->$name->save($data)) {
 				$model->validationErrors = $model->$name->validationErrors ;
 				// If first element has been created already, performe delete and return

--- a/bedita-app/models/objects/b_e_object.php
+++ b/bedita-app/models/objects/b_e_object.php
@@ -47,8 +47,11 @@ class BEObject extends BEAppModel {
 			'rule' => 'notEmpty'
 		),
 		'ip_created' => array(
-			'rule' => 'notEmpty'
-		)
+			'rule' => 'ip'
+		),
+        'status' => array(
+            'rule' => array('inList', array('on', 'off', 'draft'))
+        ),
 	) ;
 
 	var $belongsTo = array(
@@ -237,26 +240,31 @@ class BEObject extends BEAppModel {
 	}
 
 	function beforeSave() {
+        $data;
+        if(isset($this->data[$this->name])) 
+            $data = &$this->data[$this->name] ;
+        else 
+            $data = &$this->data ;
+
 		// format custom properties and searchable text fields
 		$labels = array('SearchText');
 		foreach ($labels as $label) {
-		  if(!isset($this->data[$this->name][$label])) 
-			continue ;
-			
-		  if(is_array($this->data[$this->name][$label]) && count($this->data[$this->name][$label])) {
-		      $tmps = array() ;
-		      foreach($this->data[$this->name][$label]  as $k => $v) {
-					$this->_value2array($k, $v, $arr) ;
-					$tmps[] = $arr ;
+            if(!isset($data[$label]))
+                continue;
 
-				}
-			$this->data[$this->name][$label] = $tmps ;
-		  }
+            if(is_array($data[$label]) && count($data[$label])) {
+                $tmps = array();
+                foreach($data[$label]  as $k => $v) {
+                    $this->_value2array($k, $v, $arr);
+                    array_push($tmps, $arr);
+                }
+                $data[$label] = $tmps;
+            }
 		}
 
 		// empty GeoTag array if no value is in
-		if (!empty($this->data[$this->name]['GeoTag'])) {
-			foreach ($this->data[$this->name]['GeoTag'] as $key => $geotag) {
+		if (!empty($data['GeoTag'])) {
+			foreach ($data['GeoTag'] as $key => $geotag) {
 				$concat = '';
 				$geoTagFields = array('title', 'address', 'latitude', 'longitude');
 				foreach ($geoTagFields as $field) {
@@ -265,13 +273,14 @@ class BEObject extends BEAppModel {
 					}
 				}
 				if (strlen($concat) == 0) {
-					unset($this->data[$this->name]['GeoTag'][$key]);
+					unset($data['GeoTag'][$key]);
 				}
 			}
 		}
 
 		$this->unbindModel(array("hasMany"=>array("LangText","Version")));
 		$this->unbindModel(array("hasAndBelongsToMany"=>array("User")));
+
 		return true;
 	}
 	
@@ -510,12 +519,19 @@ class BEObject extends BEAppModel {
 				}
 				$data['nickname'] = $currObj['BEObject']['nickname'];
 				$data['status'] = $currObj['BEObject']['status'];
-			} elseif (empty($data['nickname']) && !empty($currObj['BEObject']['nickname'])) {
-				$data["nickname"] = $currObj['BEObject']['nickname'];
-			} else {
-				$data['nickname'] = $this->_getDefaultNickname($data['nickname']);
-			}
+            } else {
+                // Check if nickname has changed.
+                if (empty($data['nickname']) && !empty($currObj['BEObject']['nickname'])) {
+                    $data['nickname'] = $currObj['BEObject']['nickname'];
+                } else {
+                    $data['nickname'] = $this->_getDefaultNickname($data['nickname']);
+                }
 
+                // Check if status has changed.
+                if (empty($data['status']) && !empty($currObj['BEObject']['status'])) {
+                    $data['status'] = $currObj['BEObject']['status'];
+                }
+            }
 		} else {
 			$title = isset($data['title']) ? $data['title'] : null;
 			$tmpName = !empty($data['nickname']) ? $data['nickname'] : $title;
@@ -535,7 +551,7 @@ class BEObject extends BEAppModel {
 		// Se c'e' la chiave primaria vuota la toglie
 		if(isset($data[$this->primaryKey]) && empty($data[$this->primaryKey]))
 			unset($data[$this->primaryKey]) ;
-			
+		
 		return true ;
 	}
 
@@ -743,6 +759,5 @@ class BEObject extends BEAppModel {
 	function getNicknameFromId($id) {
 		return $this->field("nickname", array("id" => $id));
 	}
-		
 }
 ?>


### PR DESCRIPTION
Some strange behaviors occurred when saving objects using the default `Model::save()` method. In some cases, a duplicate save occurred, and some values were overwritten with the default ones.

This isn't a major fix, and it should be quite smooth, but hence objects' saving is involved, I'd prefer somebody else to help me test this.