### PR TITLE
Refactor ListAssociatedAction

### DIFF
--- a/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
@@ -27,6 +27,7 @@ use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
+use Cake\Utility\Inflector;
 
 /**
  * Command to list entities associated to another entity.
@@ -41,7 +42,7 @@ class ListAssociatedAction extends BaseAction
      *
      * @var string
      */
-    const INVERSE_ASSOCIATION_NAME = 'InverseAssociation';
+    const INVERSE_ASSOCIATION_NAME = '_InverseAssociation';
 
     /**
      * Association.
@@ -135,8 +136,9 @@ class ListAssociatedAction extends BaseAction
             'className' => $this->Association->getSource()->getRegistryAlias(),
         ]);
         $targetTable->setTable($this->Association->getSource()->getTable());
+        $propertyName = Inflector::underscore(static::INVERSE_ASSOCIATION_NAME);
 
-        $options = compact('sourceTable', 'targetTable');
+        $options = compact('propertyName', 'sourceTable', 'targetTable');
         if ($this->Association instanceof HasOne || $this->Association instanceof HasMany) {
             $options += [
                 'foreignKey' => $this->Association->getForeignKey(),

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
@@ -14,12 +14,8 @@
 namespace BEdita\Core\Model\Action;
 
 use BEdita\Core\ORM\Association\RelatedTo;
-use Cake\Datasource\EntityInterface;
-use Cake\Datasource\Exception\RecordNotFoundException;
-use Cake\ORM\Query;
-use Cake\ORM\ResultSet;
+use Cake\ORM\Association;
 use Cake\ORM\TableRegistry;
-use Cake\Utility\Hash;
 
 /**
  * Command to list associated objects.
@@ -32,42 +28,13 @@ class ListRelatedObjectsAction extends ListAssociatedAction
     /**
      * {@inheritDoc}
      */
-    public function execute(array $data = [])
+    protected function initialize(array $config)
     {
-        $data += ['joinData' => true];
+        parent::initialize($config);
 
         if (!($this->Association instanceof RelatedTo)) {
-            return parent::execute($data);
+            return;
         }
-
-        $source = $this->Association->getSource();
-        $conditions = $this->primaryKeyConditions($data['primaryKey']);
-
-        $existing = $source->find()
-            ->where($conditions)
-            ->count();
-        if (!$existing) {
-            throw new RecordNotFoundException(__('Record not found in table "{0}"', $source->getTable()));
-        }
-
-        $table = $this->Association->getTarget();
-
-        $target = TableRegistry::get('InverseRelation', [
-            'className' => $source->getRegistryAlias(),
-        ]);
-        $target->setTable($source->getTable());
-
-        $options = [
-            'sourceTable' => $table,
-            'targetTable' => $target,
-            'through' => $this->Association->junction()->getRegistryAlias(),
-            'foreignKey' => $this->Association->getTargetForeignKey(),
-            'targetForeignKey' => $this->Association->getForeignKey(),
-            'conditions' => $this->Association->getConditions(),
-        ];
-        $association = new RelatedTo('InverseRelation', $options);
-
-        $inverseAssociation = $table->associations()->add($association->getName(), $association);
 
         $objectTypes = TableRegistry::get('ObjectTypes')
             ->find('byRelation', [
@@ -75,46 +42,28 @@ class ListRelatedObjectsAction extends ListAssociatedAction
                 'side' => 'right',
             ])
             ->toArray();
+        $table = $this->Association->getTarget();
         if (count($objectTypes) === 1) {
             $objectType = current($objectTypes);
         }
+        $this->ListAction = new ListObjectsAction(compact('table', 'objectType'));
+    }
 
-        $action = new ListObjectsAction(compact('table', 'objectType'));
-        $query = $action->execute($data);
+    /**
+     * {@inheritDoc}
+     */
+    protected function buildQuery($primaryKey, array $data, Association $inverseAssociation)
+    {
+        $data += ['joinData' => true];
+
+        $query = parent::buildQuery($primaryKey, $data, $inverseAssociation);
 
         if (!empty($data['list'])) {
-            $query = $query
-                ->select([
-                    $table->aliasField($table->getPrimaryKey()),
-                    $table->aliasField('object_type_id'),
-                ]);
-        } else {
-            $query = $query->enableAutoFields(true);
-        }
-
-        if (!empty($data['only'])) {
-            $query = $query->where([
-                $table->aliasField($table->getPrimaryKey()) . ' IN' => (array)$data['only'],
+            $query = $query->select([
+                $this->Association->getTarget()->aliasField('object_type_id'),
             ]);
         }
 
-        return $query
-            ->select($this->Association->junction())
-            ->innerJoinWith($inverseAssociation->getName(), function (Query $query) use ($data, $inverseAssociation) {
-                return $query->where([$inverseAssociation->aliasField('id') => $data['primaryKey']]);
-            })
-            ->order($this->Association->sort())
-            ->formatResults(function (ResultSet $results) {
-                return $results->map(function (EntityInterface $entity) {
-                    $joinData = Hash::get($entity, '_matchingData.' . $this->Association->junction()->getAlias());
-                    $entity->unsetProperty('_matchingData');
-
-                    if (!empty($joinData)) {
-                        $entity->set('_joinData', $joinData);
-                    }
-
-                    return $entity;
-                });
-            });
+        return $query;
     }
 }

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
@@ -32,21 +32,19 @@ class ListRelatedObjectsAction extends ListAssociatedAction
     {
         parent::initialize($config);
 
-        if (!($this->Association instanceof RelatedTo)) {
-            return;
+        if ($this->Association instanceof RelatedTo) {
+            $objectTypes = TableRegistry::get('ObjectTypes')
+                ->find('byRelation', [
+                    'name' => $this->Association->getName(),
+                    'side' => 'right',
+                ])
+                ->toArray();
+            $table = $this->Association->getTarget();
+            if (count($objectTypes) === 1) {
+                $objectType = current($objectTypes);
+            }
+            $this->ListAction = new ListObjectsAction(compact('table', 'objectType'));
         }
-
-        $objectTypes = TableRegistry::get('ObjectTypes')
-            ->find('byRelation', [
-                'name' => $this->Association->getName(),
-                'side' => 'right',
-            ])
-            ->toArray();
-        $table = $this->Association->getTarget();
-        if (count($objectTypes) === 1) {
-            $objectType = current($objectTypes);
-        }
-        $this->ListAction = new ListObjectsAction(compact('table', 'objectType'));
     }
 
     /**


### PR DESCRIPTION
This PR introduces a refactor similar to the one merged in #1173.

The approach we used to address issues in relations between BEdita objects can be used for associations in general. This PR aims to share most of the logic between `ListAssociatedAction` and `ListRelatedObjectsAction`.

This PR purposely doesn't include any test, since this refactor is supposed to be "internal", thus there should be no visible changes to the external world. However, this PR should simplify things a little, and should make this action slightly more reliable. 🤔 