### PR TITLE
Restore response body on create

### DIFF
--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -114,9 +114,9 @@ class ObjectsController extends ResourcesController
             $action = new SaveEntityAction(['table' => $this->Table, 'objectType' => $this->objectType]);
 
             $data = $this->request->getData();
-            $entity = $action(compact('entity', 'data'));
+            $data = $action(compact('entity', 'data'));
 
-            return $this->response
+            $this->response = $this->response
                 ->withStatus(201)
                 ->withHeader(
                     'Location',
@@ -124,25 +124,23 @@ class ObjectsController extends ResourcesController
                         [
                             '_name' => 'api:objects:resource',
                             'object_type' => $this->objectType->name,
-                            'id' => $entity->id,
+                            'id' => $data->id,
                         ],
                         true
                     )
                 );
+        } else {
+            // List existing entities.
+            $filter = $this->request->getQuery('filter');
+
+            $action = new ListObjectsAction(['table' => $this->Table, 'objectType' => $this->objectType]);
+            $query = $action(compact('filter'));
+
+            $data = $this->paginate($query);
         }
-
-        $filter = $this->request->getQuery('filter');
-
-        // List existing entities.
-        $action = new ListObjectsAction(['table' => $this->Table, 'objectType' => $this->objectType]);
-        $query = $action(compact('filter'));
-
-        $data = $this->paginate($query);
 
         $this->set(compact('data'));
         $this->set('_serialize', ['data']);
-
-        return null;
     }
 
     /**

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -111,7 +111,7 @@ abstract class ResourcesController extends AppController
      * This action represents a collection of resources.
      * If the request is a `POST` request, this action creates a new resource.
      *
-     * @return \Cake\Network\Response|null
+     * @return void
      */
     public function index()
     {
@@ -123,9 +123,9 @@ abstract class ResourcesController extends AppController
             $action = new SaveEntityAction(['table' => $this->Table]);
 
             $data = $this->request->getData();
-            $entity = $action(compact('entity', 'data'));
+            $data = $action(compact('entity', 'data'));
 
-            return $this->response
+            $this->response = $this->response
                 ->withStatus(201)
                 ->withHeader(
                     'Location',
@@ -133,23 +133,21 @@ abstract class ResourcesController extends AppController
                         [
                             '_name' => 'api:resources:resource',
                             'controller' => $this->name,
-                            'id' => $entity->id,
+                            'id' => $data->id,
                         ],
                         true
                     )
                 );
+        } else {
+            // List existing entities.
+            $action = new ListEntitiesAction(['table' => $this->Table]);
+            $query = $action();
+
+            $data = $this->paginate($query);
         }
-
-        // List existing entities.
-        $action = new ListEntitiesAction(['table' => $this->Table]);
-        $query = $action();
-
-        $data = $this->paginate($query);
 
         $this->set(compact('data'));
         $this->set('_serialize', ['data']);
-
-        return null;
     }
 
     /**
@@ -160,7 +158,7 @@ abstract class ResourcesController extends AppController
      * If the request is a `DELETE` request, this action deletes an existing resource.
      *
      * @param mixed $id Entity ID.
-     * @return \Cake\Network\Response|null
+     * @return \Cake\Http\Response|null
      */
     public function resource($id)
     {
@@ -233,7 +231,7 @@ abstract class ResourcesController extends AppController
      * If the request is a `POST` request, this action adds new relationships.
      * If the request is a `DELETE` request, this action deletes existing relationships.
      *
-     * @return \Cake\Network\Response|null
+     * @return \Cake\Http\Response|null
      */
     public function relationships()
     {

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -592,11 +592,13 @@ class ObjectsControllerTest extends IntegrationTestCase
             ],
         ]);
         $this->post('/documents', json_encode(compact('data')));
+        $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
+        static::assertArrayHasKey('data', $result);
         $this->assertHeader('Location', 'http://api.example.com/documents/10');
-        $this->assertTrue(TableRegistry::get('Documents')->exists(['title' => 'A new document']));
+        static::assertTrue(TableRegistry::get('Documents')->exists(['title' => 'A new document']));
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
@@ -29,6 +29,8 @@ class RolesControllerTest extends IntegrationTestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.roles',
         'plugin.BEdita/Core.endpoints',
         'plugin.BEdita/Core.applications',
@@ -303,11 +305,13 @@ class RolesControllerTest extends IntegrationTestCase
             ],
         ]);
         $this->post('/roles', json_encode(compact('data')));
+        $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
+        static::assertArrayHasKey('data', $result);
         $this->assertHeader('Location', 'http://api.example.com/roles/3');
-        $this->assertTrue(TableRegistry::get('Roles')->exists(['name' => 'head_of_support']));
+        static::assertTrue(TableRegistry::get('Roles')->exists(['name' => 'head_of_support']));
     }
 
     /**

--- a/plugins/BEdita/Core/src/Database/Type/DateTimeType.php
+++ b/plugins/BEdita/Core/src/Database/Type/DateTimeType.php
@@ -44,6 +44,9 @@ class DateTimeType extends CakeDateTimeType
 
         if (preg_match('/^\d{4}(-\d\d(-\d\d([T ]\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?)?$/i', $value)) {
             $value = Time::parse($value);
+            if ($value->getTimezone()->getName() === 'Z') {
+                $value = $value->setTimezone('UTC');
+            }
         }
 
         return $value;


### PR DESCRIPTION
This PR fixes a regression introduced in #1130 that caused response body to be empty when creating a resource using `POST /:resourceType` endpoint. Regression tests are present.