### PR TITLE
Use specific target table for relations when possible

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -280,6 +280,12 @@ class ObjectsControllerTest extends IntegrationTestCase
                         'self' => 'http://api.example.com/locations/8',
                     ],
                     'relationships' => [
+                        'another_test' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/locations/8/another_test',
+                                'self' => 'http://api.example.com/locations/8/relationships/another_test',
+                            ],
+                        ],
                         'inverse_another_test' => [
                             'links' => [
                                 'related' => 'http://api.example.com/locations/8/inverse_another_test',

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -279,6 +279,14 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'links' => [
                         'self' => 'http://api.example.com/locations/8',
                     ],
+                    'relationships' => [
+                        'inverse_another_test' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/locations/8/inverse_another_test',
+                                'self' => 'http://api.example.com/locations/8/relationships/inverse_another_test',
+                            ],
+                        ],
+                    ],
                 ],
                 [
                     'id' => '9',

--- a/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Model\Behavior;
 
+use BEdita\Core\Model\Entity\ObjectType;
 use BEdita\Core\ORM\Association\RelatedTo;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\ORM\Behavior;
@@ -30,6 +31,8 @@ class RelationsBehavior extends Behavior
     protected $_defaultConfig = [
         'objectType' => null,
         'implementedMethods' => [
+            'objectType' => 'objectType',
+            'setupRelations' => 'setupRelations',
             'getRelations' => 'getRelations',
         ],
     ];
@@ -48,52 +51,33 @@ class RelationsBehavior extends Behavior
     {
         parent::initialize($config);
 
-        $ObjectTypes = TableRegistry::get('ObjectTypes');
+        $this->setupRelations();
+    }
 
-        try {
-            $this->objectType = $ObjectTypes->get(
-                $this->getConfig('objectType') ?: $this->getTable()->getAlias()
-            );
-        } catch (RecordNotFoundException $e) {
-            return;
+    /**
+     * Getter/setter for object type.
+     *
+     * @param \BEdita\Core\Model\Entity\ObjectType|string|int|null $objectType
+     * @return \BEdita\Core\Model\Entity\ObjectType|null
+     */
+    public function objectType($objectType = null)
+    {
+        if ($objectType === null) {
+            return $this->objectType;
         }
 
-        $this->objectType = $ObjectTypes->loadInto(
-            $this->objectType,
-            ['LeftRelations', 'RightRelations']
+        $table = TableRegistry::get('ObjectTypes');
+        if (!($objectType instanceof ObjectType)) {
+            $objectType = $table->get($objectType);
+        }
+        $table->loadInto(
+            $objectType,
+            ['LeftRelations.RightObjectTypes', 'RightRelations.LeftObjectTypes']
         );
 
-        // Add relations to the left side.
-        foreach ($this->objectType->left_relations as $relation) {
-            $this->relatedTo($relation->alias, [
-                'className' => 'Objects',
-                'through' => 'ObjectRelations',
-                'foreignKey' => 'left_id',
-                'targetForeignKey' => 'right_id',
-                'conditions' => [
-                    'ObjectRelations.relation_id' => $relation->id,
-                ],
-                'sort' => [
-                    'ObjectRelations.priority' => 'asc',
-                ],
-            ]);
-        }
+        $this->objectType = $objectType;
 
-        // Add relations to the right side.
-        foreach ($this->objectType->right_relations as $relation) {
-            $this->relatedTo($relation->inverse_alias, [
-                'className' => 'Objects',
-                'through' => 'ObjectRelations',
-                'foreignKey' => 'right_id',
-                'targetForeignKey' => 'left_id',
-                'conditions' => [
-                    'ObjectRelations.relation_id' => $relation->id,
-                ],
-                'sort' => [
-                    'ObjectRelations.inv_priority' => 'asc',
-                ],
-            ]);
-        }
+        return $this->objectType;
     }
 
     /**
@@ -119,6 +103,85 @@ class RelationsBehavior extends Behavior
         $association = new RelatedTo($associated, $options);
 
         return $this->getTable()->associations()->add($association->getName(), $association);
+    }
+
+    /**
+     * Set up relations for the current table.
+     *
+     * @param string|int|null $objectType Object type name or ID.
+     * @return void
+     */
+    public function setupRelations($objectType = null)
+    {
+        if ($objectType === null) {
+            $objectType = $this->getConfig('objectType') ?: $this->getTable()->getAlias();
+        }
+
+        try {
+            $objectType = $this->objectType($objectType);
+        } catch (RecordNotFoundException $e) {
+            return;
+        }
+
+        // Add relations to the left side.
+        foreach ($objectType->left_relations as $relation) {
+            if ($this->getTable()->association($relation->alias) !== null) {
+                continue;
+            }
+
+            $className = 'BEdita/Core.Objects';
+            if (count($relation->right_object_types) === 1) {
+                $className = $relation->right_object_types[0]->table;
+            }
+
+            $through = TableRegistry::get(
+                $relation->alias . 'ObjectRelations',
+                ['className' => 'ObjectRelations']
+            );
+
+            $this->relatedTo($relation->alias, [
+                'className' => $className,
+                'through' => $through->getRegistryAlias(),
+                'foreignKey' => 'left_id',
+                'targetForeignKey' => 'right_id',
+                'conditions' => [
+                    $through->aliasField('relation_id') => $relation->id,
+                ],
+                'sort' => [
+                    $through->aliasField('priority') => 'asc',
+                ],
+            ]);
+        }
+
+        // Add relations to the right side.
+        foreach ($objectType->right_relations as $relation) {
+            if ($this->getTable()->association($relation->inverse_alias) !== null) {
+                continue;
+            }
+
+            $className = 'BEdita/Core.Objects';
+            if (count($relation->left_object_types) === 1) {
+                $className = $relation->left_object_types[0]->table;
+            }
+
+            $through = TableRegistry::get(
+                $relation->inverse_alias . 'ObjectRelations',
+                ['className' => 'ObjectRelations']
+            );
+
+            $this->relatedTo($relation->inverse_alias, [
+                'className' => $className,
+                'through' => $through->getRegistryAlias(),
+                'foreignKey' => 'right_id',
+                'targetForeignKey' => 'left_id',
+                'conditions' => [
+                    $through->aliasField('relation_id') => $relation->id,
+                ],
+                'sort' => [
+                    $through->aliasField('inv_priority') => 'asc',
+                ],
+            ]);
+        }
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
@@ -57,7 +57,7 @@ class RelationsBehavior extends Behavior
     /**
      * Getter/setter for object type.
      *
-     * @param \BEdita\Core\Model\Entity\ObjectType|string|int|null $objectType
+     * @param \BEdita\Core\Model\Entity\ObjectType|string|int|null $objectType Object type entity, name or ID.
      * @return \BEdita\Core\Model\Entity\ObjectType|null
      */
     public function objectType($objectType = null)

--- a/plugins/BEdita/Core/tests/Fixture/RelationTypesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/RelationTypesFixture.php
@@ -43,6 +43,16 @@ class RelationTypesFixture extends TestFixture
             'object_type_id' => 2,
             'side' => 'right',
         ],
+        [
+            'relation_id' => 2,
+            'object_type_id' => 4,
+            'side' => 'left',
+        ],
+        [
+            'relation_id' => 2,
+            'object_type_id' => 5,
+            'side' => 'right',
+        ],
     ];
 
     /**

--- a/plugins/BEdita/Core/tests/Fixture/RelationTypesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/RelationTypesFixture.php
@@ -45,7 +45,7 @@ class RelationTypesFixture extends TestFixture
         ],
         [
             'relation_id' => 2,
-            'object_type_id' => 4,
+            'object_type_id' => 5,
             'side' => 'left',
         ],
         [

--- a/plugins/BEdita/Core/tests/Fixture/RelationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/RelationsFixture.php
@@ -36,5 +36,13 @@ class RelationsFixture extends TestFixture
             'description' => 'Sample description.',
             'params' => null,
         ],
+        [
+            'name' => 'another_test',
+            'label' => 'Another test relation',
+            'inverse_name' => 'inverse_another_test',
+            'inverse_label' => 'Another inverse test relation',
+            'description' => 'Sample description /2.',
+            'params' => null,
+        ],
     ];
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/RelationsBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/RelationsBehaviorTest.php
@@ -37,6 +37,7 @@ class RelationsBehaviorTest extends TestCase
         'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.objects',
         'plugin.BEdita/Core.profiles',
+        'plugin.BEdita/Core.locations',
     ];
 
     /**
@@ -55,7 +56,7 @@ class RelationsBehaviorTest extends TestCase
 
         $Documents = TableRegistry::get('Documents');
         $Profiles = TableRegistry::get('Profiles');
-        $News = TableRegistry::get('News');
+        $Locations = TableRegistry::get('Locations');
 
         static::assertSame(1, $Documents->objectType()->id);
         static::assertSame(2, $Profiles->objectType()->id);
@@ -66,8 +67,10 @@ class RelationsBehaviorTest extends TestCase
         static::assertSame('BEdita/Core.Objects', $Documents->association('InverseTest')->className());
         static::assertInstanceOf(BelongsToMany::class, $Profiles->association('InverseTest'));
         static::assertSame('BEdita/Core.Objects', $Profiles->association('InverseTest')->className());
-        static::assertInstanceOf(BelongsToMany::class, $News->association('AnotherTest'));
-        static::assertSame('BEdita/Core.Locations', $News->association('AnotherTest')->className());
+        static::assertInstanceOf(BelongsToMany::class, $Locations->association('AnotherTest'));
+        static::assertSame('BEdita/Core.Locations', $Locations->association('AnotherTest')->className());
+        static::assertInstanceOf(BelongsToMany::class, $Locations->association('InverseAnotherTest'));
+        static::assertSame('BEdita/Core.Locations', $Locations->association('InverseAnotherTest')->className());
 
         $before = count($Profiles->associations()->keys());
         $Profiles->setupRelations('profiles');

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/RelationsBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/RelationsBehaviorTest.php
@@ -45,6 +45,8 @@ class RelationsBehaviorTest extends TestCase
      * @return void
      *
      * @covers ::initialize()
+     * @covers ::objectType()
+     * @covers ::setupRelations()
      * @covers ::relatedTo()
      */
     public function testInitialization()
@@ -54,9 +56,39 @@ class RelationsBehaviorTest extends TestCase
         $Documents = TableRegistry::get('Documents');
         $Profiles = TableRegistry::get('Profiles');
 
+        static::assertSame(1, $Documents->objectType()->id);
+        static::assertSame(2, $Profiles->objectType()->id);
+
         static::assertInstanceOf(BelongsToMany::class, $Documents->association('Test'));
+        static::assertSame('BEdita/Core.Objects', $Documents->association('Test')->className());
         static::assertInstanceOf(BelongsToMany::class, $Documents->association('InverseTest'));
+        static::assertSame('BEdita/Core.Objects', $Documents->association('InverseTest')->className());
         static::assertInstanceOf(BelongsToMany::class, $Profiles->association('InverseTest'));
+        static::assertSame('BEdita/Core.Objects', $Profiles->association('InverseTest')->className());
+
+        $before = count($Profiles->associations()->keys());
+        $Profiles->setupRelations('profiles');
+        $after = count($Profiles->associations()->keys());
+
+        static::assertSame($before, $after);
+    }
+
+    /**
+     * Test that no error occurs on an unknown object type, and no associations are set up.
+     *
+     * @return void
+     *
+     * @covers ::setupRelations()
+     */
+    public function testUnknownObjectType()
+    {
+        $FakeArticles = TableRegistry::get('FakeArticles');
+
+        $before = count($FakeArticles->associations()->keys());
+        $FakeArticles->addBehavior('BEdita/Core.Relations');
+        $after = count($FakeArticles->associations()->keys());
+
+        static::assertSame($before, $after);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/RelationsBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/RelationsBehaviorTest.php
@@ -55,6 +55,7 @@ class RelationsBehaviorTest extends TestCase
 
         $Documents = TableRegistry::get('Documents');
         $Profiles = TableRegistry::get('Profiles');
+        $News = TableRegistry::get('News');
 
         static::assertSame(1, $Documents->objectType()->id);
         static::assertSame(2, $Profiles->objectType()->id);
@@ -65,6 +66,8 @@ class RelationsBehaviorTest extends TestCase
         static::assertSame('BEdita/Core.Objects', $Documents->association('InverseTest')->className());
         static::assertInstanceOf(BelongsToMany::class, $Profiles->association('InverseTest'));
         static::assertSame('BEdita/Core.Objects', $Profiles->association('InverseTest')->className());
+        static::assertInstanceOf(BelongsToMany::class, $News->association('AnotherTest'));
+        static::assertSame('BEdita/Core.Locations', $News->association('AnotherTest')->className());
 
         $before = count($Profiles->associations()->keys());
         $Profiles->setupRelations('profiles');


### PR DESCRIPTION
This PR refactors `RelationsBehavior` in a way that uses a specific target table for relations whenever possible.

For instance, if the relation `my_relation` can have only Profiles on the right side, the behavior now creates a BelongsToMany association with `ProfilesTable` — before the association's target was always `ObjectsTable` regardless of the object types allowed on the other side.

At the moment, this works only for relations that accept only one object type on the opposite side. Surely this behavior can be made more clever, but this can be a start. 🙃 