### PR TITLE
 #1184 feat: http code 204 and no content-type

### DIFF
--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -165,7 +165,6 @@ class ObjectsController extends ResourcesController
             }
 
             return $this->response
-                ->withHeader('Content-Type', $this->request->contentType())
                 ->withStatus(204);
         }
 
@@ -269,7 +268,6 @@ class ObjectsController extends ResourcesController
 
         if ($count === 0) {
             return $this->response
-                ->withHeader('Content-Type', $this->request->contentType())
                 ->withStatus(204);
         }
 

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -179,7 +179,6 @@ abstract class ResourcesController extends AppController
             }
 
             return $this->response
-                ->withHeader('Content-Type', $this->request->contentType())
                 ->withStatus(204);
         }
 
@@ -288,7 +287,6 @@ abstract class ResourcesController extends AppController
 
         if ($count === 0) {
             return $this->response
-                ->withHeader('Content-Type', $this->request->contentType())
                 ->withStatus(204);
         }
 

--- a/plugins/BEdita/API/src/Controller/TrashController.php
+++ b/plugins/BEdita/API/src/Controller/TrashController.php
@@ -104,7 +104,6 @@ class TrashController extends AppController
         }
 
         return $this->response
-            ->withHeader('Content-Type', $this->request->contentType())
             ->withStatus(204);
     }
 
@@ -137,7 +136,7 @@ class TrashController extends AppController
         }
 
         return $this->response
-            ->withHeader('Content-Type', $this->request->contentType())
+            //->withHeader('Content-Type', $this->request->contentType())
             ->withStatus(204);
     }
 }

--- a/plugins/BEdita/API/src/Controller/TrashController.php
+++ b/plugins/BEdita/API/src/Controller/TrashController.php
@@ -136,7 +136,6 @@ class TrashController extends AppController
         }
 
         return $this->response
-            //->withHeader('Content-Type', $this->request->contentType())
             ->withStatus(204);
     }
 }


### PR DESCRIPTION
This fixes #1184, removing `content-type` from header, when http status code returned is 204.