### PR TITLE
Feature/v4/query filter trait

### DIFF
--- a/plugins/BEdita/Core/src/Model/Action/ListEntitiesAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListEntitiesAction.php
@@ -14,7 +14,6 @@
 namespace BEdita\Core\Model\Action;
 
 use BEdita\Core\ORM\QueryFilterTrait;
-use Cake\Database\Expression\QueryExpression;
 use Cake\ORM\Query;
 use Cake\Utility\Inflector;
 

--- a/plugins/BEdita/Core/src/Model/Action/ListEntitiesAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListEntitiesAction.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Model\Action;
 
+use BEdita\Core\ORM\QueryFilterTrait;
 use Cake\Database\Expression\QueryExpression;
 use Cake\ORM\Query;
 use Cake\Utility\Inflector;
@@ -24,6 +25,7 @@ use Cake\Utility\Inflector;
  */
 class ListEntitiesAction extends BaseAction
 {
+    use QueryFilterTrait;
 
     /**
      * Table.
@@ -124,17 +126,7 @@ class ListEntitiesAction extends BaseAction
             if ($this->Table->hasField($key, true)) {
                 // Filter on single field.
                 $key = $this->Table->aliasField($key);
-                if ($value === null) {
-                    $query = $query->andWhere(function (QueryExpression $exp) use ($key) {
-                        return $exp->isNull($key);
-                    });
-
-                    continue;
-                }
-
-                $query = $query->andWhere(function (QueryExpression $exp) use ($key, $value) {
-                    return $exp->in($key, (array)$value);
-                });
+                $query = $this->fieldsFilter($query, [$key => $value]);
 
                 continue;
             }

--- a/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
@@ -123,11 +123,10 @@ class DateRangesTable extends Table
     public function findDateRanges(Query $query, array $options)
     {
         $options = array_intersect_key($options, array_flip(['start_date', 'end_date']));
-
-        foreach ($options as $field => $conditions) {
-            $options[$this->aliasField($field)] = $conditions;
-            unset($options[$field]);
-        }
+        $options = array_combine(
+            array_map([$this, 'aliasField'], array_keys($options)),
+            array_values($options)
+        );
 
         return $this->fieldsFilter($query, $options);
     }

--- a/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Model\Table;
 
+use BEdita\Core\ORM\QueryFilterTrait;
 use Cake\Database\Expression\QueryExpression;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
@@ -34,6 +35,7 @@ use Cake\Validation\Validator;
  */
 class DateRangesTable extends Table
 {
+    use QueryFilterTrait;
 
     /**
      * Initialize method
@@ -123,55 +125,11 @@ class DateRangesTable extends Table
     {
         $options = array_intersect_key($options, array_flip(['start_date', 'end_date']));
 
-        return $query->where(function (QueryExpression $exp) use ($options) {
-            foreach ($options as $field => $conditions) {
-                $field = $this->aliasField($field);
+        foreach ($options as $field => $conditions) {
+            $options[$this->aliasField($field)] = $conditions;
+            unset($options[$field]);
+        }
 
-                if (!is_array($conditions)) {
-                    $exp = $exp->eq($field, $conditions);
-
-                    continue;
-                }
-
-                foreach ($conditions as $operator => $value) {
-                    switch ($operator) {
-                        case 'eq':
-                        case '=':
-                            $exp = $exp->eq($field, $value);
-                            break;
-
-                        case 'neq':
-                        case 'ne':
-                        case '!=':
-                        case '<>':
-                            $exp = $exp->notEq($field, $value);
-                            break;
-
-                        case 'lt':
-                        case '<':
-                            $exp = $exp->lt($field, $value);
-                            break;
-
-                        case 'lte':
-                        case 'le':
-                        case '<=':
-                            $exp = $exp->lte($field, $value);
-                            break;
-
-                        case 'gt':
-                        case '>':
-                            $exp = $exp->gt($field, $value);
-                            break;
-
-                        case 'gte':
-                        case 'ge':
-                        case '>=':
-                            $exp = $exp->gte($field, $value);
-                    }
-                }
-            }
-
-            return $exp;
-        });
+        return $this->fieldsFilter($query, $options);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
@@ -14,7 +14,6 @@
 namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\ORM\QueryFilterTrait;
-use Cake\Database\Expression\QueryExpression;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;

--- a/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
+++ b/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
@@ -25,7 +25,7 @@ trait QueryFilterTrait
 {
     /**
      * Create query filter using various operators on fields
-     * Options arrya must contain fields as keys and operators like
+     * Options array must contain fields as keys and operators like
      *   - 'gt' or '>' (greather than)
      *   - 'lt' or '<' (less than),
      *   - 'ge' or '>=' (greater or equal)
@@ -109,7 +109,6 @@ trait QueryFilterTrait
                         case 'ge':
                         case '>=':
                             $exp = $exp->gte($field, $value);
-
                     }
                 }
                 if (!empty($in)) {

--- a/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
+++ b/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\ORM;
+
+use Cake\Database\Expression\QueryExpression;
+use Cake\ORM\Query;
+
+/**
+ * Query Filter trait.
+ *
+ * @since 4.0.0
+ */
+trait QueryFilterTrait
+{
+    /**
+     * Create query filter using various operators on fields
+     * Options arrya must contain fields as keys and operators like
+     *   - 'gt' or '>' (greather than)
+     *   - 'lt' or '<' (less than),
+     *   - 'ge' or '>=' (greater or equal)
+     *   - 'le' or '<=' (less or equal) with a date
+     *
+     * It's also possible to specify an expected value or a list of values for a field
+     *
+     * Options array examples:
+     *
+     * ```
+     * // field1 greater than 10, field2 less then 5
+     * ['field1' => ['gt' => 10], 'field2' => ['lt' => 5]];
+     *
+     * // field1 in [1, 3, 10]
+     * ['field1' => [1, 3, 10]];
+
+     * // field1 equals 10, field2 equals 1
+     * ['field1' => 10, 'field1' => ['eq' => 1]];
+     *
+     * // field1 greater or equal 5, field2 less or equal 4
+     * ['field1' => ['>=' => 10], 'field2' => ['<=' => 4]];
+     * ```
+
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @param array $options Array of acceptable fields and conditions.
+     * @return \Cake\ORM\Query
+     */
+    public function fieldsFilter(Query $query, array $options)
+    {
+        return $query->where(function (QueryExpression $exp) use ($options) {
+            foreach ($options as $field => $conditions) {
+                if ($conditions === null) {
+                    $exp = $exp->isNull($field);
+
+                    continue;
+                }
+
+                if (!is_array($conditions)) {
+                    $exp = $exp->eq($field, $conditions);
+
+                    continue;
+                }
+
+                $in = [];
+                foreach ($conditions as $operator => $value) {
+                    if (is_numeric($operator)) {
+                        $in[] = $value;
+                        continue;
+                    }
+
+                    switch ($operator) {
+                        case 'eq':
+                        case '=':
+                            $exp = $exp->eq($field, $value);
+                            break;
+
+                        case 'neq':
+                        case 'ne':
+                        case '!=':
+                        case '<>':
+                            $exp = $exp->notEq($field, $value);
+                            break;
+
+                        case 'lt':
+                        case '<':
+                            $exp = $exp->lt($field, $value);
+                            break;
+
+                        case 'lte':
+                        case 'le':
+                        case '<=':
+                            $exp = $exp->lte($field, $value);
+                            break;
+
+                        case 'gt':
+                        case '>':
+                            $exp = $exp->gt($field, $value);
+                            break;
+
+                        case 'gte':
+                        case 'ge':
+                        case '>=':
+                            $exp = $exp->gte($field, $value);
+
+                    }
+                }
+                if (!empty($in)) {
+                    $exp = $exp->in($field, $in);
+                }
+            }
+
+            return $exp;
+        });
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\ORM;
+
+use BEdita\Core\ORM\QueryFilterTrait;
+use Cake\ORM\Query;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see BEdita\Core\ORM\QueryFilterTrait} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\ORM\QueryFilterTrait
+ */
+class QueryFilterTraitTest extends TestCase
+{
+    use QueryFilterTrait;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.fake_animals',
+    ];
+
+    /**
+     * Table FakeAnimals
+     *
+     * @var \Cake\ORM\Table
+     */
+    public $fakeAnimals;
+
+    /**
+     * Query Filter class.
+     *
+     * @var QueryFilterTestCase
+     */
+    protected $queryFilter;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->fakeAnimals = TableRegistry::get('FakeAnimals');
+    }
+
+    /**
+     * Data provider for `testFieldsFilter` test case.
+     *
+     * @return array
+     */
+    public function fieldsFilterProvider()
+    {
+        return [
+            'more' => [
+                [
+                    'legs' => ['gt' => 2],
+                ],
+                2,
+            ],
+            'nameLess' => [
+                [
+                    'name' => ['lt' => 'name'],
+                ],
+                3,
+            ],
+            'nameNull' => [
+                [
+                    'name' => null,
+                ],
+                0,
+            ],
+            'nameEagle' => [
+                [
+                    'name' => 'eagle',
+                ],
+                1,
+            ],
+            'allLegs' => [
+                [
+                    'legs' => [2, 3, 4],
+                ],
+                3,
+            ],
+            'legss' => [
+                [
+                    'legs' => ['le' => 2],
+                ],
+                1,
+            ],
+            'legsGe' => [
+                [
+                    'legs' => ['ge' => 3],
+                ],
+                2,
+            ],
+            'legsno' => [
+                [
+                    'name' => 'koala',
+                    'legs' => ['eq' => 3],
+                ],
+                0,
+            ],
+            'nobird' => [
+                [
+                    'name' => ['ne' => 'bird'],
+                ],
+                3,
+            ],
+            'nosnake' => [
+                [
+                    'name' => ['eq' => 'snake'],
+                    'legs' => ['lt' => 1],
+                ],
+                0,
+            ],
+            'catcat' => [
+                [
+                    'name' => 'cat',
+                    'legs' => ['gt' => 2],
+                ],
+                1,
+            ],
+            'multicat' => [
+                [
+                    'legs' => ['>=' => 2, '<' => 4],
+                ],
+                1,
+            ],
+        ];
+    }
+
+    /**
+     * Test fields filter method.
+     *
+     * @param array $conditions Date conditions.
+     * @param array|false $numExpected Number of expected results.
+     * @return void
+     *
+     * @dataProvider fieldsFilterProvider
+     * @covers ::fieldsFilter()
+     */
+    public function testFieldsFilter($options, $numExpected)
+    {
+        $query = new Query($this->fakeAnimals->getConnection(), $this->fakeAnimals);
+        $query = $this->fieldsFilter($query, $options);
+        $found = $query->toArray();
+        static::assertEquals(count($found), $numExpected);
+    }
+}


### PR DESCRIPTION
This PR adds operators to current field filter in `ListEntitiesAction`  via a new `QueryFilterTrait`

this enables us to build query string filters like:
```
?filter[field][gt]=somevalue
?filter[field][]=a&filter[field][]=b
?filter[field1][le]=a&filter[field2][ge]=b
```