### PR TITLE
Issue/v4/1127 geo finder

### DIFF
--- a/plugins/BEdita/API/src/Utility/JsonApi.php
+++ b/plugins/BEdita/API/src/Utility/JsonApi.php
@@ -212,6 +212,11 @@ class JsonApi
             return [];
         }
 
+        if (!empty($item['meta'])) {
+            $meta = $item['meta'];
+            unset($item['meta']);
+        }
+
         list($id, $attributes) = static::extractAttributes($item);
         if (empty($attributes)) {
             unset($attributes);
@@ -223,7 +228,7 @@ class JsonApi
             $links = compact('self');
         }
 
-        return compact('id', 'type', 'attributes', 'links', 'relationships');
+        return compact('id', 'type', 'attributes', 'links', 'relationships', 'meta');
     }
 
     /**

--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -101,8 +101,7 @@ class FilterQueryStringTest extends ApiIntegrationTestCase
     public function testFilterGeo($query, $expected, $endpoint = '/locations')
     {
         $info = Database::basicInfo();
-        if (strstr($info['driver'], 'Mysql') === false
-            && (!empty($info['version']) && $info['version'] >= '5.7.6')) {
+        if (strstr($info['driver'], 'Mysql') === false || ($info['version'] < '5.7.6')) {
             $this->markTestSkipped('Only MySQL >= 5.7.6 supported in testFindGeo');
         }
 

--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -101,8 +101,8 @@ class FilterQueryStringTest extends ApiIntegrationTestCase
     public function testFilterGeo($query, $expected, $endpoint = '/locations')
     {
         $info = Database::basicInfo();
-        if (strstr($info['driver'], 'Mysql') === false || ($info['version'] < '5.7.6')) {
-            $this->markTestSkipped('Only MySQL >= 5.7.6 supported in testFindGeo');
+        if ($info['vendor'] !== 'mysql' || $info['version'] < '5.7') {
+            $this->markTestSkipped('Only MySQL >= 5.7 supported in findGeo filter');
         }
 
         $this->configRequestHeaders();

--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -12,7 +12,7 @@
  */
 namespace BEdita\API\Test\IntegrationTest;
 
-use Cake\Datasource\ConnectionManager;
+use BEdita\Core\Utility\Database;
 use Cake\I18n\Time;
 use Cake\Utility\Hash;
 
@@ -100,9 +100,10 @@ class FilterQueryStringTest extends ApiIntegrationTestCase
      */
     public function testFilterGeo($query, $expected, $endpoint = '/locations')
     {
-        $info = ConnectionManager::get('default')->config();
-        if (strstr($info['driver'], 'Mysql') === false) {
-            $this->markTestSkipped('Only MySQL supported in testFindGeo');
+        $info = Database::basicInfo();
+        if (strstr($info['driver'], 'Mysql') === false
+            && (!empty($info['version']) && $info['version'] >= '5.7.6')) {
+            $this->markTestSkipped('Only MySQL >= 5.7.6 supported in testFindGeo');
         }
 
         $this->configRequestHeaders();

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -365,7 +365,58 @@ class JsonApiTest extends TestCase
                     ];
                 },
             ],
+
+            'metaExample' => [
+                [
+                    'id' => '1',
+                    'type' => 'customType',
+                    'attributes' => [
+                        'key' => 'value',
+                    ],
+                    'meta' => [
+                        'mkey' => 'mvalue',
+                    ],
+                ],
+                function () {
+                    return [
+                        'id' => '1',
+                        'type' => 'customType',
+                        'key' => 'value',
+                        'meta' => [
+                            'mkey' => 'mvalue',
+                        ],
+                    ];
+                },
+            ],
         ];
+    }
+
+    /**
+     * Test {@see \BEdita\Core\Utility\JsonApi::formatData()} and
+     * {@see \BEdita\Core\Utility\JsonApi::formatItem()} methods.
+     *
+     * @param array|bool $expected Expected result. If `false`, an exception is expected.
+     * @param callable $items A callable that returns the items to be converted.
+     * @param string|null $type Type of items.
+     * @return void
+     *
+     * @dataProvider formatDataProvider
+     * @covers ::formatData
+     * @covers ::formatItem
+     * @covers ::buildUrl
+     * @covers ::extractType
+     * @covers ::extractAttributes
+     * @covers ::extractRelationships
+     */
+    public function testFormatData($expected, callable $items, $type = null)
+    {
+        if ($expected === false) {
+            $this->expectException('\InvalidArgumentException');
+        }
+
+        $result = JsonApi::formatData($items($this->Roles), $type);
+
+        static::assertEquals($expected, $result);
     }
 
     /**
@@ -452,33 +503,6 @@ class JsonApiTest extends TestCase
         ];
     }
 
-    /**
-     * Test {@see \BEdita\Core\Utility\JsonApi::formatData()} and
-     * {@see \BEdita\Core\Utility\JsonApi::formatItem()} methods.
-     *
-     * @param array|bool $expected Expected result. If `false`, an exception is expected.
-     * @param callable $items A callable that returns the items to be converted.
-     * @param string|null $type Type of items.
-     * @return void
-     *
-     * @dataProvider formatDataProvider
-     * @covers ::formatData
-     * @covers ::formatItem
-     * @covers ::buildUrl
-     * @covers ::extractType
-     * @covers ::extractAttributes
-     * @covers ::extractRelationships
-     */
-    public function testFormatData($expected, callable $items, $type = null)
-    {
-        if ($expected === false) {
-            $this->expectException('\InvalidArgumentException');
-        }
-
-        $result = JsonApi::formatData($items($this->Roles), $type);
-
-        static::assertEquals($expected, $result);
-    }
 
     /**
      * Test {@see \BEdita\Core\Utility\JsonApi::parseData()} and

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -503,7 +503,6 @@ class JsonApiTest extends TestCase
         ];
     }
 
-
     /**
      * Test {@see \BEdita\Core\Utility\JsonApi::parseData()} and
      * {@see \BEdita\Core\Utility\JsonApi::parseItem()} methods.

--- a/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
@@ -88,11 +88,11 @@ class LocationsTable extends Table
 
     /**
      * Find objects by geo coordinates.
+     * Create a query to filter objects using geo data: location objects are
+     * ordered by distance, from the nearest to the farthest using a center geo point.
      *
-     * Create a query to filter objects using geo data.
      * Accepted options are:
-     *   - 'center' with point coordinates (latitude and longitude)
-     *   - 'distance' max distance in meters
+     *   - 'center' with point coordinates, latitude and longitude
      *
      * Examples
      * ```

--- a/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
@@ -120,8 +120,7 @@ class LocationsTable extends Table
         $distance = 'meta__distance';
 
         return $query->select([$distance => 'ST_Distance_sphere(ST_GeomFromText(' . $coords . '), ST_GeomFromText(\'POINT(' . $center . ')\'))'])
-                ->select($this)
-                ->select(TableRegistry::get('Objects'))
+                ->enableAutoFields(true)
                 ->order([$distance => 'ASC']);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
@@ -14,7 +14,10 @@
 namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\ORM\Inheritance\Table;
+use Cake\Database\Expression\QueryExpression;
+use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
+use Cake\ORM\TableRegistry;
 use Cake\Validation\Validator;
 
 /**
@@ -81,5 +84,44 @@ class LocationsTable extends Table
             ->allowEmpty('region');
 
         return $validator;
+    }
+
+    /**
+     * Find objects by geo coordinates.
+     *
+     * Create a query to filter objects using geo data.
+     * Accepted options are:
+     *   - 'center' with point coordinates (latitude and longitude)
+     *   - 'distance' max distance in meters
+     *
+     * Examples
+     * ```
+     * // find location objects near a given center, string with comma separated values or array
+     * $table->find('geo', ['center' => '44.4944183,11.3464055']);
+     * $table->find('geo', ['center' => [44.4944183 ,11.3464055]]);
+     * ```
+     *
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @param array $options Array of acceptable geo localization conditions.
+     * @return \Cake\ORM\Query
+     */
+    public function findGeo(Query $query, array $options)
+    {
+        $center = !empty($options['center']) ? $options['center'] : [];
+        if (empty($center)) {
+            return $query;
+        }
+        if (is_array($center)) {
+            $center = implode(' ', $center);
+        } else {
+            $center = str_replace(',', ' ', $center);
+        }
+        $coords = $this->aliasField('coords');
+        $distance = 'meta__distance';
+
+        return $query->select([$distance => 'ST_Distance_sphere(ST_GeomFromText(' . $coords . '), ST_GeomFromText(\'POINT(' . $center . ')\'))'])
+                ->select($this)
+                ->select(TableRegistry::get('Objects'))
+                ->order([$distance => 'ASC']);
     }
 }

--- a/plugins/BEdita/Core/src/Shell/BeditaShell.php
+++ b/plugins/BEdita/Core/src/Shell/BeditaShell.php
@@ -272,7 +272,7 @@ class BeditaShell extends Shell
     protected function databaseConnection()
     {
         $this->configModified = false;
-        $dbParams = Database::basicInfo();
+        $dbParams = Database::basicInfo('default', false);
         $fields = ['host', 'database', 'username', 'password'];
         foreach ($fields as $name) {
             $expected = '__BE4_DB_' . strtoupper($name) . '__';

--- a/plugins/BEdita/Core/src/Utility/Database.php
+++ b/plugins/BEdita/Core/src/Utility/Database.php
@@ -148,8 +148,13 @@ class Database
      */
     public static function basicInfo($dbConfig = 'default')
     {
-        $config = ConnectionManager::get($dbConfig)->config();
+        $connection = ConnectionManager::get($dbConfig);
+        $config = $connection->config();
         $config['vendor'] = strtolower(substr($config['driver'], strrpos($config['driver'], '\\') + 1));
+        if ($config['vendor'] !== 'sqlite') {
+            $version = $connection->execute('SELECT VERSION()')->fetch();
+            $config['version'] = implode('', $version);
+        }
 
         return $config;
     }

--- a/plugins/BEdita/Core/src/Utility/Database.php
+++ b/plugins/BEdita/Core/src/Utility/Database.php
@@ -151,6 +151,7 @@ class Database
         $connection = ConnectionManager::get($dbConfig);
         $config = $connection->config();
         $config['vendor'] = strtolower(substr($config['driver'], strrpos($config['driver'], '\\') + 1));
+        $config['version'] = 'unknown';
         if ($config['vendor'] !== 'sqlite') {
             $version = $connection->execute('SELECT VERSION()')->fetch();
             $config['version'] = implode('', $version);

--- a/plugins/BEdita/Core/src/Utility/Database.php
+++ b/plugins/BEdita/Core/src/Utility/Database.php
@@ -141,18 +141,18 @@ class Database
     /**
      * Get basic database connection info
      *
-     * @param string $dbConfig input database configuration ('default' as default)
-     *
+     * @param string $dbConfig Input database configuration ('default' as default)
+     * @param string $version Retrieve or not version info
      * @return array containing requested configuration
      *          + 'vendor' key (mysql, sqlite, postgres,...)
      */
-    public static function basicInfo($dbConfig = 'default')
+    public static function basicInfo($dbConfig = 'default', $version = true)
     {
         $connection = ConnectionManager::get($dbConfig);
         $config = $connection->config();
         $config['vendor'] = strtolower(substr($config['driver'], strrpos($config['driver'], '\\') + 1));
         $config['version'] = 'unknown';
-        if ($config['vendor'] !== 'sqlite') {
+        if ($version && $config['vendor'] !== 'sqlite') {
             $version = $connection->execute('SELECT VERSION()')->fetch();
             $config['version'] = implode('', $version);
         }

--- a/plugins/BEdita/Core/tests/Fixture/LocationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/LocationsFixture.php
@@ -18,7 +18,7 @@ class LocationsFixture extends TestFixture
     public $records = [
         [
             'id' => 8,
-            'coords' => 'POINT(44,4944183 11,3464055)',
+            'coords' => 'POINT(44.4944183 11.3464055)',
             'address' => 'Piazza di Porta Ravegnana',
             'locality' => 'Bologna',
             'postal_code' => '40126',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
@@ -2,7 +2,7 @@
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use BEdita\Core\Model\Table\LocationsTable;
-use Cake\Datasource\ConnectionManager;
+use BEdita\Core\Utility\Database;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -98,9 +98,10 @@ class LocationsTableTest extends TestCase
      */
     public function testFindGeo($conditions, $numExpected)
     {
-        $info = ConnectionManager::get('default')->config();
-        if (strstr($info['driver'], 'Mysql') === false) {
-            $this->markTestSkipped('Only MySQL supported in testFindGeo');
+        $info = Database::basicInfo();
+        if (strstr($info['driver'], 'Mysql') === false
+            && (!empty($info['version']) && $info['version'] >= '5.7.6')) {
+            $this->markTestSkipped('Only MySQL >= 5.7.6 supported in testFindGeo');
         }
 
         $result = $this->Locations->find('geo', $conditions)->toArray();

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
@@ -7,7 +7,9 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
 /**
- * BEdita\Core\Model\Table\LocationsTable Test Case
+ * {@see \BEdita\Core\Model\Table\LocationsTable} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Model\Table\LocationsTable
  */
 class LocationsTableTest extends TestCase
 {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
@@ -2,6 +2,7 @@
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use BEdita\Core\Model\Table\LocationsTable;
+use Cake\Datasource\ConnectionManager;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -55,22 +56,53 @@ class LocationsTableTest extends TestCase
     }
 
     /**
-     * Test initialize method
+     * Data provider for `testFindGeo` test case.
      *
-     * @return void
+     * @return array
      */
-    public function testInitialize()
+    public function findGeoProvider()
     {
-        $this->markTestIncomplete('Not implemented yet.');
+        return [
+            'nearPoint' => [
+                [
+                    'center' => '44.4944876,11.3464721',
+                ],
+                1,
+            ],
+            'nearArray' => [
+                [
+                    'center' => [44.4944183, 11.3464055],
+                ],
+                1,
+            ],
+            'otherFilter' => [
+                [
+                    'coords' => [44.4944183, 11.3464055],
+                ],
+                1,
+            ],
+        ];
     }
 
     /**
-     * Test validationDefault method
+     * Test findGeo finder method.
      *
+     * @param array $conditions Date conditions.
+     * @param array|false $numExpected Number of expected results.
      * @return void
+     *
+     * @dataProvider findGeoProvider
+     * @covers ::findGeo()
      */
-    public function testValidationDefault()
+    public function testFindGeo($conditions, $numExpected)
     {
-        $this->markTestIncomplete('Not implemented yet.');
+        $info = ConnectionManager::get('default')->config();
+        if (strstr($info['driver'], 'Mysql') === false) {
+            $this->markTestSkipped('Only MySQL supported in testFindGeo');
+        }
+
+        $result = $this->Locations->find('geo', $conditions)->toArray();
+
+        static::assertEquals($numExpected, count($result));
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
@@ -99,8 +99,8 @@ class LocationsTableTest extends TestCase
     public function testFindGeo($conditions, $numExpected)
     {
         $info = Database::basicInfo();
-        if (strstr($info['driver'], 'Mysql') === false || ($info['version'] < '5.7.6')) {
-            $this->markTestSkipped('Only MySQL >= 5.7.6 supported in testFindGeo');
+        if ($info['vendor'] !== 'mysql' || $info['version'] < '5.7') {
+            $this->markTestSkipped('Only MySQL >= 5.7 supported in testFindGeo');
         }
 
         $result = $this->Locations->find('geo', $conditions)->toArray();

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
@@ -99,8 +99,7 @@ class LocationsTableTest extends TestCase
     public function testFindGeo($conditions, $numExpected)
     {
         $info = Database::basicInfo();
-        if (strstr($info['driver'], 'Mysql') === false
-            && (!empty($info['version']) && $info['version'] >= '5.7.6')) {
+        if (strstr($info['driver'], 'Mysql') === false || ($info['version'] < '5.7.6')) {
             $this->markTestSkipped('Only MySQL >= 5.7.6 supported in testFindGeo');
         }
 

--- a/plugins/BEdita/Core/tests/TestCase/Utility/DatabaseTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/DatabaseTest.php
@@ -146,6 +146,7 @@ class DatabaseTest extends TestCase
         if ($info['vendor'] != 'sqlite') {
             $this->assertArrayHasKey('host', $info);
             $this->assertArrayHasKey('username', $info);
+            $this->assertArrayHasKey('version', $info);
         }
     }
 


### PR DESCRIPTION
This PR solves #1127 

 * an ugly SQL query was used to get geo distance - better use QueryExpressions, but how?
 * works only in MySQL >= 5.7 - tests are skipped also for version mismatch
 * `meta` response introduced in JSON API response, via `meta__fieldname` convention
 