### PR TITLE
Avoid empty type virtual prop for valid object entity

### DIFF
--- a/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
@@ -93,7 +93,8 @@ class ObjectEntity extends Entity
     {
         if (!$this->object_type) {
             try {
-                $this->object_type = TableRegistry::get('ObjectTypes')->get($this->object_type_id);
+                $typeId = $this->object_type_id ?: $this->getSource();
+                $this->object_type = TableRegistry::get('ObjectTypes')->get($typeId);
             } catch (RecordNotFoundException $e) {
                 return null;
             } catch (InvalidPrimaryKeyException $e) {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectEntityTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectEntityTest.php
@@ -122,6 +122,16 @@ class ObjectEntityTest extends TestCase
                 null,
                 null,
             ],
+            'typeFromSource' => [
+                'documents',
+                null,
+                ['source' => 'Documents'],
+            ],
+            'invalidTypeFromSource' => [
+                null,
+                null,
+                ['source' => 'NotValidObjectTable'],
+            ],
         ];
     }
 
@@ -130,14 +140,15 @@ class ObjectEntityTest extends TestCase
      *
      * @param string|null $expected Expected type.
      * @param mixed $objectTypeId Object type ID.
+     * @param array $options Configuration options for entity.
      * @return void
      *
      * @covers ::_getType()
      * @dataProvider getTypeProvider()
      */
-    public function testGetType($expected, $objectTypeId)
+    public function testGetType($expected, $objectTypeId, $options = [])
     {
-        $entity = new ObjectEntity();
+        $entity = new ObjectEntity([], $options);
         $entity->object_type_id = $objectTypeId;
 
         $type = $entity->type;


### PR DESCRIPTION
Before this PR the virtual prop `type` of `ObjectEntity` returned null if `object_type_id` wasn't selected:

```php
$users = TableRegistry::get('Users');
$user = $users->find()->select('username')->first();
debug($user->type); // is null
```

Now if `object_type_id` is missing it tries to get `type` starting from `Entity::getSource()`