### PR TITLE
Avoid errors on uname validation

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/UniqueNameTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/UniqueNameTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\API\Test\IntegrationTest;
+
+/**
+ * Test on `uname` field
+ */
+class UniqueNameTest extends ApiIntegrationTestCase
+{
+    /**
+     * Data provider for testDoubleInsert
+     *
+     * @return void
+     */
+    public function doubleInsertProvider()
+    {
+        return [
+            'sameTitle' => [
+                ['title' => 'test double test double'],
+            ],
+            'emptyTitle' => [
+                ['title' => ''],
+            ],
+            'empty' => [
+                []
+            ],
+        ];
+    }
+
+    /**
+     * Test inserting the same data two times for different object types.
+     *
+     * @return void
+     * @dataProvider doubleInsertProvider
+     * @coversNothing
+     */
+    public function testDoubleInsert($attributes)
+    {
+        $sendRequest = function ($type) use ($attributes) {
+            $data = [
+                'type' => $type,
+                'attributes' => $attributes,
+            ];
+            $endpoint = '/' . $type;
+            $requestBody = json_encode(compact('data'));
+            $this->configRequestHeaders('POST');
+
+            $this->post($endpoint, $requestBody);
+
+            $this->assertResponseCode(201);
+            $this->assertContentType('application/vnd.api+json');
+            $this->assertHeader('Location', sprintf('http://api.example.com/%s/%s', $type, $this->lastObjectId()));
+            $this->assertResponseNotEmpty();
+            $body = json_decode((string)$this->_response->getBody(), true);
+            static::assertArrayHasKey('data', $body);
+            static::assertArrayHasKey('attributes', $body['data']);
+            static::assertArrayHasKey('uname', $body['data']['attributes']);
+
+            return $body;
+        };
+
+        foreach (['documents', 'locations'] as $type) {
+            $bodyFirst = $sendRequest($type);
+            $bodySecond = $sendRequest($type);
+            $this->assertNotEquals($bodyFirst['data']['attributes']['uname'], $bodySecond['data']['attributes']['uname']);
+        }
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
@@ -79,6 +79,10 @@ class UniqueNameBehavior extends Behavior
     {
         $field = !empty($cfg['sourceField']) ? $cfg['sourceField'] : $this->getConfig('sourceField');
         $fieldValue = $entity->get($field);
+        if (empty($fieldValue)) {
+            $fieldValue = (string)$entity->get('type');
+            $regenerate = true;
+        }
 
         return $this->uniqueNameFromValue($fieldValue, $cfg, $regenerate);
     }
@@ -136,27 +140,5 @@ class UniqueNameBehavior extends Behavior
     public function beforeSave(Event $event, EntityInterface $entity)
     {
         $this->uniqueName($entity);
-    }
-
-    /**
-     * Setup initial unique name when a new Entity is being created with empty `uname` field
-     *
-     * @param \Cake\Event\Event $event The event dispatched
-     * @param ArrayObject $data The input data to save
-     * @param ArrayObject $options Operation options (unused)
-     * @return void
-     */
-    public function beforeMarshal(Event $event, ArrayObject $data, ArrayObject $options)
-    {
-        if (empty($data['uname']) && empty($data['id'])) {
-            $field = $this->getConfig('sourceField');
-            $fieldValue = '';
-            if (!empty($data[$field])) {
-                $fieldValue = $data[$field];
-            } elseif (!empty($data['type'])) {
-                $fieldValue = $data['type'];
-            }
-            $data['uname'] = $this->uniqueNameFromValue($fieldValue);
-        }
     }
 }


### PR DESCRIPTION
This PR solves #1154

The issue wasn't with CTI but with validation.
`beforeMarshal`  was removed and all the magic happens in `beforeSave()`.