### PR TITLE
Async job services and shell

### DIFF
--- a/plugins/BEdita/Core/src/Job/JobService.php
+++ b/plugins/BEdita/Core/src/Job/JobService.php
@@ -21,9 +21,7 @@ namespace BEdita\Core\Job;
 interface JobService
 {
     /**
-     * Run an async job.
-     *
-     * This method **MUST** return a resource object as per JSON API specifications.
+     * Run an async job using $payload input data and optional $options.
      *
      * @param array $payload Input data for running this job.
      * @param array $options Options for running this job.

--- a/plugins/BEdita/Core/src/Job/JobService.php
+++ b/plugins/BEdita/Core/src/Job/JobService.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Job;
+
+/**
+ * Interface to run async jobs services.
+ *
+ * @since 4.0.0
+ */
+interface JobService
+{
+    /**
+     * Run an async job.
+     *
+     * This method **MUST** return a resource object as per JSON API specifications.
+     *
+     * @param array $payload Input data for running this job.
+     * @param array $options Options for running this job.
+     * @return bool True on success, false on failure
+     */
+    public function run($payload, $options = []);
+}

--- a/plugins/BEdita/Core/src/Job/ServiceRunner.php
+++ b/plugins/BEdita/Core/src/Job/ServiceRunner.php
@@ -61,7 +61,6 @@ class ServiceRunner
             }
         }
         if (!$classFound) {
-            Log::write('error', 'service not found: ' . $name);
             throw new \LogicException(__d('bedita', 'Unknown service "{0}"', [$name]));
         }
         $instance = new $classFound();
@@ -82,7 +81,6 @@ class ServiceRunner
     public static function register($name, $instance)
     {
         if (!($instance instanceof JobService)) {
-            Log::write('error', 'bad service class: ' . get_class($instance));
             throw new \LogicException(__d('bedita', 'Bad service class "{0}"', [get_class($instance)]));
         }
         static::$instances[$name] = $instance;

--- a/plugins/BEdita/Core/src/Job/ServiceRunner.php
+++ b/plugins/BEdita/Core/src/Job/ServiceRunner.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Job;
 
+use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Log\Log;
 use Cake\ORM\TableRegistry;
@@ -51,11 +52,11 @@ class ServiceRunner
         }
         $className = Inflector::camelize($name);
         $plugins = array_keys(Configure::read('Plugins'));
-        $plugins[] = 'BEdita\Core';
+        $plugins[] = 'BEdita/Core';
         $classFound = null;
         foreach ($plugins as $plugin) {
-            $fullName = '\\' . $plugin . '\Service\\' . $className;
-            if (class_exists($fullName)) {
+            $fullName = App::className("$plugin.$className", 'Service');
+            if ($fullName) {
                 $classFound = $fullName;
                 break;
             }

--- a/plugins/BEdita/Core/src/Job/ServiceRunner.php
+++ b/plugins/BEdita/Core/src/Job/ServiceRunner.php
@@ -51,7 +51,7 @@ class ServiceRunner
             return static::$instances[$name];
         }
         $className = Inflector::camelize($name);
-        $plugins = array_keys(Configure::read('Plugins'));
+        $plugins = array_keys((array)Configure::read('Plugins'));
         $plugins[] = 'BEdita/Core';
         $classFound = null;
         foreach ($plugins as $plugin) {

--- a/plugins/BEdita/Core/src/Job/ServiceRunner.php
+++ b/plugins/BEdita/Core/src/Job/ServiceRunner.php
@@ -13,7 +13,6 @@
 
 namespace BEdita\Core\Job;
 
-use BEdita\Core\Job\JobService;
 use Cake\Core\Configure;
 use Cake\Log\Log;
 use Cake\ORM\TableRegistry;
@@ -102,7 +101,7 @@ class ServiceRunner
     /**
      * Run a service with $payload data read from async jobs table
      *
-     * In $options array this parameters are available:
+     * In $options array these parameters are available:
      *  - 'lockPeriod' : lock time duration, specify in the form '+5 minutes'
      *
      * @param string $uuid UUID of the job to run.
@@ -136,9 +135,9 @@ class ServiceRunner
      * Run pending jobs reading from async jobs table.
      * Using an optional max number of jobs as 'limit'
      * Resulting array will contain
-     *  - 'count' number oj jobs executed
+     *  - 'count' number of jobs executed
      *  - 'success' uuids of jobs successfully executed
-     *  - 'success' uuids of failed jobs
+     *  - 'failure' uuids of failed jobs
      *
      * @param int $limit Max number of pending jobs to run.
      * @return array Result details

--- a/plugins/BEdita/Core/src/Job/ServiceRunner.php
+++ b/plugins/BEdita/Core/src/Job/ServiceRunner.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Job;
+
+use BEdita\Core\Job\JobService;
+use Cake\Core\Configure;
+use Cake\Log\LogTrait;
+use Cake\ORM\TableRegistry;
+use Cake\Utility\Hash;
+use Cake\Utility\Inflector;
+
+/**
+ * Utility class to run async job services.
+ *
+ * @since 4.0.0
+ */
+class ServiceRunner
+{
+    use LogTrait;
+
+    /**
+     * Async Jobs table.
+     *
+     * @var \BEdita\Core\Model\Table\AsyncJobs
+     */
+    protected $AsyncJobs = null;
+
+    /**
+     * Registered instances.
+     *
+     * @var \BEdita\Core\Job\JobService[]
+     */
+    protected $instances = [];
+
+    /**
+     * Default constructor
+     * @codeCoverageIgnore
+     */
+    public function __construct()
+    {
+        $this->AsyncJobs = TableRegistry::get('AsyncJobs');
+    }
+
+    /**
+     * Get a service class instance for a given $name.
+     * If no service with a given $name was registered a corresponding class in plugins and core namespaces
+     * is searched.
+     * Example:
+     * - service $name = 'example', look for \MyPlugin\Service\Example and then for \BEdita\Core\Service\Example
+     *
+     * @param string $name The service name you want to get.
+     * @return \BEdita\Core\Job\JobService Service instance found
+     * @throws \LogicException
+     */
+    public function getService($name)
+    {
+        if (!empty($this->instances[$name])) {
+            return $this->instances[$name];
+        }
+        $className = Inflector::camelize($name);
+        $plugins = array_keys(Configure::read('Plugins'));
+        $plugins[] = 'BEdita\Core';
+        $classFound = null;
+        foreach ($plugins as $plugin) {
+            $fullName = '\\' . $plugin . '\Service\\' . $className;
+            if (class_exists($fullName)) {
+                $classFound = $fullName;
+                break;
+            }
+        }
+        if (!$classFound) {
+            $this->log('service not found: ' . $name, 'error');
+            throw new \LogicException(__d('bedita', 'Unknown service'));
+        }
+        $instance = new $classFound();
+        $this->register($name, $instance);
+
+        return $instance;
+    }
+
+    /**
+     * Register service class instance for a $name service.
+     * Instance MUST implement JobService
+     *
+     * @param string $name The service name you want to register.
+     * @param mixed $instance The instance object to be registered, MUST implement JobService
+     * @return void
+     * @throws \LogicException
+     */
+    public function register($name, $instance)
+    {
+        if (!($instance instanceof JobService)) {
+            $this->log('bad service class: ' . get_class($instance), 'error');
+            throw new \LogicException(__d('bedita', 'Bad service instance'));
+        }
+        $this->instances[$name] = $instance;
+    }
+
+    /**
+     * Reset registered service instances
+     *
+     * @return void
+     */
+    public function reset()
+    {
+        $this->instances = [];
+    }
+
+    /**
+     * Run a service with $payload data read from async jobs table
+     *
+     * In $options array this parameters are available:
+     *  - 'lockPeriod' : lock time duration, specify in the form '+5 minutes'
+     *
+     * @param string $uuid UUID of the job to run.
+     * @param array $options Options for running this job.
+     * @return bool True on success, false on failure
+     */
+    public function run($uuid, $options = [])
+    {
+        $locked = $run = false;
+        try {
+            $asyncJob = $this->AsyncJobs->lock($uuid, Hash::get($options, 'lockPeriod', '+5 minutes'));
+            $locked = true;
+            $service = $this->getService($asyncJob->service);
+            $success = $service->run($asyncJob->payload, $options);
+            $run = true;
+            $this->AsyncJobs->unlock($uuid, $success);
+
+            return $success;
+        } catch (\Exception $e) {
+            $this->log('job run failed: ' . $e->getMessage(), 'error');
+            if ($locked) {
+                // locked job failed, unlock
+                $this->AsyncJobs->unlock($uuid, false);
+            }
+
+            return false;
+        }
+    }
+
+    /**
+     * Run pending jobs reading from async jobs table.
+     * Using an optional max number of jobs as 'limit'
+     *
+     * @param int $limit Max number of pending jobs to run.
+     * @return array Result details array with boolean flag for every uuid
+     */
+    public function runPending($limit = 0)
+    {
+        $results = [];
+        $pending = $this->AsyncJobs->find('pending')->select(['uuid']);
+        if ($limit) {
+            $pending->limit($limit);
+        }
+        foreach ($pending as $job) {
+            $success = $this->run($job->uuid);
+            $results[$job->uuid] = $success;
+        }
+
+        return $results;
+    }
+}

--- a/plugins/BEdita/Core/src/Job/ServiceRunner.php
+++ b/plugins/BEdita/Core/src/Job/ServiceRunner.php
@@ -140,11 +140,11 @@ class ServiceRunner
      * @param int $limit Max number of pending jobs to run.
      * @return array Result details
      */
-    public static function runPending($limit = 0)
+    public static function runPending($limit = null)
     {
         $results = ['success' => [], 'failure' => []];
         $pending = TableRegistry::get('AsyncJobs')->find('pending')->select(['uuid']);
-        if ($limit) {
+        if ($limit !== null) {
             $pending->limit($limit);
         }
         $count = 0;

--- a/plugins/BEdita/Core/src/Service/Mail.php
+++ b/plugins/BEdita/Core/src/Service/Mail.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Service;
+
+use BEdita\Core\Job\JobService;
+
+/**
+ * Send single mail
+ *
+ * @since 4.0.0
+ */
+class Mail implements JobService
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function run($payload, $options = [])
+    {
+        return true;
+    }
+}

--- a/plugins/BEdita/Core/src/Service/Mail.php
+++ b/plugins/BEdita/Core/src/Service/Mail.php
@@ -17,6 +17,7 @@ use BEdita\Core\Job\JobService;
 
 /**
  * Send single mail
+ * [Temporary dummy implementation]
  *
  * @since 4.0.0
  */

--- a/plugins/BEdita/Core/src/Shell/JobsShell.php
+++ b/plugins/BEdita/Core/src/Shell/JobsShell.php
@@ -13,7 +13,6 @@
 namespace BEdita\Core\Shell;
 
 use BEdita\Core\Job\ServiceRunner;
-use Cake\Cache\Cache;
 use Cake\Console\Shell;
 
 /**

--- a/plugins/BEdita/Core/src/Shell/JobsShell.php
+++ b/plugins/BEdita/Core/src/Shell/JobsShell.php
@@ -53,7 +53,7 @@ class JobsShell extends Shell
     /**
      * Run async pending jobs
      *
-     * @return void
+     * @return bool False on at least a job failure, true otherwise
      */
     public function run()
     {
@@ -71,6 +71,6 @@ class JobsShell extends Shell
         $this->out(sprintf('Failure:  %s', count($result['failure'])));
         $this->hr();
 
-        return true;
+        return empty($result['failure']);
     }
 }

--- a/plugins/BEdita/Core/src/Shell/JobsShell.php
+++ b/plugins/BEdita/Core/src/Shell/JobsShell.php
@@ -40,7 +40,7 @@ class JobsShell extends Shell
                             'help' => 'Max number of jobs to run',
                             'short' => 'l',
                             'required' => false,
-                            'default' => 0,
+                            'default' => null,
                         ],
                     ],
                 ],

--- a/plugins/BEdita/Core/src/Shell/JobsShell.php
+++ b/plugins/BEdita/Core/src/Shell/JobsShell.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Core\Shell;
+
+use BEdita\Core\Job\ServiceRunner;
+use Cake\Cache\Cache;
+use Cake\Console\Shell;
+
+/**
+ * Shell class to run pending jobs
+ *
+ * @since 4.0.0
+ */
+class JobsShell extends Shell
+{
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+        $parser
+            ->addSubcommand('run', [
+                'help' => 'Run pending async jobs.',
+                'parser' => [
+                    'options' => [
+                        'limit' => [
+                            'help' => 'Max number of jobs to run',
+                            'short' => 'l',
+                            'required' => false,
+                            'default' => 0,
+                        ],
+                    ],
+                ],
+            ]);
+
+        return $parser;
+    }
+
+    /**
+     * Run async pending jobs
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $limit = $this->param('limit');
+        if (!$limit) {
+            $this->out('Running all pending jobs...');
+        } else {
+            $this->out(sprintf('Running pending jobs, limit number: %s', $limit));
+        }
+        $result = ServiceRunner::runPending($limit);
+        $this->out('<info>Jobs terminated</info>');
+        $this->hr();
+        $this->out(sprintf('Executed: %s', $result['count']));
+        $this->out(sprintf('Success:  %s', count($result['success'])));
+        $this->out(sprintf('Failure:  %s', count($result['failure'])));
+        $this->hr();
+
+        return true;
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Job/ServiceRunnerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/ServiceRunnerTest.php
@@ -33,13 +33,6 @@ class ServiceRunnerTest extends TestCase
 {
 
     /**
-     * Test subject
-     *
-     * @var \BEdita\Core\Job\ServiceRunner
-     */
-    public $ServiceRunner;
-
-    /**
      * Fixtures
      *
      * @var array
@@ -47,14 +40,6 @@ class ServiceRunnerTest extends TestCase
     public $fixtures = [
         'plugin.BEdita/Core.async_jobs',
     ];
-
-    /**
-     * {@inheritDoc}
-     */
-    public function setUp()
-    {
-        $this->ServiceRunner = new ServiceRunner();
-    }
 
     /**
      * Test getService method
@@ -65,12 +50,12 @@ class ServiceRunnerTest extends TestCase
      */
     public function testGetService()
     {
-        $result = $this->ServiceRunner->getService('mail');
+        $result = ServiceRunner::getService('mail');
         $this->assertNotEmpty($result);
         $this->assertInstanceOf(\BEdita\Core\Job\JobService::class, $result);
 
         // test instance registry
-        $result2 = $this->ServiceRunner->getService('mail');
+        $result2 = ServiceRunner::getService('mail');
         $this->assertSame($result, $result2);
     }
 
@@ -83,7 +68,7 @@ class ServiceRunnerTest extends TestCase
     public function testGetServiceFail()
     {
         $this->expectException(\LogicException::class);
-        $this->ServiceRunner->getService('gustavo');
+        ServiceRunner::getService('gustavo');
     }
 
     /**
@@ -96,9 +81,9 @@ class ServiceRunnerTest extends TestCase
     public function testRegister()
     {
         $exampleService = new Example();
-        $this->ServiceRunner->register('example', $exampleService);
+        ServiceRunner::register('example', $exampleService);
 
-        $result = $this->ServiceRunner->getService('example');
+        $result = ServiceRunner::getService('example');
         $this->assertNotEmpty($result);
         $this->assertSame($exampleService, $result);
     }
@@ -112,7 +97,7 @@ class ServiceRunnerTest extends TestCase
     public function testRegisterFail()
     {
         $this->expectException(\LogicException::class);
-        $this->ServiceRunner->register('gustavo', $this);
+        ServiceRunner::register('gustavo', $this);
     }
 
     /**
@@ -124,9 +109,9 @@ class ServiceRunnerTest extends TestCase
     public function testRun()
     {
         $exampleService = new Example();
-        $this->ServiceRunner->register('example', $exampleService);
+        ServiceRunner::register('example', $exampleService);
 
-        $result = $this->ServiceRunner->run('d6bb8c84-6b29-432e-bb84-c3c4b2c1b99c');
+        $result = ServiceRunner::run('d6bb8c84-6b29-432e-bb84-c3c4b2c1b99c');
         $this->assertTrue($result);
     }
 
@@ -139,8 +124,8 @@ class ServiceRunnerTest extends TestCase
      */
     public function testRunFail()
     {
-        $this->ServiceRunner->reset();
-        $result = $this->ServiceRunner->run('d6bb8c84-6b29-432e-bb84-c3c4b2c1b99c');
+        ServiceRunner::reset();
+        $result = ServiceRunner::run('d6bb8c84-6b29-432e-bb84-c3c4b2c1b99c');
         $this->assertFalse($result);
     }
 
@@ -153,10 +138,14 @@ class ServiceRunnerTest extends TestCase
     public function testRunPending()
     {
         $exampleService = new Example();
-        $this->ServiceRunner->register('example', $exampleService);
+        ServiceRunner::register('example', $exampleService);
 
-        $result = $this->ServiceRunner->runPending(1);
-        $expected = ['d6bb8c84-6b29-432e-bb84-c3c4b2c1b99c' => true];
+        $result = ServiceRunner::runPending(1);
+        $expected = [
+            'count' => 1,
+            'success' => ['d6bb8c84-6b29-432e-bb84-c3c4b2c1b99c'],
+            'failure' => []
+        ];
         $this->assertNotEmpty($result);
         $this->assertEquals($expected, $result);
     }

--- a/plugins/BEdita/Core/tests/TestCase/Job/ServiceRunnerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/ServiceRunnerTest.php
@@ -108,8 +108,7 @@ class ServiceRunnerTest extends TestCase
      */
     public function testRun()
     {
-        $exampleService = new Example();
-        ServiceRunner::register('example', $exampleService);
+        ServiceRunner::register('example', new Example());
 
         $result = ServiceRunner::run('d6bb8c84-6b29-432e-bb84-c3c4b2c1b99c');
         $this->assertTrue($result);
@@ -137,14 +136,36 @@ class ServiceRunnerTest extends TestCase
      */
     public function testRunPending()
     {
-        $exampleService = new Example();
-        ServiceRunner::register('example', $exampleService);
+        ServiceRunner::register('example', new Example());
 
         $result = ServiceRunner::runPending(1);
         $expected = [
             'count' => 1,
             'success' => ['d6bb8c84-6b29-432e-bb84-c3c4b2c1b99c'],
-            'failure' => []
+            'failure' => [],
+        ];
+        $this->assertNotEmpty($result);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test runPending fail
+     *
+     * @return void
+     * @covers ::runPending()
+     */
+    public function testRunPendingFail()
+    {
+        $mockService = $this->getMockBuilder(Example::class)->getMock();
+        $mockService->method('run')
+             ->will($this->returnValue(false));
+        ServiceRunner::register('example', $mockService);
+
+        $result = ServiceRunner::runPending(1);
+        $expected = [
+            'count' => 1,
+            'success' => [],
+            'failure' => ['d6bb8c84-6b29-432e-bb84-c3c4b2c1b99c'],
         ];
         $this->assertNotEmpty($result);
         $this->assertEquals($expected, $result);

--- a/plugins/BEdita/Core/tests/TestCase/Job/ServiceRunnerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/ServiceRunnerTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Core\Test\TestCase\Job;
+
+use BEdita\Core\Job\JobService;
+use BEdita\Core\Job\ServiceRunner;
+use Cake\TestSuite\TestCase;
+
+class Example implements JobService
+{
+    public function run($payload, $options = [])
+    {
+        return true;
+    }
+}
+
+/**
+ * {@see \BEdita\Core\Job\ServiceRunner} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Job\ServiceRunner
+ */
+class ServiceRunnerTest extends TestCase
+{
+
+    /**
+     * Test subject
+     *
+     * @var \BEdita\Core\Job\ServiceRunner
+     */
+    public $ServiceRunner;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.async_jobs',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        $this->ServiceRunner = new ServiceRunner();
+    }
+
+    /**
+     * Test getService method
+     *
+     * @return void
+     *
+     * @covers ::getService()
+     */
+    public function testGetService()
+    {
+        $result = $this->ServiceRunner->getService('mail');
+        $this->assertNotEmpty($result);
+        $this->assertInstanceOf(\BEdita\Core\Job\JobService::class, $result);
+
+        // test instance registry
+        $result2 = $this->ServiceRunner->getService('mail');
+        $this->assertSame($result, $result2);
+    }
+
+    /**
+     * Test getService failure
+     *
+     * @return void
+     * @covers ::getService()
+     */
+    public function testGetServiceFail()
+    {
+        $this->expectException(\LogicException::class);
+        $this->ServiceRunner->getService('gustavo');
+    }
+
+    /**
+     * Test register method
+     *
+     * @return void
+     *
+     * @covers ::register()
+     */
+    public function testRegister()
+    {
+        $exampleService = new Example();
+        $this->ServiceRunner->register('example', $exampleService);
+
+        $result = $this->ServiceRunner->getService('example');
+        $this->assertNotEmpty($result);
+        $this->assertSame($exampleService, $result);
+    }
+
+    /**
+     * Test register failure
+     *
+     * @return void
+     * @covers ::register()
+     */
+    public function testRegisterFail()
+    {
+        $this->expectException(\LogicException::class);
+        $this->ServiceRunner->register('gustavo', $this);
+    }
+
+    /**
+     * Test run method
+     *
+     * @return void
+     * @covers ::run()
+     */
+    public function testRun()
+    {
+        $exampleService = new Example();
+        $this->ServiceRunner->register('example', $exampleService);
+
+        $result = $this->ServiceRunner->run('d6bb8c84-6b29-432e-bb84-c3c4b2c1b99c');
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test run fail
+     *
+     * @return void
+     * @covers ::reset()
+     * @covers ::run()
+     */
+    public function testRunFail()
+    {
+        $this->ServiceRunner->reset();
+        $result = $this->ServiceRunner->run('d6bb8c84-6b29-432e-bb84-c3c4b2c1b99c');
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test runPending method
+     *
+     * @return void
+     * @covers ::runPending()
+     */
+    public function testRunPending()
+    {
+        $exampleService = new Example();
+        $this->ServiceRunner->register('example', $exampleService);
+
+        $result = $this->ServiceRunner->runPending(1);
+        $expected = ['d6bb8c84-6b29-432e-bb84-c3c4b2c1b99c' => true];
+        $this->assertNotEmpty($result);
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Service/MailTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Service/MailTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Core\Test\TestCase\Service;
+
+use BEdita\Core\Service\Mail;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\Core\Service\Mail} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Service\Mail
+ */
+class MailTest extends TestCase
+{
+    protected $mailService;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        $this->mailService = new Mail();
+    }
+
+    /**
+     * Test run method
+     *
+     * @return void
+     * @covers ::run()
+     */
+    public function testRun()
+    {
+        $result = $this->mailService->run([]);
+        $this->assertTrue($result);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Shell/JobsShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/JobsShellTest.php
@@ -1,0 +1,56 @@
+<?php
+namespace BEdita\Core\Test\TestCase\Shell;
+
+use BEdita\Core\Job\JobService;
+use BEdita\Core\Job\ServiceRunner;
+use BEdita\Core\Shell\JobsShell;
+use BEdita\Core\TestSuite\ShellTestCase;
+use Cake\ORM\TableRegistry;
+
+class Example implements JobService
+{
+    public function run($payload, $options = [])
+    {
+        return true;
+    }
+}
+/**
+ * \BEdita\Core\Shell\JobsShell Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Shell\JobsShell
+ */
+class JobsShellTest extends ShellTestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.async_jobs',
+    ];
+
+    /**
+     * Test run method
+     *
+     * @return void
+     * @covers ::run()
+     */
+    public function testRun()
+    {
+        ServiceRunner::register('example', new Example());
+        $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
+
+        // invoke without limit
+        $this->invoke(['jobs', 'run'], [], $io);
+
+        $pending = TableRegistry::get('AsyncJobs')->find('pending')->toArray();
+        $this->assertEmpty($pending);
+
+        // invoke with limit
+        $this->invoke(['jobs', 'run', '--limit', '10'], [], $io);
+
+        $pending = TableRegistry::get('AsyncJobs')->find('pending')->toArray();
+        $this->assertEmpty($pending);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Shell/JobsShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/JobsShellTest.php
@@ -42,15 +42,30 @@ class JobsShellTest extends ShellTestCase
         $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
 
         // invoke without limit
-        $this->invoke(['jobs', 'run'], [], $io);
-
-        $pending = TableRegistry::get('AsyncJobs')->find('pending')->toArray();
-        $this->assertEmpty($pending);
+        $result = $this->invoke(['jobs', 'run'], [], $io);
+        $this->assertTrue($result);
 
         // invoke with limit
         $this->invoke(['jobs', 'run', '--limit', '10'], [], $io);
+        $this->assertTrue($result);
+    }
 
-        $pending = TableRegistry::get('AsyncJobs')->find('pending')->toArray();
-        $this->assertEmpty($pending);
+    /**
+     * Test run failure
+     *
+     * @return void
+     * @covers ::run()
+     */
+    public function testRunFail()
+    {
+        $mockService = $this->getMockBuilder(Example::class)->getMock();
+        $mockService->method('run')
+             ->will($this->returnValue(false));
+        ServiceRunner::register('example', $mockService);
+
+        $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
+
+        $result = $this->invoke(['jobs', 'run'], [], $io);
+        $this->assertFalse($result);
     }
 }


### PR DESCRIPTION
This PR solves #1202 

- `ServiceRunner` utility class to run async jobs was introduced
- Each `'service'` saved in `async_jobs` must be run by a class implementing `JobService` interface containing a generic `run` method
- `Service` classes for a specific `'service'` may be registered using `ServiceRunner::register`, otherwise a class matching service name is searched in `Service` namespace of loaded plugins first, than in `BEdita/Core` - for an `'example'` service first a class `\MyPlugin\Service\Example` is searched and finally  `\BEdita\Core\Service\Example`
- `ServiceRunner` provides methods to run all pending jobs, with an optional limit, or a single job via uuid
- a `JobsShell` class has been introduced to run pending jobs, with an optional limit argument
- a dummy `Mail` service class has been created, its logic will be implemented in a future PR or issue 