### PR TITLE
Handle CORS through middleware

### DIFF
--- a/plugins/BEdita/API/config/bootstrap.php
+++ b/plugins/BEdita/API/config/bootstrap.php
@@ -58,9 +58,12 @@ Request::addDetector('jsonapi', function (Request $request) {
  *
  * @see \BEdita\API\Middleware\CorsMiddleware to more info on CORS configuration
  */
-EventManager::instance()->on('Server.buildMiddleware', function ($event, $middleware) {
-    $middleware->insertAfter(
-        'Cake\Error\Middleware\ErrorHandlerMiddleware',
-        new CorsMiddleware(Configure::read('CORS'))
-    );
-});
+$corsConfig = Configure::read('CORS');
+if ($corsConfig) {
+    EventManager::instance()->on('Server.buildMiddleware', function ($event, $middleware) use ($corsConfig) {
+        $middleware->insertAfter(
+            'Cake\Error\Middleware\ErrorHandlerMiddleware',
+            new CorsMiddleware($corsConfig)
+        );
+    });
+}

--- a/plugins/BEdita/API/config/bootstrap.php
+++ b/plugins/BEdita/API/config/bootstrap.php
@@ -12,9 +12,11 @@
  */
 
 use BEdita\API\Controller\Component\JsonApiComponent;
+use BEdita\API\Middleware\CorsMiddleware;
 use Cake\Console\ConsoleErrorHandler;
 use Cake\Core\Configure;
 use Cake\Error\ErrorHandler;
+use Cake\Event\EventManager;
 use Cake\Network\Request;
 
 /**
@@ -38,4 +40,25 @@ if (PHP_SAPI === 'cli') {
 Request::addDetector('html', ['accept' => ['text/html', 'application/xhtml+xml', 'application/xhtml', 'text/xhtml']]);
 Request::addDetector('jsonapi', function (Request $request) {
     return $request->accepts(JsonApiComponent::CONTENT_TYPE);
+});
+
+/**
+ * Customize middlewares for API needs
+ *
+ * Setup CORS from configuration
+ * An optional 'CORS' key in should be like this example:
+ *
+ * 'CORS' => [
+ *   'allowOrigin' => '*.example.com',
+ *   'allowMethods' => ['GET', 'POST'],
+ *   'allowHeaders' => ['X-CSRF-Token']
+ * ]
+ *
+ * @see \BEdita\API\Middleware\CorsMiddleware
+ */
+EventManager::instance()->on('Server.buildMiddleware', function ($event, $middleware) {
+    $middleware->insertAfter(
+        'Cake\Error\Middleware\ErrorHandlerMiddleware',
+        new CorsMiddleware(Configure::read('CORS'))
+    );
 });

--- a/plugins/BEdita/API/config/bootstrap.php
+++ b/plugins/BEdita/API/config/bootstrap.php
@@ -48,13 +48,15 @@ Request::addDetector('jsonapi', function (Request $request) {
  * Setup CORS from configuration
  * An optional 'CORS' key in should be like this example:
  *
+ * ```
  * 'CORS' => [
  *   'allowOrigin' => '*.example.com',
  *   'allowMethods' => ['GET', 'POST'],
  *   'allowHeaders' => ['X-CSRF-Token']
  * ]
+ * ```
  *
- * @see \BEdita\API\Middleware\CorsMiddleware
+ * @see \BEdita\API\Middleware\CorsMiddleware to more info on CORS configuration
  */
 EventManager::instance()->on('Server.buildMiddleware', function ($event, $middleware) {
     $middleware->insertAfter(

--- a/plugins/BEdita/API/src/Controller/AppController.php
+++ b/plugins/BEdita/API/src/Controller/AppController.php
@@ -63,8 +63,6 @@ class AppController extends Controller
         ]);
         $this->Auth->allow();
 
-        $this->corsSettings();
-
         if (empty(Router::fullBaseUrl())) {
             Router::fullBaseUrl(
                 rtrim(
@@ -128,39 +126,6 @@ class AppController extends Controller
 
         return true;
     }
-
-    /**
-     * Setup CORS from configuration
-     * An optional 'CORS' key in should be like this example:
-     *
-     * 'CORS' => [
-     *   'allowOrigin' => '*.example.com',
-     *   'allowMethods' => ['GET', 'POST'],
-     *   'allowHeaders' => ['X-CSRF-Token']
-     * ]
-     *
-     * where:
-     *   - 'allowOrigin' is a single domain or an array of domains
-     *   - 'allowMethods' is an array of HTTP methods
-     *   - 'allowHeaders' is an array of HTTP headers
-     *
-     *
-     * @return void
-     */
-    protected function corsSettings()
-    {
-        $corsConfig = Configure::read('CORS');
-        if (!empty($corsConfig)) {
-            $corsBuilder = $this->response->cors($this->request);
-            $corsAllowed = ['allowOrigin' => '', 'allowMethods' => '', 'allowHeaders' => ''];
-            $corsAccepted = array_intersect_key($corsConfig, $corsAllowed);
-            foreach ($corsAccepted as $corsOption => $corsValue) {
-                $corsBuilder->{$corsOption}($corsValue);
-            }
-            $corsBuilder->build();
-        }
-    }
-
 
     /**
      * Action to display HTML layout.

--- a/plugins/BEdita/API/src/Middleware/CorsMiddleware.php
+++ b/plugins/BEdita/API/src/Middleware/CorsMiddleware.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Middleware;
+
+use BEdita\API\Network\CorsBuilder;
+use Cake\Network\Exception\BadRequestException;
+use Cake\Network\Exception\ForbiddenException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Handle cross-origin HTTP requests setting the proper headers.
+ *
+ * The response of preflight request (OPTIONS) is delivered directly after the headers are applied.
+ * For simple requests the CORS headers are applied to the response then it is passed to next middleware.
+ *
+ * @since 4.0.0
+ */
+class CorsMiddleware
+{
+    /**
+     * CORS configuration
+     *
+     * where:
+     *   - 'allowOrigin' is a single domain or an array of domains
+     *   - 'allowMethods' is an array of HTTP methods (it's applied only to preflight requests)
+     *   - 'allowHeaders' is an array of HTTP headers (it's applied only to preflight requests)
+     *   - 'allowCredentials' enable cookies to be sent in CORS requests
+     *   - 'exposeHeaders' is an array of headers that a client library/browser can expose to scripting
+     *   - 'maxAge' is the max-age preflight OPTIONS requests are valid for (it's applied only to preflight requests)
+     *
+     * When value is falsy the related configuration is skipped.
+     *
+     * @var array
+     */
+    protected $corsConfig = [
+        'allowOrigin' => false,
+        'allowMethods' => false,
+        'allowHeaders' => false,
+        'allowCredentials' => false,
+        'exposeHeaders' => false,
+        'maxAge' => false,
+    ];
+
+    /**
+     * Constructor
+     *
+     * Setup CORS using `$corsConfig` array
+     *
+     * @see self::corsConfig
+     * @param array|null $corsConfig CORS configuration
+     * @return void
+     */
+    public function __construct($corsConfig = null)
+    {
+        if (empty($corsConfig) || !is_array($corsConfig)) {
+            return;
+        }
+
+        $allowedConfig = array_intersect_key($corsConfig, $this->corsConfig);
+        $this->corsConfig = $allowedConfig + $this->corsConfig;
+    }
+
+    /**
+     * If the request is a preflight send the response applying CORS rules.
+     * If it is a simple request it applies CORS rules to the response and call next middleware
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request.
+     * @param \Psr\Http\Message\ResponseInterface $response The response.
+     * @param callable $next The next middleware to call.
+     * @return \Psr\Http\Message\ResponseInterface A response.
+     */
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
+    {
+        try {
+            if ($request->getMethod() == 'OPTIONS') {
+                return $this->preflight($request, $response);
+            }
+
+            $response = $this->buildCors($request, $response);
+
+            return $next($request, $response);
+        } catch (\Exception $e) {
+            return $response->withStatus($e->getCode());
+        }
+    }
+
+    /**
+     * Prepare the response for a preflight request.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request.
+     * @param \Psr\Http\Message\ResponseInterface $response The response.
+     * @return \Psr\Http\Message\ResponseInterface A response.
+     * @throws \Cake\Network\Exception\BadRequestException When the request is malformed
+     * @throws \Cake\Network\Exception\ForbiddenException When no CORS rule matches the preflight request
+     */
+    protected function preflight(ServerRequestInterface $request, ResponseInterface $response)
+    {
+        if (!$request->hasHeader('Origin')) {
+            throw new BadRequestException('Preflight request missing of "Origin" header');
+        }
+
+        $accessControlRequestMethod = $request->getHeaderLine('Access-Control-Request-Method');
+        if (empty($accessControlRequestMethod)) {
+            throw new BadRequestException('Preflight request missing of "Access-Control-Request-Method" header');
+        }
+
+        $allowedMethods = (array)$this->corsConfig['allowMethods'];
+        if (!in_array($accessControlRequestMethod, $allowedMethods)) {
+            throw new ForbiddenException('Preflight request refused. Access-Control-Request-Method not allowed');
+        }
+
+        $accessControlRequestHeaders = explode(', ', strtolower($request->getHeaderLine('Access-Control-Request-Headers')));
+        $allowedHeaders = array_map(
+            function ($header) {
+                return strtolower($header);
+            },
+            (array)$this->corsConfig['allowHeaders']
+        );
+
+        $notAllowedHeaders = array_diff($accessControlRequestHeaders, $allowedHeaders);
+        if (!empty($notAllowedHeaders)) {
+            throw new ForbiddenException(
+                'Preflight request refused. Access-Control-Request-Headers not allowed for ' . implode(', ', $notAllowedHeaders)
+            );
+        }
+
+        return $this->buildCors($request, $response, true);
+    }
+
+    /**
+     * Build response headers following CORS configuration
+     * and return the new response
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request.
+     * @param \Psr\Http\Message\ResponseInterface $response The response.
+     * @param bool $preflight If the request is a preflight
+     * @return \Psr\Http\Message\ResponseInterface A response.
+     * @throws \Cake\Network\Exception\ForbiddenException When origin
+     */
+    protected function buildCors(ServerRequestInterface $request, ResponseInterface $response, $preflight = false)
+    {
+        $origin = $request->getHeaderLine('Origin');
+        $isSsl = ($request->getUri()->getScheme() == 'https');
+
+        $corsBuilder = new CorsBuilder($response, $origin, $isSsl);
+
+        $options = array_filter($this->corsConfig);
+        if (!$preflight) {
+            $options = array_diff_key($options, array_flip(['allowMethods', 'allowHeaders', 'maxAge']));
+        }
+
+        foreach ($options as $corsOption => $corsValue) {
+            $corsBuilder->{$corsOption}($corsValue);
+        }
+
+        $response = $corsBuilder->build();
+        if (!empty($origin) && !$response->hasHeader('Access-Control-Allow-Origin')) {
+            throw new ForbiddenException('Origin not allowed');
+        }
+
+        return $response;
+    }
+}

--- a/plugins/BEdita/API/src/Network/CorsBuilder.php
+++ b/plugins/BEdita/API/src/Network/CorsBuilder.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Network;
+
+use Cake\Network\CorsBuilder as CakeCorsBuilder;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * A builder object that assists in defining Cross Origin Request related
+ * headers.
+ *
+ * Each of the methods in this object provide a fluent interface. Once you've
+ * set all the headers you want to use, the `build()` method can be used to return
+ * a modified Response.
+ *
+ * It overrides `Cake\Network\CorsBuilder` to use PSR-7 compliant Response to use in Middlewares
+ *
+ */
+class CorsBuilder extends CakeCorsBuilder
+{
+    /**
+     * The response object this builder is attached to.
+     *
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    protected $_response;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param \Psr\Http\Message\ResponseInterface $response The Psr-7 response object.
+     * @param string $origin The request's Origin header.
+     * @param bool $isSsl Whether or not the request was over SSL.
+     */
+    public function __construct(ResponseInterface $response, $origin, $isSsl = false)
+    {
+        $this->_origin = $origin;
+        $this->_isSsl = $isSsl;
+        $this->_response = $response;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * If `Access-Control-Allow-Origin` header is different from `*`
+     * add `Origin` to `Vary` header
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function build()
+    {
+        if (empty($this->_origin) || !isset($this->_headers['Access-Control-Allow-Origin'])) {
+            return $this->_response;
+        }
+
+        foreach ($this->_headers as $name => $value) {
+            $this->_response = $this->_response->withHeader($name, $value);
+        }
+
+        if ($this->_headers['Access-Control-Allow-Origin'] != '*') {
+            $this->_response = $this->_response->withAddedHeader('Vary', 'Origin');
+        }
+
+        return $this->_response;
+    }
+}

--- a/plugins/BEdita/API/tests/TestCase/Middleware/CorsMiddlewareTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Middleware/CorsMiddlewareTest.php
@@ -289,6 +289,8 @@ class CorsMiddlewareTest extends TestCase
      * @covers ::__invoke()
      * @covers ::preflight()
      * @covers ::buildCors()
+     * @covers ::checkAccessControlRequestMethod()
+     * @covers ::checkAccessControlRequestHeaders()
      * @covers \BEdita\API\Network\CorsBuilder::build()
      */
     public function testCors($expectedStatus, $expectedCorsHeaders, $server, $corsConfig)

--- a/plugins/BEdita/API/tests/TestCase/Middleware/CorsMiddlewareTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Middleware/CorsMiddlewareTest.php
@@ -231,6 +231,48 @@ class CorsMiddlewareTest extends TestCase
                     'maxAge' => '1000'
                 ],
             ],
+            'preflightWildCardAllowMethods' => [
+                200,
+                [
+                    'Access-Control-Allow-Origin' => '*',
+                    'Access-Control-Allow-Methods' => 'GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS',
+                    'Access-Control-Allow-Headers' => 'Authorization, Content-Type',
+                ],
+                [
+                    'REQUEST_URI' => '/testpath',
+                    'REQUEST_METHOD' => 'OPTIONS',
+                    'HTTP_ACCEPT' => 'application/json',
+                    'HTTP_ORIGIN' => 'http://bedita.com',
+                    'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+                    'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'Authorization, Content-Type'
+                ],
+                [
+                    'allowOrigin' => '*',
+                    'allowMethods' => '*',
+                    'allowHeaders' => ['Authorization', 'Content-Type']
+                ],
+            ],
+            'preflightWildCardAllowHeaders' => [
+                200,
+                [
+                    'Access-Control-Allow-Origin' => '*',
+                    'Access-Control-Allow-Methods' => 'GET, POST',
+                    'Access-Control-Allow-Headers' => 'Authorization, Content-Type, X-Test-Header',
+                ],
+                [
+                    'REQUEST_URI' => '/testpath',
+                    'REQUEST_METHOD' => 'OPTIONS',
+                    'HTTP_ACCEPT' => 'application/json',
+                    'HTTP_ORIGIN' => 'http://bedita.com',
+                    'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+                    'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'Authorization, Content-Type, X-Test-Header'
+                ],
+                [
+                    'allowOrigin' => '*',
+                    'allowMethods' => ['GET', 'POST'],
+                    'allowHeaders' => '*'
+                ],
+            ],
         ];
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Middleware/CorsMiddlewareTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Middleware/CorsMiddlewareTest.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Test\TestCase\Middleware;
+
+use BEdita\API\Middleware\CorsMiddleware;
+use Cake\Http\ServerRequestFactory;
+use Cake\TestSuite\TestCase;
+use Zend\Diactoros\Request;
+use Zend\Diactoros\Response;
+
+/**
+ * Test for RoutingMiddleware
+ *
+ * @coversDefaultClass \BEdita\API\Middleware\CorsMiddleware
+ */
+class CorsMiddlewareTest extends TestCase
+{
+    /**
+     * Setup method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    /**
+     * Data provider for `testCors` test case.
+     *
+     * @return array
+     */
+    public function corsProvider()
+    {
+        return [
+            'noCors' => [
+                200, // expectedStatus
+                [], // expectedCorsHeaders
+                [ // server request
+                    'REQUEST_URI' => '/testpath',
+                    'REQUEST_METHOD' => 'GET',
+                    'HTTP_ACCEPT' => 'application/json',
+                ],
+                [], // CORS config
+            ],
+            'allAllowedOrigin' => [
+                200,
+                [
+                    'Access-Control-Allow-Origin' => '*'
+                ],
+                [
+                    'REQUEST_URI' => '/testpath',
+                    'REQUEST_METHOD' => 'GET',
+                    'HTTP_ACCEPT' => 'application/json',
+                    'HTTP_ORIGIN' => 'http://example.com'
+                ],
+                [
+                    'allowOrigin' => '*'
+                ],
+            ],
+            'specificAllowedOrigin' => [
+                200,
+                [
+                    'Access-Control-Allow-Origin' => 'http://example.com',
+                    'Vary' => 'Origin'
+                ],
+                [
+                    'REQUEST_URI' => '/testpath',
+                    'REQUEST_METHOD' => 'GET',
+                    'HTTP_ACCEPT' => 'application/json',
+                    'HTTP_ORIGIN' => 'http://example.com'
+                ],
+                [
+                    'allowOrigin' => ['http://example.com', 'http://bedita.com']
+                ],
+            ],
+            'notAllowedOrigin' => [
+                403,
+                [],
+                [
+                    'REQUEST_URI' => '/testpath',
+                    'REQUEST_METHOD' => 'GET',
+                    'HTTP_ACCEPT' => 'application/json',
+                    'HTTP_ORIGIN' => 'http://bedita.com'
+                ],
+                [
+                    'allowOrigin' => 'http://example.com'
+                ],
+            ],
+            'preflightMissingOrigin' => [
+                400,
+                [],
+                [
+                    'REQUEST_URI' => '/testpath',
+                    'REQUEST_METHOD' => 'OPTIONS',
+                    'HTTP_ACCEPT' => 'application/json',
+                ],
+                [
+                    'allowOrigin' => '*'
+                ],
+            ],
+            'preflightMissingControlRequestMethod' => [
+                400,
+                [],
+                [
+                    'REQUEST_URI' => '/testpath',
+                    'REQUEST_METHOD' => 'OPTIONS',
+                    'HTTP_ACCEPT' => 'application/json',
+                    'HTTP_ORIGIN' => 'http://bedita.com',
+                ],
+                [
+                    'allowOrigin' => '*'
+                ],
+            ],
+            'preflightWrongControlRequestMethod' => [
+                403,
+                [],
+                [
+                    'REQUEST_URI' => '/testpath',
+                    'REQUEST_METHOD' => 'OPTIONS',
+                    'HTTP_ACCEPT' => 'application/json',
+                    'HTTP_ORIGIN' => 'http://bedita.com',
+                    'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'PUT'
+                ],
+                [
+                    'allowOrigin' => '*',
+                    'allowMethods' => ['GET', 'POST']
+                ],
+            ],
+            'preflightWrongControlHeaders' => [
+                403,
+                [],
+                [
+                    'REQUEST_URI' => '/testpath',
+                    'REQUEST_METHOD' => 'OPTIONS',
+                    'HTTP_ACCEPT' => 'application/json',
+                    'HTTP_ORIGIN' => 'http://bedita.com',
+                    'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+                    'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'Authorization, Content-Type'
+                ],
+                [
+                    'allowOrigin' => '*',
+                    'allowMethods' => ['GET', 'POST'],
+                    'allowHeaders' => ['Authorization']
+                ],
+            ],
+            'preflightOk' => [
+                200,
+                [
+                    'Access-Control-Allow-Origin' => '*',
+                    'Access-Control-Allow-Methods' => 'GET, POST',
+                    'Access-Control-Allow-Headers' => 'Authorization, Content-Type',
+                ],
+                [
+                    'REQUEST_URI' => '/testpath',
+                    'REQUEST_METHOD' => 'OPTIONS',
+                    'HTTP_ACCEPT' => 'application/json',
+                    'HTTP_ORIGIN' => 'http://bedita.com',
+                    'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+                    'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'Authorization, Content-Type'
+                ],
+                [
+                    'allowOrigin' => '*',
+                    'allowMethods' => ['GET', 'POST'],
+                    'allowHeaders' => ['Authorization', 'Content-Type']
+                ],
+            ],
+            'preflightOk2' => [
+                200,
+                [
+                    'Access-Control-Allow-Origin' => 'https://example.com',
+                    'Access-Control-Allow-Methods' => 'GET, POST',
+                    'Access-Control-Allow-Headers' => 'Authorization, Content-Type',
+                    'Access-Control-Allow-Credentials' => 'true',
+                    'Access-Control-Expose-Headers' => 'X-Exposed, X-Exposed-Too',
+                    'Access-Control-Max-Age' => '1000',
+                    'Vary' => 'Origin'
+                ],
+                [
+                    'REQUEST_URI' => '/testpath',
+                    'REQUEST_METHOD' => 'OPTIONS',
+                    'HTTP_ACCEPT' => 'application/json',
+                    'HTTP_ORIGIN' => 'https://example.com',
+                    'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+                    'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'Authorization, Content-Type'
+                ],
+                [
+                    'allowOrigin' => 'https://example.com',
+                    'allowMethods' => ['GET', 'POST'],
+                    'allowHeaders' => ['Authorization', 'Content-Type'],
+                    'allowCredentials' => true,
+                    'exposeHeaders' => ['X-Exposed', 'X-Exposed-Too'],
+                    'maxAge' => '1000'
+                ],
+            ],
+            'simpleSkipPreflightConf' => [
+                200,
+                [
+                    'Access-Control-Allow-Origin' => 'https://example.com',
+                    'Access-Control-Allow-Methods' => '',
+                    'Access-Control-Allow-Headers' => '',
+                    'Access-Control-Allow-Credentials' => 'true',
+                    'Access-Control-Expose-Headers' => 'X-Exposed, X-Exposed-Too',
+                    'Access-Control-Max-Age' => '',
+                    'Vary' => 'Origin'
+                ],
+                [
+                    'REQUEST_URI' => '/testpath',
+                    'REQUEST_METHOD' => 'POST',
+                    'HTTP_ACCEPT' => 'application/json',
+                    'HTTP_ORIGIN' => 'https://example.com',
+                    'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+                    'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'Authorization, Content-Type'
+                ],
+                [
+                    'allowOrigin' => 'https://example.com',
+                    'allowMethods' => ['GET', 'POST'],
+                    'allowHeaders' => ['Authorization', 'Content-Type'],
+                    'allowCredentials' => true,
+                    'exposeHeaders' => ['X-Exposed', 'X-Exposed-Too'],
+                    'maxAge' => '1000'
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test CORS response
+     *
+     * @param int $expectedStatus The HTTP status expected
+     * @param array $expectedCorsHeaders The expected headers set from CORS conf
+     * @param array $server The server vars (see $_SERVER)
+     * @param array $corsConfig The specific CORS conf applied
+     * @return void
+     *
+     * @dataProvider corsProvider
+     * @covers ::__invoke()
+     * @covers ::preflight()
+     * @covers ::buildCors()
+     * @covers \BEdita\API\Network\CorsBuilder::build()
+     */
+    public function testCors($expectedStatus, $expectedCorsHeaders, $server, $corsConfig)
+    {
+        $request = ServerRequestFactory::fromGlobals($server);
+        $response = new Response();
+        $next = function ($req, $res) {
+            return $res;
+        };
+        $middleware = new CorsMiddleware($corsConfig);
+        $response = $middleware($request, $response, $next);
+
+        $this->assertEquals($expectedStatus, $response->getStatusCode());
+
+        if (empty($corsConfig)) {
+            $this->assertEmpty($response->getHeader('Access-Control-Allow-Origin'));
+            $this->assertEmpty($response->getHeader('Access-Control-Allow-Methods'));
+            $this->assertEmpty($response->getHeader('Access-Control-Allow-Credentials'));
+            $this->assertEmpty($response->getHeader('Access-Control-Allow-Headers'));
+            $this->assertEmpty($response->getHeader('Access-Control-Expose-Headers'));
+            $this->assertEmpty($response->getHeader('Access-Control-Max-Age'));
+        } else {
+            foreach ($expectedCorsHeaders as $header => $value) {
+                $this->assertEquals(
+                    $value,
+                    $response->getHeaderLine($header)
+                );
+            }
+        }
+    }
+}

--- a/plugins/BEdita/API/tests/TestCase/Network/CorsBuilderTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Network/CorsBuilderTest.php
@@ -21,7 +21,7 @@ use Zend\Diactoros\Response;
 /**
  * Test for RoutingMiddleware
  *
- * @coversDefaultClass \BEdita\API\Network\CorsBuilderTest
+ * @coversDefaultClass \BEdita\API\Network\CorsBuilder
  */
 class CorsBuilderTest extends TestCase
 {

--- a/plugins/BEdita/API/tests/TestCase/Network/CorsBuilderTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Network/CorsBuilderTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Test\TestCase\Network;
+
+use BEdita\API\Network\CorsBuilder;
+use Cake\Http\ServerRequestFactory;
+use Cake\TestSuite\TestCase;
+use Zend\Diactoros\Request;
+use Zend\Diactoros\Response;
+
+/**
+ * Test for RoutingMiddleware
+ *
+ * @coversDefaultClass \BEdita\API\Network\CorsBuilderTest
+ */
+class CorsBuilderTest extends TestCase
+{
+    /**
+     * Setup method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    /**
+     * Test build CORS response
+     *
+     * @return void
+     *
+     * @covers ::build()
+     */
+    public function testBuild()
+    {
+        // no origin
+        $corsBuilder = new CorsBuilder(new Response(), '');
+        $response = $corsBuilder->allowOrigin('*')
+            ->allowHeaders(['Authorization'])
+            ->allowMethods(['POST', 'PUT', 'GET'])
+            ->build();
+
+        $this->assertEmpty($response->getHeader('Access-Control-Allow-Origin'));
+        $this->assertEmpty($response->getHeader('Access-Control-Allow-Methods'));
+        $this->assertEmpty($response->getHeader('Access-Control-Allow-Headers'));
+
+        // No matching origin
+        $corsBuilder = new CorsBuilder(new Response(), 'http://example.com');
+        $response = $corsBuilder->allowOrigin('http://bedita.com')
+            ->allowHeaders(['Authorization'])
+            ->allowMethods(['POST', 'PUT', 'GET'])
+            ->build();
+
+        $this->assertEmpty($response->getHeader('Access-Control-Allow-Origin'));
+        $this->assertEmpty($response->getHeader('Access-Control-Allow-Methods'));
+        $this->assertEmpty($response->getHeader('Access-Control-Allow-Headers'));
+
+        // Matching origin
+        $corsBuilder = new CorsBuilder(new Response(), 'http://example.com');
+        $response = $corsBuilder->allowOrigin(['http://bedita.com', 'http://example.com'])
+            ->allowHeaders(['Authorization'])
+            ->allowMethods(['POST', 'PUT', 'GET'])
+            ->build();
+
+        $this->assertEquals('http://example.com', $response->getHeaderLine('Access-Control-Allow-Origin'));
+        $this->assertEquals('POST, PUT, GET', $response->getHeaderLine('Access-Control-Allow-Methods'));
+        $this->assertEquals('Authorization', $response->getHeaderLine('Access-Control-Allow-Headers'));
+    }
+}


### PR DESCRIPTION
This PR solve #929 and move all previous CORS settings in an appropriate middleware.
Because of `\Cake\Network\CorsBuilder` works with CakePHP standard response and request while middlewares works with PSR-7 compliant response and request I have also introduced `\BEdita\API\Network\CorsBuilder` that extends `\Cake\Network\CorsBuilder` but use PSR-7 response and request.
