### PR TITLE
#598 ObjectType ID lookup in DB as fallback.

### DIFF
--- a/bedita-app/app_model.php
+++ b/bedita-app/app_model.php
@@ -831,12 +831,10 @@ class BEAppObjectModel extends BEAppModel {
 	}
 
 	function save($data = null, $validate = true, $fieldList = array()) {
-		$conf = Configure::getInstance() ;
-
 		if(isset($data['BEObject']) && empty($data['BEObject']['object_type_id'])) {
-			$data['BEObject']['object_type_id'] = $conf->objectTypes[Inflector::underscore($this->name)]["id"] ;
+            $data['BEObject']['object_type_id'] = BeConfigure::getObjectTypeId($this->name);
 		} else if(!isset($data['object_type_id']) || empty($data['object_type_id'])) {
-			$data['object_type_id'] = $conf->objectTypes[Inflector::underscore($this->name)]["id"] ;
+            $data['object_type_id'] = BeConfigure::getObjectTypeId($this->name);
 		}
 
 		// Se c'e' la chiave primaria vuota la toglie
@@ -1089,8 +1087,6 @@ class BeditaObjectModel extends BeditaSimpleObjectModel {
 	);
 
 	public function save($data = null, $validate = true, $fieldList = array()) {
-		$conf = Configure::getInstance() ;
-
 		$data2 = $data;
 
 		foreach($data2 as $key => $value) {
@@ -1100,9 +1096,9 @@ class BeditaObjectModel extends BeditaSimpleObjectModel {
 		}
 
 		if(isset($data['BEObject']) && empty($data['BEObject']['object_type_id'])) {
-			$data['BEObject']['object_type_id'] = $conf->objectTypes[Inflector::underscore($this->name)]["id"] ;
+            $data['BEObject']['object_type_id'] = BeConfigure::getObjectTypeId($this->name);
 		} else if(!isset($data['object_type_id']) || empty($data['object_type_id'])) {
-			$data['object_type_id'] = $conf->objectTypes[Inflector::underscore($this->name)]["id"] ;
+            $data['object_type_id'] = BeConfigure::getObjectTypeId($this->name);
 		}
 
 		if(isset($data[$this->primaryKey]) && empty($data[$this->primaryKey])) {

--- a/bedita-app/app_model.php
+++ b/bedita-app/app_model.php
@@ -832,9 +832,9 @@ class BEAppObjectModel extends BEAppModel {
 
 	function save($data = null, $validate = true, $fieldList = array()) {
 		if(isset($data['BEObject']) && empty($data['BEObject']['object_type_id'])) {
-            $data['BEObject']['object_type_id'] = BeConfigure::getObjectTypeId($this->name);
+            $data['BEObject']['object_type_id'] = BeLib::getObject('BeConfigure')->getObjectTypeId($this->name);
 		} else if(!isset($data['object_type_id']) || empty($data['object_type_id'])) {
-            $data['object_type_id'] = BeConfigure::getObjectTypeId($this->name);
+            $data['object_type_id'] = BeLib::getObject('BeConfigure')->getObjectTypeId($this->name);
 		}
 
 		// Se c'e' la chiave primaria vuota la toglie
@@ -1096,9 +1096,9 @@ class BeditaObjectModel extends BeditaSimpleObjectModel {
 		}
 
 		if(isset($data['BEObject']) && empty($data['BEObject']['object_type_id'])) {
-            $data['BEObject']['object_type_id'] = BeConfigure::getObjectTypeId($this->name);
+            $data['BEObject']['object_type_id'] = BeLib::getObject('BeConfigure')->getObjectTypeId($this->name);
 		} else if(!isset($data['object_type_id']) || empty($data['object_type_id'])) {
-            $data['object_type_id'] = BeConfigure::getObjectTypeId($this->name);
+            $data['object_type_id'] = BeLib::getObject('BeConfigure')->getObjectTypeId($this->name);
 		}
 
 		if(isset($data[$this->primaryKey]) && empty($data[$this->primaryKey])) {

--- a/bedita-app/libs/be_configure.php
+++ b/bedita-app/libs/be_configure.php
@@ -267,16 +267,21 @@ class BeConfigure {
      * @return int ObjectType ID, or `null` if none found.
      */
     public function getObjectTypeId($modelName) {
-        $modelName = Inflector::underscore($modelName);
-        $otid = Configure::read("objectTypes.{$modelName}.id");
+        $uModelName = Inflector::underscore($modelName);
+        $otid = Configure::read("objectTypes.{$uModelName}.id");
         if (empty($otid)) {
             // Not found in config. Searching database..
-            $otid = ClassRegistry::init('ObjectType')->field('id', array(
-                'name' => $modelName,
+            $res = ClassRegistry::init('ObjectType')->find('first', array(
+                'conditions' => array('name' => $uModelName),
             ));
-            if ($otid) {
+            if ($res) {
+                $res = $res['ObjectType'];
+                $otid = $res['id'];
+
                 // Save for later use.
-                Configure::write("objectTypes.{$modelName}.id", (int) $otid);
+                $res['model'] = $modelName;
+                Configure::write("objectTypes.{$uModelName}", $res);
+                Configure::write("objectTypes.{$otid}", $res);
             }
         }
         return $otid ?: null;  // Ensure `null` is returned in case no ID has been found.

--- a/bedita-app/libs/be_configure.php
+++ b/bedita-app/libs/be_configure.php
@@ -260,6 +260,25 @@ class BeConfigure {
 		return $defaultObjRel;
 	}
 
-
+    /**
+     * Tries to read ObjectType ID for given model from config, or from database as a fallback.
+     *
+     * @param string $modelName Model name.
+     * @return int ObjectType ID, or `null` if none found.
+     */
+    public function getObjectTypeId($modelName) {
+        $modelName = Inflector::underscore($modelName);
+        $otid = Configure::read("objectTypes.{$modelName}.id");
+        if (empty($otid)) {
+            // Not found in config. Searching database..
+            $otid = ClassRegistry::init('ObjectType')->field('id', array(
+                'name' => $modelName,
+            ));
+            if ($otid) {
+                // Save for later use.
+                Configure::write("objectTypes.{$modelName}.id", (int) $otid);
+            }
+        }
+        return $otid ?: null;  // Ensure `null` is returned in case no ID has been found.
+    }
 }
-?>


### PR DESCRIPTION
Added method to `BeConfigure` that returns the correct ObjectType ID for the given model name (looks up in configuration array, and in database as a fallback, with basic "caching" to avoid duplicate searches).
Updated `BeAppObjectModel::save()` and `BeditaObjectModel::save()` to use new method when filling the `object_type_id` key.
Tested on both setup and already working instance of BE.
#598 