### PR TITLE
Use more developer friendly endpoint permissions

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -64,6 +64,7 @@ return [
      *   You should treat it as extremely sensitive data.
      * - jwt - Duration and algorithm for JSON Web Tokens.
      *   By default, `duration` is `'+2 hours'`, and `algorithm` is `'HS256'`.
+     * - disallowAnonymousApplications - Are anonymous applications (i.e. requests without an api key) forbidden?
      */
     'Security' => [
         'salt' => env('SECURITY_SALT', '__SALT__'),
@@ -71,6 +72,7 @@ return [
         //     'duration' => '+2 hours',
         //     'algorithm' => 'HS256',
         // ],
+        // 'disallowAnonymousApplications' => true,
     ],
 
     /**

--- a/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
+++ b/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
@@ -36,6 +36,7 @@ class EndpointAuthorize extends BaseAuthorize
      * {@inheritDoc}
      */
     protected $_defaultConfig = [
+        'disallowAnonymousApplications' => false,
         'apiKeyHeaderName' => 'X-Api-Key',
     ];
 
@@ -103,10 +104,13 @@ class EndpointAuthorize extends BaseAuthorize
     {
         $application = CurrentApplication::getApplication();
         if ($application === null) {
+            $header = $this->request->getHeaderLine($this->_config['apiKeyHeaderName']);
+            if (empty($header) && empty($this->_config['disallowAnonymousApplications'])) {
+                return null;
+            }
+
             try {
-                CurrentApplication::setFromApiKey(
-                    $this->request->getHeaderLine($this->_config['apiKeyHeaderName'])
-                );
+                CurrentApplication::setFromApiKey($header);
             } catch (\BadMethodCallException $e) {
                 throw new ForbiddenException(__d('bedita', 'Missing API key'));
             } catch (RecordNotFoundException $e) {
@@ -153,15 +157,15 @@ class EndpointAuthorize extends BaseAuthorize
      * Get list of applicable permissions.
      *
      * @param mixed $user Authenticated (or anonymous) user.
-     * @param \BEdita\Core\Model\Entity\Application $application Current application.
+     * @param \BEdita\Core\Model\Entity\Application|null $application Current application.
      * @param \BEdita\Core\Model\Entity\Endpoint|null $endpoint Current endpoint.
      * @return \Cake\ORM\Query
      * @todo Future optimization: Permissions that are `0` on the two bits that are interesting for the current request can be excluded...
      */
-    protected function getPermissions($user, Application $application, Endpoint $endpoint = null)
+    protected function getPermissions($user, Application $application = null, Endpoint $endpoint = null)
     {
         $roleIds = Hash::extract($user, 'roles.{n}.id');
-        $applicationId = $application->id;
+        $applicationId = $application ? $application->id : null;
         $endpointIds = $endpoint ? [$endpoint->id] : [];
 
         return TableRegistry::get('EndpointPermissions')
@@ -178,12 +182,20 @@ class EndpointAuthorize extends BaseAuthorize
      */
     protected function checkPermissions(array $permissions)
     {
+        $result = EndpointPermission::PERM_NO;
+        if (empty($permissions)) {
+            $count = TableRegistry::get('EndpointPermissions')->find()->count();
+            if ($count === 0) {
+                $result = EndpointPermission::PERM_YES;
+            }
+            return EndpointPermission::decode($result);
+        }
+
         $shift = EndpointPermission::PERM_READ;
         if (!$this->request->is(['get', 'head'])) {
             $shift = EndpointPermission::PERM_WRITE;
         }
 
-        $result = EndpointPermission::PERM_NO;
         foreach ($permissions as $permission) {
             $permission = $permission->permission >> $shift & EndpointPermission::PERM_YES;
             $result = $result | $permission;

--- a/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
+++ b/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
@@ -76,7 +76,8 @@ class EndpointAuthorize extends BaseAuthorize
         $application = $this->getApplication();
         $endpoint = $this->getEndpoint();
         $permissions = $this->getPermissions($user, $application, $endpoint)->toArray();
-        if (empty($permissions) && (!$endpoint || $this->getPermissions(false, $application, $endpoint)->count() === 0)) {
+        $allPermissions = $this->getPermissions(false, $application, $endpoint);
+        if (empty($permissions) && (!$endpoint || $allPermissions->count() === 0)) {
             $this->authorized = true;
 
             return $this->authorized;

--- a/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
+++ b/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
@@ -188,6 +188,7 @@ class EndpointAuthorize extends BaseAuthorize
             if ($count === 0) {
                 $result = EndpointPermission::PERM_YES;
             }
+
             return EndpointPermission::decode($result);
         }
 

--- a/plugins/BEdita/API/src/Controller/AppController.php
+++ b/plugins/BEdita/API/src/Controller/AppController.php
@@ -72,7 +72,7 @@ class AppController extends Controller
             'authenticate' => ['BEdita/API.Jwt', 'BEdita/API.Anonymous'],
             'authorize' => [
                 'BEdita/API.Endpoint' => [
-                    'disallowAnonymousApplications' => Configure::read('disallowAnonymousApplications'),
+                    'disallowAnonymousApplications' => Configure::read('Security.disallowAnonymousApplications'),
                 ],
             ],
             'loginAction' => ['_name' => 'api:login'],

--- a/plugins/BEdita/API/src/Controller/AppController.php
+++ b/plugins/BEdita/API/src/Controller/AppController.php
@@ -70,7 +70,11 @@ class AppController extends Controller
 
         $this->loadComponent('Auth', [
             'authenticate' => ['BEdita/API.Jwt', 'BEdita/API.Anonymous'],
-            'authorize' => ['BEdita/API.Endpoint'],
+            'authorize' => [
+                'BEdita/API.Endpoint' => [
+                    'disallowAnonymousApplications' => Configure::read('disallowAnonymousApplications'),
+                ],
+            ],
             'loginAction' => ['_name' => 'api:login'],
             'loginRedirect' => ['_name' => 'api:login'],
             'unauthorizedRedirect' => false,

--- a/plugins/BEdita/API/tests/TestCase/Auth/EndpointAuthorizeTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/EndpointAuthorizeTest.php
@@ -273,11 +273,57 @@ class EndpointAuthorizeTest extends IntegrationTestCase
      */
     public function testAllowByDefault()
     {
-        TableRegistry::get('EndpointPermissions')->deleteAll([]);
+        // Ensure no permissions apply to `/home` endpoint.
+        TableRegistry::get('EndpointPermissions')->deleteAll(['role_id IS' => null]);
+        TableRegistry::get('EndpointPermissions')->deleteAll(['role_id' => 2]);
 
         $environment = [
             'REQUEST_METHOD' => 'POST',
         ];
+        $uri = new Uri('/home');
+        $request = new ServerRequest(compact('environment', 'uri'));
+
+        $controller = new Controller();
+        $controller->loadComponent('Auth', [
+            'authenticate' => ['BEdita/API.Jwt', 'BEdita/API.Anonymous'],
+            'authorize' => ['BEdita/API.Endpoint'],
+        ]);
+        $authorize = $controller->Auth->getAuthorize('BEdita/API.Endpoint');
+
+        if (!($authorize instanceof EndpointAuthorize)) {
+            static::fail('Unexpected authorization object');
+        }
+
+        $result = $authorize->authorize(
+            [
+                '_anonymous' => true,
+            ],
+            $request
+        );
+
+        static::assertTrue($result);
+        static::assertAttributeSame(true, 'authorized', $authorize);
+    }
+
+    /**
+     * Test default permissive behavior on an unknown endpoint.
+     *
+     * @return void
+     *
+     * @covers ::authorize()
+     * @covers ::getPermissions()
+     * @covers ::checkPermissions()
+     */
+    public function testAllowByDefaultUnknownEndpoint()
+    {
+        // Ensure no permissions apply to anonymous user.
+        TableRegistry::get('EndpointPermissions')->deleteAll(['role_id IS' => null]);
+
+        $environment = [
+            'REQUEST_METHOD' => 'POST',
+            'HTTP_X_API_KEY' => API_KEY,
+        ];
+        $uri = new Uri('/this/endpoint/definitely/doesnt/exist');
         $request = new ServerRequest(compact('environment', 'uri'));
 
         $controller = new Controller();

--- a/plugins/BEdita/API/tests/TestCase/Auth/EndpointAuthorizeTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/EndpointAuthorizeTest.php
@@ -275,7 +275,7 @@ class EndpointAuthorizeTest extends IntegrationTestCase
     {
         // Ensure no permissions apply to `/home` endpoint.
         TableRegistry::get('EndpointPermissions')->deleteAll(['role_id IS' => null]);
-        TableRegistry::get('EndpointPermissions')->deleteAll(['role_id' => 2]);
+        TableRegistry::get('EndpointPermissions')->deleteAll(['endpoint_id' => 2]);
 
         $environment = [
             'REQUEST_METHOD' => 'POST',


### PR DESCRIPTION
This PR refactors recently introduced endpoint permissions in two ways:

- anonymous applications are now allowed by default. Requests that do not have an API key are treated as anonymous application. This behavior can be disabled through a configuration key that has been introduced and documented in `config/app.default.php`.
- if the table `endpoint_permissions` is completely empty, it is assumed that full permissions are allowed to anyone anywhere.