### PR TITLE
fix: add coords not null condition

### DIFF
--- a/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
@@ -147,6 +147,9 @@ class LocationsTable extends Table
         return $query
             ->select(['distance' => $distanceExpression])
             ->enableAutoFields(true)
+            ->where(function ($exp, $q) {
+                return $exp->isNotNull($this->aliasField('coords'));
+            })
             ->order(['distance' => 'ASC']);
     }
 


### PR DESCRIPTION
This PR adds a NOT NULL condition con geo finder to avoid bad results on `?filter[geo][center]` queries