### PR TITLE
Enable setup with Sqlite and Postgres

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -240,20 +240,26 @@ return [
     'Datasources' => [
         'default' => [
             'className' => 'Cake\Database\Connection',
+
+            /**
+             * Possible values for 'driver' are: Mysql, Postgres, Sqlite
+             * Simply replace Mysql with Posgres or Sqlite in 'driver' value
+             */
             'driver' => 'Cake\Database\Driver\Mysql',
-            'persistent' => false,
             'host' => '__BE4_DB_HOST__',
+
             /**
              * CakePHP will use the default DB port based on the driver selected
              * MySQL on MAMP uses port 8889, MAMP users will want to uncomment
              * the following line and set the port accordingly
              */
-            'port' => '____BE4_DB_PORT__',
+            'port' => '__BE4_DB_PORT__',
             'username' => '__BE4_DB_USERNAME__',
             'password' => '__BE4_DB_PASSWORD__',
             'database' => '__BE4_DB_DATABASE__',
             'encoding' => 'utf8',
             'timezone' => 'UTC',
+            'persistent' => false,
             'flags' => [],
             'cacheMetadata' => true,
             'log' => false,

--- a/plugins/BEdita/Core/src/Shell/BeditaShell.php
+++ b/plugins/BEdita/Core/src/Shell/BeditaShell.php
@@ -359,7 +359,8 @@ class BeditaShell extends Shell
             return;
         }
         $this->userInputData['host'] = $this->in('Host?', null, 'localhost');
-        $this->userInputData['port'] = $this->in('Port?', null, '3306');
+        $defaultPort = ($this->userInputData['driver'] === 'Mysql') ? '3306' : '5432';
+        $this->userInputData['port'] = $this->in('Port?', null, $defaultPort);
         $this->userInputData['database'] = $this->in('Database?');
         $this->userInputData['username'] = $this->in('Username?');
         $this->userInputData['password'] = $this->in('Password?');

--- a/plugins/BEdita/Core/src/Shell/BeditaShell.php
+++ b/plugins/BEdita/Core/src/Shell/BeditaShell.php
@@ -159,12 +159,6 @@ class BeditaShell extends Shell
     protected function initSchema()
     {
         $connection = ConnectionManager::get('default');
-        if (!($connection instanceof Connection)) {
-            $this->err('Unable to use connection');
-
-            return false;
-        }
-
         $tables = $connection->getSchemaCollection()->listTables();
         if (empty($tables)) {
             $this->out('Database is empty');
@@ -288,7 +282,9 @@ class BeditaShell extends Shell
         }
 
         $this->info('A working database connection is needed in order to continue');
-        $this->info('Parameter needed are: host, port, database, username, password');
+        $this->info('Parameter needed are: driver, host, port, database, username, password');
+        $this->info('For MySQL and Postgres you need to provide all parameters, for SQLite database path is sufficient');
+
         $res = $this->in('Proceed with setup?', ['y', 'n'], 'n');
         if ($res != 'y') {
             $this->info('Database setup stopped');
@@ -299,6 +295,7 @@ class BeditaShell extends Shell
         $this->dbConnectionUserInput();
         $dbParams = array_merge($dbParams, $this->userInputData);
         $dbParams['className'] = 'Cake\Database\Connection';
+        $dbParams['driver'] = 'Cake\Database\Driver\\' . $this->userInputData['driver'];
         ConnectionManager::setConfig(self::TEMP_SETUP_CFG, $dbParams);
         ConnectionManager::alias(self::TEMP_SETUP_CFG, 'default');
 
@@ -326,6 +323,11 @@ class BeditaShell extends Shell
             $content = str_replace($placeHolder, $this->userInputData[$name], $content);
         }
 
+        // update driver
+        $oldDriver = "'Cake\Database\Driver\Mysql'";
+        $newDriver = "'Cake\Database\Driver\\" . $this->userInputData['driver'] . "'";
+        $content = str_replace($oldDriver, $newDriver, $content);
+
         // TODO: better php check for $content?
         $eval = eval(str_replace('<?php', '', $content));
         if (empty($eval) || !is_array($eval)) {
@@ -349,7 +351,13 @@ class BeditaShell extends Shell
      */
     protected function dbConnectionUserInput()
     {
-        $this->userInputData = [];
+        $this->userInputData = ['host' => 'localhost', 'port' => '', 'database' => '', 'username' => '', 'password' => ''];
+        $this->userInputData['driver'] = $this->in('Driver?', ['Mysql', 'Postgres', 'Sqlite'], 'Mysql');
+        if ($this->userInputData['driver'] === 'Sqlite') {
+            $this->userInputData['database'] = $this->in('Sqlite database file path?', null, TMP . 'be4.sqlite');
+
+            return;
+        }
         $this->userInputData['host'] = $this->in('Host?', null, 'localhost');
         $this->userInputData['port'] = $this->in('Port?', null, '3306');
         $this->userInputData['database'] = $this->in('Database?');

--- a/plugins/BEdita/Core/tests/TestCase/Shell/BeditaShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/BeditaShellTest.php
@@ -221,7 +221,7 @@ class BeditaShellTest extends ShellTestCase
 
         $map = [
             ['Host?', 'localhost', $config['host']],
-            ['Port?', '3306', $fakeParams['port']],
+            ['Port?', ($driver === 'Mysql') ? '3306' : '5432', $fakeParams['port']],
             ['Database?', null, $fakeParams['database']],
             ['Username?', null, $fakeParams['username']],
             ['Password?', null, $fakeParams['password']],

--- a/plugins/BEdita/Core/tests/TestCase/Shell/BeditaShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/BeditaShellTest.php
@@ -207,6 +207,7 @@ class BeditaShellTest extends ShellTestCase
     public function testFake2()
     {
         $config = ConnectionManager::get('test', false)->config();
+        $driver = str_replace('Cake\Database\Driver\\', '', $config['driver']);
         if (strstr($config['driver'], 'Sqlite') !== false) {
             $this->markTestSkipped('Initial setup does not yet support SQLite');
         }
@@ -232,6 +233,7 @@ class BeditaShellTest extends ShellTestCase
         $this->assertFalse($res);
 
         $mapChoice = [
+            ['Driver?', ['Mysql', 'Postgres', 'Sqlite'], 'Mysql', $driver],
             ['Proceed with setup?', ['y', 'n'], 'n', 'y'],
         ];
         $io->method('askChoice')
@@ -286,6 +288,7 @@ class BeditaShellTest extends ShellTestCase
     public function testFake3($success, callable $callback)
     {
         $config = ConnectionManager::get('test', false)->config();
+        $driver = str_replace('Cake\Database\Driver\\', '', $config['driver']);
         if (strstr($config['driver'], 'Mysql') === false) {
             $this->markTestSkipped('Initial setup does not yet support SQLite nor PostgreSQL');
         }
@@ -293,6 +296,7 @@ class BeditaShellTest extends ShellTestCase
         $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
 
         $mapChoice = [
+            ['Driver?', ['Mysql', 'Postgres', 'Sqlite'], 'Mysql', $driver],
             ['Proceed with setup?', ['y', 'n'], 'n', 'y'],
             ['Proceed with database schema and data initialization?', ['y', 'n'], 'n', 'y'],
         ];


### PR DESCRIPTION
With this PR it will enable Sqlite and Postgres in `bedita setup` shell script.
User will have to input one of: Mysql (default), Postgres or Sqlite

In case of Sqlite only database file path is requested, with default path `tmp/be4.sqlite` 

With Sqlite `db_admin check_schema` fails, so a second run of  `bedita setup` is not possible.
To fix in other issue after release.