### PR TITLE
Wait until MySQL and PgSQL are up in Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,12 +49,14 @@ matrix:
     - php: hhvm
 
 before_script:
+  - curl -o wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && chmod +x wait-for-it.sh
   - |
     if [ "$DB" = 'mysql' ]; then
       if [ -n "$DB_VERSION" ]; then
         docker pull mysql:$DB_VERSION
         docker run -d -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=bedita -e MYSQL_PASSWORD=bedita -e MYSQL_DATABASE=bedita_test -p 127.0.0.1:33060:3306 mysql:$DB_VERSION
         docker ps -a
+        ./wait-for-it.sh 127.0.0.1:33060 -s -- echo 'MySQL is up'
       else
         mysql -e 'CREATE DATABASE bedita_test;'
       fi
@@ -65,6 +67,7 @@ before_script:
         docker pull postgres:$DB_VERSION
         docker run -d -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=bedita_test -p 127.0.0.1:54320:5432 postgres:$DB_VERSION
         docker ps -a
+        ./wait-for-it.sh 127.0.0.1:54320 -s -- echo 'PostgreSQL is up'
       else
         psql -c 'CREATE DATABASE bedita_test;' -U postgres
       fi


### PR DESCRIPTION
This PR _should_ solve a recurrent problem that we have in our Travis CI builds: sometimes MySQL jobs fail because "MySQL server has gone away". Jobs usually pass once restarted.

Being unable to easily debug directly on the system, we can only make assumptions on the root cause of this problem. A possible cause is that the Docker container with MySQL sometimes takes a bit more than usual to start and be able to accept connections, and in the meanwhile tests have already started thus causing an error.

This PR adds wait-for-it, that basically waits up to 15 seconds to see if the specified `host:port` is reachable. As soon as the server becomes reachable, the script continues its execution. If, on the other hand, the server still isn't reachable after 15 seconds, the script exits with a non-zero exit code in the pre-script section that causes an errored (not failed) job.

This approach should have no drawbacks, and it should make us able to discern whether this assumption was actually right.