### PR TITLE
Implement CUD actions for `/users` and `/roles` endpoints

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -71,7 +71,7 @@ Router::scope('/', function (RouteBuilder $routes) {
      * You can remove these routes once you've connected the
      * routes you want in your application.
      */
-    $routes->fallbacks('DashedRoute');
+    //$routes->fallbacks('DashedRoute');
 });
 
 /**

--- a/plugins/BEdita/API/config/bootstrap.php
+++ b/plugins/BEdita/API/config/bootstrap.php
@@ -36,6 +36,6 @@ if (PHP_SAPI === 'cli') {
 
 /** Add custom request detectors. */
 Request::addDetector('html', ['accept' => ['text/html', 'application/xhtml+xml', 'application/xhtml', 'text/xhtml']]);
-Request::addDetector('jsonApi', function (Request $request) {
+Request::addDetector('jsonapi', function (Request $request) {
     return $request->accepts(JsonApiComponent::CONTENT_TYPE);
 });

--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -73,5 +73,10 @@ Router::plugin(
             ['controller' => 'Users', 'action' => 'add', '_method' => 'POST'],
             ['_name' => 'users:add']
         );
+        $routes->connect(
+            '/users/*',
+            ['controller' => 'Users', 'action' => 'delete', '_method' => 'DELETE'],
+            ['_name' => 'users:delete']
+        );
     }
 );

--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -75,6 +75,11 @@ Router::plugin(
         );
         $routes->connect(
             '/users/*',
+            ['controller' => 'Users', 'action' => 'edit', '_method' => 'PATCH'],
+            ['_name' => 'users:edit']
+        );
+        $routes->connect(
+            '/users/*',
             ['controller' => 'Users', 'action' => 'delete', '_method' => 'DELETE'],
             ['_name' => 'users:delete']
         );

--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -56,6 +56,21 @@ Router::plugin(
             ['controller' => 'Users', 'action' => 'index', '_method' => 'GET'],
             ['_name' => 'roles:users']
         );
+        $routes->connect(
+            '/roles',
+            ['controller' => 'Roles', 'action' => 'add', '_method' => 'POST'],
+            ['_name' => 'roles:add']
+        );
+        $routes->connect(
+            '/roles/*',
+            ['controller' => 'Roles', 'action' => 'edit', '_method' => 'PATCH'],
+            ['_name' => 'roles:edit']
+        );
+        $routes->connect(
+            '/roles/*',
+            ['controller' => 'Roles', 'action' => 'delete', '_method' => 'DELETE'],
+            ['_name' => 'roles:delete']
+        );
 
         // Users.
         $routes->connect(

--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -21,11 +21,14 @@ Router::plugin(
         '_namePrefix' => 'api:',
     ],
     function (RouteBuilder $routes) {
+        // Home.
         $routes->connect(
             '/home',
             ['controller' => 'Home', 'action' => 'index', '_method' => 'GET'],
             ['_name' => 'home']
         );
+
+        // Objects.
         $routes->connect(
             '/objects',
             ['controller' => 'Objects', 'action' => 'index', '_method' => 'GET'],
@@ -36,6 +39,8 @@ Router::plugin(
             ['controller' => 'Objects', 'action' => 'view', '_method' => 'GET'],
             ['_name' => 'objects:view']
         );
+
+        // Roles.
         $routes->connect(
             '/roles',
             ['controller' => 'Roles', 'action' => 'index', '_method' => 'GET'],
@@ -52,6 +57,7 @@ Router::plugin(
             ['_name' => 'roles:users']
         );
 
+        // Users.
         $routes->connect(
             '/users',
             ['controller' => 'Users', 'action' => 'index', '_method' => 'GET'],

--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -23,44 +23,49 @@ Router::plugin(
     function (RouteBuilder $routes) {
         $routes->connect(
             '/home',
-            ['controller' => 'Home', 'action' => 'index'],
-            ['_method' => 'GET', '_name' => 'home']
+            ['controller' => 'Home', 'action' => 'index', '_method' => 'GET'],
+            ['_name' => 'home']
         );
         $routes->connect(
             '/objects',
-            ['controller' => 'Objects', 'action' => 'index'],
-            ['_method' => 'GET', '_name' => 'objects:index']
+            ['controller' => 'Objects', 'action' => 'index', '_method' => 'GET'],
+            ['_name' => 'objects:index']
         );
         $routes->connect(
             '/objects/*',
-            ['controller' => 'Objects', 'action' => 'view'],
-            ['_method' => 'GET', '_name' => 'objects:view']
+            ['controller' => 'Objects', 'action' => 'view', '_method' => 'GET'],
+            ['_name' => 'objects:view']
         );
         $routes->connect(
             '/roles',
-            ['controller' => 'Roles', 'action' => 'index'],
-            ['_method' => 'GET', '_name' => 'roles:index']
+            ['controller' => 'Roles', 'action' => 'index', '_method' => 'GET'],
+            ['_name' => 'roles:index']
         );
         $routes->connect(
             '/roles/*',
-            ['controller' => 'Roles', 'action' => 'view'],
-            ['_method' => 'GET', '_name' => 'roles:view']
+            ['controller' => 'Roles', 'action' => 'view', '_method' => 'GET'],
+            ['_name' => 'roles:view']
         );
         $routes->connect(
             '/roles/:role_id/users',
-            ['controller' => 'Users', 'action' => 'index'],
-            ['_method' => 'GET', '_name' => 'roles:users']
+            ['controller' => 'Users', 'action' => 'index', '_method' => 'GET'],
+            ['_name' => 'roles:users']
         );
 
         $routes->connect(
             '/users',
-            ['controller' => 'Users', 'action' => 'index'],
-            ['_method' => 'GET', '_name' => 'users:index']
+            ['controller' => 'Users', 'action' => 'index', '_method' => 'GET'],
+            ['_name' => 'users:index']
         );
         $routes->connect(
             '/users/*',
-            ['controller' => 'Users', 'action' => 'view'],
-            ['_method' => 'GET', '_name' => 'users:view']
+            ['controller' => 'Users', 'action' => 'view', '_method' => 'GET'],
+            ['_name' => 'users:view']
+        );
+        $routes->connect(
+            '/users',
+            ['controller' => 'Users', 'action' => 'add', '_method' => 'POST'],
+            ['_name' => 'users:add']
         );
     }
 );

--- a/plugins/BEdita/API/src/Controller/AppController.php
+++ b/plugins/BEdita/API/src/Controller/AppController.php
@@ -39,11 +39,13 @@ class AppController extends Controller
 
         $this->loadComponent('RequestHandler');
         if ($this->request->is(['json', 'jsonapi'])) {
-            $this->RequestHandler->config('viewClassMap.json', 'BEdita/API.JsonApi');
             $this->loadComponent('BEdita/API.JsonApi', [
                 'contentType' => $this->request->is('json') ? 'json' : null,
                 'checkMediaType' => $this->request->is('jsonapi'),
             ]);
+
+            $this->RequestHandler->config('inputTypeMap.json', [[$this->JsonApi, 'parseInput']], false);
+            $this->RequestHandler->config('viewClassMap.json', 'BEdita/API.JsonApi');
         }
 
         if (empty(Router::fullBaseUrl())) {

--- a/plugins/BEdita/API/src/Controller/AppController.php
+++ b/plugins/BEdita/API/src/Controller/AppController.php
@@ -38,11 +38,11 @@ class AppController extends Controller
         $this->loadComponent('BEdita/API.Paginator');
 
         $this->loadComponent('RequestHandler');
-        if ($this->request->is(['json', 'jsonApi'])) {
+        if ($this->request->is(['json', 'jsonapi'])) {
             $this->RequestHandler->config('viewClassMap.json', 'BEdita/API.JsonApi');
             $this->loadComponent('BEdita/API.JsonApi', [
                 'contentType' => $this->request->is('json') ? 'json' : null,
-                'checkMediaType' => $this->request->is('jsonApi'),
+                'checkMediaType' => $this->request->is('jsonapi'),
             ]);
         }
 
@@ -63,7 +63,7 @@ class AppController extends Controller
     {
         if ((Configure::read('debug') || Configure::read('Accept.html')) && $this->request->is('html')) {
             return $this->html();
-        } elseif (!$this->request->is(['json', 'jsonApi'])) {
+        } elseif (!$this->request->is(['json', 'jsonapi'])) {
             throw new NotAcceptableException('Bad request content type "' . implode('" "', $this->request->accepts()) . '"');
         }
 

--- a/plugins/BEdita/API/src/Controller/AppController.php
+++ b/plugins/BEdita/API/src/Controller/AppController.php
@@ -88,6 +88,7 @@ class AppController extends Controller
             'environment' => [
                 'HTTP_CONTENT_TYPE' => 'application/json',
                 'HTTP_ACCEPT' => 'application/json',
+                'REQUEST_METHOD' => $method,
             ],
         ]);
 

--- a/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
@@ -86,7 +86,6 @@ class JsonApiComponent extends Component
 
             return JsonApi::parseData((array)$json['data']);
         } catch (\InvalidArgumentException $e) {
-            debug($e->getMessage());
             return [];
         }
     }

--- a/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
@@ -213,8 +213,8 @@ class JsonApiComponent extends Component
     /**
      * Check that no resource includes a client-generated ID, if this feature is unsupported.
      *
-     * @param bool $allow
-     * @param array|null $data
+     * @param bool $allow Should client-generated IDs be allowed?
+     * @param array|null $data Data to be checked. By default, this is taken from the request.
      * @return void
      * @throws \Cake\Network\Exception\ForbiddenException Throws an exception if a resource has a client-generated
      *      ID, but this feature is not supported.

--- a/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
@@ -50,7 +50,6 @@ class JsonApiComponent extends Component
         'contentType' => null,
         'checkMediaType' => true,
         'resourceTypes' => null,
-        'clientGeneratedIds' => false,
     ];
 
     /**
@@ -188,7 +187,7 @@ class JsonApiComponent extends Component
      * @return void
      * @throws \Cake\Network\Exception\ConflictException Throws an exception if a resource has a non-supported `type`.
      */
-    public function allowedResourceTypes($types, array $data = null)
+    protected function allowedResourceTypes($types, array $data = null)
     {
         $data = ($data === null) ? $this->request->data : $data;
         if (!$data || !$types) {
@@ -223,7 +222,7 @@ class JsonApiComponent extends Component
      * @throws \Cake\Network\Exception\ForbiddenException Throws an exception if a resource has a client-generated
      *      ID, but this feature is not supported.
      */
-    public function allowClientGeneratedIds($allow = true, array $data = null)
+    protected function allowClientGeneratedIds($allow = true, array $data = null)
     {
         $data = ($data === null) ? $this->request->data : $data;
         if (!$data || $allow) {
@@ -279,7 +278,7 @@ class JsonApiComponent extends Component
         }
 
         if ($this->request->is('post')) {
-            $this->allowClientGeneratedIds($this->config('clientGeneratedIds'));
+            $this->allowClientGeneratedIds(false);
         }
     }
 

--- a/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
@@ -67,7 +67,7 @@ class JsonApiComponent extends Component
         ]);
 
         $this->RequestHandler->config('inputTypeMap.jsonapi', [[$this, 'parseInput']]); // Must be lowercase because reasons.
-        $this->RequestHandler->config('viewClassMap.jsonApi', 'BEdita/API.JsonApi');
+        $this->RequestHandler->config('viewClassMap.jsonapi', 'BEdita/API.JsonApi');
     }
 
     /**
@@ -243,6 +243,7 @@ class JsonApiComponent extends Component
     /**
      * Perform preliminary checks and operations.
      *
+     * @param \Cake\Event\Event $event Triggered event.
      * @return void
      * @throws \BEdita\API\Network\Exception\UnsupportedMediaTypeException Throws an exception if the `Accept` header
      *      does not comply to JSON API specifications and `checkMediaType` configuration is enabled.
@@ -251,8 +252,15 @@ class JsonApiComponent extends Component
      * @throws \Cake\Network\Exception\ForbiddenException Throws an exception if a resource in the payload includes a
      *      client-generated ID, but the feature is not supported.
      */
-    public function startup()
+    public function startup(Event $event)
     {
+        $controller = $event->subject();
+        if (!($controller instanceof Controller)) {
+            return;
+        }
+
+        $this->RequestHandler->renderAs($controller, 'jsonapi');
+
         if ($this->config('checkMediaType') && trim($this->request->header('accept')) != self::CONTENT_TYPE) {
             // http://jsonapi.org/format/#content-negotiation-servers
             throw new UnsupportedMediaTypeException('Bad request content type "' . implode('" "', $this->request->accepts()) . '"');
@@ -296,7 +304,5 @@ class JsonApiComponent extends Component
             '_links' => $links,
             '_meta' => $meta,
         ]);
-
-        $this->RequestHandler->renderAs($controller, 'jsonApi');
     }
 }

--- a/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
@@ -63,7 +63,7 @@ class JsonApiComponent extends Component
             $contentType = $this->response->getMimeType($config['contentType']) ?: $config['contentType'];
         }
         $this->response->type([
-            'jsonApi' => $contentType,
+            'jsonapi' => $contentType,
         ]);
 
         $this->RequestHandler->config('inputTypeMap.jsonapi', [[$this, 'parseInput']]); // Must be lowercase because reasons.

--- a/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
@@ -190,15 +190,19 @@ class JsonApiComponent extends Component
      */
     public function allowedResourceTypes($types, array $data = null)
     {
-        $data = $data ?: $this->request->data;
+        $data = ($data === null) ? $this->request->data : $data;
         if (!$data || !$types) {
             return;
         }
         $data = (array)$data;
         $types = (array)$types;
 
-        if (Hash::numeric($data)) {
+        if (Hash::numeric(array_keys($data))) {
             foreach ($data as $item) {
+                if (!is_array($item)) {
+                    continue;
+                }
+
                 $this->allowedResourceTypes($types, $item);
             }
 
@@ -221,14 +225,18 @@ class JsonApiComponent extends Component
      */
     public function allowClientGeneratedIds($allow = true, array $data = null)
     {
-        $data = $data ?: $this->request->data;
+        $data = ($data === null) ? $this->request->data : $data;
         if (!$data || $allow) {
             return;
         }
         $data = (array)$data;
 
-        if (Hash::numeric($data)) {
+        if (Hash::numeric(array_keys($data))) {
             foreach ($data as $item) {
+                if (!is_array($item)) {
+                    continue;
+                }
+
                 $this->allowClientGeneratedIds($allow, $item);
             }
 

--- a/plugins/BEdita/API/src/Controller/HomeController.php
+++ b/plugins/BEdita/API/src/Controller/HomeController.php
@@ -47,8 +47,7 @@ class HomeController extends AppController
         }
 
         $meta = compact('resources');
-        $this->set('_type', 'meta');
         $this->set('_meta', $meta);
-        $this->set('_serialize', true);
+        $this->set('_serialize', []);
     }
 }

--- a/plugins/BEdita/API/src/Controller/UsersController.php
+++ b/plugins/BEdita/API/src/Controller/UsersController.php
@@ -13,6 +13,7 @@
 namespace BEdita\API\Controller;
 
 use Cake\Network\Exception\BadRequestException;
+use Cake\Network\Exception\ConflictException;
 use Cake\Network\Exception\InternalErrorException;
 use Cake\ORM\Query;
 use Cake\Routing\Router;
@@ -83,6 +84,7 @@ class UsersController extends AppController
      * Add a new user.
      *
      * @return void
+     * @throws \Cake\Network\Exception\BadRequestException Throws an exception if submitted data is invalid.
      */
     public function add()
     {
@@ -95,6 +97,34 @@ class UsersController extends AppController
 
         $this->response->statusCode(201);
         $this->response->header('Location', Router::url(['_name' => 'api:users:view', $user->id], true));
+
+        $this->set(compact('user'));
+        $this->set('_serialize', ['user']);
+    }
+
+    /**
+     * Edit an existing user.
+     *
+     * @param int $id User ID.
+     * @return void
+     * @throws \Cake\Network\Exception\ConflictException Throws an exception if user ID in the payload doesn't match
+     *      the user ID in the URL.
+     * @throws \Cake\Network\Exception\NotFoundException Throws an exception if specified user could not be found.
+     * @throws \Cake\Network\Exception\BadRequestException Throws an exception if submitted data is invalid.
+     */
+    public function edit($id)
+    {
+        $this->request->allowMethod('patch');
+
+        if ($this->request->data('id') != $id) {
+            throw new ConflictException('IDs don\' match');
+        }
+
+        $user = $this->Users->get($id);
+        $user = $this->Users->patchEntity($user, $this->request->data);
+        if (!$this->Users->save($user)) {
+            throw new BadRequestException('Invalid data');
+        }
 
         $this->set(compact('user'));
         $this->set('_serialize', ['user']);

--- a/plugins/BEdita/API/src/Controller/UsersController.php
+++ b/plugins/BEdita/API/src/Controller/UsersController.php
@@ -15,6 +15,7 @@ namespace BEdita\API\Controller;
 use Cake\Network\Exception\BadRequestException;
 use Cake\Network\Exception\InternalErrorException;
 use Cake\ORM\Query;
+use Cake\Routing\Router;
 
 /**
  * Controller for `/users` endpoint.
@@ -93,6 +94,7 @@ class UsersController extends AppController
         }
 
         $this->response->statusCode(201);
+        $this->response->header('Location', Router::url(['_name' => 'api:users:view', $user->id], true));
 
         $this->set(compact('user'));
         $this->set('_serialize', ['user']);

--- a/plugins/BEdita/API/src/Controller/UsersController.php
+++ b/plugins/BEdita/API/src/Controller/UsersController.php
@@ -12,6 +12,9 @@
  */
 namespace BEdita\API\Controller;
 
+use Cake\Network\Exception\BadRequestException;
+use Cake\Network\Exception\ConflictException;
+use Cake\Network\Exception\ForbiddenException;
 use Cake\ORM\Query;
 
 /**
@@ -68,6 +71,34 @@ class UsersController extends AppController
     public function view($id)
     {
         $user = $this->Users->get($id);
+
+        $this->set(compact('user'));
+        $this->set('_serialize', ['user']);
+    }
+
+    /**
+     * Add a new user.
+     *
+     * @return void
+     */
+    public function add()
+    {
+        $this->request->allowMethod('post');
+        if ($this->request->data('type') !== 'users') {
+            throw new ConflictException('Invalid resource type');
+        }
+        if (!empty($this->request->data['id'])) {
+            throw new ForbiddenException('Client-generated IDs are not supported');
+        }
+
+        $user = $this->Users->newEntity();
+        $user = $this->Users->patchEntity($user, $this->request->data);
+        $user = $this->Users->save($user);
+        if (!$user) {
+            throw new BadRequestException('Invalid data');
+        }
+
+        $this->response->statusCode(201);
 
         $this->set(compact('user'));
         $this->set('_serialize', ['user']);

--- a/plugins/BEdita/API/src/Controller/UsersController.php
+++ b/plugins/BEdita/API/src/Controller/UsersController.php
@@ -97,4 +97,23 @@ class UsersController extends AppController
         $this->set(compact('user'));
         $this->set('_serialize', ['user']);
     }
+
+    /**
+     * Delete an existing user.
+     *
+     * @param int $id User ID.
+     * @return \Cake\Network\Response
+     * @throws \Cake\Network\Exception\InternalErrorException Throws an exception if an error occurs during deletion.
+     */
+    public function delete($id)
+    {
+        $this->request->allowMethod('delete');
+
+        $user = $this->Users->get($id);
+        if (!$this->Users->delete($user)) {
+            throw new InternalErrorException('Could not delete user');
+        }
+
+        return $this->response;
+    }
 }

--- a/plugins/BEdita/API/src/Controller/UsersController.php
+++ b/plugins/BEdita/API/src/Controller/UsersController.php
@@ -13,8 +13,7 @@
 namespace BEdita\API\Controller;
 
 use Cake\Network\Exception\BadRequestException;
-use Cake\Network\Exception\ConflictException;
-use Cake\Network\Exception\ForbiddenException;
+use Cake\Network\Exception\InternalErrorException;
 use Cake\ORM\Query;
 
 /**
@@ -39,6 +38,9 @@ class UsersController extends AppController
         parent::initialize();
 
         $this->set('_type', 'users');
+        if (isset($this->JsonApi)) {
+            $this->JsonApi->config('resourceTypes', ['users']);
+        }
     }
 
     /**
@@ -84,17 +86,9 @@ class UsersController extends AppController
     public function add()
     {
         $this->request->allowMethod('post');
-        if ($this->request->data('type') !== 'users') {
-            throw new ConflictException('Invalid resource type');
-        }
-        if (!empty($this->request->data['id'])) {
-            throw new ForbiddenException('Client-generated IDs are not supported');
-        }
 
-        $user = $this->Users->newEntity();
-        $user = $this->Users->patchEntity($user, $this->request->data);
-        $user = $this->Users->save($user);
-        if (!$user) {
+        $user = $this->Users->newEntity($this->request->data);
+        if (!$this->Users->save($user)) {
             throw new BadRequestException('Invalid data');
         }
 

--- a/plugins/BEdita/API/src/Error/ExceptionRenderer.php
+++ b/plugins/BEdita/API/src/Error/ExceptionRenderer.php
@@ -41,15 +41,16 @@ class ExceptionRenderer extends CakeExceptionRenderer
             ]);
         }
 
-        if ($this->controller->request->is(['json', 'jsonApi'])) {
+        if ($this->controller->request->is(['json', 'jsonapi'])) {
             $this->controller->loadComponent('RequestHandler');
             $this->controller->RequestHandler->config('viewClassMap.json', 'BEdita/API.JsonApi');
             $this->controller->loadComponent('BEdita/API.JsonApi', [
                 'contentType' => $this->controller->request->is('json') ? 'json' : null,
-                'checkMediaType' => $this->controller->request->is('jsonApi'),
+                'checkMediaType' => $this->controller->request->is('jsonapi'),
             ]);
 
             $this->controller->JsonApi->error($code, $message, '', array_filter(compact('trace')));
+            $this->controller->RequestHandler->renderAs($this->controller, 'jsonapi');
         }
 
         return parent::render();

--- a/plugins/BEdita/API/src/Utility/JsonApi.php
+++ b/plugins/BEdita/API/src/Utility/JsonApi.php
@@ -141,14 +141,16 @@ class JsonApi
      */
     protected static function parseItem(array $item)
     {
-        if (empty($item['id']) || empty($item['type'])) {
-            throw new \InvalidArgumentException('Keys `id` and `type` are mandatory');
+        if (empty($item['type'])) {
+            throw new \InvalidArgumentException('Key `type` is mandatory');
         }
 
         $data = [
-            'id' => $item['id'],
             'type' => $item['type'],
         ];
+        if (!empty($item['id'])) {
+            $data['id'] = $item['id'];
+        }
 
         if (isset($item['attributes']) && is_array($item['attributes'])) {
             $data += $item['attributes'];

--- a/plugins/BEdita/API/src/View/JsonApiView.php
+++ b/plugins/BEdita/API/src/View/JsonApiView.php
@@ -26,7 +26,7 @@ class JsonApiView extends JsonView
     /**
      * {@inheritDoc}
      */
-    protected $_responseType = 'jsonApi';
+    protected $_responseType = 'jsonapi';
 
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/API/src/View/JsonApiView.php
+++ b/plugins/BEdita/API/src/View/JsonApiView.php
@@ -60,9 +60,10 @@ class JsonApiView extends JsonView
             $meta = $this->viewVars['_meta'];
         }
 
-        if ($type && empty($data) && $type === 'meta') {
-            return compact('error', 'links', 'meta');
+        if (empty($serialize)) {
+            unset($data);
         }
+
         return compact('error', 'data', 'links', 'meta');
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/AppControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AppControllerTest.php
@@ -94,7 +94,7 @@ class AppControllerTest extends IntegrationTestCase
      * @return void
      *
      * @dataProvider contentTypeProvider
-     * @covers \BEdita\API\Controller\Component\JsonApiComponent::beforeFilter()
+     * @covers \BEdita\API\Controller\Component\JsonApiComponent::startup()
      * @covers \BEdita\API\Controller\Component\JsonApiComponent::beforeRender()
      */
     public function testContentType($expectedCode, $expectedContentType, $accept, array $config = null)

--- a/plugins/BEdita/API/tests/TestCase/Controller/AppControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AppControllerTest.php
@@ -44,12 +44,12 @@ class AppControllerTest extends IntegrationTestCase
                 'application/json',
                 'application/json',
             ],
-            'jsonApi' => [
+            'jsonapi' => [
                 200,
                 'application/vnd.api+json',
                 'application/vnd.api+json',
             ],
-            'jsonApiWrongMediaType' => [
+            'jsonapiWrongMediaType' => [
                 415,
                 'application/vnd.api+json',
                 'application/vnd.api+json; m=test',

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
@@ -85,7 +85,7 @@ class JsonApiComponentTest extends TestCase
     {
         $component = new JsonApiComponent(new ComponentRegistry(new Controller()), $config);
 
-        $this->assertEquals($expectedMimeType, $component->response->getMimeType('jsonApi'));
+        $this->assertEquals($expectedMimeType, $component->response->getMimeType('jsonapi'));
         $this->assertArrayHasKey('jsonapi', $component->RequestHandler->config('inputTypeMap'));
         $this->assertArrayHasKey('jsonapi', $component->RequestHandler->config('viewClassMap'));
     }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
@@ -256,4 +256,49 @@ class JsonApiComponentTest extends TestCase
 
         $this->assertEquals($expected, $controller->viewVars['_error']);
     }
+
+    /**
+     * Data provider for `testParseInput` test case.
+     *
+     * @return array
+     */
+    public function parseInputProvider()
+    {
+        return [
+            'valid' => [
+                [
+                    'type' => 'customType',
+                    'key' => 'value',
+                ],
+                '{"data":{"type":"customType","attributes":{"key":"value"}}}'
+            ],
+            'invalidJson' => [
+                [],
+                '{"some", "invalid":"json"',
+            ],
+            'invalidJsonApi' => [
+                [],
+                '{"data":{"type":null,"attributes":{"key":"value"}}}',
+            ],
+        ];
+    }
+
+    /**
+     * Test `parseInput()` method.
+     *
+     * @param array $expected Expected parsed array.
+     * @param string $input Input to be parsed.
+     * @return void
+     *
+     * @dataProvider parseInputProvider
+     * @covers ::parseInput()
+     */
+    public function testParseInput($expected, $input)
+    {
+        $component = new JsonApiComponent(new ComponentRegistry(new Controller()));
+
+        $result = $component->parseInput($input);
+
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
@@ -86,7 +86,7 @@ class JsonApiComponentTest extends TestCase
         $component = new JsonApiComponent(new ComponentRegistry(new Controller()), $config);
 
         $this->assertEquals($expectedMimeType, $component->response->getMimeType('jsonApi'));
-        $this->assertArrayHasKey('jsonApi', $component->RequestHandler->config('inputTypeMap'));
+        $this->assertArrayHasKey('jsonapi', $component->RequestHandler->config('inputTypeMap'));
         $this->assertArrayHasKey('jsonApi', $component->RequestHandler->config('viewClassMap'));
     }
 
@@ -106,6 +106,7 @@ class JsonApiComponentTest extends TestCase
 
         $request = new Request([
             'params' => [
+                'plugin' => 'BEdita/API',
                 'controller' => 'Users',
                 'action' => 'index',
                 '_method' => 'GET',
@@ -213,6 +214,7 @@ class JsonApiComponentTest extends TestCase
 
         $request = new Request([
             'params' => [
+                'plugin' => 'BEdita/API',
                 'controller' => 'Users',
                 'action' => 'index',
                 '_method' => 'GET',

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
@@ -301,4 +301,160 @@ class JsonApiComponentTest extends TestCase
 
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * Data provider for `testAllowedResourceTypes` test case.
+     *
+     * @return array
+     */
+    public function allowedResourceTypesProvider()
+    {
+        return [
+            'single' => [
+                true,
+                'myCustomType',
+                [
+                    'type' => 'myCustomType',
+                    'key' => 'value',
+                ],
+            ],
+            'multiple' => [
+                true,
+                ['myCustomType1', 'myCustomType2'],
+                [
+                    [
+                        'type' => 'myCustomType1',
+                        'key' => 'value',
+                    ],
+                    [
+                        'type' => 'myCustomType2',
+                        'key' => 'value',
+                    ],
+                ],
+            ],
+            'emptyData' => [
+                true,
+                ['myCustomType1', 'myCustomType2'],
+                [],
+            ],
+            'emptyTypes' => [
+                true,
+                null,
+                [
+                    'type' => 'myCustomType',
+                    'key' => 'value',
+                ],
+            ],
+            'unsupportedType' => [
+                false,
+                ['myCustomType'],
+                [
+                    'type' => 'unsupportedType',
+                    'key' => 'value',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `allowedResourceTypes()` method.
+     *
+     * @param bool $expected Expected success.
+     * @param mixed $types Allowed types.
+     * @param array $data Data to be checked.
+     * @return void
+     *
+     * @dataProvider allowedResourceTypesProvider
+     * @cover ::allowedResourceTypes()
+     */
+    public function testAllowedResourceTypes($expected, $types, array $data)
+    {
+        if (!$expected) {
+            $this->setExpectedException('\Cake\Network\Exception\ConflictException');
+        }
+
+        $component = new JsonApiComponent(new ComponentRegistry(new Controller()));
+
+        $component->allowedResourceTypes($types, $data);
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * Data provider for `testAllowClientGeneratedIds` test case.
+     *
+     * @return array
+     */
+    public function allowClientGeneratedIdsProvider()
+    {
+        return [
+            'allowed' => [
+                true,
+                true,
+                [
+                    'id' => 'my-id',
+                ],
+            ],
+            'single' => [
+                true,
+                false,
+                [
+                    'type' => 'myCustomType',
+                    'key' => 'value',
+                ],
+            ],
+            'multiple' => [
+                true,
+                false,
+                [
+                    [
+                        'type' => 'myCustomType1',
+                        'key' => 'value',
+                    ],
+                    [
+                        'type' => 'myCustomType2',
+                        'key' => 'value',
+                    ],
+                ],
+            ],
+            'emptyData' => [
+                true,
+                false,
+                [],
+            ],
+            'unsupportedClientGeneratedId' => [
+                false,
+                false,
+                [
+                    'id' => 'my-id',
+                    'type' => 'myCustomType',
+                    'key' => 'value',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `allowClientGeneratedIds()` method.
+     *
+     * @param bool $expected Expected success.
+     * @param bool $allow Should client-generated IDs be allowed?
+     * @param array $data Data to be checked.
+     * @return void
+     *
+     * @dataProvider allowClientGeneratedIdsProvider
+     * @cover ::allowClientGeneratedIds()
+     */
+    public function testAllowClientGeneratedIds($expected, $allow, array $data)
+    {
+        if (!$expected) {
+            $this->setExpectedException('\Cake\Network\Exception\ForbiddenException');
+        }
+
+        $component = new JsonApiComponent(new ComponentRegistry(new Controller()));
+
+        $component->allowClientGeneratedIds($allow, $data);
+
+        $this->assertTrue(true);
+    }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
@@ -87,7 +87,7 @@ class JsonApiComponentTest extends TestCase
 
         $this->assertEquals($expectedMimeType, $component->response->getMimeType('jsonApi'));
         $this->assertArrayHasKey('jsonapi', $component->RequestHandler->config('inputTypeMap'));
-        $this->assertArrayHasKey('jsonApi', $component->RequestHandler->config('viewClassMap'));
+        $this->assertArrayHasKey('jsonapi', $component->RequestHandler->config('viewClassMap'));
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -325,11 +325,14 @@ class JsonApiTest extends TestCase
                 ],
             ],
             'missingId' => [
-                false,
+                [
+                    'type' => 'customType',
+                    'name' => 'Gustavo',
+                ],
                 [
                     'type' => 'customType',
                     'attributes' => [
-                        'name' => 'Paolo',
+                        'name' => 'Gustavo',
                     ],
                 ],
             ],

--- a/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
+++ b/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
@@ -120,7 +120,7 @@ class JsonApiViewTest extends TestCase
                     ],
                 ],
             ],
-            'noData' =>[
+            'noData' => [
                 json_encode([
                     'links' => [
                         'self' => 'http://example.com/home',

--- a/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
+++ b/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
@@ -120,6 +120,25 @@ class JsonApiViewTest extends TestCase
                     ],
                 ],
             ],
+            'noData' =>[
+                json_encode([
+                    'links' => [
+                        'self' => 'http://example.com/home',
+                    ],
+                    'meta' => [
+                        'metaKey' => 'metaValue',
+                    ],
+                ]),
+                [
+                    '_links' => [
+                        'self' => 'http://example.com/home',
+                    ],
+                    '_meta' => [
+                        'metaKey' => 'metaValue',
+                    ],
+                    '_serialize' => [],
+                ],
+            ],
         ];
     }
 

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -74,7 +74,7 @@ class UsersTable extends Table
             ->allowEmpty('id', 'create')
 
             ->add('username', 'unique', ['rule' => 'validateUnique', 'provider' => 'table'])
-            ->requirePresence('username')
+            ->requirePresence('username', 'create')
             ->notEmpty('username')
 
             ->allowEmpty('password_hash')


### PR DESCRIPTION
This PR implements CUD (Create-Update-Delete) actions for `/users` and `/roles` API endpoints, along with tests. See #911.
