### PR TITLE
feat: dbadmin shell versions, limit object versions

### DIFF
--- a/bedita-app/vendors/shells/dbadmin.php
+++ b/bedita-app/vendors/shells/dbadmin.php
@@ -1073,7 +1073,7 @@ class DbadminShell extends BeditaBaseShell {
 					$objectVersions = $versionModel->find('all', array(
 						'fields' => array('object_id', 'revision', 'user_id', 'created', 'diff'),
 						'conditions' => array('Version.id' => $insertList),
-						'order' => array('revision ASC'),
+						'order' => array('Version.revision' => 'ASC'),
 						'contain' => array()
 					));
 					foreach ($objectVersions as &$objVersion) {

--- a/bedita-app/vendors/shells/dbadmin.php
+++ b/bedita-app/vendors/shells/dbadmin.php
@@ -1073,6 +1073,7 @@ class DbadminShell extends BeditaBaseShell {
 					$objectVersions = $versionModel->find('all', array(
 						'fields' => array('object_id', 'revision', 'user_id', 'created', 'diff'),
 						'conditions' => array('Version.id' => $insertList),
+						'order' => array('revision ASC'),
 						'contain' => array()
 					));
 					foreach ($objectVersions as &$objVersion) {


### PR DESCRIPTION
This provides method `versions` on `dbadmin` shell.
It limits versions per object, by limit passed as argument, i.e.
```
// remove versions, limiting to a maximum of 10 versions per object
./cake.sh dbadmin versions -limit 10 
```