### PR TITLE
CTI inherited fields

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/ApiIntegrationTestCase.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ApiIntegrationTestCase.php
@@ -13,7 +13,6 @@
 namespace BEdita\API\Test\IntegrationTest;
 
 use BEdita\Core\State\CurrentApplication;
-use Cake\I18n\Time;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\IntegrationTestCase;
 

--- a/plugins/BEdita/API/tests/IntegrationTest/AssociatedEntitiesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/AssociatedEntitiesTest.php
@@ -12,8 +12,6 @@
  */
 namespace BEdita\API\Test\IntegrationTest;
 
-use Cake\I18n\Time;
-
 /**
  * Test CRUD operations on objects with associated entities
  *
@@ -109,14 +107,14 @@ class AssociatedEntitiesTest extends ApiIntegrationTestCase
 
         $resultDates = $result['data']['attributes']['date_ranges'];
         $expectedDates = $attributes['date_ranges'];
-        $this->assertEquals(count($resultDates), count($expectedDates));
+        static::assertEquals(count($resultDates), count($expectedDates));
         $count = count($expectedDates);
         for ($i = 0; $i < $count; $i++) {
             foreach ($expectedDates[$i] as $k => $d) {
                 $found = $resultDates[$i][$k];
                 $exp = new \DateTime($d);
                 $exp = $exp->format('Y-m-d\TH:i:s+00:00');
-                $this->assertEquals($found, $exp);
+                static::assertEquals($found, $exp);
             }
         }
 

--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -13,7 +13,6 @@
 namespace BEdita\API\Test\IntegrationTest;
 
 use BEdita\Core\Utility\Database;
-use Cake\I18n\Time;
 use Cake\Utility\Hash;
 
 /**
@@ -64,7 +63,7 @@ class FilterQueryStringTest extends ApiIntegrationTestCase
         $result = json_decode((string)$this->_response->getBody(), true);
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertEquals($expected, count($result['data']));
+        static::assertEquals($expected, count($result['data']));
     }
 
     /**
@@ -102,7 +101,7 @@ class FilterQueryStringTest extends ApiIntegrationTestCase
     {
         $info = Database::basicInfo();
         if ($info['vendor'] !== 'mysql' || $info['version'] < '5.7') {
-            $this->markTestSkipped('Only MySQL >= 5.7 supported in findGeo filter');
+            static::markTestSkipped('Only MySQL >= 5.7 supported in findGeo filter');
         }
 
         $this->configRequestHeaders();
@@ -110,8 +109,8 @@ class FilterQueryStringTest extends ApiIntegrationTestCase
         $result = json_decode((string)$this->_response->getBody(), true);
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertEquals(count($expected), count($result['data']));
+        static::assertEquals(count($expected), count($result['data']));
         $resultDistance = Hash::extract($result['data'], '{n}.meta.distance');
-        $this->assertEquals($expected, $resultDistance);
+        static::assertEquals($expected, $resultDistance);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Action/ListEntitiesAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListEntitiesAction.php
@@ -121,7 +121,7 @@ class ListEntitiesAction extends BaseAction
                 continue;
             }
 
-            if ($this->Table->hasField($key)) {
+            if ($this->Table->hasField($key, true)) {
                 // Filter on single field.
                 $key = $this->Table->aliasField($key);
                 if ($value === null) {

--- a/plugins/BEdita/Core/src/ORM/Inheritance/Table.php
+++ b/plugins/BEdita/Core/src/ORM/Inheritance/Table.php
@@ -258,4 +258,21 @@ class Table extends CakeTable
             sprintf('Unknown finder method "%s"', $type)
         );
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param bool $inheritedFields Should fields from inherited tables be considered?
+     */
+    public function hasField($field, $inheritedFields = false)
+    {
+        $result = parent::hasField($field);
+        $inheritedTable = $this->inheritedTable();
+
+        if ($result || !$inheritedFields || $inheritedTable === null) {
+            return $result;
+        }
+
+        return $inheritedTable->hasField($field, true);
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListObjectsActionTest.php
@@ -91,7 +91,7 @@ class ListObjectsActionTest extends TestCase
      *
      * @return void
      */
-    public function testExecutedCustomFilter()
+    public function testExecuteCustomFilter()
     {
         $table = TableRegistry::get('Objects');
         $action = new ListObjectsAction(compact('table'));

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/TableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/TableTest.php
@@ -828,6 +828,8 @@ class TableTest extends TestCase
     /**
      * Test `callFinder` method.
      *
+     * @return void
+     *
      * @covers ::callFinder()
      */
     public function testCallFinder()
@@ -843,6 +845,8 @@ class TableTest extends TestCase
     /**
      * Test `callFinder` method.
      *
+     * @return void
+     *
      * @covers ::callFinder()
      * @expectedException \BadMethodCallException
      * @expectedExceptionMessage Unknown finder method "gustavo"
@@ -850,5 +854,21 @@ class TableTest extends TestCase
     public function testCallMissingFinder()
     {
         $this->fakeAnimals->find('gustavo');
+    }
+
+    /**
+     * Test `hasField` method.
+     *
+     * @return void
+     *
+     * @covers ::hasField()
+     */
+    public function testHasField()
+    {
+        $this->setupAssociations();
+
+        static::assertTrue($this->fakeMammals->hasField('legs', true));
+        static::assertFalse($this->fakeMammals->hasField('legs', false));
+        static::assertTrue($this->fakeAnimals->hasField('legs'));
     }
 }


### PR DESCRIPTION
This PR adds a boolean parameter to `Table::hasField()` to check if the passed field belongs either to the table itself, or to one of the inherited tables. This field **MUST** be `false` by default, or strange things will begin to happen. 🙃 

This PR also fixes an issue where trashed BEdita objects were being listed as usual when CTI was employed. This issue was caused by the filter on the `deleted` field (which belongs to the `objects` table) being ignored as the field was not considered a field of the table object being used.