### PR TITLE
Whitelist for endpoint authorized

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Auth/EndpointAuthorizeTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/EndpointAuthorizeTest.php
@@ -14,11 +14,13 @@
 namespace BEdita\API\Test\TestCase\Auth;
 
 use BEdita\API\Auth\EndpointAuthorize;
+use BEdita\Core\Model\Entity\Endpoint;
 use BEdita\Core\State\CurrentApplication;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Http\ServerRequest;
 use Cake\Network\Exception\ForbiddenException;
+use Cake\Network\Exception\NotFoundException;
 use Cake\Network\Exception\UnauthorizedException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -134,20 +136,40 @@ class EndpointAuthorizeTest extends TestCase
                 new Uri('/home/sweet/home'),
             ],
             '/' => [
-                null,
+                new Endpoint(
+                    [
+                        'name' => '',
+                        'enabled' => true
+                    ],
+                    [
+                        'source' => 'Endpoints'
+                    ]
+                ),
                 new Uri('/'),
             ],
             '/this/endpoint/definitely/doesnt/exist' => [
-                null,
+                new Endpoint(
+                    [
+                        'name' => 'this',
+                        'enabled' => true
+                    ],
+                    [
+                        'source' => 'Endpoints'
+                    ]
+                ),
                 new Uri('/this/endpoint/definitely/doesnt/exist'),
             ],
+            '/disabled/endpoint' => [
+                new NotFoundException('Resource not found.'),
+                new Uri('/disabled/endpoint'),
+            ]
         ];
     }
 
     /**
      * Test getting endpoint from request.
      *
-     * @param int|\Exception $expected Expected endpoint ID.
+     * @param int|\Cake\ORM\Entity $expected Expected endpoint ID or entity.
      * @param \Psr\Http\Message\UriInterface $uri Request URI.
      * @return void
      *
@@ -156,17 +178,22 @@ class EndpointAuthorizeTest extends TestCase
      */
     public function testGetEndpoint($expected, UriInterface $uri)
     {
+        if ($expected instanceof \Exception) {
+            static::expectException(get_class($expected));
+            static::expectExceptionMessage($expected->getMessage());
+        }
+
         CurrentApplication::setFromApiKey(API_KEY);
         $authorize = new EndpointAuthorize(new ComponentRegistry(), []);
         $request = new ServerRequest(compact('uri'));
 
         $authorize->authorize([], $request);
 
-        if ($expected === null) {
-            static::assertAttributeSame($expected, 'endpoint', $authorize);
-        } else {
-            static::assertAttributeEquals(TableRegistry::get('Endpoints')->get($expected), 'endpoint', $authorize);
+        if (is_int($expected)) {
+            $expected = TableRegistry::get('Endpoints')->get($expected);
         }
+
+        static::assertAttributeEquals($expected, 'endpoint', $authorize);
     }
 
     /**
@@ -212,6 +239,31 @@ class EndpointAuthorizeTest extends TestCase
                 new Uri('/unknown-endpoint'),
                 [
                     '_anonymous' => true,
+                ],
+            ],
+            'GET /disabled (anonymous)' => [
+                new NotFoundException('Resource not found.'),
+                new Uri('/disabled'),
+                [
+                    '_anonymous' => true
+                ],
+            ],
+            'GET /disabled (role_id = 1)' => [
+                new NotFoundException('Resource not found.'),
+                new Uri('/disabled'),
+                [
+                    'roles' => [
+                        [
+                            'id' => 1,
+                        ],
+                    ],
+                ],
+            ],
+            'POST /signup whitelist (anonymous)' => [
+                true,
+                new Uri('/signup'),
+                [
+                    '_anonymous' => true
                 ],
             ],
         ];

--- a/plugins/BEdita/API/tests/TestCase/Auth/EndpointAuthorizeTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/EndpointAuthorizeTest.php
@@ -169,7 +169,7 @@ class EndpointAuthorizeTest extends TestCase
     /**
      * Test getting endpoint from request.
      *
-     * @param int|\Cake\ORM\Entity $expected Expected endpoint ID or entity.
+     * @param mixed $expected Expected endpoint ID, entity, or exception.
      * @param \Psr\Http\Message\UriInterface $uri Request URI.
      * @return void
      *

--- a/plugins/BEdita/Core/tests/Fixture/EndpointsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/EndpointsFixture.php
@@ -44,5 +44,13 @@ class EndpointsFixture extends TestFixture
             'enabled' => 1,
             'object_type_id' => null
         ],
+        [
+            'name' => 'disabled',
+            'description' => '/disabled endpoint',
+            'created' => '2017-05-03 07:12:26',
+            'modified' => '2017-05-03 07:12:26',
+            'enabled' => 0,
+            'object_type_id' => null
+        ],
     ];
 }


### PR DESCRIPTION
This PR is propedeutics for #1203 

It introduces a configurable whitelist of endpoints that don't require permission check to be authorized.
An endpoint whitelisted is always authorized unless a specific permission is set on that endpoint for the current application.

In this way we can setup `signup` in whitelist and allow the request `POST /signup` for anonymous users.
