### PR TITLE
Relationship issues

### DIFF
--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -58,8 +58,8 @@ class ObjectsController extends ResourcesController
         if ($this->request->getParam('action') === 'relationships') {
             $name = $this->request->getParam('relationship');
             $allowedTypes = TableRegistry::get('ObjectTypes')
-                ->find('byRelation', compact('name'))
                 ->find('list')
+                ->find('byRelation', compact('name'))
                 ->toArray();
 
             $this->setConfig(sprintf('allowedAssociations.%s', $name), $allowedTypes);

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -198,9 +198,10 @@ class ObjectsController extends ResourcesController
         $relatedId = $this->request->getParam('related_id');
 
         $association = $this->findAssociation($relationship);
+        $filter = $this->request->getQuery('filter');
 
         $action = new ListRelatedObjectsAction(compact('association'));
-        $query = $action(['primaryKey' => $relatedId]);
+        $query = $action(['primaryKey' => $relatedId, 'filter' => $filter]);
 
         $objects = $this->paginate($query);
 
@@ -235,8 +236,10 @@ class ObjectsController extends ResourcesController
 
             case 'GET':
             default:
+                $filter = $this->request->getQuery('filter');
+
                 $action = new ListRelatedObjectsAction(compact('association'));
-                $data = $action(['primaryKey' => $id, 'list' => true]);
+                $data = $action(['primaryKey' => $id, 'list' => true, 'filter' => $filter]);
 
                 if ($data instanceof Query) {
                     $data = $this->paginate($data);

--- a/plugins/BEdita/Core/src/Model/Action/ListObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListObjectsAction.php
@@ -46,6 +46,8 @@ class ListObjectsAction extends BaseAction
 
     /**
      * {@inheritDoc}
+     *
+     * @return \Cake\ORM\Query
      */
     public function execute(array $data = [])
     {

--- a/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
@@ -260,7 +260,7 @@ class ObjectTypesTable extends Table
         if (empty($options['name'])) {
             throw new \LogicException(__d('bedita', 'Missing required parameter "{0}"', 'name'));
         }
-        $name = $options['name'];
+        $name = Inflector::underscore($options['name']);
 
         $leftField = 'inverse_name';
         $rightField = 'name';
@@ -269,8 +269,7 @@ class ObjectTypesTable extends Table
             $rightField = 'inverse_name';
         }
 
-        $query = $query->select($this->aliasField('name'));
-        $queryCopy = clone $query;
+        $queryCopy = $query->cleanCopy();
 
         return $query
             ->matching('LeftRelations', function (Query $query) use ($name, $leftField) {

--- a/plugins/BEdita/Core/tests/Fixture/ObjectRelationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ObjectRelationsFixture.php
@@ -39,5 +39,13 @@ class ObjectRelationsFixture extends TestFixture
             'inv_priority' => 1,
             'params' => '',
         ],
+        [
+            'left_id' => 8,
+            'relation_id' => 2,
+            'right_id' => 8,
+            'priority' => 1,
+            'inv_priority' => 1,
+            'params' => '',
+        ],
     ];
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsActionTest.php
@@ -36,6 +36,7 @@ class ListRelatedObjectsActionTest extends TestCase
         'plugin.BEdita/Core.objects',
         'plugin.BEdita/Core.object_relations',
         'plugin.BEdita/Core.profiles',
+        'plugin.BEdita/Core.locations',
     ];
 
     /**
@@ -112,6 +113,44 @@ class ListRelatedObjectsActionTest extends TestCase
                 'inverse_test',
                 4,
             ],
+            [
+                [
+                    [
+                        'id' => 8,
+                        'type' => 'locations',
+                        'coords' => 'POINT(44.4944183 11.3464055)',
+                        'address' => 'Piazza di Porta Ravegnana',
+                        'locality' => 'Bologna',
+                        'postal_code' => '40126',
+                        'country_name' => 'Italy',
+                        'region' => 'Emilia-romagna',
+                        'status' => 'on',
+                        'uname' => 'the-two-towers',
+                        'locked' => false,
+                        'created' => '2017-02-20T07:09:23+00:00',
+                        'modified' => '2017-02-20T07:09:23+00:00',
+                        'published' => '2017-02-20T07:09:23+00:00',
+                        'title' => 'The Two Towers',
+                        'description' => null,
+                        'body' => null,
+                        'extra' => null,
+                        'lang' => 'eng',
+                        'created_by' => 1,
+                        'modified_by' => 1,
+                        'publish_start' => null,
+                        'publish_end' => null,
+                        '_joinData' => [
+                            'priority' => 1,
+                            'inv_priority' => 1,
+                            'params' => null,
+                        ],
+                    ],
+                ],
+                'Locations',
+                'another_test',
+                8,
+                false,
+            ],
         ];
     }
 
@@ -122,17 +161,18 @@ class ListRelatedObjectsActionTest extends TestCase
      * @param string $objectType Object type name.
      * @param string $relation Relation name.
      * @param int $id ID.
+     * @param bool $list Should results be presented in a list format?
      * @return void
      *
      * @dataProvider invocationProvider()
      */
-    public function testInvocation($expected, $objectType, $relation, $id)
+    public function testInvocation($expected, $objectType, $relation, $id, $list = true)
     {
         $alias = Inflector::camelize(Inflector::underscore($relation));
         $association = TableRegistry::get($objectType)->association($alias);
         $action = new ListRelatedObjectsAction(compact('association'));
 
-        $result = $action(['primaryKey' => $id, 'list' => true]);
+        $result = $action(['primaryKey' => $id] + compact('list'));
         $result = json_decode(json_encode($result->toArray()), true);
 
         static::assertEquals($expected, $result);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsActionTest.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Test\TestCase\Model\Action;
 
 use BEdita\Core\Model\Action\ListRelatedObjectsAction;
+use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Inflector;
@@ -151,28 +152,58 @@ class ListRelatedObjectsActionTest extends TestCase
                 8,
                 false,
             ],
+            [
+                [
+                    [
+                        'id' => 2,
+                        'type' => 'documents',
+                        '_joinData' => [
+                            'priority' => 1,
+                            'inv_priority' => 2,
+                            'params' => null,
+                        ],
+                    ],
+                ],
+                'Profiles',
+                'inverse_test',
+                4,
+                true,
+                [2],
+            ],
+            [
+                new RecordNotFoundException('Record not found in table "locations"'),
+                'Locations',
+                'another_test',
+                -1,
+            ],
         ];
     }
 
     /**
      * Test command invocation.
      *
-     * @param array $expected Expected result.
+     * @param array|\Exception $expected Expected result.
      * @param string $objectType Object type name.
      * @param string $relation Relation name.
      * @param int $id ID.
      * @param bool $list Should results be presented in a list format?
+     * @param array|null $only Filter related entities by ID.
      * @return void
      *
      * @dataProvider invocationProvider()
      */
-    public function testInvocation($expected, $objectType, $relation, $id, $list = true)
+    public function testInvocation($expected, $objectType, $relation, $id, $list = true, array $only = null)
     {
+        if ($expected instanceof \Exception) {
+            static::expectException(get_class($expected));
+            static::expectExceptionMessage($expected->getMessage());
+        }
+
         $alias = Inflector::camelize(Inflector::underscore($relation));
         $association = TableRegistry::get($objectType)->association($alias);
         $action = new ListRelatedObjectsAction(compact('association'));
 
-        $result = $action(['primaryKey' => $id] + compact('list'));
+        $result = $action(['primaryKey' => $id] + compact('list', 'only'));
         $result = json_decode(json_encode($result->toArray()), true);
 
         static::assertEquals($expected, $result);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
@@ -383,8 +383,8 @@ class ObjectTypesTableTest extends TestCase
         }
 
         $result = $this->ObjectTypes
-            ->find('byRelation', $options)
             ->find('list')
+            ->find('byRelation', $options)
             ->toArray();
 
         static::assertEquals($expected, $result, '', 0, 10, true);


### PR DESCRIPTION
This PR resolves #1169.

`ListRelatedObjectAction` has been heavily refactored and it now uses a completely different strategy to list related objects. As a result of this refactor, `ListObjectsAction` is now used under the hood. This means that related objects can be filtered using `?filter` query param, and deleted objects are now properly excluded from such lists (this closes #1168).