### PR TITLE
Handle dependencies in plugins under the plugins folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 #################################################
 /.vagrant/*
 /composer.lock
+/composer.local.json
 /config/app.php
 /coverage/*
 /docs/*

--- a/composer.json
+++ b/composer.json
@@ -33,28 +33,23 @@
         "cakephp/migrations": "~1.0",
         "robmorgan/phinx": "dev-fix\/sqlite-update-column-commas as 0.6.5",
         "cakephp/plugin-installer": "*",
-        "firebase/php-jwt": "~4.0"
+        "wikimedia/composer-merge-plugin": "^1.4"
     },
     "require-dev": {
         "psy/psysh": "@stable",
         "cakephp/debug_kit": "~3.2 !=3.5.1",
         "cakephp/bake": "~1.1",
         "phpunit/phpunit": "^5.7|^6.0",
-        "cakephp/cakephp-codesniffer": "~2.1",
-        "fzaninotto/faker": "^1.5"
+        "cakephp/cakephp-codesniffer": "~2.1"
     },
     "autoload": {
         "psr-4": {
-            "BEdita\\App\\": "src",
-            "BEdita\\API\\": "./plugins/BEdita/API/src",
-            "BEdita\\Core\\": "./plugins/BEdita/Core/src"
+            "BEdita\\App\\": "src"
         }
     },
     "autoload-dev": {
         "psr-4": {
             "BEdita\\App\\Test\\": "tests",
-            "BEdita\\API\\Test\\": "./plugins/BEdita/API/tests",
-            "BEdita\\Core\\Test\\": "./plugins/BEdita/Core/tests",
             "Cake\\Test\\": "./vendor/cakephp/cakephp/tests"
         }
     },
@@ -70,5 +65,20 @@
         "cs-check": "phpcs --colors -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
         "cs-fix": "phpcbf --colors --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
         "test": "phpunit --colors=always"
+    },
+    "extra": {
+        "merge-plugin": {
+            "include": [
+                "composer.local.json",
+                "plugins/*/*/composer.json",
+                "plugins/*/composer.json"
+            ],
+            "recurse": true,
+            "replace": false,
+            "merge-dev": true,
+            "merge-extra": false,
+            "merge-extra-deep": false,
+            "merge-scripts": false
+        }
     }
 }

--- a/plugins/BEdita/API/composer.json
+++ b/plugins/BEdita/API/composer.json
@@ -23,11 +23,11 @@
     "require": {
         "php": ">=5.6.0",
         "cakephp/cakephp": "~3.4.1",
-        "firebase/php-jwt": "~3.0"
+        "firebase/php-jwt": "~4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7|^6.0",
-        "cakephp/cakephp-codesniffer": "master-dev",
+        "cakephp/cakephp-codesniffer": "~2.1",
         "phpmd/phpmd": "*"
     },
     "autoload": {

--- a/plugins/BEdita/Core/composer.json
+++ b/plugins/BEdita/Core/composer.json
@@ -23,10 +23,12 @@
     "require": {
         "php": ">=5.6.0",
         "cakephp/cakephp": "~3.4.1",
+        "cakephp/migrations": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7|^6.0",
-        "cakephp/cakephp-codesniffer": "master-dev",
+        "cakephp/cakephp-codesniffer": "~2.1",
+        "fzaninotto/faker": "^1.5",
         "phpmd/phpmd": "*"
     },
     "autoload": {


### PR DESCRIPTION
This PR resolves #1189 using https://github.com/wikimedia/composer-merge-plugin

Every plugin put in `plugins` folder and that contains `composer.json` will be hooked to app `composer.json` loading dependencies and autoloading the namespaces.

In addition an unversioned `composer.local.json` may be added to main app to customize the app requirements.

I had issues with `"robmorgan/phinx": "dev-fix\/sqlite-update-column-commas as 0.6.5"` so I left it in app `composer.json`. We'll going to remove it once `cakephp/migrations` dependencies will be updated.