### PR TITLE
Meta fields

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -65,19 +65,21 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'status' => 'on',
                         'uname' => 'first-user',
-                        'locked' => true,
-                        'created' => '2016-05-13T07:09:23+00:00',
-                        'modified' => '2016-05-13T07:09:23+00:00',
-                        'published' => null,
                         'title' => 'Mr. First User',
                         'description' => null,
                         'body' => null,
                         'extra' => null,
                         'lang' => 'eng',
-                        'created_by' => 1,
-                        'modified_by' => 1,
                         'publish_start' => null,
                         'publish_end' => null,
+                    ],
+                    'meta' => [
+                        'locked' => true,
+                        'created' => '2016-05-13T07:09:23+00:00',
+                        'modified' => '2016-05-13T07:09:23+00:00',
+                        'published' => null,
+                        'created_by' => 1,
+                        'modified_by' => 1,
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/users/1',
@@ -97,10 +99,6 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'status' => 'on',
                         'uname' => 'title-one',
-                        'locked' => true,
-                        'created' => '2016-05-13T07:09:23+00:00',
-                        'modified' => '2016-05-13T07:09:23+00:00',
-                        'published' => '2016-05-13T07:09:23+00:00',
                         'title' => 'title one',
                         'description' => 'description here',
                         'body' => 'body here',
@@ -109,10 +107,16 @@ class ObjectsControllerTest extends IntegrationTestCase
                             'list' => ['one', 'two', 'three'],
                         ],
                         'lang' => 'eng',
-                        'created_by' => 1,
-                        'modified_by' => 1,
                         'publish_start' => '2016-05-13T07:09:23+00:00',
                         'publish_end' => '2016-05-13T07:09:23+00:00',
+                    ],
+                    'meta' => [
+                        'locked' => true,
+                        'created' => '2016-05-13T07:09:23+00:00',
+                        'modified' => '2016-05-13T07:09:23+00:00',
+                        'published' => '2016-05-13T07:09:23+00:00',
+                        'created_by' => 1,
+                        'modified_by' => 1,
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/documents/2',
@@ -138,19 +142,21 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'status' => 'draft',
                         'uname' => 'title-two',
-                        'locked' => false,
-                        'created' => '2016-05-12T07:09:23+00:00',
-                        'modified' => '2016-05-13T08:30:00+00:00',
-                        'published' => null,
                         'title' => 'title two',
                         'description' => 'description here',
                         'body' => 'body here',
                         'extra' => null,
                         'lang' => 'eng',
+                        'publish_start' => null,
+                        'publish_end' => null,
+                    ],
+                    'meta' => [
+                        'locked' => false,
+                        'created' => '2016-05-12T07:09:23+00:00',
+                        'modified' => '2016-05-13T08:30:00+00:00',
+                        'published' => null,
                         'created_by' => 1,
                         'modified_by' => 2,
-                        'publish_start' => null,
-                        'publish_end' => null
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/documents/3',
@@ -176,19 +182,21 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'status' => 'on',
                         'uname' => 'gustavo-supporto',
+                        'title' => 'Gustavo Supporto profile',
+                        'description' => 'Some description about Gustavo',
+                        'lang' => 'eng',
+                        'body' => null,
+                        'extra' => null,
+                        'publish_start' => null,
+                        'publish_end' => null,
+                    ],
+                    'meta' => [
                         'locked' => false,
                         'created' => '2016-05-13T07:09:23+00:00',
                         'modified' => '2016-05-13T07:09:23+00:00',
                         'published' => null,
-                        'title' => 'Gustavo Supporto profile',
-                        'description' => 'Some description about Gustavo',
-                        'lang' => 'eng',
                         'created_by' => 1,
                         'modified_by' => 1,
-                        'body' => null,
-                        'extra' => null,
-                        'publish_start' => null,
-                        'publish_end' => null
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/profiles/4',
@@ -208,19 +216,21 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'status' => 'on',
                         'uname' => 'second-user',
-                        'locked' => false,
-                        'created' => '2016-05-13T07:09:23+00:00',
-                        'modified' => '2016-05-13T07:09:23+00:00',
-                        'published' => null,
                         'title' => 'Miss Second User',
                         'description' => null,
                         'body' => null,
                         'extra' => null,
                         'lang' => 'eng',
-                        'created_by' => 1,
-                        'modified_by' => 1,
                         'publish_start' => null,
                         'publish_end' => null,
+                    ],
+                    'meta' => [
+                        'locked' => false,
+                        'created' => '2016-05-13T07:09:23+00:00',
+                        'modified' => '2016-05-13T07:09:23+00:00',
+                        'published' => null,
+                        'created_by' => 1,
+                        'modified_by' => 1,
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/users/5',
@@ -240,19 +250,21 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'status' => 'on',
                         'uname' => 'the-two-towers',
-                        'locked' => false,
-                        'created' => '2017-02-20T07:09:23+00:00',
-                        'modified' => '2017-02-20T07:09:23+00:00',
-                        'published' => '2017-02-20T07:09:23+00:00',
                         'title' => 'The Two Towers',
                         'description' => null,
                         'body' => null,
                         'extra' => null,
                         'lang' => 'eng',
-                        'created_by' => 1,
-                        'modified_by' => 1,
                         'publish_start' => null,
                         'publish_end' => null,
+                    ],
+                    'meta' => [
+                        'locked' => false,
+                        'created' => '2017-02-20T07:09:23+00:00',
+                        'modified' => '2017-02-20T07:09:23+00:00',
+                        'published' => '2017-02-20T07:09:23+00:00',
+                        'created_by' => 1,
+                        'modified_by' => 1,
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/locations/8',
@@ -278,19 +290,21 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'status' => 'on',
                         'uname' => 'event-one',
-                        'locked' => false,
-                        'created' => '2017-03-08T07:09:23+00:00',
-                        'modified' => '2016-03-08T08:30:00+00:00',
-                        'published' => null,
                         'title' => 'first event',
                         'description' => 'event description goes here',
                         'body' => null,
                         'extra' => null,
                         'lang' => 'eng',
-                        'created_by' => 1,
-                        'modified_by' => 1,
                         'publish_start' => null,
                         'publish_end' => null,
+                    ],
+                    'meta' => [
+                        'locked' => false,
+                        'created' => '2017-03-08T07:09:23+00:00',
+                        'modified' => '2016-03-08T08:30:00+00:00',
+                        'published' => null,
+                        'created_by' => 1,
+                        'modified_by' => 1,
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/events/9',
@@ -371,10 +385,6 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'attributes' => [
                     'status' => 'on',
                     'uname' => 'title-one',
-                    'locked' => true,
-                    'created' => '2016-05-13T07:09:23+00:00',
-                    'modified' => '2016-05-13T07:09:23+00:00',
-                    'published' => '2016-05-13T07:09:23+00:00',
                     'title' => 'title one',
                     'description' => 'description here',
                     'body' => 'body here',
@@ -383,10 +393,16 @@ class ObjectsControllerTest extends IntegrationTestCase
                         'list' => ['one', 'two', 'three'],
                     ],
                     'lang' => 'eng',
-                    'created_by' => 1,
-                    'modified_by' => 1,
                     'publish_start' => '2016-05-13T07:09:23+00:00',
                     'publish_end' => '2016-05-13T07:09:23+00:00',
+                ],
+                'meta' => [
+                    'locked' => true,
+                    'created' => '2016-05-13T07:09:23+00:00',
+                    'modified' => '2016-05-13T07:09:23+00:00',
+                    'published' => '2016-05-13T07:09:23+00:00',
+                    'created_by' => 1,
+                    'modified_by' => 1,
                 ],
                 'relationships' => [
                     'test' => [
@@ -435,9 +451,6 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'attributes' => [
                     'status' => 'on',
                     'uname' => 'title-one-deleted',
-                    'locked' => false,
-                    'created' => '2016-10-13T07:09:23+00:00',
-                    'published' => '2016-10-13T07:09:23+00:00',
                     'title' => 'title one deleted',
                     'description' => 'description removed',
                     'body' => 'body no more',
@@ -445,10 +458,15 @@ class ObjectsControllerTest extends IntegrationTestCase
                         'abstract' => 'what?',
                     ],
                     'lang' => 'eng',
+                    'publish_start' => '2016-10-13T07:09:23+00:00',
+                    'publish_end' => '2016-10-13T07:09:23+00:00',
+                ],
+                'meta' => [
+                    'locked' => false,
+                    'created' => '2016-10-13T07:09:23+00:00',
+                    'published' => '2016-10-13T07:09:23+00:00',
                     'created_by' => 1,
                     'modified_by' => 1,
-                    'publish_start' => '2016-10-13T07:09:23+00:00',
-                    'publish_end' => '2016-10-13T07:09:23+00:00'
                 ],
                 'relationships' => [
                     'test' => [
@@ -483,7 +501,7 @@ class ObjectsControllerTest extends IntegrationTestCase
         $this->configRequestHeaders();
         $this->get('/objects/6');
         $result = json_decode((string)$this->_response->getBody(), true);
-        unset($result['data']['attributes']['modified']);
+        unset($result['data']['meta']['modified']);
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
         $this->assertEquals($expected, $result);
@@ -753,19 +771,13 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'status' => 'on',
                         'uname' => 'gustavo-supporto',
-                        'locked' => false,
-                        'created' => '2016-05-13T07:09:23+00:00',
-                        'modified' => '2016-05-13T07:09:23+00:00',
-                        'published' => null,
                         'title' => 'Gustavo Supporto profile',
                         'description' => 'Some description about Gustavo',
                         'lang' => 'eng',
-                        'created_by' => 1,
-                        'modified_by' => 1,
                         'body' => null,
                         'extra' => null,
                         'publish_start' => null,
-                        'publish_end' => null
+                        'publish_end' => null,
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/profiles/4',
@@ -779,6 +791,12 @@ class ObjectsControllerTest extends IntegrationTestCase
                         ],
                     ],
                     'meta' => [
+                        'locked' => false,
+                        'created' => '2016-05-13T07:09:23+00:00',
+                        'modified' => '2016-05-13T07:09:23+00:00',
+                        'published' => null,
+                        'created_by' => 1,
+                        'modified_by' => 1,
                         'priority' => 1,
                         'inv_priority' => 2,
                         'params' => null,
@@ -790,19 +808,13 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'status' => 'draft',
                         'uname' => 'title-two',
-                        'locked' => false,
-                        'created' => '2016-05-12T07:09:23+00:00',
-                        'modified' => '2016-05-13T08:30:00+00:00',
-                        'published' => null,
                         'title' => 'title two',
                         'description' => 'description here',
                         'body' => 'body here',
                         'extra' => null,
                         'lang' => 'eng',
-                        'created_by' => 1,
-                        'modified_by' => 2,
                         'publish_start' => null,
-                        'publish_end' => null
+                        'publish_end' => null,
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/documents/3',
@@ -822,6 +834,12 @@ class ObjectsControllerTest extends IntegrationTestCase
                         ],
                     ],
                     'meta' => [
+                        'locked' => false,
+                        'created' => '2016-05-12T07:09:23+00:00',
+                        'modified' => '2016-05-13T08:30:00+00:00',
+                        'published' => null,
+                        'created_by' => 1,
+                        'modified_by' => 2,
                         'priority' => 2,
                         'inv_priority' => 1,
                         'params' => null,
@@ -1438,7 +1456,7 @@ class ObjectsControllerTest extends IntegrationTestCase
     /**
      * Provider for testMissingAuth
      *
-     * @return void
+     * @return array
      */
     public function missingAuthProvider()
     {
@@ -1482,11 +1500,16 @@ class ObjectsControllerTest extends IntegrationTestCase
     /**
      * Test requests missing auth
      *
+     * @param int $expected Expected response code.
+     * @param string $method Request method.
+     * @param string $endpoint Endpoint.
+     * @param array $data Request data.
      * @return void
+     *
      * @dataProvider missingAuthProvider
      * @coversNothing
      */
-    public function testMissingAuth($expected, $method, $endpoint, $data = [])
+    public function testMissingAuth($expected, $method, $endpoint, array $data = [])
     {
         $this->configRequestHeaders($method);
         $requestMethod = strtolower($method);

--- a/plugins/BEdita/API/tests/TestCase/Controller/PropertiesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/PropertiesControllerTest.php
@@ -66,13 +66,15 @@ class PropertiesControllerTest extends IntegrationTestCase
                         'name' => 'title',
                         'multiple' => false,
                         'options_list' => null,
-                        'created' => '2016-12-31T23:09:23+00:00',
-                        'modified' => '2016-12-31T23:09:23+00:00',
                         'description' => null,
                         'property_type_name' => 'string',
                         'object_type_name' => 'documents',
                         'label' => null,
-                        'list_view' => true
+                        'list_view' => true,
+                    ],
+                    'meta' => [
+                        'created' => '2016-12-31T23:09:23+00:00',
+                        'modified' => '2016-12-31T23:09:23+00:00',
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/properties/1',
@@ -85,13 +87,15 @@ class PropertiesControllerTest extends IntegrationTestCase
                         'name' => 'description',
                         'multiple' => false,
                         'options_list' => null,
-                        'created' => '2016-12-31T23:09:23+00:00',
-                        'modified' => '2016-12-31T23:09:23+00:00',
                         'description' => null,
                         'property_type_name' => 'string',
                         'object_type_name' => 'documents',
                         'label' => 'Brief description',
-                        'list_view' => false
+                        'list_view' => false,
+                    ],
+                    'meta' => [
+                        'created' => '2016-12-31T23:09:23+00:00',
+                        'modified' => '2016-12-31T23:09:23+00:00',
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/properties/2',
@@ -104,13 +108,15 @@ class PropertiesControllerTest extends IntegrationTestCase
                         'name' => 'username',
                         'multiple' => false,
                         'options_list' => null,
-                        'created' => '2016-12-31T23:09:23+00:00',
-                        'modified' => '2016-12-31T23:09:23+00:00',
                         'description' => 'Username, unique string',
                         'property_type_name' => 'string',
                         'object_type_name' => 'users',
                         'label' => null,
-                        'list_view' => true
+                        'list_view' => true,
+                    ],
+                    'meta' => [
+                        'created' => '2016-12-31T23:09:23+00:00',
+                        'modified' => '2016-12-31T23:09:23+00:00',
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/properties/3',
@@ -123,13 +129,15 @@ class PropertiesControllerTest extends IntegrationTestCase
                         'name' => 'email',
                         'multiple' => false,
                         'options_list' => null,
-                        'created' => '2016-12-31T23:09:23+00:00',
-                        'modified' => '2016-12-31T23:09:23+00:00',
                         'description' => 'User email',
                         'property_type_name' => 'string',
                         'object_type_name' => 'users',
                         'label' => null,
-                        'list_view' => true
+                        'list_view' => true,
+                    ],
+                    'meta' => [
+                        'created' => '2016-12-31T23:09:23+00:00',
+                        'modified' => '2016-12-31T23:09:23+00:00',
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/properties/4',
@@ -142,13 +150,15 @@ class PropertiesControllerTest extends IntegrationTestCase
                         'name' => 'birthdate',
                         'multiple' => false,
                         'options_list' => null,
-                        'created' => '2016-12-31T23:09:23+00:00',
-                        'modified' => '2016-12-31T23:09:23+00:00',
                         'description' => null,
                         'property_type_name' => 'date',
                         'object_type_name' => 'profiles',
                         'label' => 'Date of birth',
-                        'list_view' => false
+                        'list_view' => false,
+                    ],
+                    'meta' => [
+                        'created' => '2016-12-31T23:09:23+00:00',
+                        'modified' => '2016-12-31T23:09:23+00:00',
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/properties/5',
@@ -161,13 +171,15 @@ class PropertiesControllerTest extends IntegrationTestCase
                         'name' => 'surname',
                         'multiple' => false,
                         'options_list' => null,
-                        'created' => '2016-12-31T23:09:23+00:00',
-                        'modified' => '2016-12-31T23:09:23+00:00',
                         'description' => null,
                         'property_type_name' => 'string',
                         'object_type_name' => 'profiles',
                         'label' => null,
-                        'list_view' => true
+                        'list_view' => true,
+                    ],
+                    'meta' => [
+                        'created' => '2016-12-31T23:09:23+00:00',
+                        'modified' => '2016-12-31T23:09:23+00:00',
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/properties/6',
@@ -249,13 +261,15 @@ class PropertiesControllerTest extends IntegrationTestCase
                     'name' => 'title',
                     'multiple' => false,
                     'options_list' => null,
-                    'created' => '2016-12-31T23:09:23+00:00',
-                    'modified' => '2016-12-31T23:09:23+00:00',
                     'description' => null,
                     'property_type_name' => 'string',
                     'object_type_name' => 'documents',
                     'label' => null,
-                    'list_view' => true
+                    'list_view' => true,
+                ],
+                'meta' => [
+                    'created' => '2016-12-31T23:09:23+00:00',
+                    'modified' => '2016-12-31T23:09:23+00:00',
                 ],
             ],
         ];

--- a/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
@@ -55,6 +55,8 @@ class RolesControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'name' => 'first role',
                         'description' => 'this is the very first role',
+                    ],
+                    'meta' => [
                         'unchangeable' => true,
                         'created' => '2016-04-15T09:57:38+00:00',
                         'modified' => '2016-04-15T09:57:38+00:00',
@@ -77,6 +79,8 @@ class RolesControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'name' => 'second role',
                         'description' => 'this is a second role',
+                    ],
+                    'meta' => [
                         'unchangeable' => false,
                         'created' => '2016-04-15T11:59:12+00:00',
                         'modified' => '2016-04-15T11:59:13+00:00',
@@ -169,6 +173,8 @@ class RolesControllerTest extends IntegrationTestCase
                 'attributes' => [
                     'name' => 'first role',
                     'description' => 'this is the very first role',
+                ],
+                'meta' => [
                     'unchangeable' => true,
                     'created' => '2016-04-15T09:57:38+00:00',
                     'modified' => '2016-04-15T09:57:38+00:00',
@@ -417,17 +423,11 @@ class RolesControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'status' => 'on',
                         'uname' => 'first-user',
-                        'locked' => true,
-                        'created' => '2016-05-13T07:09:23+00:00',
-                        'modified' => '2016-05-13T07:09:23+00:00',
-                        'published' => null,
                         'title' => 'Mr. First User',
                         'description' => null,
                         'body' => null,
                         'extra' => null,
                         'lang' => 'eng',
-                        'created_by' => 1,
-                        'modified_by' => 1,
                         'name' => 'First',
                         'surname' => 'User',
                         'email' => 'first.user@example.com',
@@ -448,6 +448,14 @@ class RolesControllerTest extends IntegrationTestCase
                         'publish_start' => null,
                         'publish_end' => null,
                         'username' => 'first user',
+                    ],
+                    'meta' => [
+                        'locked' => true,
+                        'created' => '2016-05-13T07:09:23+00:00',
+                        'modified' => '2016-05-13T07:09:23+00:00',
+                        'published' => null,
+                        'created_by' => 1,
+                        'modified_by' => 1,
                         'blocked' => false,
                         'last_login' => null,
                         'last_login_err' => null,
@@ -460,10 +468,10 @@ class RolesControllerTest extends IntegrationTestCase
                         'roles' => [
                             'links' => [
                                 'related' => 'http://api.example.com/users/1/roles',
-                                'self' => 'http://api.example.com/users/1/relationships/roles'
-                            ]
-                        ]
-                    ]
+                                'self' => 'http://api.example.com/users/1/relationships/roles',
+                            ],
+                        ],
+                    ],
                 ],
             ],
         ];

--- a/plugins/BEdita/API/tests/TestCase/Controller/TrashControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TrashControllerTest.php
@@ -73,21 +73,23 @@ class TrashControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'status' => 'on',
                         'uname' => 'title-one-deleted',
-                        'locked' => false,
-                        'created' => '2016-10-13T07:09:23+00:00',
-                        'modified' => '2016-10-13T07:09:23+00:00',
-                        'published' => '2016-10-13T07:09:23+00:00',
                         'title' => 'title one deleted',
                         'description' => 'description removed',
                         'body' => 'body no more',
                         'extra' => [
-                            'abstract' => 'what?'
+                            'abstract' => 'what?',
                         ],
                         'lang' => 'eng',
+                        'publish_start' => '2016-10-13T07:09:23+00:00',
+                        'publish_end' => '2016-10-13T07:09:23+00:00',
+                    ],
+                    'meta' => [
+                        'locked' => false,
+                        'created' => '2016-10-13T07:09:23+00:00',
+                        'modified' => '2016-10-13T07:09:23+00:00',
+                        'published' => '2016-10-13T07:09:23+00:00',
                         'created_by' => 1,
                         'modified_by' => 1,
-                        'publish_start' => '2016-10-13T07:09:23+00:00',
-                        'publish_end' => '2016-10-13T07:09:23+00:00'
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/trash/6',
@@ -99,26 +101,28 @@ class TrashControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'status' => 'on',
                         'uname' => 'title-two-deleted',
-                        'locked' => false,
-                        'created' => '2016-10-13T07:09:23+00:00',
-                        'modified' => '2016-10-13T07:09:23+00:00',
-                        'published' => '2016-10-13T07:09:23+00:00',
                         'title' => 'title two deleted',
                         'description' => 'description removed',
                         'body' => 'body no more',
                         'extra' => [
-                            'abstract' => 'what?'
+                            'abstract' => 'what?',
                         ],
                         'lang' => 'eng',
+                        'publish_start' => '2016-10-13T07:09:23+00:00',
+                        'publish_end' => '2016-10-13T07:09:23+00:00',
+                    ],
+                    'meta' => [
+                        'locked' => false,
+                        'created' => '2016-10-13T07:09:23+00:00',
+                        'modified' => '2016-10-13T07:09:23+00:00',
+                        'published' => '2016-10-13T07:09:23+00:00',
                         'created_by' => 1,
                         'modified_by' => 1,
-                        'publish_start' => '2016-10-13T07:09:23+00:00',
-                        'publish_end' => '2016-10-13T07:09:23+00:00'
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/trash/7',
                     ],
-                ]
+                ],
             ],
         ];
 
@@ -194,21 +198,23 @@ class TrashControllerTest extends IntegrationTestCase
                 'attributes' => [
                     'status' => 'on',
                     'uname' => 'title-one-deleted',
-                    'locked' => false,
-                    'created' => '2016-10-13T07:09:23+00:00',
-                    'modified' => '2016-10-13T07:09:23+00:00',
-                    'published' => '2016-10-13T07:09:23+00:00',
                     'title' => 'title one deleted',
                     'description' => 'description removed',
                     'body' => 'body no more',
                     'extra' => [
-                        'abstract' => 'what?'
+                        'abstract' => 'what?',
                     ],
                     'lang' => 'eng',
+                    'publish_start' => '2016-10-13T07:09:23+00:00',
+                    'publish_end' => '2016-10-13T07:09:23+00:00',
+                ],
+                'meta' => [
+                    'locked' => false,
+                    'created' => '2016-10-13T07:09:23+00:00',
+                    'modified' => '2016-10-13T07:09:23+00:00',
+                    'published' => '2016-10-13T07:09:23+00:00',
                     'created_by' => 1,
                     'modified_by' => 1,
-                    'publish_start' => '2016-10-13T07:09:23+00:00',
-                    'publish_end' => '2016-10-13T07:09:23+00:00'
                 ],
             ],
         ];

--- a/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
@@ -55,17 +55,11 @@ class UsersControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'status' => 'on',
                         'uname' => 'first-user',
-                        'locked' => true,
-                        'created' => '2016-05-13T07:09:23+00:00',
-                        'modified' => '2016-05-13T07:09:23+00:00',
-                        'published' => null,
                         'title' => 'Mr. First User',
                         'description' => null,
                         'body' => null,
                         'extra' => null,
                         'lang' => 'eng',
-                        'created_by' => 1,
-                        'modified_by' => 1,
                         'name' => 'First',
                         'surname' => 'User',
                         'email' => 'first.user@example.com',
@@ -86,6 +80,14 @@ class UsersControllerTest extends IntegrationTestCase
                         'publish_start' => null,
                         'publish_end' => null,
                         'username' => 'first user',
+                    ],
+                    'meta' => [
+                        'locked' => true,
+                        'created' => '2016-05-13T07:09:23+00:00',
+                        'modified' => '2016-05-13T07:09:23+00:00',
+                        'published' => null,
+                        'created_by' => 1,
+                        'modified_by' => 1,
                         'blocked' => false,
                         'last_login' => null,
                         'last_login_err' => null,
@@ -98,10 +100,10 @@ class UsersControllerTest extends IntegrationTestCase
                         'roles' => [
                             'links' => [
                                 'related' => 'http://api.example.com/users/1/roles',
-                                'self' => 'http://api.example.com/users/1/relationships/roles'
-                            ]
-                        ]
-                    ]
+                                'self' => 'http://api.example.com/users/1/relationships/roles',
+                            ],
+                        ],
+                    ],
                 ],
                 [
                     'id' => '5',
@@ -109,17 +111,11 @@ class UsersControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'status' => 'on',
                         'uname' => 'second-user',
-                        'locked' => false,
-                        'created' => '2016-05-13T07:09:23+00:00',
-                        'modified' => '2016-05-13T07:09:23+00:00',
-                        'published' => null,
                         'title' => 'Miss Second User',
                         'description' => null,
                         'body' => null,
                         'extra' => null,
                         'lang' => 'eng',
-                        'created_by' => 1,
-                        'modified_by' => 1,
                         'name' => 'Second',
                         'surname' => 'User',
                         'email' => 'second.user@example.com',
@@ -140,6 +136,14 @@ class UsersControllerTest extends IntegrationTestCase
                         'publish_start' => null,
                         'publish_end' => null,
                         'username' => 'second user',
+                    ],
+                    'meta' => [
+                        'locked' => false,
+                        'created' => '2016-05-13T07:09:23+00:00',
+                        'modified' => '2016-05-13T07:09:23+00:00',
+                        'published' => null,
+                        'created_by' => 1,
+                        'modified_by' => 1,
                         'blocked' => false,
                         'last_login' => '2016-03-15T09:57:38+00:00',
                         'last_login_err' => '2016-03-15T09:57:38+00:00',
@@ -152,10 +156,10 @@ class UsersControllerTest extends IntegrationTestCase
                         'roles' => [
                             'links' => [
                                 'related' => 'http://api.example.com/users/5/roles',
-                                'self' => 'http://api.example.com/users/5/relationships/roles'
-                            ]
-                        ]
-                    ]
+                                'self' => 'http://api.example.com/users/5/relationships/roles',
+                            ],
+                        ],
+                    ],
                 ],
             ],
         ];
@@ -232,17 +236,11 @@ class UsersControllerTest extends IntegrationTestCase
                 'attributes' => [
                     'status' => 'on',
                     'uname' => 'first-user',
-                    'locked' => true,
-                    'created' => '2016-05-13T07:09:23+00:00',
-                    'modified' => '2016-05-13T07:09:23+00:00',
-                    'published' => null,
                     'title' => 'Mr. First User',
                     'description' => null,
                     'body' => null,
                     'extra' => null,
                     'lang' => 'eng',
-                    'created_by' => 1,
-                    'modified_by' => 1,
                     'name' => 'First',
                     'surname' => 'User',
                     'email' => 'first.user@example.com',
@@ -263,6 +261,14 @@ class UsersControllerTest extends IntegrationTestCase
                     'publish_start' => null,
                     'publish_end' => null,
                     'username' => 'first user',
+                ],
+                'meta' => [
+                    'locked' => true,
+                    'created' => '2016-05-13T07:09:23+00:00',
+                    'modified' => '2016-05-13T07:09:23+00:00',
+                    'published' => null,
+                    'created_by' => 1,
+                    'modified_by' => 1,
                     'blocked' => false,
                     'last_login' => null,
                     'last_login_err' => null,
@@ -272,10 +278,10 @@ class UsersControllerTest extends IntegrationTestCase
                     'roles' => [
                         'links' => [
                             'related' => 'http://api.example.com/users/1/roles',
-                            'self' => 'http://api.example.com/users/1/relationships/roles'
-                        ]
-                    ]
-                ]
+                            'self' => 'http://api.example.com/users/1/relationships/roles',
+                        ],
+                    ],
+                ],
             ],
         ];
 
@@ -517,6 +523,8 @@ class UsersControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'name' => 'first role',
                         'description' => 'this is the very first role',
+                    ],
+                    'meta' => [
                         'unchangeable' => true,
                         'created' => '2016-04-15T09:57:38+00:00',
                         'modified' => '2016-04-15T09:57:38+00:00',

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -82,6 +82,8 @@ class JsonApiTest extends TestCase
                         'attributes' => [
                             'name' => 'first role',
                             'description' => 'this is the very first role',
+                        ],
+                        'meta' => [
                             'unchangeable' => true,
                             'created' => '2016-04-15T09:57:38+00:00',
                             'modified' => '2016-04-15T09:57:38+00:00',
@@ -104,6 +106,8 @@ class JsonApiTest extends TestCase
                         'attributes' => [
                             'name' => 'second role',
                             'description' => 'this is a second role',
+                        ],
+                        'meta' => [
                             'unchangeable' => false,
                             'created' => '2016-04-15T11:59:12+00:00',
                             'modified' => '2016-04-15T11:59:13+00:00',
@@ -134,6 +138,8 @@ class JsonApiTest extends TestCase
                         'attributes' => [
                             'name' => 'first role',
                             'description' => 'this is the very first role',
+                        ],
+                        'meta' => [
                             'unchangeable' => true,
                             'created' => '2016-04-15T09:57:38+00:00',
                             'modified' => '2016-04-15T09:57:38+00:00',
@@ -156,6 +162,8 @@ class JsonApiTest extends TestCase
                         'attributes' => [
                             'name' => 'second role',
                             'description' => 'this is a second role',
+                        ],
+                        'meta' => [
                             'unchangeable' => false,
                             'created' => '2016-04-15T11:59:12+00:00',
                             'modified' => '2016-04-15T11:59:13+00:00',
@@ -186,6 +194,8 @@ class JsonApiTest extends TestCase
                         'attributes' => [
                             'name' => 'first role',
                             'description' => 'this is the very first role',
+                        ],
+                        'meta' => [
                             'unchangeable' => true,
                             'created' => '2016-04-15T09:57:38+00:00',
                             'modified' => '2016-04-15T09:57:38+00:00',
@@ -208,6 +218,8 @@ class JsonApiTest extends TestCase
                         'attributes' => [
                             'name' => 'second role',
                             'description' => 'this is a second role',
+                        ],
+                        'meta' => [
                             'unchangeable' => false,
                             'created' => '2016-04-15T11:59:12+00:00',
                             'modified' => '2016-04-15T11:59:13+00:00',
@@ -237,6 +249,8 @@ class JsonApiTest extends TestCase
                     'attributes' => [
                         'name' => 'first role',
                         'description' => 'this is the very first role',
+                    ],
+                    'meta' => [
                         'unchangeable' => true,
                         'created' => '2016-04-15T09:57:38+00:00',
                         'modified' => '2016-04-15T09:57:38+00:00',
@@ -262,6 +276,8 @@ class JsonApiTest extends TestCase
                     'attributes' => [
                         'name' => 'first role',
                         'description' => 'this is the very first role',
+                    ],
+                    'meta' => [
                         'unchangeable' => true,
                         'created' => '2016-04-15T09:57:38+00:00',
                         'modified' => '2016-04-15T09:57:38+00:00',
@@ -585,10 +601,6 @@ class JsonApiTest extends TestCase
             'attributes' => [
                 'status' => 'on',
                 'uname' => 'title-one',
-                'locked' => true,
-                'created' => '2016-05-13T07:09:23+00:00',
-                'modified' => '2016-05-13T07:09:23+00:00',
-                'published' => '2016-05-13T07:09:23+00:00',
                 'title' => 'title one',
                 'description' => 'description here',
                 'body' => 'body here',
@@ -597,10 +609,16 @@ class JsonApiTest extends TestCase
                     'list' => ['one', 'two', 'three'],
                 ],
                 'lang' => 'eng',
-                'created_by' => 1,
-                'modified_by' => 1,
                 'publish_start' => '2016-05-13T07:09:23+00:00',
                 'publish_end' => '2016-05-13T07:09:23+00:00',
+            ],
+            'meta' => [
+                'locked' => true,
+                'created' => '2016-05-13T07:09:23+00:00',
+                'modified' => '2016-05-13T07:09:23+00:00',
+                'published' => '2016-05-13T07:09:23+00:00',
+                'created_by' => 1,
+                'modified_by' => 1,
             ],
             'relationships' => [
                 'test' => [

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
@@ -17,6 +17,7 @@ use Cake\ORM\Association;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
+use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 
 /**
@@ -40,6 +41,14 @@ trait JsonApiTrait
      * @return string
      */
     abstract public function getSource();
+
+    /**
+     * Checks if a property is accessible.
+     *
+     * @param string $property Property name to check
+     * @return bool
+     */
+    abstract public function isAccessible($property);
 
     /**
      * Magic getter for `type` property.
@@ -97,5 +106,20 @@ trait JsonApiTrait
         }
 
         return $relationships;
+    }
+
+    /**
+     * Get array of meta properties.
+     *
+     * @return array
+     */
+    protected function _getMeta()
+    {
+        return array_filter(
+            array_keys($this->_properties),
+            function ($property) {
+                return !in_array($property, ['_joinData', '_matchingData']) && !$this->isAccessible($property);
+            }
+        );
     }
 }

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
@@ -17,13 +17,15 @@ use Cake\ORM\Association;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
-use Cake\Utility\Hash;
-use Cake\Utility\Inflector;
 
 /**
  * Trait for exposing useful properties required for JSON API response formatting at the entity level.
  *
  * @since 4.0.0
+ *
+ * @property string $type
+ * @property string[] $relationships
+ * @property string[] $meta
  */
 trait JsonApiTrait
 {
@@ -111,15 +113,17 @@ trait JsonApiTrait
     /**
      * Get array of meta properties.
      *
-     * @return array
+     * @return string[]
      */
     protected function _getMeta()
     {
-        return array_filter(
-            array_keys($this->_properties),
-            function ($property) {
-                return !in_array($property, ['_joinData', '_matchingData']) && !$this->isAccessible($property);
-            }
+        return array_values(
+            array_filter(
+                array_keys($this->_properties),
+                function ($property) {
+                    return !in_array($property, ['_joinData', '_matchingData']) && !$this->isAccessible($property);
+                }
+            )
         );
     }
 }

--- a/plugins/BEdita/Core/src/Model/Entity/Location.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Location.php
@@ -26,4 +26,15 @@ namespace BEdita\Core\Model\Entity;
  */
 class Location extends ObjectEntity
 {
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function _getMeta()
+    {
+        $meta = parent::_getMeta();
+        $meta[] = 'distance';
+
+        return $meta;
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Entity/Role.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Role.php
@@ -38,9 +38,9 @@ class Role extends Entity
      * {@inheritDoc}
      */
     protected $_accessible = [
-        '*' => true,
-        'id' => false,
-        'unchangeable' => false,
+        '*' => false,
+        'name' => true,
+        'description' => true,
     ];
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
@@ -134,8 +134,6 @@ class LocationsTable extends Table
         $this->checkGeoDbSupport();
 
         $center = sprintf('POINT(%s)', $center);
-        $distance = 'meta__distance';
-
         $distanceExpression = new FunctionExpression(
             'ST_Distance_sphere',
             [
@@ -147,9 +145,9 @@ class LocationsTable extends Table
         );
 
         return $query
-            ->select([$distance => $distanceExpression])
+            ->select(['distance' => $distanceExpression])
             ->enableAutoFields(true)
-            ->order([$distance => 'ASC']);
+            ->order(['distance' => 'ASC']);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -115,4 +115,44 @@ class JsonApiTraitTest extends TestCase
 
         static::assertSame([], $relationships);
     }
+
+    /**
+     * Test magic getter for meta fields.
+     *
+     * @return void
+     *
+     * @covers ::_getMeta()
+     */
+    public function testGetMeta()
+    {
+        $expected = [
+            'id',
+            'created',
+            'modified',
+            'unchangeable',
+        ];
+
+        $role = $this->Roles->get(1);
+
+        $meta = $role->meta;
+
+        static::assertEquals($expected, $meta, '', 0, 10, true);
+    }
+
+    /**
+     * Test magic getter for meta fields.
+     *
+     * @return void
+     *
+     * @covers ::_getMeta()
+     */
+    public function testGetMetaNotAccessible()
+    {
+        $role = $this->Roles->get(1);
+        $role->setAccess('*', true);
+
+        $meta = $role->meta;
+
+        static::assertSame([], $meta);
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/LocationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/LocationTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Entity;
+
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * @coversDefaultClass \BEdita\Core\Model\Entity\Location
+ */
+class LocationTest extends TestCase
+{
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
+        'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.locations'
+    ];
+
+    /**
+     * Test subject.
+     *
+     * @var \BEdita\Core\Model\Table\LocationsTable
+     */
+    protected $Locations;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->Locations = TableRegistry::get('Locations');
+    }
+
+    /**
+     * Test magic getter for meta fields.
+     *
+     * @return void
+     *
+     * @covers ::_getMeta()
+     */
+    public function testGetMeta()
+    {
+        $location = $this->Locations->newEntity();
+        $meta = $location->get('meta');
+
+        static::assertTrue(is_array($meta));
+        static::assertContains('distance', $meta);
+    }
+}


### PR DESCRIPTION
This PR resolves #1180.

By default, all non-accessible properties (i.e. properties that cannot be modified by a `PATCH` request) are moved from `attributes` to `meta`. Join data, if present, are then merged with the resulting hash. This behavior is implemented in `JsonApiTrait`, so entity classes can override the default if needed.