### PR TITLE
Basic search

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -211,7 +211,7 @@ return [
         ],
         'test' => [
             'className' => 'Debug',
-        ]
+        ],
     ],
 
     /**
@@ -233,7 +233,7 @@ return [
         'test' => [
             'transport' => 'test',
             'from' => 'you@localhost',
-        ]
+        ],
     ],
 
     /**
@@ -412,5 +412,5 @@ return [
     'Pagination' => [
         'limit' => 20,
         'maxLimit' => 100,
-    ]
+    ],
 ];

--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -17,7 +17,9 @@ use BEdita\Core\Utility\Database;
 use Cake\Utility\Hash;
 
 /**
- * Test Query String `filter`
+ * Test Query String `filter`.
+ *
+ * @coversNothing
  */
 class FilterQueryStringTest extends IntegrationTestCase
 {
@@ -33,7 +35,9 @@ class FilterQueryStringTest extends IntegrationTestCase
     ];
 
     /**
-     * Data provider for `testFilterDate`
+     * Data provider for `testFilterDate` test case.
+     *
+     * @return array
      */
     public function filterDateProvider()
     {
@@ -63,6 +67,7 @@ class FilterQueryStringTest extends IntegrationTestCase
      * @param $query string URL with query filter string
      * @param $expected int Number of objects id expected in response
      * @param $endpoint string Endpoint to use
+     * @return void
      *
      * @dataProvider filterDateProvider
      * @coversNothing
@@ -78,7 +83,9 @@ class FilterQueryStringTest extends IntegrationTestCase
     }
 
     /**
-     * Data provider for `testFilterGeo`
+     * Data provider for `testFilterGeo` test case.
+     *
+     * @return array
      */
     public function filterGeoProvider()
     {
@@ -125,7 +132,9 @@ class FilterQueryStringTest extends IntegrationTestCase
     }
 
     /**
-     * Data provider for `testBadFilter`
+     * Data provider for `testBadFilter` test case.
+     *
+     * @return array
      */
     public function badFilterProvider()
     {
@@ -153,6 +162,7 @@ class FilterQueryStringTest extends IntegrationTestCase
      *
      * @param $query string URL with query filter string
      * @param $endpoint string Endpoint to use
+     * @return void
      *
      * @dataProvider badFilterProvider
      * @coversNothing
@@ -185,5 +195,49 @@ class FilterQueryStringTest extends IntegrationTestCase
         static::assertArrayHasKey('data', $result);
         static::assertCount(2, $result['data']);
         static::assertArrayNotHasKey('_matchingData', $result['data'][0]['attributes']);
+    }
+
+    /**
+     * Test finder of objects by query string.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testFindQuery()
+    {
+        $expected = [2, 3, 9];
+        $this->configRequestHeaders();
+
+        $this->get('/objects?filter[query]=here');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        static::assertArrayHasKey('data', $result);
+        static::assertEquals($expected, Hash::extract($result['data'], '{n}.id'), '', 0, 10, true);
+    }
+
+    /**
+     * Test finder of locations by query string.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testFindQueryLocations()
+    {
+        $expected = [8];
+        $this->configRequestHeaders();
+
+        $this->get('/locations?filter[query]=bologna');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        static::assertArrayHasKey('data', $result);
+        static::assertEquals($expected, Hash::extract($result['data'], '{n}.id'), '', 0, 10, true);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Model\Behavior;
+
+use BEdita\Core\Exception\BadFilterException;
+use BEdita\Core\ORM\Inheritance\Table as InheritanceTable;
+use Cake\Database\Expression\QueryExpression;
+use Cake\ORM\Behavior;
+use Cake\ORM\Query;
+use Cake\ORM\Table;
+
+/**
+ * Behavior to add text-based search to model.
+ *
+ * @since 4.0.0
+ */
+class SearchableBehavior extends Behavior
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_defaultConfig = [
+        'minLength' => 3,
+        'columnTypes' => [
+            'string',
+            'text',
+        ],
+        'fields' => [
+            '*' => 1,
+        ],
+        'implementedFinders' => [
+            'query' => 'findQuery',
+        ],
+    ];
+
+    /**
+     * {@inheritDoc}
+     *
+     * If fields or column types are specified - do *not* merge them with existing config,
+     * overwrite the fields to search on.
+     */
+    public function initialize(array $config)
+    {
+        foreach (['columnTypes', 'fields'] as $key) {
+            if (isset($config[$key])) {
+                $this->setConfig($key, $config[$key], false);
+            }
+        }
+    }
+
+    /**
+     * Get all fields whose column type is amongst those allowed in `columnTypes` configuration key.
+     *
+     * @param \Cake\ORM\Table $table Table object.
+     * @return string[]
+     */
+    protected function getAllFields(Table $table)
+    {
+        $columnTypes = $this->getConfig('columnTypes');
+        $fields = array_filter( // Filter fields that are of a searchable type.
+            $table->getSchema()->columns(),
+            function ($column) use ($columnTypes, $table) {
+                return in_array($table->getSchema()->columnType($column), $columnTypes);
+            }
+        );
+
+        if ($table instanceof InheritanceTable && $table->inheritedTable() !== null) {
+            // If table inherits from another table, merge parent table's fields.
+            $fields = array_merge($fields, $this->getAllFields($table->inheritedTable()));
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Get searchable fields and their priorities.
+     *
+     * @return array Array where keys are columns, and values are priorities.
+     */
+    public function getFields()
+    {
+        $wildCard = $this->getConfig('fields.*');
+
+        $fields = (array)$this->getConfig('fields');
+        $allFields = $this->getAllFields($this->getTable());
+
+        $fields = array_intersect_key($fields, array_flip($allFields));
+        if ($wildCard !== null) {
+            // If wildcard `*` is present, all other fields have default priority.
+            $fields += array_diff_key(
+                array_fill_keys($allFields, $wildCard),
+                $fields
+            );
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Finder for query search.
+     *
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @param array $options Options.
+     * @return \Cake\ORM\Query
+     */
+    public function findQuery(Query $query, array $options)
+    {
+        if (!isset($options[0]) || !is_string($options[0])) {
+            // Bad filter options.
+            throw new BadFilterException('blablabla');
+        }
+
+        $minLength = $this->getConfig('minLength');
+        $words = array_map( // Escape `%`, `_` and `\` characters in words.
+            function ($word) {
+                return str_replace(
+                    ['%', '_', '\\'],
+                    ['\\%', '\\_', '\\\\'],
+                    $word
+                );
+            },
+            array_filter( // Filter out words that are too short.
+                preg_split('/\W+/', $options[0]), // Split words.
+                function ($word) use ($minLength) {
+                    return mb_strlen($word) >= $minLength;
+                }
+            )
+        );
+        if (count($words) === 0) {
+            // Query contained only short words.
+            throw new BadFilterException('blablabla');
+        }
+
+        $fields = array_map( // Alias fields to avoid ambiguities.
+            [$this->getTable(), 'aliasField'],
+            array_keys($this->getFields())
+        );
+
+        // Build query conditions.
+        return $query
+            ->where(function (QueryExpression $exp) use ($fields, $words) {
+                return $exp->or_(function (QueryExpression $exp) use ($fields, $words) {
+                    foreach ($fields as $field) {
+                        foreach ($words as $word) {
+                            $exp = $exp->like($field, sprintf('%%%s%%', $word));
+                        }
+                    }
+
+                    return $exp;
+                });
+            });
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
@@ -58,6 +58,18 @@ class LocationsTable extends Table
         ]);
 
         $this->addBehavior('BEdita/Core.Relations');
+
+        $this->addBehavior('BEdita/Core.Searchable', [
+            'fields' => [
+                'title' => 10,
+                'description' => 7,
+                'body' => 5,
+                'address' => 1,
+                'locality' => 2,
+                'country_name' => 2,
+                'region' => 2,
+            ],
+        ]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -90,6 +90,14 @@ class ObjectsTable extends Table
         ]);
 
         $this->addBehavior('BEdita/Core.UniqueName');
+
+        $this->addBehavior('BEdita/Core.Searchable', [
+            'fields' => [
+                'title' => 10,
+                'description' => 7,
+                'body' => 5,
+            ],
+        ]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
@@ -48,6 +48,22 @@ class ProfilesTable extends Table
             'sourceField' => 'title',
             'prefix' => 'profile-'
         ]);
+
+        $this->addBehavior('BEdita/Core.Searchable', [
+            'fields' => [
+                'title' => 10,
+                'description' => 7,
+                'body' => 5,
+                'name' => 10,
+                'surname' => 10,
+                'email' => 7,
+                'company_name' => 10,
+                'street_address' => 1,
+                'city' => 2,
+                'country' => 2,
+                'state_name' => 2,
+            ],
+        ]);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Behavior;
+
+use BEdita\Core\Exception\BadFilterException;
+use BEdita\Core\ORM\Inheritance\Table;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\Core\Model\Behavior\SearchableBehavior} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Model\Behavior\SearchableBehavior
+ */
+class SearchableBehaviorTest extends TestCase
+{
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.fake_animals',
+        'plugin.BEdita/Core.fake_mammals',
+        'plugin.BEdita/Core.fake_felines',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        TableRegistry::get('FakeMammals', ['className' => Table::class])
+            ->extensionOf('FakeAnimals');
+        TableRegistry::get('FakeFelines', ['className' => Table::class])
+            ->extensionOf('FakeMammals');
+    }
+
+    /**
+     * Test behavior initialization process.
+     *
+     * @return void
+     *
+     * @covers ::initialize()
+     */
+    public function testInitialize()
+    {
+        $columnTypes = [
+            'integer',
+        ];
+        $fields = [
+            'my_field' => 17,
+        ];
+
+        $table = TableRegistry::get('FakeAnimals');
+        $table->addBehavior('BEdita/Core.Searchable', compact('columnTypes', 'fields'));
+
+        /* @var \BEdita\Core\Model\Behavior\SearchableBehavior $behavior */
+        $behavior = $table->behaviors()->get('Searchable');
+
+        static::assertEquals($columnTypes, $behavior->getConfig('columnTypes'));
+        static::assertEquals($fields, $behavior->getConfig('fields'));
+    }
+
+    /**
+     * Data provider for `testGetFields` test case.
+     *
+     * @return array
+     */
+    public function getFieldsProvider()
+    {
+        return [
+            'default' => [
+                [
+                    'name' => 1,
+                ],
+            ],
+            'inherited fields with custom priorities' => [
+                [
+                    'name' => 1,
+                    'subclass' => 2,
+                ],
+                [
+                    'fields' => [
+                        '*' => 1,
+                        'subclass' => 2,
+                    ],
+                ],
+                'FakeMammals',
+            ],
+            'excluded fields' => [
+                [
+                    'subclass' => 2,
+                    'family' => 5,
+                ],
+                [
+                    'fields' => [
+                        'subclass' => 2,
+                        'family' => 5,
+                    ],
+                ],
+                'FakeFelines',
+            ],
+        ];
+    }
+
+    /**
+     * Test listing all searchable fields along with their priorities.
+     *
+     * @param array $expected Expected result.
+     * @param array $config Behavior configuration.
+     * @param string $table Table.
+     * @return void
+     *
+     * @dataProvider getFieldsProvider()
+     * @covers ::getAllFields()
+     * @covers ::getFields()
+     */
+    public function testGetFields(array $expected, array $config = [], $table = 'FakeAnimals')
+    {
+        $table = TableRegistry::get($table);
+        $table->addBehavior('BEdita/Core.Searchable', $config);
+
+        /* @var \BEdita\Core\Model\Behavior\SearchableBehavior $behavior */
+        $behavior = $table->behaviors()->get('Searchable');
+
+        $fields = $behavior->getFields();
+
+        static::assertEquals($expected, $fields);
+    }
+
+    /**
+     * Data provider for `testFindQuery` test case.
+     *
+     * @return array
+     */
+    public function findQueryProvider()
+    {
+        return [
+            'basic' => [
+                [
+                    2 => 'koala',
+                ],
+                'ala',
+            ],
+            'two words' => [
+                [
+                    2 => 'koala',
+                    3 => 'eagle',
+                ],
+                'ala gle',
+            ],
+            'bad type' => [
+                new BadFilterException('blablabla'),
+                ['not', 'a', 'string'],
+            ],
+            'short words' => [
+                new BadFilterException('blablabla'),
+                'I am me',
+            ],
+        ];
+    }
+
+    /**
+     * Test finder for query string.
+     *
+     * @param array|\Exception $expected Expected result.
+     * @param string $query Query string.
+     * @param string $table Table.
+     * @return void
+     *
+     * @dataProvider findQueryProvider()
+     * @covers ::findQuery()
+     */
+    public function testFindQuery($expected, $query, $table = 'FakeAnimals')
+    {
+        if ($expected instanceof \Exception) {
+            $this->expectException(get_class($expected));
+            $this->expectExceptionCode($expected->getCode());
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+
+        $table = TableRegistry::get($table);
+        $table->addBehavior('BEdita/Core.Searchable');
+
+        static::assertTrue($table->hasFinder('query'));
+
+        $result = $table
+            ->find('query', [$query])
+            ->find('list')
+            ->toArray();
+
+        static::assertEquals($expected, $result);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
@@ -165,12 +165,25 @@ class SearchableBehaviorTest extends TestCase
                 'ala gle',
             ],
             'bad type' => [
-                new BadFilterException('blablabla'),
+                new BadFilterException([
+                    'title' => 'Invalid data',
+                    'detail' => 'query filter requires a non-empty query string',
+                ]),
                 ['not', 'a', 'string'],
             ],
             'short words' => [
-                new BadFilterException('blablabla'),
+                new BadFilterException([
+                    'title' => 'Invalid data',
+                    'detail' => 'query filter requires a non-empty query string',
+                ]),
                 'I am me',
+            ],
+            'too many words' => [
+                new BadFilterException([
+                    'title' => 'Invalid data',
+                    'detail' => 'query string too long',
+                ]),
+                'this query string contains too many words thus will be rejected to avoid denial of service',
             ],
         ];
     }


### PR DESCRIPTION
This PR resolves #1220.

A new filter is added for BEdita objects: `?filter[query]=my+query+string`.

On a standard object, the above will result in a query similar to:
```sql
SELECT * FROM `objects`
    WHERE `title` LIKE '%query%' OR `title` LIKE '%string%'
        OR `description` LIKE '%query%' OR `description` LIKE '%string%'
        OR `body` LIKE '%query%' OR `body` LIKE '%string%';
```

The query string is split into single words, then words shorter than three characters (by default) are filtered out (in the example above, `my` is excluded), then a matrix of searchable fields and query words is built and the resulting `LIKE` conditions are joined with `OR`.

Searchable fields are, by default, all `string` or `text` fields, but a whitelist of fields can be passed. In `ObjectsTable` only `title`, `description` and `body` are configured as searchable fields, hence fields like `status` are not considered when issuing a search.