### PR TITLE
Implement JSON API-compatible sorting

### DIFF
--- a/plugins/BEdita/API/src/Controller/Component/PaginatorComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/PaginatorComponent.php
@@ -15,6 +15,7 @@ namespace BEdita\API\Controller\Component;
 
 use Cake\Controller\Component\PaginatorComponent as CakePaginatorComponent;
 use Cake\Datasource\RepositoryInterface;
+use Cake\Network\Exception\BadRequestException;
 
 /**
  * Handles pagination.
@@ -53,7 +54,9 @@ class PaginatorComponent extends CakePaginatorComponent
      */
     public function validateSort(RepositoryInterface $object, array $options)
     {
+        $sortedRequest = false;
         if (!empty($options['sort'])) {
+            $sortedRequest = true;
             $firstChar = substr($options['sort'], 0, 1);
             switch ($firstChar) {
                 case '+':
@@ -67,6 +70,12 @@ class PaginatorComponent extends CakePaginatorComponent
             }
         }
 
-        return parent::validateSort($object, $options);
+        $options = parent::validateSort($object, $options);
+
+        if ($sortedRequest && empty($options['order'])) {
+            throw new BadRequestException(__('Unsupported sorting field'));
+        }
+
+        return $options;
     }
 }

--- a/plugins/BEdita/API/src/Controller/Component/PaginatorComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/PaginatorComponent.php
@@ -14,6 +14,7 @@
 namespace BEdita\API\Controller\Component;
 
 use Cake\Controller\Component\PaginatorComponent as CakePaginatorComponent;
+use Cake\Datasource\RepositoryInterface;
 
 /**
  * Handles pagination.
@@ -45,5 +46,27 @@ class PaginatorComponent extends CakePaginatorComponent
         unset($options['page_size']);
 
         return $options;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function validateSort(RepositoryInterface $object, array $options)
+    {
+        if (!empty($options['sort'])) {
+            $firstChar = substr($options['sort'], 0, 1);
+            switch ($firstChar) {
+                case '+':
+                    $options['sort'] = substr($options['sort'], 1);
+                    $options['direction'] = 'asc';
+                    break;
+                case '-':
+                    $options['sort'] = substr($options['sort'], 1);
+                    $options['direction'] = 'desc';
+                    break;
+            }
+        }
+
+        return parent::validateSort($object, $options);
     }
 }

--- a/plugins/BEdita/API/src/Controller/Component/PaginatorComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/PaginatorComponent.php
@@ -57,16 +57,9 @@ class PaginatorComponent extends CakePaginatorComponent
         $sortedRequest = false;
         if (!empty($options['sort'])) {
             $sortedRequest = true;
-            $firstChar = substr($options['sort'], 0, 1);
-            switch ($firstChar) {
-                case '+':
-                    $options['sort'] = substr($options['sort'], 1);
-                    $options['direction'] = 'asc';
-                    break;
-                case '-':
-                    $options['sort'] = substr($options['sort'], 1);
-                    $options['direction'] = 'desc';
-                    break;
+            if (substr($options['sort'], 0, 1) == '-') {
+                $options['sort'] = substr($options['sort'], 1);
+                $options['direction'] = 'desc';
             }
         }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -17,6 +17,7 @@ use BEdita\API\Controller\Component\PaginatorComponent;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Network\Request;
+use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -24,6 +25,20 @@ use Cake\TestSuite\TestCase;
  */
 class PaginatorComponentTest extends TestCase
 {
+    /**
+     * {@inheritDoc}
+     */
+    public $autoFixtures = false;
+
+    /**
+     * Fixtures.
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.users',
+    ];
+
     /**
      * Data provider for `testMergeOptions` test case.
      *
@@ -115,6 +130,57 @@ class PaginatorComponentTest extends TestCase
             $component->config('whitelist', $whitelist, false);
         }
 
-        $this->assertEquals($expected, $component->mergeOptions($alias, $settings));
+        $options = $component->mergeOptions($alias, $settings);
+        $this->assertEquals($expected, $options);
+    }
+
+    /**
+     * Data provider for `testValidateSort` test case.
+     *
+     * @return array
+     */
+    public function validateSortProvider()
+    {
+        return [
+            'default' => [
+                [],
+            ],
+            'implicitAsc' => [
+                ['Users.username' => 'asc'],
+                'username',
+            ],
+            'explicitAsc' => [
+                ['Users.username' => 'asc'],
+                '+username',
+            ],
+            'desc' => [
+                ['Users.username' => 'desc'],
+                '-username',
+            ],
+        ];
+    }
+
+    /**
+     * Test `validateSort()` method.
+     *
+     * @param array $expected Expected result.
+     * @param string|null $sort `sort` query parameter in request.
+     * @return void
+     *
+     * @dataProvider validateSortProvider
+     * @covers ::validateSort()
+     */
+    public function testValidateSort(array $expected, $sort = null)
+    {
+        $this->loadFixtures('Users');
+
+        $request = new Request(['query' => compact('sort')]);
+        $component = new PaginatorComponent(new ComponentRegistry(new Controller($request)), []);
+
+        $repository = TableRegistry::get('Users')->find()->repository();
+        $options = $component->mergeOptions('Users', []);
+
+        $options = $component->validateSort($repository, $options);
+        $this->assertEquals($expected, $options['order']);
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -145,13 +145,9 @@ class PaginatorComponentTest extends TestCase
             'default' => [
                 [],
             ],
-            'implicitAsc' => [
+            'asc' => [
                 ['Users.username' => 'asc'],
                 'username',
-            ],
-            'explicitAsc' => [
-                ['Users.username' => 'asc'],
-                '+username',
             ],
             'desc' => [
                 ['Users.username' => 'desc'],
@@ -164,6 +160,10 @@ class PaginatorComponentTest extends TestCase
             'unallowedField' => [
                 false,
                 '-this_field_does_not_exist',
+            ],
+            'explicitAsc' => [
+                false,
+                '+username',
             ],
         ];
     }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -157,22 +157,34 @@ class PaginatorComponentTest extends TestCase
                 ['Users.username' => 'desc'],
                 '-username',
             ],
+            'multipleFields' => [
+                false,
+                'username,created',
+            ],
+            'unallowedField' => [
+                false,
+                '-this_field_does_not_exist',
+            ],
         ];
     }
 
     /**
      * Test `validateSort()` method.
      *
-     * @param array $expected Expected result.
+     * @param array|false $expected Expected result.
      * @param string|null $sort `sort` query parameter in request.
      * @return void
      *
      * @dataProvider validateSortProvider
      * @covers ::validateSort()
      */
-    public function testValidateSort(array $expected, $sort = null)
+    public function testValidateSort($expected, $sort = null)
     {
         $this->loadFixtures('Users');
+
+        if ($expected === false) {
+            $this->setExpectedException('Cake\Network\Exception\BadRequestException');
+        }
 
         $request = new Request(['query' => compact('sort')]);
         $component = new PaginatorComponent(new ComponentRegistry(new Controller($request)), []);


### PR DESCRIPTION
This PR implements JSON API-compliant sorting, according to [JSON API specification](http://jsonapi.org/format/#fetching-sorting), as required by #867. Specifically:
- `?sort=field` applies ascending order based on `field`
- `?sort=-field` applies descending order based on `field`
- `?sort=non_existing_field` responds with a **400 Bad Request** status

Please note that ordering on multiple fields is **NOT** supported (or at least, is not implemented by this PR), thus `?sort=field1,field2` would result in a 400 response as well.
