### PR TITLE
feat: comma separated items in string treated like list

### DIFF
--- a/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
+++ b/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
@@ -41,7 +41,10 @@ trait QueryFilterTrait
      *
      * // field1 in [1, 3, 10]
      * ['field1' => [1, 3, 10]];
-
+     *
+     * // a comma separated string has the same effect as a list of values
+     * ['field1' => '1,3,10'];
+     *
      * // field1 equals 10, field2 equals 1
      * ['field1' => 10, 'field1' => ['eq' => 1]];
      *
@@ -64,9 +67,13 @@ trait QueryFilterTrait
                 }
 
                 if (!is_array($conditions)) {
-                    $exp = $exp->eq($field, $conditions);
+                    if (is_string($conditions) && strpos($conditions, ',') !== false) {
+                        $conditions = explode(',', $conditions);
+                    } else {
+                        $exp = $exp->eq($field, $conditions);
 
-                    continue;
+                        continue;
+                    }
                 }
 
                 $in = [];

--- a/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
@@ -92,6 +92,12 @@ class QueryFilterTraitTest extends TestCase
                 ],
                 1,
             ],
+            'allLegsComma' => [
+                [
+                    'legs' => '2,3,4',
+                ],
+                3,
+            ],
             'allLegs' => [
                 [
                     'legs' => [2, 3, 4],


### PR DESCRIPTION
With this PR a filter with a comma separated items string will be handled like a list of item.

`?filter[id]=1,2,3,4` will extract only items with id in 1,2,3,4
