### PR TITLE
Refactor tests

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
@@ -225,7 +225,7 @@ class JsonApiComponentTest extends TestCase
             'query' => $query,
         ]);
         $controller = new Controller($request);
-        $controller->paginate(TableRegistry::get('BEdita/Core.Users'));
+        $controller->paginate(TableRegistry::get('Users'));
         $component = new JsonApiComponent(new ComponentRegistry($controller), []);
 
         $this->assertEquals($expectedLinks, $component->getLinks());

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -46,7 +46,7 @@ class JsonApiTest extends TestCase
     {
         parent::setUp();
 
-        $this->Users = TableRegistry::get('BEdita/Core.Users');
+        $this->Users = TableRegistry::get('Users');
     }
 
     /**

--- a/plugins/BEdita/Core/config/bootstrap.php
+++ b/plugins/BEdita/Core/config/bootstrap.php
@@ -20,6 +20,9 @@ TableRegistry::config('Config', ['className' => 'BEdita/Core.Config']);
 TableRegistry::config('Roles', ['className' => 'BEdita/Core.Roles']);
 TableRegistry::config('Users', ['className' => 'BEdita/Core.Users']);
 
+TableRegistry::config('Objects', ['className' => 'BEdita/Core.Objects']);
+TableRegistry::config('Profiles', ['className' => 'BEdita/Core.Profiles']);
+
 /**
  * Load 'core' configuration parameters
  */

--- a/plugins/BEdita/Core/src/Model/Table/AuthProvidersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/AuthProvidersTable.php
@@ -30,6 +30,8 @@ class AuthProvidersTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     public function initialize(array $config)
     {
@@ -47,6 +49,8 @@ class AuthProvidersTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     public function validationDefault(Validator $validator)
     {
@@ -69,6 +73,8 @@ class AuthProvidersTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     public function buildRules(RulesChecker $rules)
     {
@@ -79,6 +85,8 @@ class AuthProvidersTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     protected function _initializeSchema(Schema $schema)
     {

--- a/plugins/BEdita/Core/src/Model/Table/ConfigTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ConfigTable.php
@@ -27,6 +27,8 @@ class ConfigTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     public function initialize(array $config)
     {
@@ -47,6 +49,8 @@ class ConfigTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     public function validationDefault(Validator $validator)
     {

--- a/plugins/BEdita/Core/src/Model/Table/ExternalAuthTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ExternalAuthTable.php
@@ -31,6 +31,8 @@ class ExternalAuthTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     public function initialize(array $config)
     {
@@ -54,6 +56,8 @@ class ExternalAuthTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     public function validationDefault(Validator $validator)
     {
@@ -71,6 +75,8 @@ class ExternalAuthTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     public function buildRules(RulesChecker $rules)
     {
@@ -85,6 +91,8 @@ class ExternalAuthTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     protected function _initializeSchema(Schema $schema)
     {

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -152,7 +152,7 @@ class ObjectsTable extends Table
      */
     public function findType(Query $query, array $options)
     {
-        $ObjectTypes = TableRegistry::get('BEdita/Core.ObjectTypes');
+        $ObjectTypes = TableRegistry::get('ObjectTypes');
         foreach ($options as &$type) {
             $type = $ObjectTypes->get($type)->id;
         }

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -34,6 +34,8 @@ class ObjectsTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     public function initialize(array $config)
     {
@@ -64,6 +66,8 @@ class ObjectsTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     public function validationDefault(Validator $validator)
     {
@@ -113,11 +117,9 @@ class ObjectsTable extends Table
     }
 
     /**
-     * Returns a rules checker object that will be used for validating
-     * application integrity.
+     * {@inheritDoc}
      *
-     * @param \Cake\ORM\RulesChecker $rules The rules object to be modified.
-     * @return \Cake\ORM\RulesChecker
+     * @codeCoverageIgnore
      */
     public function buildRules(RulesChecker $rules)
     {
@@ -129,6 +131,8 @@ class ObjectsTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     protected function _initializeSchema(Schema $schema)
     {

--- a/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
@@ -29,6 +29,8 @@ class ProfilesTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     public function initialize(array $config)
     {
@@ -53,6 +55,8 @@ class ProfilesTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     public function validationDefault(Validator $validator)
     {
@@ -104,11 +108,9 @@ class ProfilesTable extends Table
     }
 
     /**
-     * Returns a rules checker object that will be used for validating
-     * application integrity.
+     * {@inheritDoc}
      *
-     * @param \Cake\ORM\RulesChecker $rules The rules object to be modified.
-     * @return \Cake\ORM\RulesChecker
+     * @codeCoverageIgnore
      */
     public function buildRules(RulesChecker $rules)
     {

--- a/plugins/BEdita/Core/src/Model/Table/RolesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RolesTable.php
@@ -29,6 +29,8 @@ class RolesTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     public function initialize(array $config)
     {
@@ -54,6 +56,8 @@ class RolesTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     public function validationDefault(Validator $validator)
     {
@@ -78,6 +82,8 @@ class RolesTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     public function buildRules(RulesChecker $rules)
     {

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -30,6 +30,8 @@ class UsersTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     public function initialize(array $config)
     {
@@ -66,6 +68,8 @@ class UsersTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     public function validationDefault(Validator $validator)
     {
@@ -96,6 +100,8 @@ class UsersTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
      */
     public function buildRules(RulesChecker $rules)
     {

--- a/plugins/BEdita/Core/src/Shell/DataSeedShell.php
+++ b/plugins/BEdita/Core/src/Shell/DataSeedShell.php
@@ -186,7 +186,7 @@ class DataSeedShell extends Shell
         if (!method_exists($this, $method)) {
             $this->abort('Table "' . $tableName . '" is not yet supported');
         }
-        $table = TableRegistry::get('BEdita/Core.' . $tableName);
+        $table = TableRegistry::get($tableName);
         $count = max(1, intval($this->params['number']));
 
         $fields = [];

--- a/plugins/BEdita/Core/tests/TestCase/Configure/ConfigureTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Configure/ConfigureTest.php
@@ -42,9 +42,6 @@ class ConfigureTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        TableRegistry::remove('Config');
-        TableRegistry::clear();
-        TableRegistry::config('Config', ['className' => 'BEdita/Core.Config']);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Configure/Engine/DatabaseConfigTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Configure/Engine/DatabaseConfigTest.php
@@ -48,8 +48,7 @@ class DatabaseConfigTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        TableRegistry::clear();
-        TableRegistry::config('Config', ['className' => 'BEdita/Core.Config']);
+
         $this->DatabaseConfig = new DatabaseConfig();
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Database/Type/JsonTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Database/Type/JsonTypeTest.php
@@ -65,8 +65,6 @@ class JsonTypeTest extends TestCase
     {
         unset($this->JsonSchemaTable);
 
-        TableRegistry::clear();
-
         parent::tearDown();
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ClassTableInheritanceBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ClassTableInheritanceBehaviorTest.php
@@ -95,7 +95,10 @@ class ClassTableInheritanceBehaviorTest extends TestCase
         unset($this->fakeAnimals);
         unset($this->fakeMammals);
         unset($this->fakeFelines);
-        TableRegistry::clear();
+
+        TableRegistry::remove('FakeAnimals');
+        TableRegistry::remove('FakeMammals');
+        TableRegistry::remove('FakeFelines');
 
         parent::tearDown();
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/AuthProviderTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/AuthProviderTest.php
@@ -48,7 +48,7 @@ class AuthProviderTest extends TestCase
     {
         parent::setUp();
 
-        $this->AuthProviders = TableRegistry::get('BEdita/Core.AuthProviders');
+        $this->AuthProviders = TableRegistry::get('AuthProviders');
     }
 
     /**
@@ -57,8 +57,6 @@ class AuthProviderTest extends TestCase
     public function tearDown()
     {
         unset($this->AuthProviders);
-
-        TableRegistry::clear();
 
         parent::tearDown();
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ConfigTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ConfigTest.php
@@ -46,7 +46,7 @@ class ConfigTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->Config = TableRegistry::get('BEdita/Core.Config');
+        $this->Config = TableRegistry::get('Config');
     }
 
     /**
@@ -55,6 +55,7 @@ class ConfigTest extends TestCase
     public function tearDown()
     {
         unset($this->Config);
+
         parent::tearDown();
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ExternalAuthTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ExternalAuthTest.php
@@ -50,7 +50,7 @@ class ExternalAuthTest extends TestCase
     {
         parent::setUp();
 
-        $this->ExternalAuth = TableRegistry::get('BEdita/Core.ExternalAuth');
+        $this->ExternalAuth = TableRegistry::get('ExternalAuth');
     }
 
     /**
@@ -59,8 +59,6 @@ class ExternalAuthTest extends TestCase
     public function tearDown()
     {
         unset($this->ExternalAuth);
-
-        TableRegistry::clear();
 
         parent::tearDown();
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTest.php
@@ -50,7 +50,7 @@ class ObjectTest extends TestCase
     {
         parent::setUp();
 
-        $this->Objects = TableRegistry::get('BEdita/Core.Objects');
+        $this->Objects = TableRegistry::get('Objects');
     }
 
     /**
@@ -59,8 +59,6 @@ class ObjectTest extends TestCase
     public function tearDown()
     {
         unset($this->Objects);
-
-        TableRegistry::clear();
 
         parent::tearDown();
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -52,7 +52,7 @@ class ObjectTypeTest extends TestCase
 
         Cache::clear(false, ObjectTypesTable::CACHE_CONFIG);
 
-        $this->ObjectTypes = TableRegistry::get('BEdita/Core.ObjectTypes');
+        $this->ObjectTypes = TableRegistry::get('ObjectTypes');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ProfileTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ProfileTest.php
@@ -52,7 +52,7 @@ class ProfileTest extends TestCase
     {
         parent::setUp();
 
-        $this->Profiles = TableRegistry::get('BEdita/Core.Profiles');
+        $this->Profiles = TableRegistry::get('Profiles');
     }
 
     /**
@@ -61,8 +61,6 @@ class ProfileTest extends TestCase
     public function tearDown()
     {
         unset($this->Profiles);
-
-        TableRegistry::clear();
 
         parent::tearDown();
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/RoleTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/RoleTest.php
@@ -47,7 +47,8 @@ class RoleTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->Roles = TableRegistry::get('BEdita/Core.Roles');
+
+        $this->Roles = TableRegistry::get('Roles');
     }
 
     /**
@@ -56,7 +57,7 @@ class RoleTest extends TestCase
     public function tearDown()
     {
         unset($this->Roles);
-        TableRegistry::clear();
+
         parent::tearDown();
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/UserTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/UserTest.php
@@ -49,7 +49,7 @@ class UserTest extends TestCase
     {
         parent::setUp();
 
-        $this->Users = TableRegistry::get('BEdita/Core.Users');
+        $this->Users = TableRegistry::get('Users');
     }
 
     /**
@@ -58,8 +58,6 @@ class UserTest extends TestCase
     public function tearDown()
     {
         unset($this->Users);
-
-        TableRegistry::clear();
 
         parent::tearDown();
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/AuthProvidersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/AuthProvidersTableTest.php
@@ -64,8 +64,7 @@ class AuthProvidersTableTest extends TestCase
      * Test initialization.
      *
      * @return void
-     * @covers ::initialize()
-     * @covers ::_initializeSchema()
+     * @coversNothing
      */
     public function testInitialization()
     {
@@ -125,8 +124,7 @@ class AuthProvidersTableTest extends TestCase
      *
      * @return void
      * @dataProvider validationProvider
-     * @covers ::validationDefault
-     * @covers ::buildRules
+     * @coversNothing
      */
     public function testValidation($expected, array $data)
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/AuthProvidersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/AuthProvidersTableTest.php
@@ -47,7 +47,7 @@ class AuthProvidersTableTest extends TestCase
     {
         parent::setUp();
 
-        $this->AuthProviders = TableRegistry::get('BEdita/Core.AuthProviders');
+        $this->AuthProviders = TableRegistry::get('AuthProviders');
     }
 
     /**
@@ -56,8 +56,6 @@ class AuthProvidersTableTest extends TestCase
     public function tearDown()
     {
         unset($this->AuthProviders);
-
-        TableRegistry::clear();
 
         parent::tearDown();
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
@@ -46,7 +46,7 @@ class ConfigTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->Config = TableRegistry::get('BEdita/Core.Config');
+        $this->Config = TableRegistry::get('Config');
     }
 
     /**
@@ -55,7 +55,7 @@ class ConfigTableTest extends TestCase
     public function tearDown()
     {
         unset($this->Config);
-        TableRegistry::clear();
+
         parent::tearDown();
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
@@ -63,7 +63,7 @@ class ConfigTableTest extends TestCase
      * Test initialization.
      *
      * @return void
-     * @covers ::initialize()
+     * @coversNothing
      */
     public function testInitialization()
     {
@@ -114,7 +114,7 @@ class ConfigTableTest extends TestCase
      *
      * @return void
      * @dataProvider validationProvider
-     * @covers ::validationDefault
+     * @coversNothing
      */
     public function testValidation($expected, array $data)
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ExternalAuthTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ExternalAuthTableTest.php
@@ -66,8 +66,7 @@ class ExternalAuthTableTest extends TestCase
      * Test initialization.
      *
      * @return void
-     * @covers ::initialize()
-     * @covers ::_initializeSchema()
+     * @coversNothing
      */
     public function testInitialization()
     {
@@ -130,8 +129,7 @@ class ExternalAuthTableTest extends TestCase
      *
      * @return void
      * @dataProvider validationProvider
-     * @covers ::validationDefault
-     * @covers ::buildRules
+     * @coversNothing
      */
     public function testValidation($expected, array $data)
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ExternalAuthTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ExternalAuthTableTest.php
@@ -49,7 +49,7 @@ class ExternalAuthTableTest extends TestCase
     {
         parent::setUp();
 
-        $this->ExternalAuth = TableRegistry::get('BEdita/Core.ExternalAuth');
+        $this->ExternalAuth = TableRegistry::get('ExternalAuth');
     }
 
     /**
@@ -58,8 +58,6 @@ class ExternalAuthTableTest extends TestCase
     public function tearDown()
     {
         unset($this->ExternalAuth);
-
-        TableRegistry::clear();
 
         parent::tearDown();
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
@@ -53,7 +53,7 @@ class ObjectTypesTableTest extends TestCase
 
         Cache::clear(false, ObjectTypesTable::CACHE_CONFIG);
 
-        $this->ObjectTypes = TableRegistry::get('BEdita/Core.ObjectTypes');
+        $this->ObjectTypes = TableRegistry::get('ObjectTypes');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -37,7 +37,7 @@ class ObjectsTableTest extends TestCase
     {
         parent::setUp();
 
-        $this->Objects = TableRegistry::get('BEdita/Core.Objects');
+        $this->Objects = TableRegistry::get('Objects');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -54,7 +54,7 @@ class ObjectsTableTest extends TestCase
      * Test initialization.
      *
      * @return void
-     * @covers ::initialize()
+     * @coversNothing
      */
     public function testInitialization()
     {
@@ -123,8 +123,7 @@ class ObjectsTableTest extends TestCase
      *
      * @return void
      * @dataProvider validationProvider
-     * @covers ::validationDefault
-     * @covers ::buildRules
+     * @coversNothing
      */
     public function testValidation($expected, array $data)
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
@@ -52,7 +52,7 @@ class ProfilesTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->Profiles = TableRegistry::get('BEdita/Core.Profiles');
+        $this->Profiles = TableRegistry::get('Profiles');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
@@ -71,6 +71,7 @@ class ProfilesTableTest extends TestCase
      * Test initialize method
      *
      * @return void
+     * @coversNothing
      */
     public function testInitialize()
     {
@@ -120,8 +121,7 @@ class ProfilesTableTest extends TestCase
      *
      * @return void
      * @dataProvider validationProvider
-     * @covers ::validationDefault
-     * @covers ::buildRules
+     * @coversNothing
      */
     public function testValidation($expected, array $data)
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
@@ -46,7 +46,7 @@ class RolesTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->Roles = TableRegistry::get('BEdita/Core.Roles');
+        $this->Roles = TableRegistry::get('Roles');
     }
 
     /**
@@ -55,7 +55,7 @@ class RolesTableTest extends TestCase
     public function tearDown()
     {
         unset($this->Roles);
-        TableRegistry::clear();
+
         parent::tearDown();
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
@@ -63,7 +63,7 @@ class RolesTableTest extends TestCase
      * Test initialization.
      *
      * @return void
-     * @covers ::initialize()
+     * @coversNothing
      */
     public function testInitialization()
     {
@@ -106,8 +106,7 @@ class RolesTableTest extends TestCase
      *
      * @return void
      * @dataProvider validationProvider
-     * @covers ::validationDefault
-     * @covers ::buildRules
+     * @coversNothing
      */
     public function testValidation($expected, array $data)
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -47,7 +47,7 @@ class UsersTableTest extends TestCase
     {
         parent::setUp();
 
-        $this->Users = TableRegistry::get('BEdita/Core.Users');
+        $this->Users = TableRegistry::get('Users');
     }
 
     /**
@@ -56,8 +56,6 @@ class UsersTableTest extends TestCase
     public function tearDown()
     {
         unset($this->Users);
-
-        TableRegistry::clear();
 
         parent::tearDown();
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -64,7 +64,7 @@ class UsersTableTest extends TestCase
      * Test initialization.
      *
      * @return void
-     * @covers ::initialize()
+     * @coversNothing
      */
     public function testInitialization()
     {
@@ -110,8 +110,7 @@ class UsersTableTest extends TestCase
      *
      * @return void
      * @dataProvider validationProvider
-     * @covers ::validationDefault
-     * @covers ::buildRules
+     * @coversNothing
      */
     public function testValidation($expected, array $data)
     {

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Association/ExtensionOfTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Association/ExtensionOfTest.php
@@ -80,7 +80,11 @@ class ExtensionOfTest extends TestCase
         unset($this->fakeFelines);
         unset($this->fakeMammals);
         unset($this->fakeAnimals);
-        TableRegistry::clear();
+
+        TableRegistry::remove('FakeFelines');
+        TableRegistry::remove('FakeMammals');
+        TableRegistry::remove('FakeAnimals');
+
         parent::tearDown();
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/QueryPatcherTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/QueryPatcherTest.php
@@ -91,9 +91,12 @@ class QueryPatcherTest extends TestCase
      */
     public function tearDown()
     {
-        TableRegistry::clear();
         unset($this->fakeFelines);
         unset($this->fakeMammals);
+
+        TableRegistry::remove('FakeFelines');
+        TableRegistry::remove('FakeMammals');
+
         parent::tearDown();
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/TableInheritanceManagerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/TableInheritanceManagerTest.php
@@ -61,8 +61,10 @@ class TableInheritanceManagerTest extends TestCase
      */
     public function tearDown()
     {
-        TableRegistry::clear();
         unset($this->fakeFelines);
+
+        TableRegistry::remove('FakeFelines');
+
         parent::tearDown();
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Shell/DataSeedShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/DataSeedShellTest.php
@@ -97,7 +97,7 @@ class DataSeedShellTest extends ShellTestCase
     {
         $this->loadFixtures('Users');
 
-        $Users = TableRegistry::get('BEdita/Core.Users');
+        $Users = TableRegistry::get('Users');
         $before = $Users->find('all')->count();
 
         $this->invoke(['data_seed', 'insert', '-t', 'users', '-n', '10']);


### PR DESCRIPTION
This PR refactors test as of #934.

`TableRegistry::clear()` is always avoided in tests. Plus, some configuration-only methods that were previously marked as covered by tests, while nothing was actually happening, are now marked to be ignored by coverage.

Code coverage is very likely to decrease with this PR. 
