### PR TITLE
Display available relations for ObjectTypes

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectTypesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectTypesControllerTest.php
@@ -62,6 +62,12 @@ class ObjectTypesControllerTest extends IntegrationTestCase
                         'table' => 'BEdita/Core.Objects',
                         'associations' => null,
                     ],
+                    'meta' => [
+                        'relations' => [
+                            'test',
+                            'inverse_test',
+                        ],
+                    ],
                     'links' => [
                         'self' => 'http://api.example.com/object_types/1',
                     ],
@@ -86,6 +92,11 @@ class ObjectTypesControllerTest extends IntegrationTestCase
                         'model' => 'Profiles',
                         'table' => 'BEdita/Core.Profiles',
                         'associations' => null,
+                    ],
+                    'meta' => [
+                        'relations' => [
+                            'inverse_test',
+                        ],
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/object_types/2',
@@ -112,6 +123,9 @@ class ObjectTypesControllerTest extends IntegrationTestCase
                         'table' => 'BEdita/Core.Users',
                         'associations' => null,
                     ],
+                    'meta' => [
+                        'relations' => [],
+                    ],
                     'links' => [
                         'self' => 'http://api.example.com/object_types/3',
                     ],
@@ -136,6 +150,9 @@ class ObjectTypesControllerTest extends IntegrationTestCase
                         'model' => 'Objects',
                         'table' => 'BEdita/Core.Objects',
                         'associations' => null,
+                    ],
+                    'meta' => [
+                        'relations' => [],
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/object_types/4',
@@ -162,6 +179,12 @@ class ObjectTypesControllerTest extends IntegrationTestCase
                         'table' => 'BEdita/Core.Locations',
                         'associations' => null,
                     ],
+                    'meta' => [
+                        'relations' => [
+                            'another_test',
+                            'inverse_another_test',
+                        ],
+                    ],
                     'links' => [
                         'self' => 'http://api.example.com/object_types/5',
                     ],
@@ -186,6 +209,9 @@ class ObjectTypesControllerTest extends IntegrationTestCase
                         'model' => 'Objects',
                         'table' => 'BEdita/Core.Objects',
                         'associations' => ['DateRanges'],
+                    ],
+                    'meta' => [
+                        'relations' => [],
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/object_types/6',
@@ -280,6 +306,12 @@ class ObjectTypesControllerTest extends IntegrationTestCase
                     'model' => 'Objects',
                     'table' => 'BEdita/Core.Objects',
                     'associations' => null,
+                ],
+                'meta' => [
+                    'relations' => [
+                        'test',
+                        'inverse_test',
+                    ],
                 ],
                 'relationships' => [
                     'properties' => [

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Model\Entity;
 
 use Cake\ORM\Entity;
+use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 
 /**
@@ -28,6 +29,7 @@ use Cake\Utility\Inflector;
  * @property string $model
  * @property string $table
  * @property array $associations
+ * @property string[] $relations
  * @property \BEdita\Core\Model\Entity\ObjectEntity[] $objects
  * @property \BEdita\Core\Model\Entity\Relation[] $left_relations
  * @property \BEdita\Core\Model\Entity\Relation[] $right_relations
@@ -35,7 +37,9 @@ use Cake\Utility\Inflector;
 class ObjectType extends Entity
 {
 
-    use JsonApiTrait;
+    use JsonApiTrait {
+        _getMeta as protected jsonApiMeta;
+    }
 
     /**
      * {@inheritDoc}
@@ -57,6 +61,7 @@ class ObjectType extends Entity
     protected $_virtual = [
         'alias',
         'table',
+        'relations',
     ];
 
     /**
@@ -149,5 +154,37 @@ class ObjectType extends Entity
 
         $this->plugin = $plugin;
         $this->model = $model;
+    }
+
+    /**
+     * Getter for virtual property `relations`.
+     *
+     * @return string[]|null
+     */
+    protected function _getRelations()
+    {
+        if (!$this->has('left_relations') || !$this->has('right_relations')) {
+            return null;
+        }
+
+        $relations = array_merge(
+            Hash::extract($this->left_relations, '{n}.name'),
+            Hash::extract($this->right_relations, '{n}.inverse_name')
+        );
+
+        return $relations;
+    }
+
+    /**
+     * Get array of meta properties.
+     *
+     * @return string[]
+     */
+    protected function _getMeta()
+    {
+        $meta = $this->jsonApiMeta();
+        $meta[] = 'relations';
+
+        return $meta;
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
@@ -34,6 +34,15 @@ use Cake\Validation\Validator;
  * @property \Cake\ORM\Association\HasMany $Properties
  * @property \Cake\ORM\Association\BelongsToMany $LeftRelations
  * @property \Cake\ORM\Association\BelongsToMany $RightRelations
+ *
+ * @method \BEdita\Core\Model\Entity\ObjectType newEntity($data = null, array $options = [])
+ * @method \BEdita\Core\Model\Entity\ObjectType[] newEntities(array $data, array $options = [])
+ * @method \BEdita\Core\Model\Entity\ObjectType|bool save(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \BEdita\Core\Model\Entity\ObjectType patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
+ * @method \BEdita\Core\Model\Entity\ObjectType[] patchEntities($entities, array $data, array $options = [])
+ * @method \BEdita\Core\Model\Entity\ObjectType findOrCreate($search, callable $callback = null, $options = [])
+ *
+ * @since 4.0.0
  */
 class ObjectTypesTable extends Table
 {
@@ -160,6 +169,8 @@ class ObjectTypesTable extends Table
 
     /**
      * {@inheritDoc}
+     *
+     * @return \BEdita\Core\Model\Entity\ObjectType
      */
     public function get($primaryKey, $options = [])
     {
@@ -226,6 +237,14 @@ class ObjectTypesTable extends Table
         Cache::delete('id_' . $entity->id, self::CACHE_CONFIG);
         Cache::delete('map', self::CACHE_CONFIG);
         Cache::delete('map_singular', self::CACHE_CONFIG);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function findAll(Query $query, array $options)
+    {
+        return $query->contain(['LeftRelations', 'RightRelations']);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -222,12 +222,28 @@ class ObjectTypeTest extends TestCase
     public function testGetRelations()
     {
         $expected = [
-            'test',
             'inverse_test',
         ];
-        $objectType = $this->ObjectTypes->get(1);
+        $objectType = $this->ObjectTypes->get(2);
 
         static::assertEquals($expected, $objectType->relations, '', 0, 10, true);
+    }
+
+    /**
+     * Test getter for relations when associations haven't been loaded.
+     *
+     * @return void
+     *
+     * @covers ::_getRelations()
+     */
+    public function testGetRelationsAssociationsNotLoaded()
+    {
+        $objectType = $this->ObjectTypes->find()
+            ->contain(['LeftRelations'], true)
+            ->firstOrFail();
+
+        static::assertInstanceOf($this->ObjectTypes->getEntityClass(), $objectType);
+        static::assertNull($objectType->relations);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -13,9 +13,6 @@
 
 namespace BEdita\Core\Test\TestCase\Model\Entity;
 
-use BEdita\Core\Model\Entity\ObjectType;
-use BEdita\Core\Model\Table\ObjectTypesTable;
-use Cake\Cache\Cache;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -41,6 +38,8 @@ class ObjectTypeTest extends TestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
     ];
 
     /**
@@ -78,12 +77,9 @@ class ObjectTypeTest extends TestCase
             'name' => 'patched_name',
         ];
         $objectType = $this->ObjectTypes->patchEntity($objectType, $data);
-        if (!($objectType instanceof ObjectType)) {
-            throw new \InvalidArgumentException();
-        }
 
-        $this->assertEquals(1, $objectType->id);
-        $this->assertEquals('patched_name', $objectType->name);
+        static::assertEquals(1, $objectType->id);
+        static::assertEquals('patched_name', $objectType->name);
     }
 
     /**
@@ -104,14 +100,15 @@ class ObjectTypeTest extends TestCase
             'model' => 'Objects',
             'table' => 'BEdita/Core.Objects',
             'associations' => null,
+            'relations' => [
+                'test',
+                'inverse_test',
+            ],
         ];
 
         $objectType = $this->ObjectTypes->get(1);
-        if (!($objectType instanceof ObjectType)) {
-            throw new \InvalidArgumentException();
-        }
 
-        $this->assertEquals($expected, $objectType->toArray());
+        static::assertEquals($expected, $objectType->toArray());
     }
 
     /**
@@ -126,11 +123,8 @@ class ObjectTypeTest extends TestCase
             'name' => 'FooBar',
         ];
         $objectType = $this->ObjectTypes->newEntity($data);
-        if (!($objectType instanceof ObjectType)) {
-            throw new \InvalidArgumentException();
-        }
 
-        $this->assertEquals('foo_bar', $objectType->name);
+        static::assertEquals('foo_bar', $objectType->name);
     }
 
     /**
@@ -162,11 +156,8 @@ class ObjectTypeTest extends TestCase
     {
         $data = compact('name', 'singular');
         $objectType = $this->ObjectTypes->newEntity($data);
-        if (!($objectType instanceof ObjectType)) {
-            throw new \InvalidArgumentException();
-        }
 
-        $this->assertEquals($expected, $objectType->singular);
+        static::assertEquals($expected, $objectType->singular);
     }
 
     /**
@@ -181,11 +172,8 @@ class ObjectTypeTest extends TestCase
             'name' => 'foo_bars',
         ];
         $objectType = $this->ObjectTypes->newEntity($data);
-        if (!($objectType instanceof ObjectType)) {
-            throw new \InvalidArgumentException();
-        }
 
-        $this->assertEquals('FooBars', $objectType->alias);
+        static::assertEquals('FooBars', $objectType->alias);
     }
 
     /**
@@ -218,12 +206,42 @@ class ObjectTypeTest extends TestCase
     {
         $data = compact('table');
         $objectType = $this->ObjectTypes->newEntity($data);
-        if (!($objectType instanceof ObjectType)) {
-            throw new \InvalidArgumentException();
-        }
 
-        $this->assertEquals($expectedPlugin, $objectType->plugin);
-        $this->assertEquals($expectedModel, $objectType->model);
-        $this->assertEquals($expected, $objectType->table);
+        static::assertEquals($expectedPlugin, $objectType->plugin);
+        static::assertEquals($expectedModel, $objectType->model);
+        static::assertEquals($expected, $objectType->table);
+    }
+
+    /**
+     * Test getter for relations.
+     *
+     * @return void
+     *
+     * @covers ::_getRelations()
+     */
+    public function testGetRelations()
+    {
+        $expected = [
+            'test',
+            'inverse_test',
+        ];
+        $objectType = $this->ObjectTypes->get(1);
+
+        static::assertEquals($expected, $objectType->relations, '', 0, 10, true);
+    }
+
+    /**
+     * Test getter for meta fields.
+     *
+     * @return void
+     *
+     * @covers ::_getMeta()
+     */
+    public function testGetMeta()
+    {
+        $objectType = $this->ObjectTypes->newEntity();
+        $meta = $objectType->meta;
+
+        static::assertContains('relations', $meta);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
@@ -198,6 +198,10 @@ class ObjectTypesTableTest extends TestCase
                     'model' => 'Objects',
                     'table' => 'BEdita/Core.Objects',
                     'associations' => null,
+                    'relations' => [
+                        'test',
+                        'inverse_test',
+                    ],
                 ],
                 1,
             ],
@@ -212,6 +216,10 @@ class ObjectTypesTableTest extends TestCase
                     'model' => 'Objects',
                     'table' => 'BEdita/Core.Objects',
                     'associations' => null,
+                    'relations' => [
+                        'test',
+                        'inverse_test',
+                    ],
                 ],
                 '1',
             ],
@@ -226,6 +234,10 @@ class ObjectTypesTableTest extends TestCase
                     'model' => 'Objects',
                     'table' => 'BEdita/Core.Objects',
                     'associations' => null,
+                    'relations' => [
+                        'test',
+                        'inverse_test',
+                    ],
                 ],
                 'document',
             ],
@@ -240,6 +252,10 @@ class ObjectTypesTableTest extends TestCase
                     'model' => 'Objects',
                     'table' => 'BEdita/Core.Objects',
                     'associations' => null,
+                    'relations' => [
+                        'test',
+                        'inverse_test',
+                    ],
                 ],
                 'documents',
             ],
@@ -254,6 +270,10 @@ class ObjectTypesTableTest extends TestCase
                     'model' => 'Objects',
                     'table' => 'BEdita/Core.Objects',
                     'associations' => null,
+                    'relations' => [
+                        'test',
+                        'inverse_test',
+                    ],
                 ],
                 'Documents',
             ],
@@ -388,5 +408,21 @@ class ObjectTypesTableTest extends TestCase
             ->toArray();
 
         static::assertEquals($expected, $result, '', 0, 10, true);
+    }
+
+    /**
+     * Test default finder.
+     *
+     * @return void
+     *
+     * @covers ::findAll()
+     */
+    public function testFindAll()
+    {
+        $query = $this->ObjectTypes->find();
+        $contain = $query->contain();
+
+        static::assertArrayHasKey('LeftRelations', $contain);
+        static::assertArrayHasKey('RightRelations', $contain);
     }
 }


### PR DESCRIPTION
This PR adds a `relations` array to ObjectTypes entities containing a list of available relations names.

This is helpful for clients that want to know what relations are available for an object type before creating a real object.

Example:
```http
GET /object_types/3
Accept: application/vnd.api+json

{
  "data": {
    "id": "3",
    "type": "object_types",
    "attributes": {
      "singular": "user",
      "name": "users",
      "description": "BEdita user profile",
      "plugin": "BEdita/Core",
      "model": "Users",
      "associations": null,
      "alias": "Users",
      "table": "BEdita/Core.Users"
    },
    "relationships": {
      "properties": {
        "links": {
          "related": "http://example.org/object_types/3/properties",
          "self": "http://example.org/object_types/3/relationships/properties"
        }
      }
    },
    "meta": {
      "relations": [
        "my_relation",
        "another_relation"
      ]
    }
  },
  "links": {
    "self": "http://example.org/object_types/3",
    "home": "http://example.org/home"
  }
}
```