### PR TITLE
List related objects

### DIFF
--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -214,6 +214,11 @@ Router::plugin(
 
         // Objects.
         $routes->connect(
+            '/:object_type/:related_id/:relationship',
+            ['controller' => 'Objects', 'action' => 'index'],
+            ['_name' => 'objects:related']
+        );
+        $routes->connect(
             '/:object_type',
             ['controller' => 'Objects', 'action' => 'index', '_method' => 'GET'],
             ['_name' => 'objects:index']

--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -11,9 +11,9 @@
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
 
-use Cake\Routing\Route\InflectedRoute;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
+use Cake\Routing\Route\InflectedRoute;
 
 Router::plugin(
     'BEdita/API',

--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -11,6 +11,7 @@
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
 
+use Cake\Routing\Route\InflectedRoute;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
 
@@ -21,6 +22,8 @@ Router::plugin(
         '_namePrefix' => 'api:',
     ],
     function (RouteBuilder $routes) {
+        $routes->routeClass(InflectedRoute::class);
+
         // Home.
         $routes->redirect(
             '/',
@@ -40,16 +43,11 @@ Router::plugin(
             ['_name' => 'status']
         );
 
-        // Roles and Users rules that must be on top
+        // Link to related resources.
         $routes->connect(
-            '/users/:user_id/roles',
-            ['controller' => 'Roles', 'action' => 'index', '_method' => 'GET'],
-            ['_name' => 'users:roles']
-        );
-        $routes->connect(
-            '/roles/:role_id/users',
-            ['controller' => 'Users', 'action' => 'index', '_method' => 'GET'],
-            ['_name' => 'roles:users']
+            '/:relationship/:related_id/:controller',
+            ['action' => 'related', '_method' => 'GET'],
+            ['_name' => 'related']
         );
 
         // Roles.
@@ -84,18 +82,6 @@ Router::plugin(
             ['_name' => 'roles:relationships']
         );
 
-
-        // Object Types and Properties rules that must be on top
-        $routes->connect(
-            '/object_types/:object_type_id/properties',
-            ['controller' => 'Properties', 'action' => 'index', '_method' => 'GET'],
-            ['_name' => 'object_types:properties']
-        );
-        $routes->connect(
-            '/properties/:property_id/object_types',
-            ['controller' => 'ObjectTypes', 'action' => 'index', '_method' => 'GET'],
-            ['_name' => 'properties:object_types']
-        );
         // Object Types.
         $routes->connect(
             '/object_types',
@@ -122,12 +108,12 @@ Router::plugin(
             ['controller' => 'ObjectTypes', 'action' => 'delete', '_method' => 'DELETE'],
             ['_name' => 'object_types:delete', 'pass' => ['id']]
         );
-
         $routes->connect(
             '/object_types/:id/relationships/:relationship',
             ['controller' => 'ObjectTypes', 'action' => 'relationships'],
             ['_name' => 'object_types:relationships']
         );
+
         // Properties.
         $routes->connect(
             '/properties',
@@ -159,8 +145,6 @@ Router::plugin(
             ['controller' => 'Properties', 'action' => 'relationships'],
             ['_name' => 'properties:relationships']
         );
-
-
 
         // Users.
         $routes->connect(

--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -47,7 +47,7 @@ Router::plugin(
         $routes->connect(
             '/:relationship/:related_id/:controller',
             ['action' => 'related', '_method' => 'GET'],
-            ['_name' => 'related']
+            ['_name' => 'resources:related']
         );
 
         // Roles.

--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -47,7 +47,7 @@ Router::plugin(
         $routes->connect(
             '/:relationship/:related_id/:controller',
             ['action' => 'related', '_method' => 'GET'],
-            ['_name' => 'resources:related']
+            ['_name' => 'resources:related', 'controller' => 'object_types|properties|roles|users']
         );
 
         // Roles.
@@ -215,7 +215,7 @@ Router::plugin(
         // Objects.
         $routes->connect(
             '/:object_type/:related_id/:relationship',
-            ['controller' => 'Objects', 'action' => 'index'],
+            ['controller' => 'Objects', 'action' => 'related'],
             ['_name' => 'objects:related']
         );
         $routes->connect(

--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -59,9 +59,9 @@ Router::plugin(
             ['_name' => 'roles:index']
         );
         $routes->connect(
-            '/roles/*',
+            '/roles/:id',
             ['controller' => 'Roles', 'action' => 'view', '_method' => 'GET'],
-            ['_name' => 'roles:view']
+            ['_name' => 'roles:view', 'pass' => ['id']]
         );
         $routes->connect(
             '/roles',
@@ -69,14 +69,14 @@ Router::plugin(
             ['_name' => 'roles:add']
         );
         $routes->connect(
-            '/roles/*',
+            '/roles/:id',
             ['controller' => 'Roles', 'action' => 'edit', '_method' => 'PATCH'],
-            ['_name' => 'roles:edit']
+            ['_name' => 'roles:edit', 'pass' => ['id']]
         );
         $routes->connect(
-            '/roles/*',
+            '/roles/:id',
             ['controller' => 'Roles', 'action' => 'delete', '_method' => 'DELETE'],
-            ['_name' => 'roles:delete']
+            ['_name' => 'roles:delete', 'pass' => ['id']]
         );
         $routes->connect(
             '/roles/:id/relationships/:relationship',
@@ -103,9 +103,9 @@ Router::plugin(
             ['_name' => 'object_types:index']
         );
         $routes->connect(
-            '/object_types/*',
+            '/object_types/:id',
             ['controller' => 'ObjectTypes', 'action' => 'view', '_method' => 'GET'],
-            ['_name' => 'object_types:view']
+            ['_name' => 'object_types:view', 'pass' => ['id']]
         );
         $routes->connect(
             '/object_types',
@@ -113,14 +113,14 @@ Router::plugin(
             ['_name' => 'object_types:add']
         );
         $routes->connect(
-            '/object_types/*',
+            '/object_types/:id',
             ['controller' => 'ObjectTypes', 'action' => 'edit', '_method' => 'PATCH'],
-            ['_name' => 'object_types:edit']
+            ['_name' => 'object_types:edit', 'pass' => ['id']]
         );
         $routes->connect(
-            '/object_types/*',
+            '/object_types/:id',
             ['controller' => 'ObjectTypes', 'action' => 'delete', '_method' => 'DELETE'],
-            ['_name' => 'object_types:delete']
+            ['_name' => 'object_types:delete', 'pass' => ['id']]
         );
 
         $routes->connect(
@@ -135,9 +135,9 @@ Router::plugin(
             ['_name' => 'properties:index']
         );
         $routes->connect(
-            '/properties/*',
+            '/properties/:id',
             ['controller' => 'Properties', 'action' => 'view', '_method' => 'GET'],
-            ['_name' => 'properties:view']
+            ['_name' => 'properties:view', 'pass' => ['id']]
         );
         $routes->connect(
             '/properties',
@@ -145,14 +145,14 @@ Router::plugin(
             ['_name' => 'properties:add']
         );
         $routes->connect(
-            '/properties/*',
+            '/properties/:id',
             ['controller' => 'Properties', 'action' => 'edit', '_method' => 'PATCH'],
-            ['_name' => 'properties:edit']
+            ['_name' => 'properties:edit', 'pass' => ['id']]
         );
         $routes->connect(
-            '/properties/*',
+            '/properties/:id',
             ['controller' => 'Properties', 'action' => 'delete', '_method' => 'DELETE'],
-            ['_name' => 'properties:delete']
+            ['_name' => 'properties:delete', 'pass' => ['id']]
         );
         $routes->connect(
             '/properties/:id/relationships/:relationship',
@@ -169,9 +169,9 @@ Router::plugin(
             ['_name' => 'users:index']
         );
         $routes->connect(
-            '/users/*',
+            '/users/:id',
             ['controller' => 'Users', 'action' => 'view', '_method' => 'GET'],
-            ['_name' => 'users:view']
+            ['_name' => 'users:view', 'pass' => ['id']]
         );
         $routes->connect(
             '/users',
@@ -179,14 +179,14 @@ Router::plugin(
             ['_name' => 'users:add']
         );
         $routes->connect(
-            '/users/*',
+            '/users/:id',
             ['controller' => 'Users', 'action' => 'edit', '_method' => 'PATCH'],
-            ['_name' => 'users:edit']
+            ['_name' => 'users:edit', 'pass' => ['id']]
         );
         $routes->connect(
-            '/users/*',
+            '/users/:id',
             ['controller' => 'Users', 'action' => 'delete', '_method' => 'DELETE'],
-            ['_name' => 'users:delete']
+            ['_name' => 'users:delete', 'pass' => ['id']]
         );
         $routes->connect(
             '/users/:id/relationships/:relationship',
@@ -213,19 +213,19 @@ Router::plugin(
             ['_name' => 'trash:index']
         );
         $routes->connect(
-            '/trash/*',
+            '/trash/:id',
             ['controller' => 'Trash', 'action' => 'view', '_method' => 'GET'],
-            ['_name' => 'trash:view']
+            ['_name' => 'trash:view', 'pass' => ['id']]
         );
         $routes->connect(
-            '/trash/*',
+            '/trash/:id',
             ['controller' => 'Trash', 'action' => 'restore', '_method' => 'PATCH'],
-            ['_name' => 'trash:restore']
+            ['_name' => 'trash:restore', 'pass' => ['id']]
         );
         $routes->connect(
-            '/trash/*',
+            '/trash/:id',
             ['controller' => 'Trash', 'action' => 'delete', '_method' => 'DELETE'],
-            ['_name' => 'trash:delete']
+            ['_name' => 'trash:delete', 'pass' => ['id']]
         );
 
         // Objects.
@@ -235,9 +235,9 @@ Router::plugin(
             ['_name' => 'objects:index']
         );
         $routes->connect(
-            '/:object_type/*',
+            '/:object_type/:id',
             ['controller' => 'Objects', 'action' => 'view', '_method' => 'GET'],
-            ['_name' => 'objects:view']
+            ['_name' => 'objects:view', 'pass' => ['id']]
         );
         $routes->connect(
             '/:object_type',
@@ -245,14 +245,14 @@ Router::plugin(
             ['_name' => 'objects:add']
         );
         $routes->connect(
-            '/:object_type/*',
+            '/:object_type/:id',
             ['controller' => 'Objects', 'action' => 'edit', '_method' => 'PATCH'],
-            ['_name' => 'objects:edit']
+            ['_name' => 'objects:edit', 'pass' => ['id']]
         );
         $routes->connect(
-            '/:object_type/*',
+            '/:object_type/:id',
             ['controller' => 'Objects', 'action' => 'delete', '_method' => 'DELETE'],
-            ['_name' => 'objects:delete']
+            ['_name' => 'objects:delete', 'pass' => ['id']]
         );
         $routes->connect(
             '/:object_type/:id/relationships/:relationship',

--- a/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
@@ -123,7 +123,7 @@ class JsonApiComponent extends Component
      */
     public function getLinks()
     {
-        $request = $this->getController()->request;
+        $request = $this->getController()->request->withParam('pass', []);
         $links = [
             'self' => Router::reverse($request, true),
             'home' => Router::url(['_name' => 'api:home'], true),

--- a/plugins/BEdita/API/src/Controller/ObjectTypesController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectTypesController.php
@@ -61,6 +61,18 @@ class ObjectTypesController extends ResourcesController
     {
         $query = $this->ObjectTypes->find('all');
 
+        $relatedId = $this->request->getParam('related_id');
+        if ($relatedId !== false) {
+            $relationship = $this->request->getParam('relationship');
+            $Association = $this->findAssociation($relationship);
+            $query = $query->innerJoinWith(
+                $Association->getName(),
+                function (Query $query) use ($Association, $relatedId) {
+                    return $query->where([$Association->aliasField('id') => $relatedId]);
+                }
+            );
+        }
+
         $objectTypes = $this->paginate($query);
 
         $this->set(compact('objectTypes'));

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -12,11 +12,13 @@
  */
 namespace BEdita\API\Controller;
 
+use BEdita\Core\Model\Action\ListRelatedObjects;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Network\Exception\BadRequestException;
 use Cake\Network\Exception\ConflictException;
 use Cake\Network\Exception\InternalErrorException;
 use Cake\Network\Exception\NotFoundException;
+use Cake\Network\Exception\NotImplementedException;
 use Cake\ORM\TableRegistry;
 use Cake\Routing\Router;
 
@@ -210,5 +212,39 @@ class ObjectsController extends AppController
         return $this->response
             ->withHeader('Content-Type', $this->request->contentType())
             ->withStatus(204);
+    }
+
+    /**
+     * View and manage relationships.
+     *
+     * @return \Cake\Network\Response|null
+     */
+    public function relationships()
+    {
+        $this->request->allowMethod(['get', 'post', 'patch', 'delete']);
+
+        $id = $this->request->getParam('id');
+        $relationship = $this->request->getParam('relationship');
+
+        switch ($this->request->getMethod()) {
+            case 'PATCH':
+            case 'POST':
+            case 'DELETE':
+                throw new NotImplementedException(__d('bedita', 'Not yet implemented'));
+
+            case 'GET':
+            default:
+                $action = new ListRelatedObjects($this->Objects, $relationship);
+                $data = $action($id);
+
+                $data = $this->paginate($data);
+
+                $this->set(compact('data'));
+                $this->set([
+                    '_serialize' => ['data'],
+                ]);
+
+                return null;
+        }
     }
 }

--- a/plugins/BEdita/API/src/Controller/PropertiesController.php
+++ b/plugins/BEdita/API/src/Controller/PropertiesController.php
@@ -63,17 +63,22 @@ class PropertiesController extends ResourcesController
     {
         $query = $this->Properties->find('all');
 
-        $objectTypeId = $this->request->getParam('object_type_id');
-        if ($objectTypeId !== false) {
-            $query = $query->innerJoinWith('ObjectTypes', function (Query $query) use ($objectTypeId) {
-                return $query->where(['ObjectTypes.id' => $objectTypeId]);
-            });
+        $relatedId = $this->request->getParam('related_id');
+        if ($relatedId !== false) {
+            $relationship = $this->request->getParam('relationship');
+            $Association = $this->findAssociation($relationship);
+            $query = $query->innerJoinWith(
+                $Association->getName(),
+                function (Query $query) use ($Association, $relatedId) {
+                    return $query->where([$Association->aliasField('id') => $relatedId]);
+                }
+            );
         }
 
-        $Properties = $this->paginate($query);
+        $properties = $this->paginate($query);
 
-        $this->set(compact('Properties'));
-        $this->set('_serialize', ['Properties']);
+        $this->set(compact('properties'));
+        $this->set('_serialize', ['properties']);
     }
 
     /**

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -66,6 +66,26 @@ abstract class ResourcesController extends AppController
     }
 
     /**
+     * Paginated list of resources.
+     *
+     * @return void
+     */
+    public abstract function index();
+
+    /**
+     * Paginated list of related resources.
+     *
+     * This method is an alias of {@see self::index()}. However, this is required because of how routes
+     * are matched by Cake.
+     *
+     * @return void
+     */
+    public function related()
+    {
+        $this->index();
+    }
+
+    /**
      * Find the association corresponding to the relationship name.
      *
      * @param string $relationship Relationship name.

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -70,7 +70,7 @@ abstract class ResourcesController extends AppController
      *
      * @return void
      */
-    public abstract function index();
+    abstract public function index();
 
     /**
      * Paginated list of related resources.

--- a/plugins/BEdita/API/src/Controller/RolesController.php
+++ b/plugins/BEdita/API/src/Controller/RolesController.php
@@ -63,11 +63,16 @@ class RolesController extends ResourcesController
     {
         $query = $this->Roles->find('all');
 
-        $userId = $this->request->getParam('user_id');
-        if ($userId !== false) {
-            $query = $query->innerJoinWith('Users', function (Query $query) use ($userId) {
-                return $query->where(['Users.id' => $userId]);
-            });
+        $relatedId = $this->request->getParam('related_id');
+        if ($relatedId !== false) {
+            $relationship = $this->request->getParam('relationship');
+            $Association = $this->findAssociation($relationship);
+            $query = $query->innerJoinWith(
+                $Association->getName(),
+                function (Query $query) use ($Association, $relatedId) {
+                    return $query->where([$Association->aliasField('id') => $relatedId]);
+                }
+            );
         }
 
         $roles = $this->paginate($query);

--- a/plugins/BEdita/API/src/Controller/UsersController.php
+++ b/plugins/BEdita/API/src/Controller/UsersController.php
@@ -62,11 +62,16 @@ class UsersController extends ResourcesController
     {
         $query = $this->Users->find('all')->where(['deleted' => 0]);
 
-        $roleId = $this->request->getParam('role_id');
-        if ($roleId !== false) {
-            $query = $query->innerJoinWith('Roles', function (Query $query) use ($roleId) {
-                return $query->where(['Roles.id' => $roleId]);
-            });
+        $relatedId = $this->request->getParam('related_id');
+        if ($relatedId !== false) {
+            $relationship = $this->request->getParam('relationship');
+            $Association = $this->findAssociation($relationship);
+            $query = $query->innerJoinWith(
+                $Association->getName(),
+                function (Query $query) use ($Association, $relatedId) {
+                    return $query->where([$Association->aliasField('id') => $relatedId]);
+                }
+            );
         }
 
         $users = $this->paginate($query);

--- a/plugins/BEdita/API/src/Utility/JsonApi.php
+++ b/plugins/BEdita/API/src/Utility/JsonApi.php
@@ -160,6 +160,7 @@ class JsonApi
             $relationships[$name] = [
                 'links' => compact('related', 'self'),
             ];
+            unset($related, $self);
         }
 
         return $relationships;

--- a/plugins/BEdita/API/src/Utility/JsonApi.php
+++ b/plugins/BEdita/API/src/Utility/JsonApi.php
@@ -151,7 +151,7 @@ class JsonApi
                 try {
                     $options = [
                         '_name' => sprintf('api:%s:related', $endpoint),
-                        'controller' => $endpoint,
+                        'object_type' => $type,
                         'related_id' => $entity->id,
                         'relationship' => $name,
                     ];

--- a/plugins/BEdita/API/src/Utility/JsonApi.php
+++ b/plugins/BEdita/API/src/Utility/JsonApi.php
@@ -13,15 +13,11 @@
 namespace BEdita\API\Utility;
 
 use Cake\Collection\CollectionInterface;
-use Cake\ORM\Association;
-use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
-use Cake\ORM\TableRegistry;
 use Cake\Routing\Exception\MissingRouteException;
 use Cake\Routing\Router;
 use Cake\Utility\Hash;
-use Cake\Utility\Inflector;
 
 /**
  * JSON API formatter API.

--- a/plugins/BEdita/API/src/Utility/JsonApi.php
+++ b/plugins/BEdita/API/src/Utility/JsonApi.php
@@ -140,10 +140,10 @@ class JsonApi
 
             try {
                 $options = [
-                    '_name' => 'api:related',
+                    '_name' => 'api:resources:related',
                     'controller' => $name,
                     'related_id' => $entity->id,
-                    'relationship' => $endpoint,
+                    'relationship' => $type,
                 ];
 
                 $related = Router::url($options, true);

--- a/plugins/BEdita/API/src/Utility/JsonApi.php
+++ b/plugins/BEdita/API/src/Utility/JsonApi.php
@@ -219,7 +219,7 @@ class JsonApi
                 $options['object_type'] = $type;
             }
             $links = [
-                'self' => Router::url($options + ['_name' => sprintf('api:%s:view', $endpoint), $id], true),
+                'self' => Router::url($options + ['_name' => sprintf('api:%s:view', $endpoint), 'id' => $id], true),
             ];
         }
 

--- a/plugins/BEdita/API/src/Utility/JsonApi.php
+++ b/plugins/BEdita/API/src/Utility/JsonApi.php
@@ -118,7 +118,6 @@ class JsonApi
     protected static function extractRelationships(Entity $entity, $endpoint, $type = null, $options = [])
     {
         $associations = (array)$entity->get('relationships') ?: [];
-        $relatedParam = sprintf('%s_id', Inflector::singularize($endpoint));
 
         if (!empty($options['allowedAssociations'])) {
             $associations = array_intersect(
@@ -145,8 +144,10 @@ class JsonApi
 
             try {
                 $options = [
-                    '_name' => sprintf('api:%s:%s', $endpoint, $name),
-                    $relatedParam => $entity->id,
+                    '_name' => 'api:related',
+                    'controller' => $name,
+                    'related_id' => $entity->id,
+                    'relationship' => $endpoint,
                 ];
 
                 $related = Router::url($options, true);

--- a/plugins/BEdita/API/src/Utility/JsonApi.php
+++ b/plugins/BEdita/API/src/Utility/JsonApi.php
@@ -148,6 +148,17 @@ class JsonApi
 
                 $related = Router::url($options, true);
             } catch (MissingRouteException $e) {
+                try {
+                    $options = [
+                        '_name' => sprintf('api:%s:related', $endpoint),
+                        'controller' => $endpoint,
+                        'related_id' => $entity->id,
+                        'relationship' => $name,
+                    ];
+
+                    $related = Router::url($options, true);
+                } catch (MissingRouteException $e) {
+                }
             }
 
             if (empty($self) && empty($related)) {

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
@@ -37,7 +37,11 @@ class JsonApiComponentTest extends TestCase
         'plugin.BEdita/Core.object_types',
         'plugin.BEdita/Core.relations',
         'plugin.BEdita/Core.relation_types',
+        'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.profiles',
+        'plugin.BEdita/Core.users',
         'plugin.BEdita/Core.roles',
+        'plugin.BEdita/Core.roles_users',
     ];
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -36,7 +36,9 @@ class ObjectsControllerTest extends IntegrationTestCase
         'plugin.BEdita/Core.applications',
         'plugin.BEdita/Core.endpoint_permissions',
         'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.locations',
         'plugin.BEdita/Core.profiles',
+        'plugin.BEdita/Core.users',
         'plugin.BEdita/Core.object_relations',
     ];
 
@@ -102,6 +104,14 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'links' => [
                         'self' => 'http://api.example.com/users/1',
                     ],
+                    'relationships' => [
+                        'roles' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/users/1/roles',
+                                'self' => 'http://api.example.com/users/1/relationships/roles',
+                            ],
+                        ],
+                    ],
                 ],
                 [
                     'id' => '2',
@@ -129,6 +139,20 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'links' => [
                         'self' => 'http://api.example.com/documents/2',
                     ],
+                    'relationships' => [
+                        'test' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/documents/2/test',
+                                'self' => 'http://api.example.com/documents/2/relationships/test',
+                            ],
+                        ],
+                        'inverse_test' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/documents/2/inverse_test',
+                                'self' => 'http://api.example.com/documents/2/relationships/inverse_test',
+                            ],
+                        ],
+                    ],
                 ],
                 [
                     'id' => '3',
@@ -152,6 +176,20 @@ class ObjectsControllerTest extends IntegrationTestCase
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/documents/3',
+                    ],
+                    'relationships' => [
+                        'test' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/documents/3/test',
+                                'self' => 'http://api.example.com/documents/3/relationships/test',
+                            ],
+                        ],
+                        'inverse_test' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/documents/3/inverse_test',
+                                'self' => 'http://api.example.com/documents/3/relationships/inverse_test',
+                            ],
+                        ],
                     ],
                 ],
                 [
@@ -177,6 +215,14 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'links' => [
                         'self' => 'http://api.example.com/profiles/4',
                     ],
+                    'relationships' => [
+                        'inverse_test' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/profiles/4/inverse_test',
+                                'self' => 'http://api.example.com/profiles/4/relationships/inverse_test',
+                            ],
+                        ],
+                    ],
                 ],
                 [
                     'id' => '5',
@@ -200,6 +246,14 @@ class ObjectsControllerTest extends IntegrationTestCase
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/users/5',
+                    ],
+                    'relationships' => [
+                        'roles' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/users/5/roles',
+                                'self' => 'http://api.example.com/users/5/relationships/roles',
+                            ],
+                        ],
                     ],
                 ],
                 [
@@ -328,6 +382,20 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'publish_start' => '2016-05-13T07:09:23+00:00',
                     'publish_end' => '2016-05-13T07:09:23+00:00',
                 ],
+                'relationships' => [
+                    'test' => [
+                        'links' => [
+                            'related' => 'http://api.example.com/documents/3/test',
+                            'self' => 'http://api.example.com/documents/3/relationships/test',
+                        ],
+                    ],
+                    'inverse_test' => [
+                        'links' => [
+                            'related' => 'http://api.example.com/documents/3/inverse_test',
+                            'self' => 'http://api.example.com/documents/3/relationships/inverse_test',
+                        ],
+                    ],
+                ],
             ],
         ];
 
@@ -380,6 +448,20 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'modified_by' => 1,
                     'publish_start' => '2016-10-13T07:09:23+00:00',
                     'publish_end' => '2016-10-13T07:09:23+00:00'
+                ],
+                'relationships' => [
+                    'test' => [
+                        'links' => [
+                            'related' => 'http://api.example.com/documents/3/test',
+                            'self' => 'http://api.example.com/documents/3/relationships/test',
+                        ],
+                    ],
+                    'inverse_test' => [
+                        'links' => [
+                            'related' => 'http://api.example.com/documents/3/inverse_test',
+                            'self' => 'http://api.example.com/documents/3/relationships/inverse_test',
+                        ],
+                    ],
                 ],
             ],
         ];

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -385,14 +385,14 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'relationships' => [
                     'test' => [
                         'links' => [
-                            'related' => 'http://api.example.com/documents/3/test',
-                            'self' => 'http://api.example.com/documents/3/relationships/test',
+                            'related' => 'http://api.example.com/documents/2/test',
+                            'self' => 'http://api.example.com/documents/2/relationships/test',
                         ],
                     ],
                     'inverse_test' => [
                         'links' => [
-                            'related' => 'http://api.example.com/documents/3/inverse_test',
-                            'self' => 'http://api.example.com/documents/3/relationships/inverse_test',
+                            'related' => 'http://api.example.com/documents/2/inverse_test',
+                            'self' => 'http://api.example.com/documents/2/relationships/inverse_test',
                         ],
                     ],
                 ],
@@ -452,14 +452,14 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'relationships' => [
                     'test' => [
                         'links' => [
-                            'related' => 'http://api.example.com/documents/3/test',
-                            'self' => 'http://api.example.com/documents/3/relationships/test',
+                            'related' => 'http://api.example.com/documents/6/test',
+                            'self' => 'http://api.example.com/documents/6/relationships/test',
                         ],
                     ],
                     'inverse_test' => [
                         'links' => [
-                            'related' => 'http://api.example.com/documents/3/inverse_test',
-                            'self' => 'http://api.example.com/documents/3/relationships/inverse_test',
+                            'related' => 'http://api.example.com/documents/6/inverse_test',
+                            'self' => 'http://api.example.com/documents/6/relationships/inverse_test',
                         ],
                     ],
                 ],

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -799,7 +799,6 @@ class ObjectsControllerTest extends IntegrationTestCase
      *
      * @covers ::initialize()
      * @covers ::relationships()
-     * @covers ::findAssociation()
      */
     public function testListAssociations()
     {
@@ -882,7 +881,6 @@ class ObjectsControllerTest extends IntegrationTestCase
      *
      * @covers ::initialize()
      * @covers ::relationships()
-     * @covers ::findAssociation()
      */
     public function testListAssociationsNotFound()
     {

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -793,12 +793,130 @@ class ObjectsControllerTest extends IntegrationTestCase
     }
 
     /**
+     * Test related method to list related objects.
+     *
+     * @return void
+     *
+     * @covers ::initialize()
+     * @covers ::related()
+     * @covers ::findAssociation()
+     */
+    public function testRelated()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/documents/2/test',
+                'home' => 'http://api.example.com/home',
+                'first' => 'http://api.example.com/documents/2/test',
+                'last' => 'http://api.example.com/documents/2/test',
+                'prev' => null,
+                'next' => null,
+            ],
+            'data' => [
+                [
+                    'id' => '4',
+                    'type' => 'profiles',
+                    'attributes' => [
+                        'status' => 'on',
+                        'uname' => 'gustavo-supporto',
+                        'locked' => false,
+                        'created' => '2016-05-13T07:09:23+00:00',
+                        'modified' => '2016-05-13T07:09:23+00:00',
+                        'published' => null,
+                        'title' => 'Gustavo Supporto profile',
+                        'description' => 'Some description about Gustavo',
+                        'lang' => 'eng',
+                        'created_by' => 1,
+                        'modified_by' => 1,
+                        'body' => null,
+                        'extra' => null,
+                        'publish_start' => null,
+                        'publish_end' => null
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/profiles/4',
+                    ],
+                    'relationships' => [
+                        'inverse_test' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/profiles/4/inverse_test',
+                                'self' => 'http://api.example.com/profiles/4/relationships/inverse_test',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'id' => '3',
+                    'type' => 'documents',
+                    'attributes' => [
+                        'status' => 'draft',
+                        'uname' => 'title-two',
+                        'locked' => false,
+                        'created' => '2016-05-12T07:09:23+00:00',
+                        'modified' => '2016-05-13T08:30:00+00:00',
+                        'published' => null,
+                        'title' => 'title two',
+                        'description' => 'description here',
+                        'body' => 'body here',
+                        'extra' => null,
+                        'lang' => 'eng',
+                        'created_by' => 1,
+                        'modified_by' => 2,
+                        'publish_start' => null,
+                        'publish_end' => null
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/documents/3',
+                    ],
+                    'relationships' => [
+                        'test' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/documents/3/test',
+                                'self' => 'http://api.example.com/documents/3/relationships/test',
+                            ],
+                        ],
+                        'inverse_test' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/documents/3/inverse_test',
+                                'self' => 'http://api.example.com/documents/3/relationships/inverse_test',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'meta' => [
+                'pagination' => [
+                    'count' => 2,
+                    'page' => 1,
+                    'page_count' => 1,
+                    'page_items' => 2,
+                    'page_size' => 20,
+                ],
+            ],
+        ];
+
+        $this->configRequest([
+            'headers' => [
+                'Host' => 'api.example.com',
+                'Accept' => 'application/vnd.api+json',
+            ],
+        ]);
+        $this->get('/documents/2/test');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * Test relationships method to list existing relationships.
      *
      * @return void
      *
      * @covers ::initialize()
      * @covers ::relationships()
+     * @covers ::findAssociation()
      */
     public function testListAssociations()
     {
@@ -881,6 +999,7 @@ class ObjectsControllerTest extends IntegrationTestCase
      *
      * @covers ::initialize()
      * @covers ::relationships()
+     * @covers ::findAssociation()
      */
     public function testListAssociationsNotFound()
     {

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -36,6 +36,8 @@ class ObjectsControllerTest extends IntegrationTestCase
         'plugin.BEdita/Core.applications',
         'plugin.BEdita/Core.endpoint_permissions',
         'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.profiles',
+        'plugin.BEdita/Core.object_relations',
     ];
 
     /**
@@ -704,6 +706,112 @@ class ObjectsControllerTest extends IntegrationTestCase
             ],
         ]);
         $this->delete('/documents/4');
+        $this->assertResponseCode(404);
+        $this->assertContentType('application/vnd.api+json');
+    }
+
+    /**
+     * Test relationships method to list existing relationships.
+     *
+     * @return void
+     *
+     * @covers ::initialize()
+     * @covers ::relationships()
+     * @covers ::findAssociation()
+     */
+    public function testListAssociations()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/documents/2/relationships/test',
+                'home' => 'http://api.example.com/home',
+                'first' => 'http://api.example.com/documents/2/relationships/test',
+                'last' => 'http://api.example.com/documents/2/relationships/test',
+                'prev' => null,
+                'next' => null,
+            ],
+            'data' => [
+                [
+                    'id' => '4',
+                    'type' => 'profiles',
+                    'links' => [
+                        'self' => 'http://api.example.com/profiles/4',
+                    ],
+                    'relationships' => [
+                        'inverse_test' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/profiles/4/inverse_test',
+                                'self' => 'http://api.example.com/profiles/4/relationships/inverse_test',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'id' => '3',
+                    'type' => 'documents',
+                    'links' => [
+                        'self' => 'http://api.example.com/documents/3',
+                    ],
+                    'relationships' => [
+                        'test' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/documents/3/test',
+                                'self' => 'http://api.example.com/documents/3/relationships/test',
+                            ],
+                        ],
+                        'inverse_test' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/documents/3/inverse_test',
+                                'self' => 'http://api.example.com/documents/3/relationships/inverse_test',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'meta' => [
+                'pagination' => [
+                    'count' => 2,
+                    'page' => 1,
+                    'page_count' => 1,
+                    'page_items' => 2,
+                    'page_size' => 20,
+                ],
+            ],
+        ];
+
+        $this->configRequest([
+            'headers' => [
+                'Host' => 'api.example.com',
+                'Accept' => 'application/vnd.api+json',
+            ],
+        ]);
+        $this->get('/documents/2/relationships/test');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test relationships method to list existing relationships.
+     *
+     * @return void
+     *
+     * @covers ::initialize()
+     * @covers ::relationships()
+     * @covers ::findAssociation()
+     */
+    public function testListAssociationsNotFound()
+    {
+        $this->configRequest([
+            'headers' => [
+                'Host' => 'api.example.com',
+                'Accept' => 'application/vnd.api+json',
+            ],
+        ]);
+        $this->get('/documents/99/relationships/test');
+
         $this->assertResponseCode(404);
         $this->assertContentType('application/vnd.api+json');
     }

--- a/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
@@ -81,10 +81,10 @@ class ResourcesControllerTest extends IntegrationTestCase
                         'roles' => [
                             'links' => [
                                 'related' => 'http://api.example.com/users/1/roles',
-                                'self' => 'http://api.example.com/users/1/relationships/roles'
-                            ]
-                        ]
-                    ]
+                                'self' => 'http://api.example.com/users/1/relationships/roles',
+                            ],
+                        ],
+                    ],
                 ],
             ],
             'meta' => [

--- a/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
@@ -145,6 +145,7 @@ class RolesControllerTest extends IntegrationTestCase
      * @return void
      *
      * @covers ::index()
+     * @covers ::related()
      * @covers ::initialize()
      */
     public function testUserRoles()

--- a/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
@@ -211,6 +211,7 @@ class UsersControllerTest extends IntegrationTestCase
      * @return void
      *
      * @covers ::index()
+     * @covers ::related()
      * @covers ::initialize()
      */
     public function testIndexRoles()

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -39,7 +39,11 @@ class JsonApiTest extends TestCase
         'plugin.BEdita/Core.object_types',
         'plugin.BEdita/Core.relations',
         'plugin.BEdita/Core.relation_types',
+        'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.profiles',
+        'plugin.BEdita/Core.users',
         'plugin.BEdita/Core.roles',
+        'plugin.BEdita/Core.roles_users',
     ];
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -476,7 +476,7 @@ class JsonApiTest extends TestCase
 
         $result = JsonApi::formatData($items($this->Roles), $type);
 
-        $this->assertEquals($expected, $result);
+        static::assertEquals($expected, $result);
     }
 
     /**
@@ -499,6 +499,66 @@ class JsonApiTest extends TestCase
 
         $result = JsonApi::parseData($items);
 
-        $this->assertEquals($expected, $result);
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test generation of relationships links.
+     *
+     * @return void
+     *
+     * @covers ::formatData
+     * @covers ::formatItem
+     * @covers ::extractType
+     * @covers ::extractAttributes
+     * @covers ::extractRelationships
+     */
+    public function testFallbackLinks()
+    {
+        $expected = [
+            'id' => '2',
+            'type' => 'documents',
+            'attributes' => [
+                'status' => 'on',
+                'uname' => 'title-one',
+                'locked' => true,
+                'created' => '2016-05-13T07:09:23+00:00',
+                'modified' => '2016-05-13T07:09:23+00:00',
+                'published' => '2016-05-13T07:09:23+00:00',
+                'title' => 'title one',
+                'description' => 'description here',
+                'body' => 'body here',
+                'extra' => [
+                    'abstract' => 'abstract here',
+                    'list' => ['one', 'two', 'three'],
+                ],
+                'lang' => 'eng',
+                'created_by' => 1,
+                'modified_by' => 1,
+                'publish_start' => '2016-05-13T07:09:23+00:00',
+                'publish_end' => '2016-05-13T07:09:23+00:00',
+            ],
+            'relationships' => [
+                'test' => [
+                    'links' => [
+                        'related' => '/documents/2/test',
+                        'self' => '/documents/2/relationships/test',
+                    ],
+                ],
+                'inverse_test' => [
+                    'links' => [
+                        'related' => '/documents/2/inverse_test',
+                        'self' => '/documents/2/relationships/inverse_test',
+                    ],
+                ],
+            ],
+        ];
+
+        $result = JsonApi::formatData(
+            TableRegistry::get('Documents')->get(2),
+            'objects'
+        );
+
+        static::assertEquals($expected, $result);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedObjects.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedObjects.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Model\Action;
+
+use Cake\Network\Exception\NotFoundException;
+use Cake\ORM\Table;
+use Cake\Utility\Inflector;
+
+/**
+ * Command to list associated objects.
+ *
+ * @since 4.0.0
+ */
+class ListRelatedObjects
+{
+
+    /**
+     * Inner action.
+     *
+     * @var \BEdita\Core\Model\Action\ListAssociated
+     */
+    protected $Action;
+
+    /**
+     * Association.
+     *
+     * @var \Cake\ORM\Association\BelongsToMany
+     */
+    protected $Association;
+
+    /**
+     * Command constructor.
+     *
+     * @param \Cake\ORM\Table $Table Table object instance.
+     * @param string $relation Relation name.
+     */
+    public function __construct(Table $Table, $relation)
+    {
+        if (!$Table->hasBehavior('Relations')) {
+            throw new \InvalidArgumentException(
+                __d('bedita', 'Table "{0}" does not implement relations', $Table->getRegistryAlias())
+            );
+        }
+
+        $associationName = Inflector::camelize($relation);
+        if (!$Table->associations()->has($associationName)) {
+            throw new NotFoundException(
+                __d(
+                    'bedita',
+                    'Relation "{0}" does not exist for object type "{1}"',
+                    Inflector::underscore($relation),
+                    Inflector::underscore($Table->getAlias())
+                )
+            );
+        }
+
+        $this->Association = $Table->association($associationName);
+        $this->Action = new ListAssociated($this->Association);
+    }
+
+    /**
+     * Find existing relations.
+     *
+     * @param int $id Object ID.
+     * @return \Cake\ORM\Query
+     */
+    public function __invoke($id)
+    {
+        return $this->Action->__invoke($id)
+            ->select([$this->Association->aliasField('object_type_id')])
+            ->order($this->Association->sort());
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedObjects.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedObjects.php
@@ -13,9 +13,7 @@
 
 namespace BEdita\Core\Model\Action;
 
-use Cake\Network\Exception\NotFoundException;
-use Cake\ORM\Table;
-use Cake\Utility\Inflector;
+use Cake\ORM\Association;
 
 /**
  * Command to list associated objects.
@@ -42,30 +40,17 @@ class ListRelatedObjects
     /**
      * Command constructor.
      *
-     * @param \Cake\ORM\Table $Table Table object instance.
-     * @param string $relation Relation name.
+     * @param \Cake\ORM\Association $Association Association.
      */
-    public function __construct(Table $Table, $relation)
+    public function __construct(Association $Association)
     {
-        if (!$Table->hasBehavior('Relations')) {
+        if (!$Association->getSource()->hasBehavior('Relations')) {
             throw new \InvalidArgumentException(
-                __d('bedita', 'Table "{0}" does not implement relations', $Table->getRegistryAlias())
+                __d('bedita', 'Table "{0}" does not implement relations', $Association->getSource()->getRegistryAlias())
             );
         }
 
-        $associationName = Inflector::camelize($relation);
-        if (!$Table->associations()->has($associationName)) {
-            throw new NotFoundException(
-                __d(
-                    'bedita',
-                    'Relation "{0}" does not exist for object type "{1}"',
-                    Inflector::underscore($relation),
-                    Inflector::underscore($Table->getAlias())
-                )
-            );
-        }
-
-        $this->Association = $Table->association($associationName);
+        $this->Association = $Association;
         $this->Action = new ListAssociated($this->Association);
     }
 

--- a/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
@@ -29,6 +29,9 @@ class RelationsBehavior extends Behavior
      */
     protected $_defaultConfig = [
         'objectType' => null,
+        'implementedMethods' => [
+            'getRelations' => 'getRelations',
+        ],
     ];
 
     /**
@@ -91,5 +94,22 @@ class RelationsBehavior extends Behavior
                 ],
             ]);
         }
+    }
+
+    /**
+     * Get a list of all available relations indexed by their name with regards of side.
+     *
+     * @return \BEdita\Core\Model\Entity\Relation[]
+     */
+    public function getRelations()
+    {
+        $relations = collection($this->objectType->left_relations)
+            ->indexBy('name')
+            ->append(
+                collection($this->objectType->right_relations)
+                    ->indexBy('inverse_name')
+            );
+
+        return $relations->toArray();
     }
 }

--- a/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
@@ -15,7 +15,6 @@ namespace BEdita\Core\Model\Behavior;
 
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\ORM\Behavior;
-use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 
@@ -71,6 +70,9 @@ class RelationsBehavior extends Behavior
                 'conditions' => [
                     'ObjectRelations.relation_id' => $relation->id,
                 ],
+                'sort' => [
+                    'ObjectRelations.priority' => 'asc',
+                ],
             ]);
         }
 
@@ -83,6 +85,9 @@ class RelationsBehavior extends Behavior
                 'targetForeignKey' => 'left_id',
                 'conditions' => [
                     'ObjectRelations.relation_id' => $relation->id,
+                ],
+                'sort' => [
+                    'ObjectRelations.inv_priority' => 'asc',
                 ],
             ]);
         }

--- a/plugins/BEdita/Core/src/Model/Entity/Application.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Application.php
@@ -30,6 +30,9 @@ use Cake\ORM\Entity;
  */
 class Application extends Entity
 {
+
+    use JsonApiTrait;
+
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Entity/Endpoint.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Endpoint.php
@@ -33,6 +33,9 @@ use Cake\ORM\Entity;
  */
 class Endpoint extends Entity
 {
+
+    use JsonApiTrait;
+
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
@@ -31,14 +31,14 @@ trait JsonApiTrait
      *
      * @return string[]
      */
-    public abstract function getHidden();
+    abstract public function getHidden();
 
     /**
      * Getter for source model registry alias.
      *
      * @return string
      */
-    public abstract function getSource();
+    abstract public function getSource();
 
     /**
      * Magic getter for `type` property.

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Model\Entity;
+
+use Cake\ORM\Association;
+use Cake\ORM\Association\BelongsToMany;
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+
+/**
+ * Trait for exposing useful properties required for JSON API response formatting at the entity level.
+ *
+ * @since 4.0.0
+ */
+trait JsonApiTrait
+{
+
+    /**
+     * Getter for entity's hidden properties.
+     *
+     * @return string[]
+     */
+    public abstract function getHidden();
+
+    /**
+     * Getter for source model registry alias.
+     *
+     * @return string
+     */
+    public abstract function getSource();
+
+    /**
+     * Magic getter for `type` property.
+     *
+     * @return string
+     */
+    protected function _getType()
+    {
+        return TableRegistry::get($this->getSource())->getTable();
+    }
+
+    /**
+     * Magic getter for `relationships` property.
+     *
+     * The `relationships` property is supposed to provide a list of available
+     * relationships for this entity.
+     *
+     * @return string[]
+     */
+    protected function _getRelationships()
+    {
+        return static::listAssociations(TableRegistry::get($this->getSource()), $this->getHidden());
+    }
+
+    /**
+     * List all available relationships for a model.
+     *
+     * @param \Cake\ORM\Table $Table Table object instance.
+     * @param array $hidden List of relationships to be excluded.
+     * @return array
+     */
+    protected static function listAssociations(Table $Table, array $hidden = [])
+    {
+        $associations = $Table->associations();
+        $btmJunctionAliases = array_map(
+            function (BelongsToMany $val) {
+                return $val->junction()->getAlias();
+            },
+            $associations->type('BelongsToMany')
+        );
+
+        $relationships = [];
+        foreach ($associations as $association) {
+            list(, $associationType) = namespaceSplit(get_class($association));
+            $name = $association->property();
+            if (!($association instanceof Association) ||
+                $associationType === 'ExtensionOf' ||
+                in_array($name, $hidden) ||
+                ($associationType === 'HasMany' && in_array($association->getTarget()->getAlias(), $btmJunctionAliases))
+            ) {
+                continue;
+            }
+
+            $relationships[] = $name;
+        }
+
+        return $relationships;
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
@@ -46,6 +46,8 @@ use Cake\ORM\TableRegistry;
 class ObjectEntity extends Entity
 {
 
+    use JsonApiTrait;
+
     /**
      * {@inheritDoc}
      */
@@ -118,5 +120,22 @@ class ObjectEntity extends Entity
         }
 
         return $type;
+    }
+
+    /**
+     * Getter for `relationships` virtual property.
+     *
+     * @return string[]
+     */
+    protected function _getRelationships()
+    {
+        $Table = TableRegistry::get($this->type ?: $this->getSource());
+
+        $entity = $this;
+        if ($Table->getRegistryAlias() !== $this->getSource()) {
+            $entity = $Table->newEntity();
+        }
+
+        return static::listAssociations($Table, $entity->getHidden());
     }
 }

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
@@ -34,6 +34,8 @@ use Cake\Utility\Inflector;
 class ObjectType extends Entity
 {
 
+    use JsonApiTrait;
+
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Entity/Property.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Property.php
@@ -40,6 +40,9 @@ use Cake\ORM\TableRegistry;
  */
 class Property extends Entity
 {
+
+    use JsonApiTrait;
+
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Entity/PropertyType.php
+++ b/plugins/BEdita/Core/src/Model/Entity/PropertyType.php
@@ -25,4 +25,6 @@ use Cake\ORM\Entity;
  */
 class PropertyType extends Entity
 {
+
+    use JsonApiTrait;
 }

--- a/plugins/BEdita/Core/src/Model/Entity/Relation.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Relation.php
@@ -33,6 +33,8 @@ use Cake\ORM\Entity;
 class Relation extends Entity
 {
 
+    use JsonApiTrait;
+
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Entity/Role.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Role.php
@@ -32,6 +32,8 @@ use Cake\ORM\Entity;
 class Role extends Entity
 {
 
+    use JsonApiTrait;
+
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Table/RolesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RolesTable.php
@@ -22,6 +22,14 @@ use Cake\Validation\Validator;
  *
  * @property \Cake\ORM\Association\BelongsToMany $Users
  *
+ * @method \BEdita\Core\Model\Entity\Role get($primaryKey, $options = [])
+ * @method \BEdita\Core\Model\Entity\Role newEntity($data = null, array $options = [])
+ * @method \BEdita\Core\Model\Entity\Role[] newEntities(array $data, array $options = [])
+ * @method \BEdita\Core\Model\Entity\Role|bool save(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \BEdita\Core\Model\Entity\Role patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
+ * @method \BEdita\Core\Model\Entity\Role[] patchEntities($entities, array $data, array $options = [])
+ * @method \BEdita\Core\Model\Entity\Role findOrCreate($search, callable $callback = null, $options = [])
+ *
  * @since 4.0.0
  */
 class RolesTable extends Table

--- a/plugins/BEdita/Core/tests/Fixture/ObjectRelationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ObjectRelationsFixture.php
@@ -4,8 +4,7 @@ namespace BEdita\Core\Test\Fixture;
 use BEdita\Core\TestSuite\Fixture\TestFixture;
 
 /**
- * ObjectRelationsFixture
- *
+ * Fixture for `object_relations` table.
  */
 class ObjectRelationsFixture extends TestFixture
 {
@@ -17,12 +16,28 @@ class ObjectRelationsFixture extends TestFixture
      */
     public $records = [
         [
-            'left_id' => 1,
+            'left_id' => 2,
             'relation_id' => 1,
-            'right_id' => 1,
+            'right_id' => 4,
+            'priority' => 1,
+            'inv_priority' => 2,
+            'params' => '',
+        ],
+        [
+            'left_id' => 3,
+            'relation_id' => 1,
+            'right_id' => 4,
             'priority' => 1,
             'inv_priority' => 1,
-            'params' => 'Lorem ipsum dolor sit amet, aliquet feugiat. Convallis morbi fringilla gravida, phasellus feugiat dapibus velit nunc, pulvinar eget sollicitudin venenatis cum nullam, vivamus ut a sed, mollitia lectus. Nulla vestibulum massa neque ut et, id hendrerit sit, feugiat in taciti enim proin nibh, tempor dignissim, rhoncus duis vestibulum nunc mattis convallis.'
+            'params' => '',
+        ],
+        [
+            'left_id' => 2,
+            'relation_id' => 1,
+            'right_id' => 3,
+            'priority' => 2,
+            'inv_priority' => 1,
+            'params' => '',
         ],
     ];
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsTest.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Action;
+
+use BEdita\Core\Model\Action\ListAssociated;
+use BEdita\Core\Model\Action\ListRelatedObjects;
+use Cake\ORM\Association\BelongsToMany;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * @coversDefaultClass \BEdita\Core\Model\Action\ListRelatedObjects
+ */
+class ListRelatedObjectsTest extends TestCase
+{
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
+        'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.object_relations',
+        'plugin.BEdita/Core.profiles',
+    ];
+
+    /**
+     * Test constructor with a table that does not have the required behavior.
+     *
+     * @return void
+     *
+     * @covers ::__construct()
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Table "ObjectTypes" does not implement relations
+     */
+    public function testConstructInvalidTable()
+    {
+        new ListRelatedObjects(TableRegistry::get('ObjectTypes'), 'test');
+    }
+
+    /**
+     * Test constructor with a relation name that is not valid for the passed object type.
+     *
+     * @return void
+     *
+     * @covers ::__construct()
+     * @expectedException \Cake\Network\Exception\NotFoundException
+     * @expectedExceptionMessage Relation "invalid_relation" does not exist for object type "documents"
+     */
+    public function testConstructInvalidRelation()
+    {
+        new ListRelatedObjects(TableRegistry::get('Documents'), 'InvalidRelation');
+    }
+
+    /**
+     * Test constructor with valid arguments.
+     *
+     * @return void
+     *
+     * @covers ::__construct()
+     */
+    public function testConstruct()
+    {
+        $Action = new ListRelatedObjects(TableRegistry::get('Documents'), 'test');
+
+        static::assertAttributeInstanceOf(BelongsToMany::class, 'Association', $Action);
+        static::assertAttributeInstanceOf(ListAssociated::class, 'Action', $Action);
+    }
+
+    /**
+     * Data provider for `testInvocation` test case.
+     *
+     * @return array
+     */
+    public function invocationProvider()
+    {
+        return [
+            [
+                [
+                    [
+                        'id' => 4,
+                        'type' => 'profiles',
+                    ],
+                    [
+                        'id' => 3,
+                        'type' => 'documents',
+                    ],
+                ],
+                'Documents',
+                'test',
+                2,
+            ],
+            [
+                [
+                    [
+                        'id' => 4,
+                        'type' => 'profiles',
+                    ],
+                ],
+                'Documents',
+                'test',
+                3,
+            ],
+            [
+                [
+                    [
+                        'id' => 3,
+                        'type' => 'documents',
+                    ],
+                    [
+                        'id' => 2,
+                        'type' => 'documents',
+                    ],
+                ],
+                'Profiles',
+                'inverse_test',
+                4,
+            ],
+        ];
+    }
+
+    /**
+     * Test command invocation.
+     *
+     * @param array $expected Expected result.
+     * @param string $objectType Object type name.
+     * @param string $relation Relation name.
+     * @param int $id ID.
+     * @return void
+     *
+     * @covers ::__invoke()
+     * @dataProvider invocationProvider()
+     */
+    public function testInvocation($expected, $objectType, $relation, $id)
+    {
+        $Action = new ListRelatedObjects(TableRegistry::get($objectType), $relation);
+
+        $result = json_decode(json_encode($Action($id)->toArray()), true);
+
+        static::assertEquals($expected, $result);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsTest.php
@@ -18,6 +18,7 @@ use BEdita\Core\Model\Action\ListRelatedObjects;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Inflector;
 
 /**
  * @coversDefaultClass \BEdita\Core\Model\Action\ListRelatedObjects
@@ -50,21 +51,7 @@ class ListRelatedObjectsTest extends TestCase
      */
     public function testConstructInvalidTable()
     {
-        new ListRelatedObjects(TableRegistry::get('ObjectTypes'), 'test');
-    }
-
-    /**
-     * Test constructor with a relation name that is not valid for the passed object type.
-     *
-     * @return void
-     *
-     * @covers ::__construct()
-     * @expectedException \Cake\Network\Exception\NotFoundException
-     * @expectedExceptionMessage Relation "invalid_relation" does not exist for object type "documents"
-     */
-    public function testConstructInvalidRelation()
-    {
-        new ListRelatedObjects(TableRegistry::get('Documents'), 'InvalidRelation');
+        new ListRelatedObjects(TableRegistry::get('ObjectTypes')->association('Properties'));
     }
 
     /**
@@ -76,7 +63,7 @@ class ListRelatedObjectsTest extends TestCase
      */
     public function testConstruct()
     {
-        $Action = new ListRelatedObjects(TableRegistry::get('Documents'), 'test');
+        $Action = new ListRelatedObjects(TableRegistry::get('Documents')->association('Test'), 'test');
 
         static::assertAttributeInstanceOf(BelongsToMany::class, 'Association', $Action);
         static::assertAttributeInstanceOf(ListAssociated::class, 'Action', $Action);
@@ -148,7 +135,7 @@ class ListRelatedObjectsTest extends TestCase
      */
     public function testInvocation($expected, $objectType, $relation, $id)
     {
-        $Action = new ListRelatedObjects(TableRegistry::get($objectType), $relation);
+        $Action = new ListRelatedObjects(TableRegistry::get($objectType)->association(Inflector::camelize($relation)));
 
         $result = json_decode(json_encode($Action($id)->toArray()), true);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/RelationsBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/RelationsBehaviorTest.php
@@ -13,7 +13,7 @@
 
 namespace BEdita\Core\Test\TestCase\Model\Behavior;
 
-use BEdita\Core\Model\Behavior\RelationsBehavior;
+use BEdita\Core\Model\Entity\Relation;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -21,7 +21,7 @@ use Cake\TestSuite\TestCase;
 /**
  * {@see \BEdita\Core\Model\Behavior\RelationsBehavior} Test Case
  *
- * @covers \BEdita\Core\Model\Behavior\RelationsBehavior
+ * @coversDefaultClass \BEdita\Core\Model\Behavior\RelationsBehavior
  */
 class RelationsBehaviorTest extends TestCase
 {
@@ -43,6 +43,8 @@ class RelationsBehaviorTest extends TestCase
      * Test initial setup
      *
      * @return void
+     *
+     * @covers ::initialize()
      */
     public function testInitialization()
     {
@@ -54,5 +56,30 @@ class RelationsBehaviorTest extends TestCase
         static::assertInstanceOf(BelongsToMany::class, $Documents->association('Test'));
         static::assertInstanceOf(BelongsToMany::class, $Documents->association('InverseTest'));
         static::assertInstanceOf(BelongsToMany::class, $Profiles->association('InverseTest'));
+    }
+
+    /**
+     * Test getter of relations.
+     *
+     * @return void
+     *
+     * @covers ::getRelations()
+     */
+    public function testGetRelations()
+    {
+        $expected = [
+            'test',
+            'inverse_test',
+        ];
+
+        $Documents = TableRegistry::get('Documents');
+
+        static::assertTrue($Documents->behaviors()->hasMethod('getRelations'));
+
+        $relations = $Documents->behaviors()->call('getRelations');
+        static::assertEquals($expected, array_keys($relations));
+        foreach ($relations as $relation) {
+            static::assertInstanceOf(Relation::class, $relation);
+        }
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -111,7 +111,7 @@ class JsonApiTraitTest extends TestCase
         $role = $this->Roles->newEntity();
         $role->setHidden(['users' => true], true);
 
-        $relationships = $role->get('relationships');
+        $relationships = $role->relationships;
 
         static::assertSame([], $relationships);
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Entity;
+
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * @coversDefaultClass \BEdita\Core\Model\Entity\JsonApiTrait
+ */
+class JsonApiTraitTest extends TestCase
+{
+
+    /**
+     * Helper table.
+     *
+     * @var \BEdita\Core\Model\Table\RolesTable
+     */
+    public $Roles;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
+        'plugin.BEdita/Core.roles',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->Roles = TableRegistry::get('Roles');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        unset($this->Roles);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test magic getter for type.
+     *
+     * @return void
+     *
+     * @covers ::_getType()
+     */
+    public function testGetType()
+    {
+        $role = $this->Roles->newEntity();
+
+        $type = $role->type;
+
+        static::assertSame($this->Roles->getTable(), $type);
+    }
+
+    /**
+     * Test magic getter for relationships.
+     *
+     * @return void
+     *
+     * @covers ::_getRelationships()
+     * @covers ::listAssociations()
+     */
+    public function testGetRelationships()
+    {
+        $expected = [
+            'users',
+        ];
+
+        $role = $this->Roles->newEntity();
+
+        $relationships = $role->relationships;
+
+        static::assertSame($expected, $relationships);
+    }
+
+    /**
+     * Test magic getter for relationships.
+     *
+     * @return void
+     *
+     * @covers ::_getRelationships()
+     * @covers ::listAssociations()
+     */
+    public function testGetRelationshipsHidden()
+    {
+        $role = $this->Roles->newEntity();
+        $role->setHidden(['users' => true], true);
+
+        $relationships = $role->get('relationships');
+
+        static::assertSame([], $relationships);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectEntityTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectEntityTest.php
@@ -39,7 +39,10 @@ class ObjectEntityTest extends TestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.profiles',
     ];
 
     /**
@@ -179,5 +182,48 @@ class ObjectEntityTest extends TestCase
         $objectTypeId = $entity->object_type_id;
 
         static::assertSame($expected, $objectTypeId);
+    }
+
+    /**
+     * Test magic getter for relations.
+     *
+     * @return void
+     *
+     * @covers ::_getRelationships()
+     */
+    public function testGetRelationships()
+    {
+        $expected = [
+            'test',
+            'inverse_test',
+        ];
+
+        $entity = TableRegistry::get('Documents')->newEntity();
+        $entity->set('type', 'documents');
+
+        $relations = $entity->get('relationships') ?: [];
+
+        static::assertSame($expected, $relations);
+    }
+
+    /**
+     * Test magic getter for relations.
+     *
+     * @return void
+     *
+     * @covers ::_getRelationships()
+     */
+    public function testGetRelationshipsOfAssociated()
+    {
+        $expected = [
+            'inverse_test',
+        ];
+
+        $entity = TableRegistry::get('Documents')->association('Test')->newEntity();
+        $entity->set('type', 'profile');
+
+        $relations = $entity->get('relationships') ?: [];
+
+        static::assertSame($expected, $relations);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -50,8 +50,6 @@ class ObjectTypeTest extends TestCase
     {
         parent::setUp();
 
-        Cache::clear(false, ObjectTypesTable::CACHE_CONFIG);
-
         $this->ObjectTypes = TableRegistry::get('ObjectTypes');
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
@@ -52,7 +52,8 @@ class ObjectTypesTableTest extends TestCase
     {
         parent::setUp();
 
-        Cache::clear(false, ObjectTypesTable::CACHE_CONFIG);
+        Cache::drop('_bedita_object_types_');
+        Cache::setConfig('_bedita_object_types_', ['className' => 'File']);
 
         $this->ObjectTypes = TableRegistry::get('ObjectTypes');
     }
@@ -63,6 +64,10 @@ class ObjectTypesTableTest extends TestCase
     public function tearDown()
     {
         unset($this->ObjectTypes);
+
+        Cache::clear(false, ObjectTypesTable::CACHE_CONFIG);
+        Cache::drop('_bedita_object_types_');
+        Cache::setConfig('_bedita_object_types_', ['className' => 'Null']);
 
         parent::tearDown();
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,6 +11,7 @@ require dirname(__DIR__) . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR 
 
 $_SERVER['PHP_SELF'] = '/';
 
+use Cake\Cache\Cache;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
 
@@ -21,6 +22,9 @@ if (getenv('db_dsn')) {
 if (!defined('API_KEY')) {
     define('API_KEY', 'API_KEY');
 }
+
+Cache::drop('_bedita_object_types_');
+Cache::setConfig('_bedita_object_types_', ['className' => 'Null']);
 
 if (getenv('DEBUG_LOG_QUERIES')) {
     ConnectionManager::get('test')->logQueries(true);


### PR DESCRIPTION
This PR implements both `GET /:objectType/:id/:relation` and `GET /:objectType/:id/relationships/:relation` endpoint, and should solve #1113.

In order to display relationships links correctly, a minor refactor of `JsonApi` utility class was necessary. As a result, a `JsonApiTrait` has been introduced to expose some useful properties (e.g. type, or list of available relationships) at the entity level.

Furthermore, routing has been slightly simplified. In #1074 we might be able to simplify it furtherly.