### PR TITLE
Filter for generic resources

### DIFF
--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -141,8 +141,10 @@ abstract class ResourcesController extends AppController
                 );
         } else {
             // List existing entities.
+            $filter = $this->request->getQuery('filter');
+
             $action = new ListEntitiesAction(['table' => $this->Table]);
-            $query = $action();
+            $query = $action(compact('filter'));
 
             $data = $this->paginate($query);
         }
@@ -214,9 +216,10 @@ abstract class ResourcesController extends AppController
         $relatedId = $this->request->getParam('related_id');
 
         $association = $this->findAssociation($relationship);
+        $filter = $this->request->getQuery('filter');
 
         $action = new ListAssociatedAction(compact('association'));
-        $query = $action->execute(['primaryKey' => $relatedId]);
+        $query = $action->execute(['primaryKey' => $relatedId, 'filter' => $filter]);
 
         $data = $this->paginate($query);
 
@@ -258,8 +261,10 @@ abstract class ResourcesController extends AppController
 
             case 'GET':
             default:
+                $filter = $this->request->getQuery('filter');
+
                 $action = new ListAssociatedAction(compact('association'));
-                $data = $action(['primaryKey' => $id, 'list' => true]);
+                $data = $action(['primaryKey' => $id, 'list' => true, 'filter' => $filter]);
 
                 if ($data instanceof Query) {
                     $data = $this->paginate($data);

--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -27,6 +27,9 @@ class FilterQueryStringTest extends IntegrationTestCase
     public $fixtures = [
         'plugin.BEdita/Core.date_ranges',
         'plugin.BEdita/Core.locations',
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
     ];
 
     /**
@@ -158,8 +161,29 @@ class FilterQueryStringTest extends IntegrationTestCase
     {
         $this->configRequestHeaders();
         $this->get($endpoint . '?' . $query);
-        $result = json_decode((string)$this->_response->getBody(), true);
         $this->assertResponseCode(400);
         $this->assertContentType('application/vnd.api+json');
+    }
+
+    /**
+     * Test finder of object types by relation.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testFindByRelation()
+    {
+        $this->configRequestHeaders();
+
+        $this->get('/object_types?filter[by_relation][name]=test');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        static::assertArrayHasKey('data', $result);
+        static::assertCount(2, $result['data']);
+        static::assertArrayNotHasKey('_matchingData', $result['data'][0]['attributes']);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
@@ -15,6 +15,7 @@ namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\ORM\Rule\IsUniqueAmongst;
 use Cake\Cache\Cache;
+use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\Exception\RecordNotFoundException;
@@ -22,6 +23,7 @@ use Cake\Event\Event;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 use Cake\Validation\Validator;
 
@@ -65,22 +67,24 @@ class ObjectTypesTable extends Table
             'className' => 'Properties',
         ]);
 
+        $through = TableRegistry::get('LeftRelationTypes', ['className' => 'RelationTypes']);
         $this->belongsToMany('LeftRelations', [
             'className' => 'Relations',
-            'through' => 'RelationTypes',
+            'through' => $through->getRegistryAlias(),
             'foreignKey' => 'object_type_id',
             'targetForeignKey' => 'relation_id',
             'conditions' => [
-                'RelationTypes.side' => 'left',
+                $through->aliasField('side') => 'left',
             ],
         ]);
+        $through = TableRegistry::get('RightRelationTypes', ['className' => 'RelationTypes']);
         $this->belongsToMany('RightRelations', [
             'className' => 'Relations',
-            'through' => 'RelationTypes',
+            'through' => $through->getRegistryAlias(),
             'foreignKey' => 'object_type_id',
             'targetForeignKey' => 'relation_id',
             'conditions' => [
-                'RelationTypes.side' => 'right',
+                $through->aliasField('side') => 'right',
             ],
         ]);
     }
@@ -269,20 +273,23 @@ class ObjectTypesTable extends Table
             $rightField = 'inverse_name';
         }
 
-        $queryCopy = $query->cleanCopy();
-
         return $query
-            ->innerJoinWith('LeftRelations', function (Query $query) use ($name, $leftField) {
-                return $query->where([
-                    $this->LeftRelations->aliasField($leftField) => $name,
-                ]);
+            ->leftJoinWith('LeftRelations', function (Query $query) use ($name, $leftField) {
+                return $query->where(function (QueryExpression $exp) use ($name, $leftField) {
+                    return $exp->eq($this->LeftRelations->aliasField($leftField), $name);
+                });
             })
-            ->unionAll(
-                $queryCopy->innerJoinWith('RightRelations', function (Query $query) use ($name, $rightField) {
-                    return $query->where([
-                        $this->RightRelations->aliasField($rightField) => $name,
-                    ]);
-                })
-            );
+            ->leftJoinWith('RightRelations', function (Query $query) use ($name, $rightField) {
+                return $query->where(function (QueryExpression $exp) use ($name, $rightField) {
+                    return $exp->eq($this->RightRelations->aliasField($rightField), $name);
+                });
+            })
+            ->where(function (QueryExpression $exp) use ($leftField, $rightField) {
+                return $exp->or_(function (QueryExpression $exp) use ($leftField, $rightField) {
+                    return $exp
+                        ->isNotNull($this->LeftRelations->aliasField($leftField))
+                        ->isNotNull($this->RightRelations->aliasField($rightField));
+                });
+            });
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
@@ -272,13 +272,13 @@ class ObjectTypesTable extends Table
         $queryCopy = $query->cleanCopy();
 
         return $query
-            ->matching('LeftRelations', function (Query $query) use ($name, $leftField) {
+            ->innerJoinWith('LeftRelations', function (Query $query) use ($name, $leftField) {
                 return $query->where([
                     $this->LeftRelations->aliasField($leftField) => $name,
                 ]);
             })
             ->unionAll(
-                $queryCopy->matching('RightRelations', function (Query $query) use ($name, $rightField) {
+                $queryCopy->innerJoinWith('RightRelations', function (Query $query) use ($name, $rightField) {
                     return $query->where([
                         $this->RightRelations->aliasField($rightField) => $name,
                     ]);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
@@ -383,8 +383,8 @@ class ObjectTypesTableTest extends TestCase
         }
 
         $result = $this->ObjectTypes
-            ->find('list')
             ->find('byRelation', $options)
+            ->find('list')
             ->toArray();
 
         static::assertEquals($expected, $result, '', 0, 10, true);


### PR DESCRIPTION
This PR enables `?filter` query parameter in "normal resources" controllers.

For instance, it is now possible to do a `GET /object_types?filter[by_relation][name]=my_relation&filter[by_relation][side]=right` to find all object types that can be appended to the right side of that relation.

In this case, the query used an `UNION ALL` strategy that caused some trouble in SQLite — the custom finder `byRelation` has been refactored to use a more reliable `LEFT JOIN` strategy.