### PR TITLE
Add custom TableLocator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "cakephp/cakephp": "< 3.3.4",
+        "cakephp/cakephp": "3.3.*",
         "mobiledetect/mobiledetectlib": "2.*",
         "cakephp/migrations": "~1.0",
         "cakephp/plugin-installer": "*",

--- a/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
@@ -45,10 +45,6 @@ class LoginControllerTest extends IntegrationTestCase
      */
     public function testSuccessfulLogin()
     {
-        // Force event listener on `Auth.afterIdentify` to be re-attached.
-        TableRegistry::remove('Users');
-        TableRegistry::config('Users', ['className' => 'BEdita/Core.Users']);
-
         $this->configRequest([
             'headers' => [
                 'Host' => 'api.example.com',

--- a/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateAssociatedTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateAssociatedTest.php
@@ -64,18 +64,6 @@ class UpdateAssociatedTest extends TestCase
     }
 
     /**
-     * {@inheritDoc}
-     */
-    public function tearDown()
-    {
-        TableRegistry::remove('FakeTags');
-        TableRegistry::remove('FakeArticles');
-        TableRegistry::remove('FakeAnimals');
-
-        parent::tearDown();
-    }
-
-    /**
      * Data provider for `testInvocation` test case.
      *
      * @return array

--- a/plugins/BEdita/Core/config/bootstrap.php
+++ b/plugins/BEdita/Core/config/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 use BEdita\Core\Configure\Engine\DatabaseConfig;
+use BEdita\Core\ORM\Locator\TableLocator;
 use Cake\Core\Configure;
 use Cake\Core\Configure\Engine\IniConfig;
 use Cake\ORM\TableRegistry;
@@ -8,15 +9,7 @@ use Cake\ORM\TableRegistry;
 /**
  * Register tables.
  */
-TableRegistry::config('AuthProviders', ['className' => 'BEdita/Core.AuthProviders']);
-TableRegistry::config('ExternalAuth', ['className' => 'BEdita/Core.ExternalAuth']);
-TableRegistry::config('ObjectTypes', ['className' => 'BEdita/Core.ObjectTypes']);
-TableRegistry::config('Config', ['className' => 'BEdita/Core.Config']);
-TableRegistry::config('Roles', ['className' => 'BEdita/Core.Roles']);
-TableRegistry::config('Users', ['className' => 'BEdita/Core.Users']);
-
-TableRegistry::config('Objects', ['className' => 'BEdita/Core.Objects']);
-TableRegistry::config('Profiles', ['className' => 'BEdita/Core.Profiles']);
+TableRegistry::locator(new TableLocator());
 
 /**
  * Load 'core' configuration parameters

--- a/plugins/BEdita/Core/config/bootstrap.php
+++ b/plugins/BEdita/Core/config/bootstrap.php
@@ -7,7 +7,7 @@ use Cake\Core\Configure\Engine\IniConfig;
 use Cake\ORM\TableRegistry;
 
 /**
- * Register tables.
+ * Plug table locator.
  */
 TableRegistry::locator(new TableLocator());
 

--- a/plugins/BEdita/Core/src/ORM/Locator/TableLocator.php
+++ b/plugins/BEdita/Core/src/ORM/Locator/TableLocator.php
@@ -39,7 +39,7 @@ class TableLocator extends CakeLocator
         }
 
         $className = App::className($options['className'], 'Model/Table', 'Table');
-        if ($className) {
+        if ($className !== false) {
             return $className;
         }
 

--- a/plugins/BEdita/Core/src/ORM/Locator/TableLocator.php
+++ b/plugins/BEdita/Core/src/ORM/Locator/TableLocator.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\ORM\Locator;
+
+use Cake\Core\App;
+use Cake\ORM\Locator\TableLocator as CakeLocator;
+use Cake\Utility\Inflector;
+
+/**
+ * Custom table locator for BEdita.
+ *
+ * @since 4.0.0
+ */
+class TableLocator extends CakeLocator
+{
+
+    /**
+     * Gets the table class name.
+     *
+     * @param string $alias The alias name you want to get.
+     * @param array $options Table options array.
+     * @return string
+     */
+    protected function _getClassName($alias, array $options = [])
+    {
+        if (empty($options['className'])) {
+            $options['className'] = Inflector::camelize($alias);
+        }
+
+        $className = App::className($options['className'], 'Model/Table', 'Table');
+        if ($className) {
+            return $className;
+        }
+
+        $options['className'] = sprintf('BEdita/Core.%s', $options['className']);
+
+        return App::className($options['className'], 'Model/Table', 'Table');
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Configure/ConfigureTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Configure/ConfigureTest.php
@@ -15,8 +15,6 @@ namespace BEdita\Core\Test\TestCase\Configure;
 
 use BEdita\Core\Configure\Engine\DatabaseConfig;
 use Cake\Core\Configure;
-use Cake\Core\Configure\Engine\PhpConfig;
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
 /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddAssociatedTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddAssociatedTest.php
@@ -61,18 +61,6 @@ class AddAssociatedTest extends TestCase
     }
 
     /**
-     * {@inheritDoc}
-     */
-    public function tearDown()
-    {
-        TableRegistry::remove('FakeTags');
-        TableRegistry::remove('FakeArticles');
-        TableRegistry::remove('FakeAnimals');
-
-        parent::tearDown();
-    }
-
-    /**
      * Data provider for `testInvocation` test case.
      *
      * @return array

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedTest.php
@@ -62,18 +62,6 @@ class ListAssociatedTest extends TestCase
     }
 
     /**
-     * {@inheritDoc}
-     */
-    public function tearDown()
-    {
-        TableRegistry::remove('FakeTags');
-        TableRegistry::remove('FakeArticles');
-        TableRegistry::remove('FakeAnimals');
-
-        parent::tearDown();
-    }
-
-    /**
      * Data provider for `testInvocation` test case.
      *
      * @return array

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveAssociatedTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveAssociatedTest.php
@@ -61,18 +61,6 @@ class RemoveAssociatedTest extends TestCase
     }
 
     /**
-     * {@inheritDoc}
-     */
-    public function tearDown()
-    {
-        TableRegistry::remove('FakeTags');
-        TableRegistry::remove('FakeArticles');
-        TableRegistry::remove('FakeAnimals');
-
-        parent::tearDown();
-    }
-
-    /**
      * Data provider for `testInvocation` test case.
      *
      * @return array

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SetAssociatedTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SetAssociatedTest.php
@@ -61,18 +61,6 @@ class SetAssociatedTest extends TestCase
     }
 
     /**
-     * {@inheritDoc}
-     */
-    public function tearDown()
-    {
-        TableRegistry::remove('FakeTags');
-        TableRegistry::remove('FakeArticles');
-        TableRegistry::remove('FakeAnimals');
-
-        parent::tearDown();
-    }
-
-    /**
      * Data provider for `testInvocation` test case.
      *
      * @return array

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ClassTableInheritanceBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ClassTableInheritanceBehaviorTest.php
@@ -86,24 +86,6 @@ class ClassTableInheritanceBehaviorTest extends TestCase
     }
 
     /**
-     * tearDown method
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        unset($this->fakeAnimals);
-        unset($this->fakeMammals);
-        unset($this->fakeFelines);
-
-        TableRegistry::remove('FakeAnimals');
-        TableRegistry::remove('FakeMammals');
-        TableRegistry::remove('FakeFelines');
-
-        parent::tearDown();
-    }
-
-    /**
      * Data provider for `testAddBehavior` test case.
      *
      * @return array

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Association/ExtensionOfTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Association/ExtensionOfTest.php
@@ -77,25 +77,6 @@ class ExtensionOfTest extends TestCase
     }
 
     /**
-     * tearDown method
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        unset($this->fakeFelines);
-        unset($this->fakeMammals);
-        unset($this->fakeAnimals);
-
-        TableRegistry::remove('FakeFelines');
-        TableRegistry::remove('FakeMammals');
-        TableRegistry::remove('FakeAnimals');
-        TableRegistry::remove('FakeArticles');
-
-        parent::tearDown();
-    }
-
-    /**
      * Test __constructor to see if Model.afterDelete is set
      *
      * @return void

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/QueryPatcherTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/QueryPatcherTest.php
@@ -85,22 +85,6 @@ class QueryPatcherTest extends TestCase
     }
 
     /**
-     * tearDown method
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        unset($this->fakeFelines);
-        unset($this->fakeMammals);
-
-        TableRegistry::remove('FakeFelines');
-        TableRegistry::remove('FakeMammals');
-
-        parent::tearDown();
-    }
-
-    /**
      * testNewQueryPatcherWithWrongTable method
      *
      * @return void

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/TableInheritanceManagerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/TableInheritanceManagerTest.php
@@ -51,21 +51,8 @@ class TableInheritanceManagerTest extends TestCase
     public function setUp()
     {
         parent::setUp();
+
         $this->fakeFelines = TableRegistry::get('FakeFelines');
-    }
-
-    /**
-     * tearDown method
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        unset($this->fakeFelines);
-
-        TableRegistry::remove('FakeFelines');
-
-        parent::tearDown();
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/ORM/TableLocatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/TableLocatorTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\ORM;
+
+use BEdita\Core\ORM\Locator\TableLocator;
+use Cake\TestSuite\TestCase;
+
+/**
+ * @covers \BEdita\Core\ORM\Locator\TableLocator
+ */
+class TableLocatorTest extends TestCase
+{
+
+    /**
+     * Table locator instance.
+     *
+     * @var \Cake\ORM\Locator\LocatorInterface
+     */
+    protected $TableLocator;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->TableLocator = new TableLocator();
+    }
+
+    /**
+     * Data provider for `testGetClassName` test case.
+     *
+     * @return array
+     */
+    public function getClassNameProvider()
+    {
+        return [
+            'withPluginName' => [
+                'BEdita\Core\Model\Table\RolesTable',
+                'BEdita/Core.Roles',
+            ],
+            'fallbackBEditaCore' => [
+                'BEdita\Core\Model\Table\RolesTable',
+                'Roles',
+            ],
+            'fallback' => [
+                'Cake\ORM\Table',
+                'ThisTableDoesNotExists',
+            ],
+            'fallbackWithPluginName' => [
+                'Cake\ORM\Table',
+                'BEdita/Core.ThisTableDoesNotExists',
+            ],
+        ];
+    }
+
+    /**
+     * Test class name finder.
+     *
+     * @param string $expected Expected class name of table instance.
+     * @param string $alias Table alias.
+     * @param array $options Table options.
+     * @return void
+     *
+     * @dataProvider getClassNameProvider()
+     */
+    public function testGetClassName($expected, $alias, array $options = [])
+    {
+        $result = $this->TableLocator->get($alias, $options);
+
+        $this->assertInstanceOf($expected, $result);
+    }
+}


### PR DESCRIPTION
This PR adds a custom Table Locator to solve issue #995, which was caused by cakephp/cakephp#9489.

The new TableLocator tries to find a table in the "traditional" way. Then, if no table is found that way, it makes a second attempt prefixing the class name with `BEdita/Core.` before falling back to `Cake\ORM\Table`.

The introduced TableLocator could and should be improved by adding another step to check if a BEdita object type is defined with that name by querying `ObjectTypesTable` and properly handling this case. Also, additional BEdita plugins are not quite really taken into account by this, and we should probably put some thoughts into this topic.
