### PR TITLE
Replace existing date ranges on save

### DIFF
--- a/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
@@ -40,6 +40,7 @@ use Cake\ORM\TableRegistry;
  * @property int $modified_by
  * @property \Cake\I18n\Time $publish_start
  * @property \Cake\I18n\Time $publish_end
+ * @property \Bedita\Core\Model\Entity\DateRange[] $date_ranges
  *
  * @since 4.0.0
  */

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -92,8 +92,7 @@ class ObjectsTable extends Table
 
             ->notEmpty('status')
 
-            ->requirePresence('uname', 'create')
-            ->notEmpty('uname')
+            ->allowEmpty('uname')
             ->add('uname', 'unique', ['rule' => 'validateUnique', 'provider' => 'table'])
 
             ->boolean('locked')

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -57,6 +57,7 @@ class ObjectsTable extends Table
         $this->hasMany('DateRanges', [
             'foreignKey' => 'object_id',
             'className' => 'BEdita/Core.DateRanges',
+            'saveStrategy' => 'replace',
         ]);
 
         $this->belongsTo('ObjectTypes', [

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -3,7 +3,6 @@ namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
-use Cake\Utility\Text;
 
 /**
  * {@see \BEdita\Core\Model\Table\ObjectsTable} Test Case

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -3,6 +3,7 @@ namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Text;
 
 /**
  * {@see \BEdita\Core\Model\Table\ObjectsTable} Test Case
@@ -203,5 +204,44 @@ class ObjectsTableTest extends TestCase
     {
         $result = $this->Objects->find('dateRanges', ['start_date' => ['gt' => '2017-01-01']])->toArray();
         $this->assertNotEmpty($result);
+    }
+
+    /**
+     * Test save of date ranges using 'replace' save strategy ({@see https://github.com/bedita/bedita/issues/1152}).
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testSaveDateRanges()
+    {
+        $object = $this->Objects->newEntity();
+        $object->type = 'events';
+
+        $data = [
+            'date_ranges' => [
+                [
+                    'start_date' => '1992-08-17',
+                ],
+            ],
+        ];
+        $object = $this->Objects->patchEntity($object, $data);
+        $object = $this->Objects->save($object);
+        if (!$object) {
+            static::fail('Unable to save object');
+        }
+
+        $data['date_ranges'][0]['start_date'] = date('Y-m-d');
+        $object = $this->Objects->patchEntity($object, $data);
+        $object = $this->Objects->save($object);
+        if (!$object) {
+            static::fail('Unable to save object');
+        }
+
+        $object = $this->Objects->get($object->id, ['contain' => ['DateRanges']]);
+
+        static::assertCount(1, $object->date_ranges);
+        static::assertSame(1, $this->Objects->DateRanges->find()->where(['object_id' => $object->id])->count());
+        static::assertSame(0, $this->Objects->DateRanges->find()->where(['object_id IS' => null])->count());
     }
 }


### PR DESCRIPTION
This PR fixes #1152. Now, existing date ranges are replaced when an entity is patched.

This has a drawback: since date ranges IDs are not exposed via API, every time an object is saved _all_ associated date ranges are deleted, and new ones are saved even if nothing at all has changed. I think we should think of some sort of optimization to avoid `date_ranges` table `AUTO_INCREMENT` go crazy. 😄  This should probably be achieved with a `_setDateRanges()` custom setter in `ObjectEntity` class.