### PR TITLE
Run test suite against multiple database versions in Travis using Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,24 +49,22 @@ matrix:
     - php: hhvm
 
 before_script:
-  - echo "$TRAVIS_PHP_VERSION"
-  - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi
-  - composer install --prefer-dist --no-interaction
-
   - |
     if [ "$DB" = 'mysql' ]; then
       docker pull mysql:$DB_VERSION
       docker run -d -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=bedita -e MYSQL_PASSWORD=bedita -e MYSQL_DATABASE=bedita_test -p 127.0.0.1:33060:3306 mysql:$DB_VERSION
       docker ps -a
-      until nc -z 127.0.0.1 33060; do sleep 1; echo 'Waiting for MySQL to come up...'; done
     fi
   - |
     if [ "$DB" = 'pgsql' ]; then
       docker pull postgres:$DB_VERSION
       docker run -d -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=bedita_test -p 127.0.0.1:54320:5432 postgres:$DB_VERSION
       docker ps -a
-      until nc -z 127.0.0.1 54320; do sleep 1; echo 'Waiting for PostgreSQL to come up...'; done
     fi
+
+  - echo "$TRAVIS_PHP_VERSION"
+  - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi
+  - composer install --prefer-dist --no-interaction
 
   - |
     if [ "$TRAVIS_PHP_VERSION" != 'hhvm' ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ group: edge
 services:
   - docker
   - memcached
+  - mysql
   - redis-server
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ before_script:
     if [ "$DB" = 'mysql' ]; then
       docker pull mysql:$DB_VERSION
       docker run -d -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=bedita -e MYSQL_PASSWORD=bedita -e MYSQL_DATABASE=bedita_test -p 127.0.0.1:33060:3306 mysql:$DB_VERSION
+      docker ps -a
     fi
   - if [ "$DB" = 'pgsql' ]; then psql -c 'CREATE DATABASE bedita_test;' -U postgres; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ php:
   - hhvm
 
 sudo: required
-dist: trusty
-group: edge
 
 services:
   - docker
@@ -23,12 +21,8 @@ cache:
 env:
   matrix:
     - "DB=sqlite db_dsn='sqlite:///:memory:'"
-    - "DB=mysql DB_VERSION=5.5 db_dsn='mysql://bedita:bedita@127.0.0.1:33060/bedita_test'"
-    - "DB=mysql DB_VERSION=5.6 db_dsn='mysql://bedita:bedita@127.0.0.1:33060/bedita_test'"
-    - "DB=mysql DB_VERSION=5.7 db_dsn='mysql://bedita:bedita@127.0.0.1:33060/bedita_test'"
-    - "DB=pgsql DB_VERSION=9.3 db_dsn='postgres://postgres:postgres@127.0.0.1:54320/bedita_test'"
-    - "DB=pgsql DB_VERSION=9.4 db_dsn='postgres://postgres:postgres@127.0.0.1:54320/bedita_test'"
-    - "DB=pgsql DB_VERSION=9.5 db_dsn='postgres://postgres:postgres@127.0.0.1:54320/bedita_test'"
+    - "DB=mysql db_dsn='mysql://travis@0.0.0.0/bedita_test'"
+    - "DB=pgsql db_dsn='postgres://postgres@127.0.0.1/bedita_test'"
   global:
     - RUN_TESTS=1
 
@@ -37,15 +31,33 @@ matrix:
 
   include:
     - php: 7.0
+      env: "DB=mysql DB_VERSION=5.5 db_dsn='mysql://bedita:bedita@127.0.0.1:33060/bedita_test'"
+      sudo: required
+    - php: 7.0
+      env: "DB=mysql DB_VERSION=5.6 db_dsn='mysql://bedita:bedita@127.0.0.1:33060/bedita_test'"
+      sudo: required
+    - php: 7.0
+      env: "DB=mysql DB_VERSION=5.7 db_dsn='mysql://bedita:bedita@127.0.0.1:33060/bedita_test'"
+      sudo: required
+    - php: 7.0
+      env: "DB=pgsql DB_VERSION=9.3 db_dsn='postgres://postgres:postgres@127.0.0.1:54320/bedita_test'"
+      sudo: required
+    - php: 7.0
+      env: "DB=pgsql DB_VERSION=9.4 db_dsn='postgres://postgres:postgres@127.0.0.1:54320/bedita_test'"
+      sudo: required
+    - php: 7.0
+      env: "DB=pgsql DB_VERSION=9.5 db_dsn='postgres://postgres:postgres@127.0.0.1:54320/bedita_test'"
+      sudo: required
+    - php: 7.0
       env: RUN_CS=1 RUN_TESTS=0
 
   exclude:
+    - php: 7.0
+      env: "DB=mysql db_dsn='mysql://travis@0.0.0.0/bedita_test'"
+    - php: 7.0
+      env: "DB=pgsql db_dsn='postgres://postgres@127.0.0.1/bedita_test'"
     - php: hhvm
-      env: "DB=pgsql DB_VERSION=9.3 db_dsn='postgres://postgres:postgres@127.0.0.1:54320/bedita_test'"
-    - php: hhvm
-      env: "DB=pgsql DB_VERSION=9.4 db_dsn='postgres://postgres:postgres@127.0.0.1:54320/bedita_test'"
-    - php: hhvm
-      env: "DB=pgsql DB_VERSION=9.5 db_dsn='postgres://postgres:postgres@127.0.0.1:54320/bedita_test'"
+      env: "DB=pgsql db_dsn='postgres://postgres@127.0.0.1/bedita_test'"
 
   allow_failures:
     - php: hhvm
@@ -53,18 +65,15 @@ matrix:
 before_script:
   - |
     if [ "$DB" = 'mysql' ]; then
-      docker pull mysql:$DB_VERSION
-      docker run -d -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=bedita -e MYSQL_PASSWORD=bedita -e MYSQL_DATABASE=bedita_test -p 127.0.0.1:33060:3306 mysql:$DB_VERSION
-      docker ps -a
+      mysql -e 'CREATE DATABASE bedita_test;'
+      if [ -n "$DB_VERSION" ]; then
+        docker pull mysql:$DB_VERSION
+        docker run -d -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=bedita -e MYSQL_PASSWORD=bedita -e MYSQL_DATABASE=bedita_test -p 127.0.0.1:33060:3306 mysql:$DB_VERSION
+        docker ps -a
+      fi
     fi
-  - |
-    if [ "$DB" = 'pgsql' ]; then
-      docker pull postgres:$DB_VERSION
-      docker run -d -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=bedita_test -p 127.0.0.1:54320:5432 postgres:$DB_VERSION
-      docker ps -a
-    fi
+  - if [ "$DB" = 'pgsql' ]; then psql -c 'CREATE DATABASE bedita_test;' -U postgres; fi
 
-  - echo "$TRAVIS_PHP_VERSION"
   - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi
   - composer install --prefer-dist --no-interaction
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ group: edge
 services:
   - docker
   - memcached
-  - mysql
   - redis-server
 
 cache:
@@ -24,7 +23,7 @@ cache:
 env:
   matrix:
     - "DB=sqlite db_dsn='sqlite:///:memory:'"
-    - "DB=mysql db_dsn='mysql://travis@127.0.0.1/bedita_test'"
+    - "DB=mysql DB_VERSION=5.6 db_dsn='mysql://bedita:bedita@127.0.0.1:33060/bedita_test'"
     - "DB=pgsql db_dsn='postgres://postgres@127.0.0.1/bedita_test'"
   global:
     - RUN_TESTS=1
@@ -35,8 +34,6 @@ matrix:
   include:
     - php: 7.0
       env: "DB=mysql DB_VERSION=5.5 db_dsn='mysql://bedita:bedita@127.0.0.1:33060/bedita_test'"
-    - php: 7.0
-      env: "DB=mysql DB_VERSION=5.6 db_dsn='mysql://bedita:bedita@127.0.0.1:33060/bedita_test'"
     - php: 7.0
       env: "DB=mysql DB_VERSION=5.7 db_dsn='mysql://bedita:bedita@127.0.0.1:33060/bedita_test'"
     - php: 7.0
@@ -49,8 +46,6 @@ matrix:
       env: RUN_CS=1 RUN_TESTS=0
 
   exclude:
-    - php: 7.0
-      env: "DB=mysql db_dsn='mysql://travis@127.0.0.1/bedita_test'"
     - php: 7.0
       env: "DB=pgsql db_dsn='postgres://postgres@127.0.0.1/bedita_test'"
     - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ php:
   - 7.0
   - hhvm
 
-sudo: false
+sudo: required
+dist: trusty
+group: edge
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,9 @@ env:
     - "DB=mysql DB_VERSION=5.5 db_dsn='mysql://bedita:bedita@127.0.0.1:33060/bedita_test'"
     - "DB=mysql DB_VERSION=5.6 db_dsn='mysql://bedita:bedita@127.0.0.1:33060/bedita_test'"
     - "DB=mysql DB_VERSION=5.7 db_dsn='mysql://bedita:bedita@127.0.0.1:33060/bedita_test'"
-    - "DB=pgsql db_dsn='postgres://postgres@127.0.0.1/bedita_test'"
+    - "DB=pgsql DB_VERSION=9.3 db_dsn='postgres://postgres:postgres@127.0.0.1:54320/bedita_test'"
+    - "DB=pgsql DB_VERSION=9.4 db_dsn='postgres://postgres:postgres@127.0.0.1:54320/bedita_test'"
+    - "DB=pgsql DB_VERSION=9.5 db_dsn='postgres://postgres:postgres@127.0.0.1:54320/bedita_test'"
   global:
     - RUN_TESTS=1
 
@@ -37,7 +39,11 @@ matrix:
 
   exclude:
     - php: hhvm
-      env: "DB=pgsql db_dsn='postgres://postgres@127.0.0.1/bedita_test'"
+      env: "DB=pgsql DB_VERSION=9.3 db_dsn='postgres://postgres:postgres@127.0.0.1:54320/bedita_test'"
+    - php: hhvm
+      env: "DB=pgsql DB_VERSION=9.4 db_dsn='postgres://postgres:postgres@127.0.0.1:54320/bedita_test'"
+    - php: hhvm
+      env: "DB=pgsql DB_VERSION=9.5 db_dsn='postgres://postgres:postgres@127.0.0.1:54320/bedita_test'"
 
   allow_failures:
     - php: hhvm
@@ -52,8 +58,15 @@ before_script:
       docker pull mysql:$DB_VERSION
       docker run -d -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=bedita -e MYSQL_PASSWORD=bedita -e MYSQL_DATABASE=bedita_test -p 127.0.0.1:33060:3306 mysql:$DB_VERSION
       docker ps -a
+      until nc -z 127.0.0.1 33060; do sleep 1; echo 'Waiting for MySQL to come up...'; done
     fi
-  - if [ "$DB" = 'pgsql' ]; then psql -c 'CREATE DATABASE bedita_test;' -U postgres; fi
+  - |
+    if [ "$DB" = 'pgsql' ]; then
+      docker pull postgres:$DB_VERSION
+      docker run -d -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=bedita_test -p 127.0.0.1:54320:5432 postgres:$DB_VERSION
+      docker ps -a
+      until nc -z 127.0.0.1 54320; do sleep 1; echo 'Waiting for PostgreSQL to come up...'; done
+    fi
 
   - |
     if [ "$TRAVIS_PHP_VERSION" != 'hhvm' ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ php:
   - 7.0
   - hhvm
 
-sudo: false
+sudo: required
+dist: trusty
+group: edge
 
 services:
   - docker
@@ -21,7 +23,7 @@ cache:
 env:
   matrix:
     - "DB=sqlite db_dsn='sqlite:///:memory:'"
-    - "DB=mysql db_dsn='mysql://travis@0.0.0.0/bedita_test'"
+    - "DB=mysql db_dsn='mysql://travis@127.0.0.1/bedita_test'"
     - "DB=pgsql db_dsn='postgres://postgres@127.0.0.1/bedita_test'"
   global:
     - RUN_TESTS=1
@@ -32,28 +34,22 @@ matrix:
   include:
     - php: 7.0
       env: "DB=mysql DB_VERSION=5.5 db_dsn='mysql://bedita:bedita@127.0.0.1:33060/bedita_test'"
-      sudo: required
     - php: 7.0
       env: "DB=mysql DB_VERSION=5.6 db_dsn='mysql://bedita:bedita@127.0.0.1:33060/bedita_test'"
-      sudo: required
     - php: 7.0
       env: "DB=mysql DB_VERSION=5.7 db_dsn='mysql://bedita:bedita@127.0.0.1:33060/bedita_test'"
-      sudo: required
     - php: 7.0
       env: "DB=pgsql DB_VERSION=9.3 db_dsn='postgres://postgres:postgres@127.0.0.1:54320/bedita_test'"
-      sudo: required
     - php: 7.0
       env: "DB=pgsql DB_VERSION=9.4 db_dsn='postgres://postgres:postgres@127.0.0.1:54320/bedita_test'"
-      sudo: required
     - php: 7.0
       env: "DB=pgsql DB_VERSION=9.5 db_dsn='postgres://postgres:postgres@127.0.0.1:54320/bedita_test'"
-      sudo: required
     - php: 7.0
       env: RUN_CS=1 RUN_TESTS=0
 
   exclude:
     - php: 7.0
-      env: "DB=mysql db_dsn='mysql://travis@0.0.0.0/bedita_test'"
+      env: "DB=mysql db_dsn='mysql://travis@127.0.0.1/bedita_test'"
     - php: 7.0
       env: "DB=pgsql db_dsn='postgres://postgres@127.0.0.1/bedita_test'"
     - php: hhvm
@@ -65,14 +61,24 @@ matrix:
 before_script:
   - |
     if [ "$DB" = 'mysql' ]; then
-      mysql -e 'CREATE DATABASE bedita_test;'
       if [ -n "$DB_VERSION" ]; then
         docker pull mysql:$DB_VERSION
         docker run -d -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=bedita -e MYSQL_PASSWORD=bedita -e MYSQL_DATABASE=bedita_test -p 127.0.0.1:33060:3306 mysql:$DB_VERSION
         docker ps -a
+      else
+        mysql -e 'CREATE DATABASE bedita_test;'
       fi
     fi
-  - if [ "$DB" = 'pgsql' ]; then psql -c 'CREATE DATABASE bedita_test;' -U postgres; fi
+  - |
+    if [ "$DB" = 'pgsql' ]; then
+      if [ -n "$DB_VERSION" ]; then
+        docker pull postgres:$DB_VERSION
+        docker run -d -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=bedita_test -p 127.0.0.1:54320:5432 postgres:$DB_VERSION
+        docker ps -a
+      else
+        psql -c 'CREATE DATABASE bedita_test;' -U postgres
+      fi
+    fi
 
   - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi
   - composer install --prefer-dist --no-interaction

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
 sudo: false
 
 services:
+  - docker
   - memcached
   - redis-server
 
@@ -20,7 +21,9 @@ cache:
 env:
   matrix:
     - "DB=sqlite db_dsn='sqlite:///:memory:'"
-    - "DB=mysql db_dsn='mysql://travis@0.0.0.0/bedita_test'"
+    - "DB=mysql DB_VERSION=5.5 db_dsn='mysql://bedita:bedita@127.0.0.1:33060/bedita_test'"
+    - "DB=mysql DB_VERSION=5.6 db_dsn='mysql://bedita:bedita@127.0.0.1:33060/bedita_test'"
+    - "DB=mysql DB_VERSION=5.7 db_dsn='mysql://bedita:bedita@127.0.0.1:33060/bedita_test'"
     - "DB=pgsql db_dsn='postgres://postgres@127.0.0.1/bedita_test'"
   global:
     - RUN_TESTS=1
@@ -41,15 +44,23 @@ matrix:
 
 before_script:
   - echo "$TRAVIS_PHP_VERSION"
-  - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
+  - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi
   - composer install --prefer-dist --no-interaction
 
-  - if [ "$DB" = 'mysql' ]; then mysql -e 'CREATE DATABASE bedita_test;'; fi
+  - |
+    if [ "$DB" = 'mysql' ]; then
+      docker pull mysql:$DB_VERSION
+      docker run -d -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=bedita -e MYSQL_PASSWORD=bedita -e MYSQL_DATABASE=bedita_test -p 127.0.0.1:33060:3306 mysql:$DB_VERSION
+    fi
   - if [ "$DB" = 'pgsql' ]; then psql -c 'CREATE DATABASE bedita_test;' -U postgres; fi
 
-  - if [ "$TRAVIS_PHP_VERSION" != 'hhvm' ]; then echo 'extension = memcached.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
-  - if [ "$TRAVIS_PHP_VERSION" != 'hhvm' ]; then echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
-  - if [ "$TRAVIS_PHP_VERSION" = 'hhvm' ]; then composer require lorenzo/multiple-iterator=~1.0; fi
+  - |
+    if [ "$TRAVIS_PHP_VERSION" != 'hhvm' ]; then
+      echo 'extension = memcached.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+      echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+    else
+      composer require lorenzo/multiple-iterator=~1.0
+    fi
 
   - phpenv rehash
   - set +H

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - 7.0
   - hhvm
 
-sudo: required
+sudo: false
 
 services:
   - docker


### PR DESCRIPTION
This PR increments the number of jobs per Travis CI build, as per #914. Tests are run against several versions of each database vendor:
- MySQL versions: 5.5, 5.6, 5.7
- PostgreSQL versions: 9.3, 9.4, 9.5 (tests not run on HHVM)
- SQLite 3

This is achieved using Docker containers for databases. Docker images used are the official ones, and are pulled from the default repository.
