### PR TITLE
Models for endpoint permissions

### DIFF
--- a/plugins/BEdita/Core/src/Model/Entity/Application.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Application.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Model\Entity;
+
+use Cake\ORM\Entity;
+
+/**
+ * Application Entity
+ *
+ * @property int $id
+ * @property string $api_key
+ * @property string $name
+ * @property string $description
+ * @property \Cake\I18n\Time $created
+ * @property \Cake\I18n\Time $modified
+ * @property bool $enabled
+ *
+ * @property \BEdita\Core\Model\Entity\EndpointPermission[] $endpoint_permissions
+ */
+class Application extends Entity
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected $_accessible = [
+        '*' => true,
+        'id' => false,
+        'api_key' => false,
+        'created' => false,
+        'modified' => false,
+    ];
+}

--- a/plugins/BEdita/Core/src/Model/Entity/Endpoint.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Endpoint.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Model\Entity;
+
+use Cake\ORM\Entity;
+
+/**
+ * Endpoint Entity
+ *
+ * @property int $id
+ * @property string $name
+ * @property string $description
+ * @property \Cake\I18n\Time $created
+ * @property \Cake\I18n\Time $modified
+ * @property bool $enabled
+ * @property int $object_type_id
+ *
+ * @property \BEdita\Core\Model\Entity\ObjectType $object_type
+ * @property \BEdita\Core\Model\Entity\EndpointPermission[] $endpoint_permissions
+ *
+ * @since 4.0.0
+ */
+class Endpoint extends Entity
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected $_accessible = [
+        '*' => true,
+        'id' => false,
+        'created' => false,
+        'modified' => false,
+    ];
+}

--- a/plugins/BEdita/Core/src/Model/Entity/EndpointPermission.php
+++ b/plugins/BEdita/Core/src/Model/Entity/EndpointPermission.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Model\Entity;
+
+use Cake\ORM\Entity;
+
+/**
+ * EndpointPermission Entity
+ *
+ * @property int $id
+ * @property int $endpoint_id
+ * @property int $application_id
+ * @property int $role_id
+ * @property int $permission
+ *
+ * @property \BEdita\Core\Model\Entity\Endpoint $endpoint
+ * @property \BEdita\Core\Model\Entity\Application $application
+ * @property \BEdita\Core\Model\Entity\Role $role
+ *
+ * @since 4.0.0
+ */
+class EndpointPermission extends Entity
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected $_accessible = [
+        '*' => true,
+        'id' => false
+    ];
+}

--- a/plugins/BEdita/Core/src/Model/Entity/Role.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Role.php
@@ -25,6 +25,7 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\Time $created
  * @property \Cake\I18n\Time $modified
  * @property \BEdita\Core\Model\Entity\User[] $users
+ * @property \BEdita\Core\Model\Entity\EndpointPermission[] $endpoint_permissions
  *
  * @since 4.0.0
  */
@@ -38,5 +39,12 @@ class Role extends Entity
         '*' => true,
         'id' => false,
         'unchangeable' => false,
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_hidden = [
+        'endpoint_permissions',
     ];
 }

--- a/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Model\Table;
+
+use Cake\Datasource\EntityInterface;
+use Cake\Event\Event;
+use Cake\ORM\Query;
+use Cake\ORM\RulesChecker;
+use Cake\ORM\Table;
+use Cake\Utility\Security;
+use Cake\Utility\Text;
+use Cake\Validation\Validator;
+
+/**
+ * Applications Model
+ *
+ * @property \Cake\ORM\Association\HasMany $EndpointPermissions
+ *
+ * @since 4.0.0
+ */
+class ApplicationsTable extends Table
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function initialize(array $config)
+    {
+        parent::initialize($config);
+
+        $this->displayField('name');
+        $this->addBehavior('Timestamp');
+        $this->hasMany('EndpointPermissions');
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function validationDefault(Validator $validator)
+    {
+        $validator
+            ->integer('id')
+            ->allowEmpty('id', 'create')
+
+            ->notEmpty('api_key')
+            ->add('api_key', 'unique', ['rule' => 'validateUnique', 'provider' => 'table'])
+
+            ->requirePresence('name', 'create')
+            ->notEmpty('name')
+            ->add('name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table'])
+
+            ->allowEmpty('description')
+
+            ->boolean('enabled')
+            ->notEmpty('enabled');
+
+        return $validator;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function buildRules(RulesChecker $rules)
+    {
+        $rules->add($rules->isUnique(['name']));
+        $rules->add($rules->isUnique(['api_key']));
+
+        return $rules;
+    }
+
+    /**
+     * Generate the api key on application creation
+     *
+     * @param \Cake\Event\Event $event The event dispatched
+     * @param \Cake\Datasource\EntityInterface $entity The entity to save
+     * @param \ArrayObject $options The save options
+     * @return void
+     */
+    public function beforeSave(Event $event, EntityInterface $entity, \ArrayObject $options)
+    {
+        if (!$entity->isNew() || !empty($entity->api_key)) {
+            return;
+        }
+
+        $entity->api_key = $this->generateApiKey();
+    }
+
+    /**
+     * Generate a unique api key
+     *
+     * @return string
+     */
+    public function generateApiKey()
+    {
+        return Security::hash(Text::uuid(), 'sha1');
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Table/EndpointPermissionsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/EndpointPermissionsTable.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Model\Table;
+
+use Cake\ORM\Query;
+use Cake\ORM\RulesChecker;
+use Cake\ORM\Table;
+use Cake\Validation\Validator;
+
+/**
+ * EndpointPermissions Model
+ *
+ * @property \Cake\ORM\Association\BelongsTo $Endpoints
+ * @property \Cake\ORM\Association\BelongsTo $Applications
+ * @property \Cake\ORM\Association\BelongsTo $Roles
+ *
+ * @since 4.0.0
+ */
+class EndpointPermissionsTable extends Table
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function initialize(array $config)
+    {
+        parent::initialize($config);
+
+        $this->table('endpoint_permissions');
+        $this->displayField('id');
+
+        $this->belongsTo('Endpoints', [
+            'joinType' => 'INNER',
+        ]);
+        $this->belongsTo('Applications');
+        $this->belongsTo('Roles');
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function validationDefault(Validator $validator)
+    {
+        $validator
+            ->integer('id')
+            ->allowEmpty('id', 'create');
+
+        $validator
+            ->integer('permission')
+            ->notEmpty('permission');
+
+        return $validator;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function buildRules(RulesChecker $rules)
+    {
+        $rules->add($rules->existsIn(['endpoint_id'], 'Endpoints'));
+        $rules->add($rules->existsIn(['application_id'], 'Applications'));
+        $rules->add($rules->existsIn(['role_id'], 'Roles'));
+
+        return $rules;
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Table/EndpointsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/EndpointsTable.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Model\Table;
+
+use Cake\ORM\Query;
+use Cake\ORM\RulesChecker;
+use Cake\ORM\Table;
+use Cake\Validation\Validator;
+
+/**
+ * Endpoints Model
+ *
+ * @property \Cake\ORM\Association\BelongsTo $ObjectTypes
+ * @property \Cake\ORM\Association\HasMany $EndpointPermissions
+ *
+ * @since 4.0.0
+ */
+class EndpointsTable extends Table
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function initialize(array $config)
+    {
+        parent::initialize($config);
+
+        $this->displayField('name');
+
+        $this->addBehavior('Timestamp');
+
+        $this->belongsTo('ObjectTypes');
+        $this->hasMany('EndpointPermissions');
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function validationDefault(Validator $validator)
+    {
+        $validator
+            ->integer('id')
+            ->allowEmpty('id', 'create')
+
+            ->requirePresence('name', 'create')
+            ->notEmpty('name')
+            ->add('name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table'])
+
+            ->allowEmpty('description')
+
+            ->boolean('enabled')
+            ->notEmpty('enabled');
+
+        return $validator;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function buildRules(RulesChecker $rules)
+    {
+        $rules->add($rules->isUnique(['name']));
+        $rules->add($rules->existsIn(['object_type_id'], 'ObjectTypes'));
+
+        return $rules;
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Table/RolesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RolesTable.php
@@ -36,22 +36,12 @@ class RolesTable extends Table
     {
         parent::initialize($config);
 
-        $this->table('roles');
-        $this->primaryKey('id');
         $this->displayField('name');
 
-        $this->addBehavior('Timestamp', [
-            'events' => [
-                'Model.beforeSave' => [
-                    'created' => 'new',
-                    'modified' => 'always',
-                ]
-            ],
-        ]);
+        $this->addBehavior('Timestamp');
 
-        $this->belongsToMany('Users', [
-            'className' => 'BEdita/Core.Users',
-        ]);
+        $this->belongsToMany('Users');
+        $this->hasMany('EndpointPermissions');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/Fixture/ApplicationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ApplicationsFixture.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\Fixture;
+
+use BEdita\Core\TestSuite\Fixture\TestFixture;
+
+/**
+ * ApplicationsFixture
+ *
+ * @since 4.0.0
+ */
+class ApplicationsFixture extends TestFixture
+{
+    /**
+     * Records
+     *
+     * @var array
+     */
+    public $records = [
+        [
+            'api_key' => 'abcdefghijklmnopqrstuvwxyz',
+            'name' => 'First app',
+            'description' => 'Lorem ipsum dolor sit amet, aliquet feugiat.',
+            'created' => '2016-10-28 07:10:57',
+            'modified' => '2016-10-28 07:10:57',
+            'enabled' => 1
+        ],
+    ];
+}

--- a/plugins/BEdita/Core/tests/Fixture/EndpointPermissionsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/EndpointPermissionsFixture.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\Fixture;
+
+use BEdita\Core\TestSuite\Fixture\TestFixture;
+
+/**
+ * EndpointPermissionsFixture
+ *
+ * @since 4.0.0
+ */
+class EndpointPermissionsFixture extends TestFixture
+{
+    /**
+     * Records
+     *
+     * @var array
+     */
+    public $records = [
+        [
+            'endpoint_id' => 1,
+            'application_id' => 1,
+            'role_id' => 1,
+            'permission' => 1
+        ],
+    ];
+}

--- a/plugins/BEdita/Core/tests/Fixture/EndpointsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/EndpointsFixture.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\Fixture;
+
+use BEdita\Core\TestSuite\Fixture\TestFixture;
+
+/**
+ * EndpointsFixture
+ *
+ * @since 4.0.0
+ */
+class EndpointsFixture extends TestFixture
+{
+    /**
+     * Records
+     *
+     * @var array
+     */
+    public $records = [
+        [
+            'name' => 'auth',
+            'description' => '/auth endpoint',
+            'created' => '2016-11-07 13:32:25',
+            'modified' => '2016-11-07 13:32:25',
+            'enabled' => 1,
+            'object_type_id' => null
+        ],
+        [
+            'name' => 'home',
+            'description' => '/home endpoint',
+            'created' => '2016-11-07 13:32:26',
+            'modified' => '2016-11-07 13:32:26',
+            'enabled' => 1,
+            'object_type_id' => null
+        ],
+        [
+            'name' => 'users',
+            'description' => '/users endpoint',
+            'created' => '2016-11-07 13:32:27',
+            'modified' => '2016-11-07 13:32:27',
+            'enabled' => 1,
+            'object_type_id' => 3
+        ],
+        [
+            'name' => 'roles',
+            'description' => '/roles endpoint',
+            'created' => '2016-11-07 13:32:28',
+            'modified' => '2016-11-07 13:32:28',
+            'enabled' => 1,
+            'object_type_id' => null
+        ],
+        [
+            'name' => 'object_types',
+            'description' => '/object_types endpoint',
+            'created' => '2016-11-07 13:32:29',
+            'modified' => '2016-11-07 13:32:29',
+            'enabled' => 1,
+            'object_type_id' => null
+        ],
+        [
+            'name' => 'objects',
+            'description' => '/objects endpoint',
+            'created' => '2016-11-07 13:32:30',
+            'modified' => '2016-11-07 13:32:30',
+            'enabled' => 1,
+            'object_type_id' => null
+        ],
+    ];
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/Application.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/Application.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Entity;
+
+use BEdita\Core\Model\Entity\Application;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\Core\Model\Entity\Application} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Model\Entity\Application
+ */
+class ApplicationTest extends TestCase
+{
+
+    /**
+     * Test subject's table
+     *
+     * @var \BEdita\Core\Model\Table\ApplicationsTable
+     */
+    public $Applications;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.applications',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->Applications = TableRegistry::get('Applications');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        unset($this->Applications);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test accessible properties.
+     *
+     * @return void
+     * @coversNothing
+     */
+    public function testAccessible()
+    {
+        $application = $this->Applications->get(1);
+
+        $created = $application->created;
+        $modified = $application->modified;
+        $apiKey = $application->api_key;
+
+        $data = [
+            'id' => 42,
+            'api_key' => '123abc',
+            'created' => '2016-01-01 12:00:00',
+            'modified' => '2016-01-01 12:00:00',
+        ];
+        $application = $this->Applications->patchEntity($application, $data);
+        if (!($application instanceof Application)) {
+            throw new \InvalidArgumentException();
+        }
+
+        $this->assertEquals(1, $application->id);
+        $this->assertEquals($apiKey, $application->api_key);
+        $this->assertEquals($created, $application->created);
+        $this->assertEquals($modified, $application->modified);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/Endpoint.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/Endpoint.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Entity;
+
+use BEdita\Core\Model\Entity\Endpoint;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\Core\Model\Entity\Endpoint} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Model\Entity\Endpoint
+ */
+class EndpointTest extends TestCase
+{
+
+    /**
+     * Test subject's table
+     *
+     * @var \BEdita\Core\Model\Table\EndpointsTable
+     */
+    public $Endpoints;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.endpoints',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->Endpoints = TableRegistry::get('Endpoints');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        unset($this->Endpoints);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test accessible properties.
+     *
+     * @return void
+     * @coversNothing
+     */
+    public function testAccessible()
+    {
+        $endpoint = $this->Endpoints->get(1);
+
+        $created = $endpoint->created;
+        $modified = $endpoint->modified;
+
+        $data = [
+            'id' => 42,
+            'created' => '2016-01-01 12:00:00',
+            'modified' => '2016-01-01 12:00:00',
+        ];
+        $endpoint = $this->Endpoints->patchEntity($endpoint, $data);
+        if (!($endpoint instanceof Endpoint)) {
+            throw new \InvalidArgumentException();
+        }
+
+        $this->assertEquals(1, $endpoint->id);
+        $this->assertEquals($created, $endpoint->created);
+        $this->assertEquals($modified, $endpoint->modified);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointPermission.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointPermission.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Entity;
+
+use BEdita\Core\Model\Entity\EndpointPermission;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\Core\Model\Entity\EndpointPermission} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Model\Entity\EndpointPermission
+ *
+ * @since 4.0.0
+ */
+class EndpointTest extends TestCase
+{
+
+    /**
+     * Test subject's table
+     *
+     * @var \BEdita\Core\Model\Table\EndpointPermissionsTable
+     */
+    public $EndpointPermissions;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.roles',
+        'plugin.BEdita/Core.endpoints',
+        'plugin.BEdita/Core.applications',
+        'plugin.BEdita/Core.endpoint_permissions',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->EndpointPermissions = TableRegistry::get('EndpointPermissions');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        unset($this->EndpointPermissions);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test accessible properties.
+     *
+     * @return void
+     * @coversNothing
+     */
+    public function testAccessible()
+    {
+        $endpointPermission = $this->EndpointPermissions->get(1);
+
+        $data = [
+            'id' => 42,
+        ];
+        $endpointPermission = $this->EndpointPermissions->patchEntity($endpointPermission, $data);
+        if (!($endpointPermission instanceof EndpointPermission)) {
+            throw new \InvalidArgumentException();
+        }
+
+        $this->assertEquals(1, $endpointPermission->id);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ApplicationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ApplicationsTableTest.php
@@ -92,12 +92,14 @@ class ApplicationsTableTest extends TestCase
                 true,
                 [
                     'name' => 'Unique Application Name',
+                    'description' => 'app description'
                 ],
             ],
             'notUniqueName' => [
                 false,
                 [
                     'name' => 'First app',
+                    'description' => 'app description'
                 ],
             ],
             'missingName' => [
@@ -171,7 +173,10 @@ class ApplicationsTableTest extends TestCase
         if ($update) {
             $application = $this->Applications->get(1);
         } else {
-            $application = $this->Applications->newEntity(['name' => 'Second App']);
+            $application = $this->Applications->newEntity([
+                'name' => 'Second App',
+                'description' => 'app description'
+            ]);
         }
 
         if ($apiKey) {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ApplicationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ApplicationsTableTest.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Table;
+
+use BEdita\Core\Model\Table\ApplicationsTable;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\Core\Model\Table\ApplicationsTable} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Model\Table\ApplicationsTable
+ */
+class ApplicationsTableTest extends TestCase
+{
+    /**
+     * Test subject
+     *
+     * @var \BEdita\Core\Model\Table\ApplicationsTable
+     */
+    public $Applications;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.applications',
+    ];
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->Applications = TableRegistry::get('Applications');
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->Applications);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test initialize method
+     *
+     * @return void
+     */
+    public function testInitialize()
+    {
+        $this->Applications->initialize([]);
+        $this->assertEquals('applications', $this->Applications->table());
+        $this->assertEquals('id', $this->Applications->primaryKey());
+        $this->assertEquals('name', $this->Applications->displayField());
+
+        $this->assertInstanceOf('\Cake\ORM\Behavior\TimestampBehavior', $this->Applications->behaviors()->get('Timestamp'));
+        $this->assertInstanceOf('\Cake\ORM\Association\hasMany', $this->Applications->EndpointPermissions);
+        $this->assertInstanceOf('\BEdita\Core\Model\Table\EndpointPermissionsTable', $this->Applications->EndpointPermissions->target());
+    }
+
+    /**
+     * Data provider for `testValidation` test case.
+     *
+     * @return array
+     */
+    public function validationProvider()
+    {
+        return [
+            'valid' => [
+                true,
+                [
+                    'name' => 'Unique Application Name',
+                ],
+            ],
+            'notUniqueName' => [
+                false,
+                [
+                    'name' => 'First app',
+                ],
+            ],
+            'missingName' => [
+                false,
+                [
+                    'description' => 'Where is app name?',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test validation.
+     *
+     * @param bool $expected Expected result.
+     * @param array $data Data to be validated.
+     *
+     * @return void
+     * @dataProvider validationProvider
+     * @coversNothing
+     */
+    public function testValidation($expected, array $data)
+    {
+        $application = $this->Applications->newEntity($data);
+        $error = (bool)$application->errors();
+        $this->assertEquals($expected, !$error);
+        if ($expected) {
+            $success = $this->Applications->save($application);
+            $this->assertTrue((bool)$success);
+        }
+    }
+
+    /**
+     * Data provider for `testApiKey` test case.
+     *
+     * @return array
+     */
+    public function apiKeyGenerationProvider()
+    {
+        return [
+            'new' => [
+                null,
+                false,
+            ],
+            'newAndSet' => [
+                '123abc',
+                false,
+            ],
+            'updateNoApiKey' => [
+                null,
+                true,
+            ],
+            'updateApiKey' => [
+                '456dfg',
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * Test api key generation.
+     *
+     * @param string $apiKey The api key to set. Empty to leave unchanged on update or auto generation on create
+     * @param bool $update If the operation is an update or create
+     *
+     * @return void
+     * @dataProvider apiKeyGenerationProvider
+     */
+    public function testApiKeyGeneration($apiKey, $update)
+    {
+        if ($update) {
+            $application = $this->Applications->get(1);
+        } else {
+            $application = $this->Applications->newEntity(['name' => 'Second App']);
+        }
+
+        if ($apiKey) {
+            $application->api_key = $apiKey;
+        }
+
+        $success = $this->Applications->save($application);
+        $this->assertTrue((bool)$success);
+
+        $testApp = $this->Applications->get($application->id);
+        if ($update) {
+            if ($apiKey) {
+                $this->assertEquals($apiKey, $testApp->api_key);
+            } else {
+                $this->assertEquals($application->api_key, $testApp->api_key);
+            }
+        } else {
+            if ($apiKey) {
+                $this->assertEquals($apiKey, $testApp->api_key);
+            } else {
+                $this->assertNotEmpty($testApp->api_key);
+                // check sha1
+                $this->assertTrue(ctype_xdigit($testApp->api_key));
+                $this->assertEquals(40, strlen($testApp->api_key));
+            }
+        }
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointPermissionsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointPermissionsTableTest.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Table;
+
+use BEdita\Core\Model\Table\EndpointPermissionsTable;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * BEdita\Core\Model\Table\EndpointPermissionsTable Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Model\Table\EndpointPermissionsTable
+ *
+ * @since 4.0.0
+ */
+class EndpointPermissionsTableTest extends TestCase
+{
+
+    /**
+     * Test subject
+     *
+     * @var \BEdita\Core\Model\Table\EndpointPermissionsTable
+     */
+    public $EndpointPermissions;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.roles',
+        'plugin.BEdita/Core.endpoints',
+        'plugin.BEdita/Core.applications',
+        'plugin.BEdita/Core.endpoint_permissions',
+    ];
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->EndpointPermissions = TableRegistry::get('EndpointPermissions');
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->EndpointPermissions);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test initialize method
+     *
+     * @return void
+     */
+    public function testInitialize()
+    {
+        $this->EndpointPermissions->initialize([]);
+        $this->assertEquals('endpoint_permissions', $this->EndpointPermissions->table());
+        $this->assertEquals('id', $this->EndpointPermissions->primaryKey());
+        $this->assertEquals('id', $this->EndpointPermissions->displayField());
+
+        $this->assertInstanceOf('\Cake\ORM\Association\belongsTo', $this->EndpointPermissions->Endpoints);
+        $this->assertInstanceOf('\BEdita\Core\Model\Table\EndpointsTable', $this->EndpointPermissions->Endpoints->target());
+        $this->assertInstanceOf('\Cake\ORM\Association\belongsTo', $this->EndpointPermissions->Applications);
+        $this->assertInstanceOf('\BEdita\Core\Model\Table\ApplicationsTable', $this->EndpointPermissions->Applications->target());
+        $this->assertInstanceOf('\Cake\ORM\Association\belongsTo', $this->EndpointPermissions->Roles);
+        $this->assertInstanceOf('\BEdita\Core\Model\Table\RolesTable', $this->EndpointPermissions->Roles->target());
+    }
+
+    /**
+     * Data provider for `testValidation` test case.
+     *
+     * @return array
+     */
+    public function validationProvider()
+    {
+        return [
+            'valid' => [
+                true,
+                [
+                    'endpoint_id' => 2,
+                    'application_id' => 1,
+                    'role_id' => 1,
+                    'permission' => 1
+                ],
+            ],
+            'valid2' => [
+                true,
+                [
+                    'endpoint_id' => 1,
+                ],
+            ],
+            'emptyPermission' => [
+                false,
+                [
+                    'permission' => '',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test validation.
+     *
+     * @param bool $expected Expected result.
+     * @param array $data Data to be validated.
+     *
+     * @return void
+     * @dataProvider validationProvider
+     * @coversNothing
+     */
+    public function testValidation($expected, array $data)
+    {
+        $endpointPermission = $this->EndpointPermissions->newEntity($data);
+        $error = (bool)$endpointPermission->errors();
+        $this->assertEquals($expected, !$error);
+        if ($expected) {
+            $success = $this->EndpointPermissions->save($endpointPermission);
+            $this->assertTrue((bool)$success);
+        }
+    }
+
+    /**
+     * Data provider for `testBuildRules` test case.
+     *
+     * @return array
+     */
+    public function buildRulesProvider()
+    {
+        return [
+            'inValidEndpoint' => [
+                false,
+                [
+                    'endpoint_id' => 1234,
+                    'application_id' => 1,
+                    'role_id' => 1,
+                ],
+            ],
+            'inValidApp' => [
+                false,
+                [
+                    'endpoint_id' => 1,
+                    'application_id' => 1234,
+                    'role_id' => 1,
+                ],
+            ],
+            'inValidRole' => [
+                false,
+                [
+                    'endpoint_id' => 1,
+                    'application_id' => 1,
+                    'role_id' => 1234,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test build rules validation.
+     *
+     * @param bool $expected Expected result.
+     * @param array $data Data to be validated.
+     *
+     * @return void
+     * @dataProvider buildRulesProvider
+     * @coversNothing
+     */
+    public function testBuildRules($expected, array $data)
+    {
+        $endpointPermission = $this->EndpointPermissions->newEntity($data, ['validate' => false]);
+        $success = $this->EndpointPermissions->save($endpointPermission);
+        $this->assertEquals($expected, (bool)$success, print_r($endpointPermission->errors(), true));
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointsTableTest.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Table;
+
+use BEdita\Core\Model\Table\EndpointsTable;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * BEdita\Core\Model\Table\EndpointsTable Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Model\Table\EndpointsTable
+ */
+class EndpointsTableTest extends TestCase
+{
+    /**
+     * Test subject
+     *
+     * @var \BEdita\Core\Model\Table\EndpointsTable
+     */
+    public $Endpoints;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.endpoints',
+    ];
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->Endpoints = TableRegistry::get('Endpoints');
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->Endpoints);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test initialize method
+     *
+     * @return void
+     */
+    public function testInitialize()
+    {
+        $this->Endpoints->initialize([]);
+        $this->assertEquals('endpoints', $this->Endpoints->table());
+        $this->assertEquals('id', $this->Endpoints->primaryKey());
+        $this->assertEquals('name', $this->Endpoints->displayField());
+
+        $this->assertInstanceOf('\Cake\ORM\Behavior\TimestampBehavior', $this->Endpoints->behaviors()->get('Timestamp'));
+        $this->assertInstanceOf('\Cake\ORM\Association\hasMany', $this->Endpoints->EndpointPermissions);
+        $this->assertInstanceOf('\BEdita\Core\Model\Table\EndpointPermissionsTable', $this->Endpoints->EndpointPermissions->target());
+    }
+
+    /**
+     * Data provider for `testValidation` test case.
+     *
+     * @return array
+     */
+    public function validationProvider()
+    {
+        return [
+            'valid' => [
+                true,
+                [
+                    'name' => 'custom_endpoint',
+                ],
+            ],
+            'notUniqueName' => [
+                false,
+                [
+                    'name' => 'roles',
+                ],
+            ],
+            'missingName' => [
+                false,
+                [
+                    'description' => 'Where is apendpoint name?',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test validation.
+     *
+     * @param bool $expected Expected result.
+     * @param array $data Data to be validated.
+     *
+     * @return void
+     * @dataProvider validationProvider
+     * @coversNothing
+     */
+    public function testValidation($expected, array $data)
+    {
+        $endpoint = $this->Endpoints->newEntity($data);
+        $error = (bool)$endpoint->errors();
+        $this->assertEquals($expected, !$error);
+        if ($expected) {
+            $success = $this->Endpoints->save($endpoint);
+            $this->assertTrue((bool)$success);
+        }
+    }
+
+    /**
+     * Data provider for `testBuildRules` test case.
+     *
+     * @return array
+     */
+    public function buildRulesProvider()
+    {
+        return [
+            'wrongObjectType' => [
+                false,
+                [
+                    'name' => 'custom_endpoint',
+                    'object_type_id' => 1234
+                ]
+            ],
+            'notUnique' => [
+                false,
+                [
+                    'name' => 'roles'
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * Test build rules validation.
+     *
+     * @param bool $expected Expected result.
+     * @param array $data Data to be validated.
+     *
+     * @return void
+     * @dataProvider buildRulesProvider
+     * @coversNothing
+     */
+    public function testBuildRules($expected, array $data)
+    {
+        $endpoint = $this->Endpoints->newEntity($data, ['validate' => false]);
+        $success = $this->Endpoints->save($endpoint);
+        $this->assertEquals($expected, (bool)$success, print_r($endpoint->errors(), true));
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
@@ -73,6 +73,9 @@ class RolesTableTest extends TestCase
         $this->assertEquals('name', $this->Roles->displayField());
 
         $this->assertInstanceOf('\Cake\ORM\Association\BelongsToMany', $this->Roles->Users);
+        $this->assertInstanceOf('\BEdita\Core\Model\Table\UsersTable', $this->Roles->Users->target());
+        $this->assertInstanceOf('\Cake\ORM\Association\hasMany', $this->Roles->EndpointPermissions);
+        $this->assertInstanceOf('\BEdita\Core\Model\Table\EndpointPermissionsTable', $this->Roles->EndpointPermissions->target());
     }
 
     /**


### PR DESCRIPTION
It solves #967 introducing basic models (tables and entities) to handle `endpoints`, `applications`, and `endpoint_permissions`.