### PR TITLE
Superpower date ranges 💪🏼💊

### DIFF
--- a/plugins/BEdita/Core/config/bootstrap.php
+++ b/plugins/BEdita/Core/config/bootstrap.php
@@ -40,5 +40,6 @@ if (!Configure::configured('ini')) {
  * Use custom DateTimeType
  */
 Type::set('datetime', new DateTimeType());
+Type::set('timestamp', new DateTimeType());
 
 Configure::load('BEdita/Core.bedita', 'ini');

--- a/plugins/BEdita/Core/src/Model/Entity/DateRange.php
+++ b/plugins/BEdita/Core/src/Model/Entity/DateRange.php
@@ -51,7 +51,8 @@ class DateRange extends Entity
      * @param \BEdita\Core\Model\Entity\DateRange $dateRange Date Range being compared.
      * @return bool
      */
-    public function isBefore(DateRange $dateRange) {
+    public function isBefore(DateRange $dateRange)
+    {
         return $this->start_date < $dateRange->start_date && ($this->end_date === null || $this->end_date <= $dateRange->start_date);
     }
 
@@ -61,17 +62,19 @@ class DateRange extends Entity
      * @param \BEdita\Core\Model\Entity\DateRange $dateRange Date Range being compared.
      * @return bool
      */
-    public function isAfter(DateRange $dateRange) {
+    public function isAfter(DateRange $dateRange)
+    {
         return $this->start_date > $dateRange->start_date && ($dateRange->end_date === null || $this->start_date >= $dateRange->end_date);
     }
 
     /**
      * Normalize an array of Date Ranges by sorting and joining overlapping Date Ranges.
      *
-     * @param \BEdita\Core\Model\Entity\DateRange[] $dateRanges
+     * @param \BEdita\Core\Model\Entity\DateRange[] $dateRanges Set of Date Ranges.
      * @return \BEdita\Core\Model\Entity\DateRange[]
      */
-    public static function normalize(array $dateRanges) {
+    public static function normalize(array $dateRanges)
+    {
         if (empty($dateRanges)) {
             return [];
         }
@@ -162,7 +165,6 @@ class DateRange extends Entity
 
                     break;
                 }
-
 
                 $dateRange->start_date = $dateRange2->end_date;
 

--- a/plugins/BEdita/Core/src/Model/Entity/DateRange.php
+++ b/plugins/BEdita/Core/src/Model/Entity/DateRange.php
@@ -21,7 +21,7 @@ use Cake\ORM\Entity;
  * @property int $id
  * @property int $object_id
  * @property \Cake\I18n\Time $start_date
- * @property \Cake\I18n\Time $end_date
+ * @property \Cake\I18n\Time|null $end_date
  * @property array $params
  *
  * @property \BEdita\Core\Model\Entity\ObjectEntity $object
@@ -44,4 +44,136 @@ class DateRange extends Entity
         'id',
         'object_id',
     ];
+
+    /**
+     * Check if this Date Range is before the passed Date Range.
+     *
+     * @param \BEdita\Core\Model\Entity\DateRange $dateRange Date Range being compared.
+     * @return bool
+     */
+    public function isBefore(DateRange $dateRange) {
+        return $this->start_date < $dateRange->start_date && ($this->end_date === null || $this->end_date <= $dateRange->start_date);
+    }
+
+    /**
+     * Check if this Date Range is after the passed Date Range.
+     *
+     * @param \BEdita\Core\Model\Entity\DateRange $dateRange Date Range being compared.
+     * @return bool
+     */
+    public function isAfter(DateRange $dateRange) {
+        return $this->start_date > $dateRange->start_date && ($dateRange->end_date === null || $this->start_date >= $dateRange->end_date);
+    }
+
+    /**
+     * Normalize an array of Date Ranges by sorting and joining overlapping Date Ranges.
+     *
+     * @param \BEdita\Core\Model\Entity\DateRange[] $dateRanges
+     * @return \BEdita\Core\Model\Entity\DateRange[]
+     */
+    public static function normalize(array $dateRanges) {
+        if (empty($dateRanges)) {
+            return [];
+        }
+
+        // Sort items.
+        usort($dateRanges, function (DateRange $dateRange1, DateRange $dateRange2) {
+            if ($dateRange1->isBefore($dateRange2)) {
+                return -1;
+            }
+            if ($dateRange1->isAfter($dateRange2)) {
+                return 1;
+            }
+
+            return 0;
+        });
+
+        // Merge items.
+        $result = [];
+        $last = array_shift($dateRanges);
+        while (($current = array_shift($dateRanges)) !== null) {
+            if ($last->isBefore($current) && $last->end_date < $current->start_date) {
+                $result[] = $last;
+                $last = $current;
+
+                continue;
+            }
+
+            $last->start_date = $last->start_date->min($current->start_date);
+            if ($last->end_date === null || ($current->end_date !== null && $last->end_date < $current->end_date)) {
+                $last->end_date = $current->end_date;
+            }
+        }
+        $result[] = $last;
+
+        return $result;
+    }
+
+    /**
+     * Compute difference between two sets of Date Ranges.
+     *
+     * @param \BEdita\Core\Model\Entity\DateRange[] $array1 First set of Date Ranges.
+     * @param \BEdita\Core\Model\Entity\DateRange[] $array2 Second set of Date Ranges.
+     * @return \BEdita\Core\Model\Entity\DateRange[]
+     */
+    public static function diff(array $array1, array $array2)
+    {
+        // Ensure array are normalized.
+        $array1 = static::normalize($array1);
+        $array2 = static::normalize($array2);
+
+        $result = [];
+        $dateRange = null;
+        foreach ($array1 as $dateRange1) {
+            if ($dateRange !== null) {
+                $result[] = $dateRange;
+            }
+            $dateRange = clone $dateRange1;
+
+            while (($dateRange2 = current($array2)) !== false) {
+                if ($dateRange->end_date === null && $dateRange2->end_date === null && $dateRange->start_date == $dateRange2->start_date) {
+                    // Discard range.
+                    $dateRange = null;
+                    next($array2);
+
+                    break;
+                }
+                if ($dateRange2->end_date === null || $dateRange2->isBefore($dateRange)) {
+                    // Does not affect intersection.
+                    next($array2);
+
+                    continue;
+                }
+                if ($dateRange2->isAfter($dateRange)) {
+                    // A step too far.
+                    break;
+                }
+                if ($dateRange->start_date < $dateRange2->start_date) {
+                    // Split the range.
+                    $temp = clone $dateRange;
+                    $temp->end_date = $dateRange2->start_date;
+                    $result[] = $temp;
+
+                    $dateRange->start_date = $dateRange2->start_date;
+                }
+                if ($dateRange->end_date < $dateRange2->end_date) {
+                    // Discard range.
+                    $dateRange = null;
+
+                    break;
+                }
+
+
+                $dateRange->start_date = $dateRange2->end_date;
+
+                next($array2);
+            }
+        }
+
+        if ($dateRange !== null) {
+            $result[] = $dateRange;
+        }
+
+        return $result;
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Entity/DateRange.php
+++ b/plugins/BEdita/Core/src/Model/Entity/DateRange.php
@@ -139,10 +139,10 @@ class DateRange extends Entity
      *
      * **Warning**: this method **does not** take `params` into account.
      *
-     * @param array[] ...$dateRanges Set of Date Ranges.
+     * @param \BEdita\Core\Model\Entity\DateRange[][] ...$dateRanges Set of Date Ranges.
      * @return \BEdita\Core\Model\Entity\DateRange[]
      */
-    public static function union(array ...$dateRanges)
+    public static function union(...$dateRanges)
     {
         $dateRanges = call_user_func_array('array_merge', $dateRanges);
 

--- a/plugins/BEdita/Core/src/Model/Entity/DateRange.php
+++ b/plugins/BEdita/Core/src/Model/Entity/DateRange.php
@@ -132,6 +132,24 @@ class DateRange extends Entity
     }
 
     /**
+     * Compute union of multiple sets of Date Ranges.
+     *
+     * This method computes union of multiple sets of Date Ranges.
+     * The result is returned in normalized form.
+     *
+     * **Warning**: this method **does not** take `params` into account.
+     *
+     * @param array[] ...$dateRanges Set of Date Ranges.
+     * @return \BEdita\Core\Model\Entity\DateRange[]
+     */
+    public static function union(array ...$dateRanges)
+    {
+        $dateRanges = call_user_func_array('array_merge', $dateRanges);
+
+        return static::normalize($dateRanges);
+    }
+
+    /**
      * Compute difference between two sets of Date Ranges.
      *
      * When computing complement of `$array1` with respect to `$array2`:

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/DateRangeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/DateRangeTest.php
@@ -575,7 +575,7 @@ class DateRangeTest extends TestCase
         $dateRanges1 = $this->DateRanges->newEntities($dateRanges1);
         $dateRanges2 = $this->DateRanges->newEntities($dateRanges2);
 
-        $result = DateRange::diff($dateRanges1,$dateRanges2);
+        $result = DateRange::diff($dateRanges1, $dateRanges2);
 
         $expected = json_decode(json_encode($expected), true);
         $result = json_decode(json_encode($result), true);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/DateRangeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/DateRangeTest.php
@@ -649,4 +649,84 @@ class DateRangeTest extends TestCase
 
         static::assertEquals($expected, $result);
     }
+
+    /**
+     * Data provider for `testCheckWellFormed` test case.
+     *
+     * @return array
+     */
+    public function checkWellFormedProvider()
+    {
+        return [
+            'not a date range' => [
+                new \LogicException('Invalid Date Range entity class: expected "BEdita\Core\Model\Entity\DateRange", got "resource"'),
+                [
+                    fopen(__FILE__, 'r'),
+                ],
+                false,
+            ],
+            'not a date range /2' => [
+                new \LogicException('Invalid Date Range entity class: expected "BEdita\Core\Model\Entity\DateRange", got "Cake\ORM\TableRegistry"'),
+                [
+                    new TableRegistry(),
+                ],
+                false,
+            ],
+            'invalid start date' => [
+                new \LogicException('Invalid "start_date": expected "Cake\I18n\Time", got "NULL"'),
+                [
+                    [
+                        'start_date' => null,
+                        'end_date' => '2017-01-01',
+                    ],
+                ],
+            ],
+            'invalid end date' => [
+                new \LogicException('Invalid "end_date": expected "Cake\I18n\Time", got "string"'),
+                [
+                    [
+                        'start_date' => '2017-01-01',
+                        'end_date' => 'better than yesterday, worse than tomorrow',
+                    ],
+                ],
+            ],
+            'ok' => [
+                true,
+                [
+                    [
+                        'start_date' => '2017-01-01',
+                        'end_date' => null,
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test case for checker method.
+     *
+     * @param bool|\Exception $expected Expected result
+     * @param array $dateRanges Date Ranges.
+     * @param bool $marshal Should entities be marshalled first?
+     * @return void
+     *
+     * @covers ::checkWellFormed()
+     * @dataProvider checkWellFormedProvider()
+     */
+    public function testCheckWellFormed($expected, array $dateRanges, $marshal = true)
+    {
+        if ($expected instanceof \Exception) {
+            static::expectException(get_class($expected));
+            static::expectExceptionMessage($expected->getMessage());
+        }
+
+        if ($marshal) {
+            $dateRanges = $this->DateRanges->newEntities($dateRanges);
+        }
+
+        DateRange::checkWellFormed(...$dateRanges);
+
+        // If we reached this point, either we `$expect === true` or something went wrong.
+        static::assertTrue($expected);
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/DateRangeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/DateRangeTest.php
@@ -1,0 +1,585 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Entity;
+
+use BEdita\Core\Model\Entity\DateRange;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * @coversDefaultClass \BEdita\Core\Model\Entity\DateRange
+ */
+class DateRangeTest extends TestCase
+{
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.date_ranges',
+    ];
+
+    /**
+     * Date Ranges table.
+     *
+     * @var \BEdita\Core\Model\Table\DateRangesTable
+     */
+    protected $DateRanges;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->DateRanges = TableRegistry::get('DateRanges');
+    }
+
+    /**
+     * Data provider for `testIsBefore` test case.
+     *
+     * @return array
+     */
+    public function isBeforeProvider()
+    {
+        return [
+            [
+                true,
+                [
+                    'start_date' => '2017-01-01',
+                    'end_date' => '2017-01-10',
+                ],
+                [
+                    'start_date' => '2017-02-01',
+                    'end_date' => '2017-02-10',
+                ],
+            ],
+            [
+                true,
+                [
+                    'start_date' => '2017-01-01',
+                    'end_date' => '2017-02-01',
+                ],
+                [
+                    'start_date' => '2017-02-01',
+                    'end_date' => null,
+                ],
+            ],
+            [
+                true,
+                [
+                    'start_date' => '2017-01-01',
+                    'end_date' => null,
+                ],
+                [
+                    'start_date' => '2017-02-01',
+                    'end_date' => '2017-02-10',
+                ],
+            ],
+            [
+                true,
+                [
+                    'start_date' => '2017-01-01',
+                    'end_date' => null,
+                ],
+                [
+                    'start_date' => '2017-02-01',
+                    'end_date' => null,
+                ],
+            ],
+            [
+                false,
+                [
+                    'start_date' => '2017-02-01',
+                    'end_date' => '2017-02-10',
+                ],
+                [
+                    'start_date' => '2017-01-01',
+                    'end_date' => '2017-01-10',
+                ],
+            ],
+            [
+                false,
+                [
+                    'start_date' => '2017-01-01',
+                    'end_date' => '2017-01-10',
+                ],
+                [
+                    'start_date' => '2017-01-01',
+                    'end_date' => '2017-01-10',
+                ],
+            ],
+            [
+                false,
+                [
+                    'start_date' => '2017-01-01',
+                    'end_date' => '2017-01-10',
+                ],
+                [
+                    'start_date' => '2017-01-05',
+                    'end_date' => null,
+                ],
+            ],
+            [
+                false,
+                [
+                    'start_date' => '2017-01-05',
+                    'end_date' => null,
+                ],
+                [
+                    'start_date' => '2017-01-01',
+                    'end_date' => '2017-01-10',
+                ],
+            ],
+            [
+                false,
+                [
+                    'start_date' => '2017-01-05',
+                    'end_date' => null,
+                ],
+                [
+                    'start_date' => '2017-01-01',
+                    'end_date' => null,
+                ],
+            ],
+            [
+                false,
+                [
+                    'start_date' => '2017-01-05',
+                    'end_date' => null,
+                ],
+                [
+                    'start_date' => '2017-01-05',
+                    'end_date' => null,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `isBefore` method.
+     *
+     * @param bool $expected Expected result
+     * @param array $dateRange1 Date Range 1.
+     * @param array $dateRange2 Date Range 2.
+     * @return void
+     *
+     * @covers ::isBefore()
+     * @dataProvider isBeforeProvider()
+     */
+    public function testIsBefore($expected, array $dateRange1, array $dateRange2)
+    {
+        $dateRange1 = $this->DateRanges->newEntity($dateRange1);
+        $dateRange2 = $this->DateRanges->newEntity($dateRange2);
+
+        $result = $dateRange1->isBefore($dateRange2);
+
+        static::assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider for `testIsAfter` test case.
+     *
+     * @return array
+     */
+    public function isAfterProvider()
+    {
+        return [
+            [
+                true,
+                [
+                    'start_date' => '2017-02-01',
+                    'end_date' => '2017-02-10',
+                ],
+                [
+                    'start_date' => '2017-01-01',
+                    'end_date' => '2017-01-10',
+                ],
+            ],
+            [
+                true,
+                [
+                    'start_date' => '2017-02-01',
+                    'end_date' => null,
+                ],
+                [
+                    'start_date' => '2017-01-01',
+                    'end_date' => '2017-02-01',
+                ],
+            ],
+            [
+                true,
+                [
+                    'start_date' => '2017-02-01',
+                    'end_date' => '2017-02-10',
+                ],
+                [
+                    'start_date' => '2017-01-01',
+                    'end_date' => null,
+                ],
+            ],
+            [
+                true,
+                [
+                    'start_date' => '2017-02-01',
+                    'end_date' => null,
+                ],
+                [
+                    'start_date' => '2017-01-01',
+                    'end_date' => null,
+                ],
+            ],
+            [
+                false,
+                [
+                    'start_date' => '2017-01-01',
+                    'end_date' => '2017-01-10',
+                ],
+                [
+                    'start_date' => '2017-02-01',
+                    'end_date' => '2017-02-10',
+                ],
+            ],
+            [
+                false,
+                [
+                    'start_date' => '2017-01-01',
+                    'end_date' => '2017-01-10',
+                ],
+                [
+                    'start_date' => '2017-01-01',
+                    'end_date' => '2017-01-10',
+                ],
+            ],
+            [
+                false,
+                [
+                    'start_date' => '2017-01-01',
+                    'end_date' => '2017-01-10',
+                ],
+                [
+                    'start_date' => '2017-01-05',
+                    'end_date' => null,
+                ],
+            ],
+            [
+                false,
+                [
+                    'start_date' => '2017-01-05',
+                    'end_date' => null,
+                ],
+                [
+                    'start_date' => '2017-01-01',
+                    'end_date' => '2017-01-10',
+                ],
+            ],
+            [
+                false,
+                [
+                    'start_date' => '2017-01-01',
+                    'end_date' => null,
+                ],
+                [
+                    'start_date' => '2017-01-05',
+                    'end_date' => null,
+                ],
+            ],
+            [
+                false,
+                [
+                    'start_date' => '2017-01-05',
+                    'end_date' => null,
+                ],
+                [
+                    'start_date' => '2017-01-05',
+                    'end_date' => null,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `$this->isAfter()` method.
+     *
+     * @param bool $expected Expected result
+     * @param array $dateRange1 Date Range 1.
+     * @param array $dateRange2 Date Range 2.
+     * @return void
+     *
+     * @covers ::isAfter()
+     * @dataProvider isAfterProvider()
+     */
+    public function testIsAfter($expected, array $dateRange1, array $dateRange2)
+    {
+        $dateRange1 = $this->DateRanges->newEntity($dateRange1);
+        $dateRange2 = $this->DateRanges->newEntity($dateRange2);
+
+        $result = $dateRange1->isAfter($dateRange2);
+
+        static::assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider for `testNormalize` test case.
+     *
+     * @return array
+     */
+    public function normalizeProvider()
+    {
+        return [
+            'empty' => [
+                [],
+                [],
+            ],
+            'sort' => [
+                [
+                    [
+                        'start_date' => '2017-01-01',
+                        'end_date' => '2017-01-10',
+                    ],
+                    [
+                        'start_date' => '2017-01-20',
+                        'end_date' => null,
+                    ],
+                    [
+                        'start_date' => '2017-02-01',
+                        'end_date' => '2017-02-10',
+                    ],
+                ],
+                [
+                    [
+                        'start_date' => '2017-02-01',
+                        'end_date' => '2017-02-10',
+                    ],
+                    [
+                        'start_date' => '2017-01-01',
+                        'end_date' => '2017-01-10',
+                    ],
+                    [
+                        'start_date' => '2017-01-20',
+                        'end_date' => null,
+                    ],
+                ],
+            ],
+            'merge' => [
+                [
+                    [
+                        'start_date' => '2017-01-01',
+                        'end_date' => '2017-01-10',
+                    ],
+                    [
+                        'start_date' => '2017-01-20',
+                        'end_date' => null,
+                    ],
+                    [
+                        'start_date' => '2017-02-01',
+                        'end_date' => '2017-02-10',
+                    ],
+                ],
+                [
+                    [
+                        'start_date' => '2017-02-01',
+                        'end_date' => '2017-02-07',
+                    ],
+                    [
+                        'start_date' => '2017-01-01',
+                        'end_date' => '2017-01-05',
+                    ],
+                    [
+                        'start_date' => '2017-02-02',
+                        'end_date' => '2017-02-06',
+                    ],
+                    [
+                        'start_date' => '2017-02-04',
+                        'end_date' => null,
+                    ],
+                    [
+                        'start_date' => '2017-01-05',
+                        'end_date' => '2017-01-10',
+                    ],
+                    [
+                        'start_date' => '2017-01-20',
+                        'end_date' => null,
+                    ],
+                    [
+                        'start_date' => '2017-02-07',
+                        'end_date' => '2017-02-10',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test case for normalization method.
+     *
+     * @param array $expected Expected result.
+     * @param array $dateRanges Date Ranges.
+     * @return void
+     *
+     * @covers ::normalize()
+     * @dataProvider normalizeProvider()
+     */
+    public function testNormalize(array $expected, array $dateRanges)
+    {
+        $expected = $this->DateRanges->newEntities($expected);
+        $dateRanges = $this->DateRanges->newEntities($dateRanges);
+
+        $result = DateRange::normalize($dateRanges);
+
+        $expected = json_decode(json_encode($expected), true);
+        $result = json_decode(json_encode($result), true);
+
+        static::assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider for `testDiff` test case.
+     *
+     * @return array
+     */
+    public function diffProvider()
+    {
+        return [
+            'empty' => [
+                [],
+                [],
+                [
+                    [
+                        'start_date' => '2017-01-01',
+                        'end_date' => '2017-01-10',
+                    ],
+                ],
+            ],
+            'sort' => [
+                [
+                    [
+                        'start_date' => '2017-01-01',
+                        'end_date' => '2017-01-02',
+                    ],
+                    [
+                        'start_date' => '2017-01-03',
+                        'end_date' => '2017-01-08',
+                    ],
+                    [
+                        'start_date' => '2017-01-20',
+                        'end_date' => null,
+                    ],
+                    [
+                        'start_date' => '2017-02-05',
+                        'end_date' => '2017-02-07',
+                    ],
+                    [
+                        'start_date' => '2017-03-02',
+                        'end_date' => '2017-03-05',
+                    ],
+                ],
+                [
+                    [
+                        'start_date' => '2017-01-01',
+                        'end_date' => '2017-01-10',
+                    ],
+                    [
+                        'start_date' => '2017-01-17',
+                        'end_date' => null,
+                    ],
+                    [
+                        'start_date' => '2017-01-20',
+                        'end_date' => null,
+                    ],
+                    [
+                        'start_date' => '2017-01-27',
+                        'end_date' => null,
+                    ],
+                    [
+                        'start_date' => '2017-02-01',
+                        'end_date' => '2017-02-10',
+                    ],
+                    [
+                        'start_date' => '2017-02-15',
+                        'end_date' => '2017-02-20',
+                    ],
+                    [
+                        'start_date' => '2017-01-25',
+                        'end_date' => null,
+                    ],
+                    [
+                        'start_date' => '2017-03-01',
+                        'end_date' => '2017-03-05',
+                    ],
+                ],
+                [
+                    [
+                        'start_date' => '2017-01-02',
+                        'end_date' => '2017-01-03',
+                    ],
+                    [
+                        'start_date' => '2017-01-05',
+                        'end_date' => null,
+                    ],
+                    [
+                        'start_date' => '2017-01-08',
+                        'end_date' => '2017-01-09',
+                    ],
+                    [
+                        'start_date' => '2017-01-09',
+                        'end_date' => '2017-01-15',
+                    ],
+                    [
+                        'start_date' => '2017-01-17',
+                        'end_date' => null,
+                    ],
+                    [
+                        'start_date' => '2017-01-25',
+                        'end_date' => '2017-02-05',
+                    ],
+                    [
+                        'start_date' => '2017-02-07',
+                        'end_date' => '2017-03-02',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test case for difference method.
+     *
+     * @param array $expected Expected result.
+     * @param array $dateRanges1 Date Ranges.
+     * @param array $dateRanges2 Date Ranges.
+     * @return void
+     *
+     * @covers ::diff()
+     * @dataProvider diffProvider()
+     */
+    public function testDiff(array $expected, array $dateRanges1, array $dateRanges2)
+    {
+        $expected = $this->DateRanges->newEntities($expected);
+        $dateRanges1 = $this->DateRanges->newEntities($dateRanges1);
+        $dateRanges2 = $this->DateRanges->newEntities($dateRanges2);
+
+        $result = DateRange::diff($dateRanges1,$dateRanges2);
+
+        $expected = json_decode(json_encode($expected), true);
+        $result = json_decode(json_encode($result), true);
+
+        static::assertEquals($expected, $result);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/DateRangeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/DateRangeTest.php
@@ -450,6 +450,73 @@ class DateRangeTest extends TestCase
     }
 
     /**
+     * Test case for union method.
+     *
+     * @return void
+     *
+     * @covers ::union()
+     */
+    public function testUnion()
+    {
+        $expected = $this->DateRanges->newEntities([
+            [
+                'start_date' => '2017-01-01',
+                'end_date' => '2017-01-10',
+            ],
+            [
+                'start_date' => '2017-01-20',
+                'end_date' => null,
+            ],
+            [
+                'start_date' => '2017-02-01',
+                'end_date' => '2017-02-10',
+            ],
+        ]);
+
+        $dateRanges1 = $this->DateRanges->newEntities([
+            [
+                'start_date' => '2017-01-01',
+                'end_date' => '2017-01-05',
+            ],
+            [
+                'start_date' => '2017-01-20',
+                'end_date' => null,
+            ],
+        ]);
+        $dateRanges2 = $this->DateRanges->newEntities([
+            [
+                'start_date' => '2017-02-05',
+                'end_date' => null,
+            ],
+            [
+                'start_date' => '2017-01-20',
+                'end_date' => null,
+            ],
+        ]);
+        $dateRanges3 = $this->DateRanges->newEntities([
+            [
+                'start_date' => '2017-01-05',
+                'end_date' => '2017-01-10',
+            ],
+            [
+                'start_date' => '2017-02-01',
+                'end_date' => '2017-02-10',
+            ],
+            [
+                'start_date' => '2017-01-20',
+                'end_date' => null,
+            ],
+        ]);
+
+        $result = DateRange::union($dateRanges1, $dateRanges2, $dateRanges3);
+
+        $expected = json_decode(json_encode($expected), true);
+        $result = json_decode(json_encode($result), true);
+
+        static::assertSame($expected, $result);
+    }
+
+    /**
      * Data provider for `testDiff` test case.
      *
      * @return array
@@ -467,7 +534,7 @@ class DateRangeTest extends TestCase
                     ],
                 ],
             ],
-            'sort' => [
+            'complex' => [
                 [
                     [
                         'start_date' => '2017-01-01',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/DateRangesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/DateRangesTableTest.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
+use Cake\I18n\Time;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -59,6 +60,24 @@ class DateRangesTableTest extends TestCase
         unset($this->DateRanges);
 
         parent::tearDown();
+    }
+
+    /**
+     * Test marshalling of new entities.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testMarshal()
+    {
+        $dateRange = $this->DateRanges->newEntity([
+            'start_date' => '2017-01-01',
+            'end_date' => '2017-01-10T17:18:19Z',
+        ]);
+
+        static::assertInstanceOf(Time::class, $dateRange->start_date);
+        static::assertInstanceOf(Time::class, $dateRange->end_date);
     }
 
     /**


### PR DESCRIPTION
This PR adds some utility methods to `DateRanges` entity class. It also fixes an issue with marshalling DateRanges when using a PostgreSQL backend.

### Comparison methods

Methods are introduced to:
- `isBefore()`: check if a date range is before another date range.
- `isAfter()`: check if a date range is after another date range.

In both cases, if the date ranges being compared do overlap, they are considered "not sortable", thus both `isBefore()` and `isAfter()` methods will return `false`.

### Operations on unions of date ranges

Static methods are introduced to:
- `normalize()`: normalize an array of date ranges — sort by start date, merge overlapping date ranges.
- `union()`: compute set union of two or more arrays of date ranges.
- `diff()`: compute [set difference](https://en.wikipedia.org/wiki/Complement_(set_theory)) between two arrays of date ranges. Special thanks to @didoda.

In all cases "[singleton](https://en.wikipedia.org/wiki/Singleton_(mathematics))" date ranges (i.e. date ranges with `end_date === null`) are considered irrelevant when compared to an interval. For instance, computing the relative complement of the interval `[2017-01-01 00:00:00, 2017-01-10 23:59:59]` with respect to the unit set `{2017-01-05 12:00:00}` will have no effect. Doing the opposite (`{2017-01-05 12:00:00} \ [2017-01-01 00:00:00, 2017-01-10 23:59:59]`) will result in an empty set, as well as subtracting two identical unit sets (`{2017-01-05 12:00:00} \ {2017-01-05 12:00:00}`).