### PR TITLE
Implement `page_size` query param in pagination

### DIFF
--- a/plugins/BEdita/API/src/Controller/AppController.php
+++ b/plugins/BEdita/API/src/Controller/AppController.php
@@ -35,6 +35,8 @@ class AppController extends Controller
     {
         parent::initialize();
 
+        $this->loadComponent('BEdita/API.Paginator');
+
         $this->loadComponent('RequestHandler');
         if ($this->request->is(['json', 'jsonApi'])) {
             $this->RequestHandler->config('viewClassMap.json', 'BEdita/API.JsonApi');

--- a/plugins/BEdita/API/src/Controller/Component/PaginatorComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/PaginatorComponent.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\API\Controller\Component;
+
+use Cake\Controller\Component\PaginatorComponent as CakePaginatorComponent;
+
+/**
+ * Handles pagination.
+ *
+ * @since 4.0.0
+ */
+class PaginatorComponent extends CakePaginatorComponent
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected $_defaultConfig = [
+        'page' => 1,
+        'limit' => 20,
+        'maxLimit' => 100,
+        'whitelist' => ['page', 'page_size', 'sort'],
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function mergeOptions($alias, $settings)
+    {
+        $options = parent::mergeOptions($alias, $settings);
+
+        if (!empty($options['page_size'])) {
+            $options['limit'] = $options['page_size'];
+        }
+        unset($options['page_size']);
+
+        return $options;
+    }
+}

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\API\Test\TestCase\Controller\Component;
+
+use BEdita\API\Controller\Component\PaginatorComponent;
+use Cake\Controller\ComponentRegistry;
+use Cake\Controller\Controller;
+use Cake\Network\Request;
+use Cake\TestSuite\TestCase;
+
+/**
+ * @coversDefaultClass \BEdita\API\Controller\Component\PaginatorComponent
+ */
+class PaginatorComponentTest extends TestCase
+{
+    /**
+     * Data provider for `testMergeOptions` test case.
+     *
+     * @return array
+     */
+    public function mergeOptionsProvider()
+    {
+        return [
+            'default' => [
+                [
+                    'page' => 1,
+                    'limit' => 20,
+                    'maxLimit' => 100,
+                    'whitelist' => ['page', 'page_size', 'sort'],
+                ],
+                [],
+                'MyModel',
+            ],
+            'customLimit' => [
+                [
+                    'page' => 1,
+                    'limit' => 10,
+                    'maxLimit' => 100,
+                    'whitelist' => ['page', 'page_size', 'sort'],
+                ],
+                [
+                    'limit' => 5,
+                ],
+                'MyModel',
+                [
+                    'limit' => 10,
+                    'maxLimit' => 100,
+                ],
+            ],
+            'customPageSize' => [
+                [
+                    'page' => 1,
+                    'limit' => 5,
+                    'maxLimit' => 100,
+                    'whitelist' => ['page', 'page_size', 'sort'],
+                ],
+                [
+                    'page_size' => 5,
+                ],
+                'MyModel',
+                [
+                    'limit' => 10,
+                    'maxLimit' => 100,
+                ],
+            ],
+            'noOverride' => [
+                [
+                    'page' => 1,
+                    'limit' => 10,
+                    'maxLimit' => 100,
+                    'whitelist' => ['page'],
+                ],
+                [
+                    'page_size' => 5,
+                ],
+                'MyModel',
+                [
+                    'limit' => 10,
+                    'maxLimit' => 100,
+                ],
+                ['page'],
+            ],
+        ];
+    }
+
+    /**
+     * Test `mergeOptions()` method.
+     *
+     * @param array $expected Expected result.
+     * @param array $query Query params.
+     * @param string $alias Model alias.
+     * @param array $settings Additional settings.
+     * @param array|null $whitelist Overridable configuration items whitelist.
+     * @return void
+     *
+     * @dataProvider mergeOptionsProvider
+     * @covers ::mergeOptions()
+     */
+    public function testMergeOptions(array $expected, array $query, $alias, array $settings = [], array $whitelist = null)
+    {
+        $request = new Request(compact('query'));
+        $component = new PaginatorComponent(new ComponentRegistry(new Controller($request)), []);
+        if ($whitelist) {
+            $component->config('whitelist', $whitelist, false);
+        }
+
+        $this->assertEquals($expected, $component->mergeOptions($alias, $settings));
+    }
+}


### PR DESCRIPTION
This PR extends the default `PaginatorComponent` in CakePHP 3 to provide custom functionality required by BEdita 4 APIs.

To begin with, as described in #862, `limit` query param is overridden with `page_size`.
