### PR TITLE
Display available relationships in JSON API response

### DIFF
--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -254,5 +254,10 @@ Router::plugin(
             ['controller' => 'Objects', 'action' => 'delete', '_method' => 'DELETE'],
             ['_name' => 'objects:delete']
         );
+        $routes->connect(
+            '/:object_type/:id/relationships/:relationship',
+            ['controller' => 'Objects', 'action' => 'relationships'],
+            ['_name' => 'objects:relationships']
+        );
     }
 );

--- a/plugins/BEdita/API/tests/TestCase/Controller/AppControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AppControllerTest.php
@@ -33,6 +33,8 @@ class AppControllerTest extends IntegrationTestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.roles',
         'plugin.BEdita/Core.endpoints',
         'plugin.BEdita/Core.applications',

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
@@ -27,10 +27,6 @@ use Cake\TestSuite\TestCase;
  */
 class JsonApiComponentTest extends TestCase
 {
-    /**
-     * {@inheritDoc}
-     */
-    public $autoFixtures = false;
 
     /**
      * Fixtures.
@@ -38,6 +34,9 @@ class JsonApiComponentTest extends TestCase
      * @var array
      */
     public $fixtures = [
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.roles',
     ];
 
@@ -211,8 +210,6 @@ class JsonApiComponentTest extends TestCase
      */
     public function testPagination(array $expectedLinks, array $expectedMeta, array $query)
     {
-        $this->loadFixtures('Roles');
-
         $request = new Request([
             'params' => [
                 'plugin' => 'BEdita/API',

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -25,10 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class PaginatorComponentTest extends TestCase
 {
-    /**
-     * {@inheritDoc}
-     */
-    public $autoFixtures = false;
 
     /**
      * Fixtures.
@@ -36,6 +32,9 @@ class PaginatorComponentTest extends TestCase
      * @var array
      */
     public $fixtures = [
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.roles',
     ];
 
@@ -180,8 +179,6 @@ class PaginatorComponentTest extends TestCase
      */
     public function testValidateSort($expected, $sort = null)
     {
-        $this->loadFixtures('Roles');
-
         if ($expected === false) {
             $this->expectException('Cake\Network\Exception\BadRequestException');
         }

--- a/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
@@ -30,6 +30,8 @@ class LoginControllerTest extends IntegrationTestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.roles',
         'plugin.BEdita/Core.endpoints',
         'plugin.BEdita/Core.applications',

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectTypesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectTypesControllerTest.php
@@ -29,6 +29,8 @@ class ObjectTypesControllerTest extends IntegrationTestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.roles',
         'plugin.BEdita/Core.endpoints',
         'plugin.BEdita/Core.applications',

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -29,6 +29,8 @@ class ObjectsControllerTest extends IntegrationTestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.roles',
         'plugin.BEdita/Core.endpoints',
         'plugin.BEdita/Core.applications',

--- a/plugins/BEdita/API/tests/TestCase/Controller/PropertiesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/PropertiesControllerTest.php
@@ -34,7 +34,7 @@ class PropertiesControllerTest extends IntegrationTestCase
         'plugin.BEdita/Core.applications',
         'plugin.BEdita/Core.endpoint_permissions',
         'plugin.BEdita/Core.property_types',
-        'plugin.BEdita/Core.properties'
+        'plugin.BEdita/Core.properties',
     ];
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
@@ -29,6 +29,8 @@ class UsersControllerTest extends IntegrationTestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.roles',
         'plugin.BEdita/Core.endpoints',
         'plugin.BEdita/Core.applications',

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -36,6 +36,9 @@ class JsonApiTest extends TestCase
      * @var array
      */
     public $fixtures = [
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.roles',
     ];
 

--- a/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Model\Behavior;
+
+use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\ORM\Behavior;
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+use Cake\Utility\Inflector;
+
+/**
+ * Relations behavior
+ */
+class RelationsBehavior extends Behavior
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_defaultConfig = [
+        'objectType' => null,
+    ];
+
+    /**
+     * Object type instance.
+     *
+     * @var \BEdita\Core\Model\Entity\ObjectType
+     */
+    protected $objectType;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function initialize(array $config)
+    {
+        parent::initialize($config);
+
+        $ObjectTypes = TableRegistry::get('ObjectTypes');
+
+        try {
+            $this->objectType = $ObjectTypes->get(
+                $this->getConfig('objectType') ?: $this->getTable()->getAlias()
+            );
+        } catch (RecordNotFoundException $e) {
+            return;
+        }
+
+        $this->objectType = $ObjectTypes->loadInto(
+            $this->objectType,
+            ['LeftRelations', 'RightRelations']
+        );
+
+        // Add relations to the left side.
+        foreach ($this->objectType->left_relations as $relation) {
+            $this->getTable()->belongsToMany(Inflector::camelize($relation->name), [
+                'className' => 'Objects',
+                'through' => 'ObjectRelations',
+                'foreignKey' => 'left_id',
+                'targetForeignKey' => 'right_id',
+                'conditions' => [
+                    'ObjectRelations.relation_id' => $relation->id,
+                ],
+            ]);
+        }
+
+        // Add relations to the right side.
+        foreach ($this->objectType->right_relations as $relation) {
+            $this->getTable()->belongsToMany(Inflector::camelize($relation->inverse_name), [
+                'className' => 'Objects',
+                'through' => 'ObjectRelations',
+                'foreignKey' => 'right_id',
+                'targetForeignKey' => 'left_id',
+                'conditions' => [
+                    'ObjectRelations.relation_id' => $relation->id,
+                ],
+            ]);
+        }
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
@@ -75,6 +75,8 @@ class ObjectEntity extends Entity
      * {@inheritDoc}
      */
     protected $_hidden = [
+        'created_by_user',
+        'modified_by_user',
         'object_type_id',
         'object_type',
         'deleted',

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
@@ -28,6 +28,8 @@ use Cake\Utility\Inflector;
  * @property string $model
  * @property string $table
  * @property \BEdita\Core\Model\Entity\ObjectEntity[] $objects
+ * @property \BEdita\Core\Model\Entity\Relation[] $left_relations
+ * @property \BEdita\Core\Model\Entity\Relation[] $right_relations
  */
 class ObjectType extends Entity
 {
@@ -51,6 +53,14 @@ class ObjectType extends Entity
     protected $_virtual = [
         'alias',
         'table',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_hidden = [
+        'left_relations',
+        'right_relations',
     ];
 
     /**

--- a/plugins/BEdita/Core/src/Model/Entity/Relation.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Relation.php
@@ -1,4 +1,16 @@
 <?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
 namespace BEdita\Core\Model\Entity;
 
 use Cake\ORM\Entity;
@@ -15,22 +27,30 @@ use Cake\ORM\Entity;
  * @property string $params
  *
  * @property \BEdita\Core\Model\Entity\ObjectRelation[] $object_relations
- * @property \BEdita\Core\Model\Entity\RelationType[] $relation_types
+ * @property \BEdita\Core\Model\Entity\ObjectType[] $left_object_types
+ * @property \BEdita\Core\Model\Entity\ObjectType[] $right_object_types
  */
 class Relation extends Entity
 {
 
     /**
-     * Fields that can be mass assigned using newEntity() or patchEntity().
-     *
-     * Note that when '*' is set to true, this allows all unspecified fields to
-     * be mass assigned. For security purposes, it is advised to set '*' to false
-     * (or remove it), and explicitly make individual fields accessible as needed.
-     *
-     * @var array
+     * {@inheritDoc}
      */
     protected $_accessible = [
-        '*' => true,
-        'id' => false
+        '*' => false,
+        'name' => true,
+        'label' => true,
+        'inverse_name' => true,
+        'inverse_label' => true,
+        'description' => true,
+        'params' => true,
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_hidden = [
+        'left_object_types',
+        'right_object_types',
     ];
 }

--- a/plugins/BEdita/Core/src/Model/Entity/RelationType.php
+++ b/plugins/BEdita/Core/src/Model/Entity/RelationType.php
@@ -1,4 +1,16 @@
 <?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
 namespace BEdita\Core\Model\Entity;
 
 use Cake\ORM\Entity;
@@ -17,18 +29,9 @@ class RelationType extends Entity
 {
 
     /**
-     * Fields that can be mass assigned using newEntity() or patchEntity().
-     *
-     * Note that when '*' is set to true, this allows all unspecified fields to
-     * be mass assigned. For security purposes, it is advised to set '*' to false
-     * (or remove it), and explicitly make individual fields accessible as needed.
-     *
-     * @var array
+     * {@inheritDoc}
      */
     protected $_accessible = [
         '*' => true,
-        'relation_id' => false,
-        'object_type_id' => false,
-        'side' => false
     ];
 }

--- a/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
@@ -40,13 +40,15 @@ class LocationsTable extends Table
     {
         parent::initialize($config);
 
-        $this->table('locations');
-        $this->displayField('id');
-        $this->primaryKey('id');
+        $this->setTable('locations');
+        $this->setDisplayField('id');
+        $this->setPrimaryKey('id');
 
         $this->extensionOf('Objects', [
             'className' => 'BEdita/Core.Objects'
         ]);
+
+        $this->addBehavior('BEdita/Core.Relations');
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
@@ -20,6 +20,7 @@ use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Event\Event;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
+use Cake\Utility\Inflector;
 use Cake\Validation\Validator;
 
 /**
@@ -133,6 +134,7 @@ class ObjectTypesTable extends Table
                     ->toArray()
             );
 
+            $primaryKey = Inflector::underscore($primaryKey);
             if (!isset($allTypes[$primaryKey])) {
                 throw new RecordNotFoundException(sprintf(
                     'Record not found in table "%s"',

--- a/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
@@ -54,12 +54,31 @@ class ObjectTypesTable extends Table
 
         $this->hasMany('Objects', [
             'foreignKey' => 'object_type_id',
-            'className' => 'BEdita/Core.Objects',
+            'className' => 'Objects',
         ]);
 
         $this->hasMany('Properties', [
             'foreignKey' => 'property_type_id',
-            'className' => 'BEdita/Core.Properties',
+            'className' => 'Properties',
+        ]);
+
+        $this->belongsToMany('LeftRelations', [
+            'className' => 'Relations',
+            'through' => 'RelationTypes',
+            'foreignKey' => 'object_type_id',
+            'targetForeignKey' => 'relation_id',
+            'conditions' => [
+                'RelationTypes.side' => 'left',
+            ],
+        ]);
+        $this->belongsToMany('RightRelations', [
+            'className' => 'Relations',
+            'through' => 'RelationTypes',
+            'foreignKey' => 'object_type_id',
+            'targetForeignKey' => 'relation_id',
+            'conditions' => [
+                'RelationTypes.side' => 'right',
+            ],
         ]);
     }
 

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -52,6 +52,8 @@ class ObjectsTable extends Table
 
         $this->addBehavior('BEdita/Core.UserModified');
 
+        $this->addBehavior('BEdita/Core.Relations');
+
         $this->belongsTo('ObjectTypes', [
             'foreignKey' => 'object_type_id',
             'joinType' => 'INNER',

--- a/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
@@ -38,6 +38,8 @@ class ProfilesTable extends Table
         $this->setPrimaryKey('id');
         $this->setDisplayField('name');
 
+        $this->addBehavior('BEdita/Core.Relations');
+
         $this->extensionOf('Objects', [
             'className' => 'BEdita/Core.Objects'
         ]);

--- a/plugins/BEdita/Core/src/Model/Table/RelationTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationTypesTable.php
@@ -1,4 +1,17 @@
 <?php
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
 namespace BEdita\Core\Model\Table;
 
 use Cake\ORM\RulesChecker;
@@ -55,7 +68,9 @@ class RelationTypesTable extends Table
     public function validationDefault(Validator $validator)
     {
         $validator
-            ->allowEmpty('side', 'create');
+            ->inList('side', ['left', 'right'])
+            ->notEmpty('side')
+            ->requirePresence('side', 'create');
 
         return $validator;
     }
@@ -67,6 +82,7 @@ class RelationTypesTable extends Table
      */
     public function buildRules(RulesChecker $rules)
     {
+        $rules->add($rules->isUnique(['relation_id', 'object_type_id', 'side']));
         $rules->add($rules->existsIn(['relation_id'], 'Relations'));
         $rules->add($rules->existsIn(['object_type_id'], 'ObjectTypes'));
 

--- a/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
@@ -1,6 +1,19 @@
 <?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
 namespace BEdita\Core\Model\Table;
 
+use Cake\Database\Schema\TableSchema;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
@@ -35,13 +48,24 @@ class RelationsTable extends Table
         $this->setDisplayField('name');
         $this->setPrimaryKey('id');
 
-        $this->hasMany('ObjectRelations', [
+        $this->hasMany('ObjectRelations');
+        $this->belongsToMany('LeftObjectTypes', [
+            'className' => 'ObjectTypes',
+            'through' => 'RelationTypes',
             'foreignKey' => 'relation_id',
-            'className' => 'BEdita/Core.ObjectRelations'
+            'targetForeignKey' => 'object_type_id',
+            'conditions' => [
+                'RelationTypes.side' => 'left',
+            ],
         ]);
-        $this->hasMany('RelationTypes', [
+        $this->belongsToMany('RightObjectTypes', [
+            'className' => 'ObjectTypes',
+            'through' => 'RelationTypes',
             'foreignKey' => 'relation_id',
-            'className' => 'BEdita/Core.RelationTypes'
+            'targetForeignKey' => 'object_type_id',
+            'conditions' => [
+                'RelationTypes.side' => 'right',
+            ],
         ]);
     }
 
@@ -94,5 +118,17 @@ class RelationsTable extends Table
         $rules->add($rules->isUnique(['inverse_name']));
 
         return $rules;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    protected function _initializeSchema(TableSchema $schema)
+    {
+        $schema->columnType('params', 'json');
+
+        return $schema;
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -67,6 +67,8 @@ class UsersTable extends Table
             'prefix' => 'user-'
         ]);
 
+        $this->addBehavior('BEdita/Core.Relations');
+
         EventManager::instance()->on('Auth.afterIdentify', [$this, 'login']);
     }
 

--- a/plugins/BEdita/Core/src/ORM/Locator/TableLocator.php
+++ b/plugins/BEdita/Core/src/ORM/Locator/TableLocator.php
@@ -55,7 +55,7 @@ class TableLocator extends CakeLocator
 
         try {
             $objectTypes = $this->get('ObjectTypes');
-            $objectType = $objectTypes->get(Inflector::underscore($alias));
+            $objectType = $objectTypes->get($alias);
             $options['className'] = $objectType->table;
         } catch (\Exception $e) {
             if (!($e instanceof RecordNotFoundException)) {

--- a/plugins/BEdita/Core/tests/Fixture/RelationTypesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/RelationTypesFixture.php
@@ -1,11 +1,23 @@
 <?php
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
 namespace BEdita\Core\Test\Fixture;
 
 use BEdita\Core\TestSuite\Fixture\TestFixture;
 
 /**
- * RelationTypesFixture
- *
+ * Fixture for `relation_types` table.
  */
 class RelationTypesFixture extends TestFixture
 {
@@ -19,7 +31,17 @@ class RelationTypesFixture extends TestFixture
         [
             'relation_id' => 1,
             'object_type_id' => 1,
-            'side' => 'left'
+            'side' => 'left',
+        ],
+        [
+            'relation_id' => 1,
+            'object_type_id' => 1,
+            'side' => 'right',
+        ],
+        [
+            'relation_id' => 1,
+            'object_type_id' => 2,
+            'side' => 'right',
         ],
     ];
 

--- a/plugins/BEdita/Core/tests/Fixture/RelationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/RelationsFixture.php
@@ -29,7 +29,6 @@ class RelationsFixture extends TestFixture
      */
     public $records = [
         [
-            'id' => 1,
             'name' => 'test',
             'label' => 'Test relation',
             'inverse_name' => 'inverse_test',

--- a/plugins/BEdita/Core/tests/Fixture/RelationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/RelationsFixture.php
@@ -1,11 +1,23 @@
 <?php
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
 namespace BEdita\Core\Test\Fixture;
 
 use BEdita\Core\TestSuite\Fixture\TestFixture;
 
 /**
- * RelationsFixture
- *
+ * Fixture for `relations` table.
  */
 class RelationsFixture extends TestFixture
 {
@@ -18,12 +30,12 @@ class RelationsFixture extends TestFixture
     public $records = [
         [
             'id' => 1,
-            'name' => 'Lorem ipsum dolor sit amet',
-            'label' => 'Lorem ipsum dolor sit amet',
-            'inverse_name' => 'Lorem ipsum dolor sit amet',
-            'inverse_label' => 'Lorem ipsum dolor sit amet',
-            'description' => 'Lorem ipsum dolor sit amet, aliquet feugiat. Convallis morbi fringilla gravida, phasellus feugiat dapibus velit nunc, pulvinar eget sollicitudin venenatis cum nullam, vivamus ut a sed, mollitia lectus. Nulla vestibulum massa neque ut et, id hendrerit sit, feugiat in taciti enim proin nibh, tempor dignissim, rhoncus duis vestibulum nunc mattis convallis.',
-            'params' => 'Lorem ipsum dolor sit amet, aliquet feugiat. Convallis morbi fringilla gravida, phasellus feugiat dapibus velit nunc, pulvinar eget sollicitudin venenatis cum nullam, vivamus ut a sed, mollitia lectus. Nulla vestibulum massa neque ut et, id hendrerit sit, feugiat in taciti enim proin nibh, tempor dignissim, rhoncus duis vestibulum nunc mattis convallis.'
+            'name' => 'test',
+            'label' => 'Test relation',
+            'inverse_name' => 'inverse_test',
+            'inverse_label' => 'Inverse test relation',
+            'description' => 'Sample description.',
+            'params' => null,
         ],
     ];
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/RelationsBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/RelationsBehaviorTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Behavior;
+
+use BEdita\Core\Model\Behavior\RelationsBehavior;
+use Cake\ORM\Association\BelongsToMany;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\Core\Model\Behavior\RelationsBehavior} Test Case
+ *
+ * @covers \BEdita\Core\Model\Behavior\RelationsBehavior
+ */
+class RelationsBehaviorTest extends TestCase
+{
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
+        'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.profiles',
+    ];
+
+    /**
+     * Test initial setup
+     *
+     * @return void
+     */
+    public function testInitialization()
+    {
+        TableRegistry::clear();
+
+        $Documents = TableRegistry::get('Documents');
+        $Profiles = TableRegistry::get('Profiles');
+
+        static::assertInstanceOf(BelongsToMany::class, $Documents->association('Test'));
+        static::assertInstanceOf(BelongsToMany::class, $Documents->association('InverseTest'));
+        static::assertInstanceOf(BelongsToMany::class, $Profiles->association('InverseTest'));
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
@@ -33,6 +33,8 @@ class UniqueNameBehaviorTest extends TestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.objects',
         'plugin.BEdita/Core.profiles',
         'plugin.BEdita/Core.users',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ExternalAuthTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ExternalAuthTableTest.php
@@ -38,6 +38,8 @@ class ExternalAuthTableTest extends TestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.objects',
         'plugin.BEdita/Core.profiles',
         'plugin.BEdita/Core.users',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
@@ -25,6 +25,8 @@ class LocationsTableTest extends TestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.objects',
         'plugin.BEdita/Core.locations'
     ];

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
@@ -219,6 +219,19 @@ class ObjectTypesTableTest extends TestCase
                 ],
                 'documents',
             ],
+            'notUnderscored' => [
+                [
+                    'id' => 1,
+                    'name' => 'document',
+                    'pluralized' => 'documents',
+                    'description' => null,
+                    'alias' => 'Documents',
+                    'plugin' => 'BEdita/Core',
+                    'model' => 'Objects',
+                    'table' => 'BEdita/Core.Objects',
+                ],
+                'Documents',
+            ],
             'missingId' => [
                 false,
                 99,

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationTypesTableTest.php
@@ -1,4 +1,17 @@
 <?php
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use Cake\ORM\TableRegistry;
@@ -24,7 +37,6 @@ class RelationTypesTableTest extends TestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.object_types',
-        'plugin.BEdita/Core.objects',
         'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.relations',
     ];
@@ -37,8 +49,8 @@ class RelationTypesTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $config = TableRegistry::exists('RelationTypes') ? [] : ['className' => 'BEdita\Core\Model\Table\RelationTypesTable'];
-        $this->RelationTypes = TableRegistry::get('RelationTypes', $config);
+
+        $this->RelationTypes = TableRegistry::get('RelationTypes');
     }
 
     /**
@@ -54,32 +66,56 @@ class RelationTypesTableTest extends TestCase
     }
 
     /**
-     * Test initialize method
+     * Data provider for `testValidation` test case.
      *
-     * @return void
+     * @return array
      */
-    public function testInitialize()
+    public function validationProvider()
     {
-        $this->markTestIncomplete('Not implemented yet.');
+        return [
+            'validLeft' => [
+                true,
+                [
+                    'object_type_id' => 3,
+                    'relation_id' => 1,
+                    'side' => 'left',
+                ],
+            ],
+            'validRight' => [
+                true,
+                [
+                    'object_type_id' => 3,
+                    'relation_id' => 1,
+                    'side' => 'right',
+                ],
+            ],
+            'invalidSide' => [
+                false,
+                [
+                    'object_type_id' => 3,
+                    'relation_id' => 1,
+                    'side' => 'Dark side of the Moon',
+                ],
+            ],
+        ];
     }
 
     /**
-     * Test validationDefault method
+     * Test validation.
      *
+     * @param bool $expected Expected result.
+     * @param array $data Data to be validated.
      * @return void
+     *
+     * @dataProvider validationProvider
+     * @coversNothing
      */
-    public function testValidationDefault()
+    public function testValidation($expected, array $data)
     {
-        $this->markTestIncomplete('Not implemented yet.');
-    }
+        $objectType = $this->RelationTypes->newEntity();
+        $this->RelationTypes->patchEntity($objectType, $data);
 
-    /**
-     * Test buildRules method
-     *
-     * @return void
-     */
-    public function testBuildRules()
-    {
-        $this->markTestIncomplete('Not implemented yet.');
+        $success = $this->RelationTypes->save($objectType);
+        static::assertEquals($expected, (bool)$success);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
@@ -1,4 +1,17 @@
 <?php
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use Cake\ORM\TableRegistry;
@@ -37,8 +50,8 @@ class RelationsTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $config = TableRegistry::exists('Relations') ? [] : ['className' => 'BEdita\Core\Model\Table\RelationsTable'];
-        $this->Relations = TableRegistry::get('Relations', $config);
+
+        $this->Relations = TableRegistry::get('Relations');
     }
 
     /**
@@ -54,32 +67,59 @@ class RelationsTableTest extends TestCase
     }
 
     /**
-     * Test initialize method
+     * Data provider for `testValidation` test case.
      *
-     * @return void
+     * @return array
      */
-    public function testInitialize()
+    public function validationProvider()
     {
-        $this->markTestIncomplete('Not implemented yet.');
+        return [
+            'valid' => [
+                true,
+                [
+                    'name' => 'my_relation',
+                    'label' => 'My Relation',
+                    'inverse_name' => 'my_inverse_relation',
+                    'inverse_label' => 'My Inverse Relation',
+                    'description' => 'null',
+                    'params' => [
+                        [
+                            'name' => 'param1',
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'notUnique' => [
+                false,
+                [
+                    'name' => 'test',
+                    'label' => 'Some label',
+                    'inverse_name' => 'tset',
+                    'inverse_label' => 'Same label :)',
+                    'description' => null,
+                    'params' => null,
+                ],
+            ],
+        ];
     }
 
     /**
-     * Test validationDefault method
+     * Test validation.
      *
+     * @param bool $expected Expected result.
+     * @param array $data Data to be validated.
      * @return void
+     *
+     * @dataProvider validationProvider
+     * @coversNothing
      */
-    public function testValidationDefault()
+    public function testValidation($expected, array $data)
     {
-        $this->markTestIncomplete('Not implemented yet.');
-    }
+        $objectType = $this->Relations->newEntity();
+        $this->Relations->patchEntity($objectType, $data);
 
-    /**
-     * Test buildRules method
-     *
-     * @return void
-     */
-    public function testBuildRules()
-    {
-        $this->markTestIncomplete('Not implemented yet.');
+        $success = $this->Relations->save($objectType);
+        static::assertEquals($expected, (bool)$success);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
@@ -37,6 +37,9 @@ class RolesTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.roles',
     ];
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -39,6 +39,8 @@ class UsersTableTest extends TestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.objects',
         'plugin.BEdita/Core.profiles',
         'plugin.BEdita/Core.users',

--- a/plugins/BEdita/Core/tests/TestCase/ORM/TableLocatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/TableLocatorTest.php
@@ -28,6 +28,8 @@ class TableLocatorTest extends TestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.objects',
     ];
 

--- a/plugins/BEdita/Core/tests/TestCase/Shell/DataSeedShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/DataSeedShellTest.php
@@ -26,14 +26,15 @@ class DataSeedShellTest extends ShellTestCase
      * @var array
      */
     public $fixtures = [
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.config',
         'plugin.BEdita/Core.roles',
+        'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.profiles',
+        'plugin.BEdita/Core.users',
     ];
-
-    /**
-     * {@inheritDoc}
-     */
-    public $autoFixtures = false;
 
     /**
      * Test validation with invalid table name.
@@ -42,7 +43,6 @@ class DataSeedShellTest extends ShellTestCase
      */
     public function testUnsupportedTable()
     {
-        $this->loadFixtures('Config');
         $this->invoke(['data_seed', 'insert', '-t', 'thisTableDoesNotExist']);
 
         $this->assertAborted();
@@ -56,7 +56,6 @@ class DataSeedShellTest extends ShellTestCase
      */
     public function testInvalidFields()
     {
-        $this->loadFixtures('Config');
         $this->invoke(['data_seed', 'insert', '-f', 'someField=someValue,someOtherInvalidField']);
 
         $this->assertAborted();
@@ -70,7 +69,6 @@ class DataSeedShellTest extends ShellTestCase
      */
     public function testValidationErrors()
     {
-        $this->loadFixtures('Config', 'Roles');
         $this->invoke(['data_seed', 'insert', '-t', 'roles', '-n', '1', '-f', 'unchangeable=no']);
 
         $this->assertAborted();
@@ -84,7 +82,6 @@ class DataSeedShellTest extends ShellTestCase
      */
     public function testBuildRulesErrors()
     {
-        $this->loadFixtures('Config', 'Roles');
         $this->invoke(['data_seed', 'insert', '-t', 'roles', '-n', '2', '-f', 'name=double']);
 
         $this->assertAborted();
@@ -98,8 +95,6 @@ class DataSeedShellTest extends ShellTestCase
      */
     public function testRoleSeeding()
     {
-        $this->loadFixtures('Config', 'Roles');
-
         $Roles = TableRegistry::get('Roles');
         $before = $Roles->find('all')->count();
 


### PR DESCRIPTION
This PR _should_ solve #1076.

We use the approach described in the issue and tested by @batopa : when a BEdita object model is instantiated, associations are dynamically created for each relationship type that that object type can have.

For instance, if we set up a `see_also` relationship that can have **Documents** on the left side, the `Documents` table will have a `SeeAlso` association set up (belongs to many with `Objects` table). Therefore, getting a list of "see also" objects for a document should be possible via `TableRegistry::get('Documents')->get($documentId)->see_also`.