### PR TITLE
refactor: ObjectsHandler::save() existing objects too

### DIFF
--- a/plugins/BEdita/Core/config/Seeds/DocumentsFakerSeed.php
+++ b/plugins/BEdita/Core/config/Seeds/DocumentsFakerSeed.php
@@ -20,6 +20,6 @@ class DocumentsFakerSeed extends AbstractSeed
             'description' => $faker->paragraph,
             'publish_start' => Time::now(),
         ];
-        ObjectsHandler::create('documents', $data);
+        ObjectsHandler::save('documents', $data);
     }
 }

--- a/plugins/BEdita/Core/config/Seeds/EventsFakerSeed.php
+++ b/plugins/BEdita/Core/config/Seeds/EventsFakerSeed.php
@@ -29,6 +29,6 @@ class EventsFakerSeed extends AbstractSeed
                 ],
             ],
         ];
-        $entity = ObjectsHandler::create('events', $data);
+        $entity = ObjectsHandler::save('events', $data);
     }
 }

--- a/plugins/BEdita/Core/config/Seeds/LocationsFakerSeed.php
+++ b/plugins/BEdita/Core/config/Seeds/LocationsFakerSeed.php
@@ -20,6 +20,6 @@ class LocationsFakerSeed extends AbstractSeed
             'country' => $faker->country,
             'region' => $faker->stateAbbr,
         ];
-        ObjectsHandler::create('locations', $data);
+        ObjectsHandler::save('locations', $data);
     }
 }

--- a/plugins/BEdita/Core/config/Seeds/NewsFakerSeed.php
+++ b/plugins/BEdita/Core/config/Seeds/NewsFakerSeed.php
@@ -18,6 +18,6 @@ class NewsFakerSeed extends AbstractSeed
             'body' => $faker->optional()->text,
             'description' => $faker->paragraph,
         ];
-        ObjectsHandler::create('news', $data);
+        ObjectsHandler::save('news', $data);
     }
 }

--- a/plugins/BEdita/Core/config/Seeds/ProfilesFakerSeed.php
+++ b/plugins/BEdita/Core/config/Seeds/ProfilesFakerSeed.php
@@ -30,6 +30,6 @@ class ProfilesFakerSeed extends AbstractSeed
             'phone' => $faker->phoneNumber,
             'website' => 'www.' . $faker->domainName,
         ];
-        ObjectsHandler::create('profiles', $data);
+        ObjectsHandler::save('profiles', $data);
     }
 }

--- a/plugins/BEdita/Core/config/Seeds/UsersFakerSeed.php
+++ b/plugins/BEdita/Core/config/Seeds/UsersFakerSeed.php
@@ -16,6 +16,6 @@ class UsersFakerSeed extends AbstractSeed
             'password' => $faker->password,
             'email' => $faker->email,
         ];
-        ObjectsHandler::create('users', $data);
+        ObjectsHandler::save('users', $data);
     }
 }

--- a/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
+++ b/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
@@ -47,21 +47,23 @@ class ObjectsHandler
     }
 
     /**
-     * Create a new object of type $type from $data array
+     * Save an object of type $type from $data array
      * Input data array is of the form
      * ['field1' => 'value1', 'field2' => 'value2']
      * User data must contain at least user 'id'.
      * If user data is missing current user is used if present
      * or sytem user (with 'id' = 1)
      *
+     * If $data['id'] is set, corresponding object is updated.
+     * On missing $data['id'] a new object is created.
      *
      * @param string|int $type Object type name or id
      * @param array $data Input data array
      * @param array $user User performing action data
      * @throws \Cake\Console\Exception\StopException
-     * @return \Cake\Datasource\EntityInterface|bool Entity created or false on error
+     * @return \Cake\Datasource\EntityInterface|bool Entity saved or false on error
      */
-    public static function create($type, $data, $user = [])
+    public static function save($type, $data, $user = [])
     {
         static::checkEnvironment();
         $currentUser = LoggedUser::getUser();
@@ -72,8 +74,13 @@ class ObjectsHandler
 
         $objectType = TableRegistry::get('ObjectTypes')->get($type);
         $table = TableRegistry::get($objectType->model);
-        $entity = $table->newEntity($data);
-        $entity->type = $objectType->name;
+        if (!empty($data['id'])) {
+            $entity = $table->get($data['id']);
+        } else {
+            $entity = $table->newEntity();
+        }
+        $entity = $table->patchEntity($entity, $data);
+        $entity->set('type', $objectType->name);
         $saveResult = $table->save($entity);
         if (!$saveResult) {
             Log::write('error', 'Object creation failed  - ' . $type . ' - ' . json_encode($entity->errors()));

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHanlderTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHanlderTest.php
@@ -43,7 +43,7 @@ class ObjectsHandlerTest extends TestCase
      * Test `create` and `remove` method
      *
      * @return void
-     * @covers ::create()
+     * @covers ::save()
      * @covers ::remove()
      * @covers ::checkEnvironment()
      */
@@ -51,13 +51,13 @@ class ObjectsHandlerTest extends TestCase
     {
         $data = ['username' => 'somenewusername', 'password' => 'somepassword'];
 
-        $entity = ObjectsHandler::create('users', $data);
+        $entity = ObjectsHandler::save('users', $data);
         $this->assertNotEmpty($entity);
         $userId = $entity->id;
         $this->assertInternalType('integer', $userId);
 
         $data = ['title' => 'a pragmatic title', 'description' => 'an agile descriptio'];
-        $entity = ObjectsHandler::create('documents', $data, ['id' => $userId]);
+        $entity = ObjectsHandler::save('documents', $data, ['id' => $userId]);
         $this->assertNotEmpty($entity);
         $docId = $entity->id;
         $this->assertInternalType('integer', $docId);
@@ -70,23 +70,37 @@ class ObjectsHandlerTest extends TestCase
     }
 
     /**
-     * Test `create` failure
+     * Test `save` failure
      *
      * @return void
-     * @covers ::create()
+     * @covers ::save()
      * @expectedException Cake\Console\Exception\StopException
      */
-    public function testCreateException()
+    public function testSaveException()
     {
         $data = [];
-        ObjectsHandler::create('users', $data);
+        ObjectsHandler::save('users', $data);
+    }
+
+    /**
+     * Test `save` existing object
+     *
+     * @return void
+     * @covers ::save()
+     */
+    public function testSaveExisting()
+    {
+        $data = ['id' => 5, 'description' => 'a new description'];
+        $entity = ObjectsHandler::save('users', $data);
+        $this->assertNotEmpty($entity);
+        $this->assertEquals(5, $entity->id);
     }
 
     /**
      * Test `delete` failure
      *
      * @return void
-     * @covers ::create()
+     * @covers ::remove()
      * @expectedException Cake\Datasource\Exception\RecordNotFoundException
      */
     public function testDeleteException()
@@ -104,7 +118,7 @@ class ObjectsHandlerTest extends TestCase
     public function testEnvironment()
     {
         Configure::write('debug', false);
-        ObjectsHandler::create('documents', []);
+        ObjectsHandler::save('documents', []);
         Configure::write('debug', true);
     }
 }


### PR DESCRIPTION
This PR allows `ObjectsHandler` actions on existing objects. 
`save()` method replaces `create()` - if `$data['id'] is set, corrsponding object is updated.