### PR TITLE
signup endpoint first step: create user, job and send mail for activation

### DIFF
--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -61,6 +61,13 @@ Router::plugin(
             ['_name' => 'login:whoami']
         );
 
+        // Signup.
+        $routes->connect(
+            '/signup',
+            ['controller' => 'Signup', 'action' => 'signup'],
+            ['_name' => 'signup']
+        );
+
         // Resources.
         $resourcesControllers = implode('|', $resourcesControllers);
         $routes->connect(

--- a/plugins/BEdita/API/postman/BE4.postman_collection.json
+++ b/plugins/BEdita/API/postman/BE4.postman_collection.json
@@ -1443,7 +1443,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"data\": {\n        \"type\": \"users\",\n        \"attributes\": {\n            \"username\": \"johannadoe\",\n            \"password\": \"j0h4nn4d0e\",\n            \"email\": \"johannadoe@nowhere.xx\"\n        }\n    }\n}"
+							"raw": "{\n    \"data\": {\n        \"type\": \"users\",\n        \"attributes\": {\n            \"username\": \"johannadoe\",\n            \"password\": \"j0h4nn4d0e\",\n            \"email\": \"johannadoe@nowhere.xx\"\n        },\n        \"meta\": {\n            \"activation_url\": \"http://myactivationsys.xx?dum=my\",\n            \"redirect_url\": \"app://xx?dum=my\"\n        }\n    }\n}"
 						},
 						"description": "Create new User"
 					},

--- a/plugins/BEdita/API/postman/BE4.postman_collection.json
+++ b/plugins/BEdita/API/postman/BE4.postman_collection.json
@@ -1434,11 +1434,6 @@
 								"key": "Content-Type",
 								"value": "application/vnd.api+json",
 								"description": ""
-							},
-							{
-								"key": "Authorization",
-								"value": "Bearer {{jwt}}",
-								"description": ""
 							}
 						],
 						"body": {

--- a/plugins/BEdita/API/postman/BE4.postman_collection.json
+++ b/plugins/BEdita/API/postman/BE4.postman_collection.json
@@ -1401,6 +1401,53 @@
 						"description": "Remove a user's role"
 					},
 					"response": []
+				},
+				{
+					"name": "Signup user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"try {",
+									"    tests[\"Status code is 202\"] = responseCode.code === 202;",
+									"    tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';",
+									"    tests[\"Body matches string\"] = responseBody === \"\";",
+									"} catch (e) {",
+									"    tests[\"Error in parsing response\"] = e;",
+									"}"
+								]
+							}
+						}
+					],
+					"request": {
+						"url": "{{be4Url}}/signup",
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.api+json",
+								"description": ""
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/vnd.api+json",
+								"description": ""
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"data\": {\n        \"type\": \"users\",\n        \"attributes\": {\n            \"username\": \"johannadoe\",\n            \"password\": \"j0h4nn4d0e\",\n            \"email\": \"johannadoe@nowhere.xx\"\n        }\n    }\n}"
+						},
+						"description": "Create new User"
+					},
+					"response": []
 				}
 			]
 		},

--- a/plugins/BEdita/API/src/Controller/SignupController.php
+++ b/plugins/BEdita/API/src/Controller/SignupController.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published

--- a/plugins/BEdita/API/src/Controller/SignupController.php
+++ b/plugins/BEdita/API/src/Controller/SignupController.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Controller;
+
+use BEdita\Core\Model\Action\SignupUserAction;
+use Cake\Routing\Router;
+
+/**
+ * Controller for `/signup` endpoint.
+ *
+ * @since 4.0.0
+ *
+ */
+class SignupController extends AppController
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function initialize()
+    {
+        parent::initialize();
+        $this->JsonApi->setConfig('resourceTypes', ['users']);
+    }
+
+    /**
+     * Signup action.
+     *
+     * @return \Cake\Http\Response
+     */
+    public function signup()
+    {
+        $this->request->allowMethod('post');
+
+        $data = $this->request->getData();
+        if (!empty($data['password'])) {
+            $data['password_hash'] = $data['password'];
+            unset($data['password']);
+        }
+
+        $urlOptions = $this->request->getData('_meta') ?: [];
+        $urlOptions += ['activation_url' => Router::url(['_name' => 'api:signup'], true)];
+
+        $action = new SignupUserAction();
+        $action([
+            'data' => $data,
+            'urlOptions' => $urlOptions
+        ]);
+
+        return $this->response->withStatus(202);
+    }
+}

--- a/plugins/BEdita/API/src/Error/ExceptionRenderer.php
+++ b/plugins/BEdita/API/src/Error/ExceptionRenderer.php
@@ -18,6 +18,7 @@ use Cake\Core\Exception\Exception as CakeException;
 use Cake\Core\Plugin;
 use Cake\Error\ExceptionRenderer as CakeExceptionRenderer;
 use Cake\Network\Request;
+use Cake\Utility\Hash;
 
 /**
  * Exception renderer.
@@ -114,19 +115,12 @@ class ExceptionRenderer extends CakeExceptionRenderer
         if (is_string($d)) {
             return $d;
         }
+
         $res = '';
         if (is_array($d)) {
-            foreach ($d as $errDetail) {
-                if (is_array($errDetail)) {
-                    foreach ($errDetail as $item => $desc) {
-                        $res .= " '$item' : ";
-                        if (is_array($desc)) {
-                            foreach ($desc as $cause => $w) {
-                                $res .= " [$cause] $w";
-                            }
-                        }
-                    }
-                }
+            $d = Hash::flatten($d);
+            foreach ($d as $item => $errDetail) {
+                $res .= "[$item]: $errDetail. ";
             }
         }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
@@ -13,6 +13,7 @@
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use Cake\Mailer\Email;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -178,6 +179,11 @@ class SignupControllerTest extends IntegrationTestCase
      */
     public function testSignup($statusCode, $expected, $method, $data)
     {
+        Email::dropTransport('default');
+        Email::setConfigTransport('default', [
+            'className' => 'Debug'
+        ]);
+
         $this->configRequestHeaders($method);
         $methodName = strtolower($method);
         $this->$methodName('/signup', json_encode(compact('data')));

--- a/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published

--- a/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Test\TestCase\Controller;
+
+use BEdita\API\TestSuite\IntegrationTestCase;
+use Cake\ORM\TableRegistry;
+
+/**
+ * @coversDefaultClass \BEdita\API\Controller\SignupController
+ */
+class SignupControllerTest extends IntegrationTestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.async_jobs',
+    ];
+
+    /**
+     * Provider for `testSignup()`
+     *
+     * @return array
+     */
+    public function signupProvider()
+    {
+        return [
+            'not allowed' => [
+                405,
+                [
+                    'error' => [
+                        'status' => '405',
+                        'title' => 'Method Not Allowed',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/signup',
+                        'home' => 'http://api.example.com/home',
+                    ],
+                ],
+                'GET',
+                [],
+            ],
+            'ok' => [
+                202,
+                null,
+                'POST',
+                [
+                    'type' => 'users',
+                    'attributes' => [
+                        'username' => 'gustavo',
+                        'password' => 'supporto',
+                        'email' => 'gus.sup@channelweb.it',
+                    ]
+                ],
+            ],
+            'ok with activation_url' => [
+                202,
+                null,
+                'POST',
+                [
+                    'type' => 'users',
+                    'attributes' => [
+                        'username' => 'gustavo',
+                        'password' => 'supporto',
+                        'email' => 'gus.sup@channelweb.it',
+                    ],
+                    'meta' => [
+                        'activation_url' => 'http://example.com'
+                    ]
+                ],
+            ],
+            'ok with activation_url and redirect_url' => [
+                202,
+                null,
+                'POST',
+                [
+                    'type' => 'users',
+                    'attributes' => [
+                        'username' => 'gustavo',
+                        'password' => 'supporto',
+                        'email' => 'gus.sup@channelweb.it',
+                    ],
+                    'meta' => [
+                        'activation_url' => 'http://example.com',
+                        'redirect_url' => 'myapp://'
+                    ]
+                ],
+            ],
+            'missing username' => [
+                400,
+                [
+                    'error' => [
+                        'status' => '400',
+                        'title' => 'Invalid data',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/signup',
+                        'home' => 'http://api.example.com/home',
+                    ],
+                ],
+                'POST',
+                [
+                    'type' => 'users',
+                    'attributes' => [
+                        'username' => '',
+                        'password' => 'supporto',
+                        'email' => 'gus.sup@channelweb.it',
+                    ],
+                ],
+            ],
+            'missing password' => [
+                400,
+                [
+                    'error' => [
+                        'status' => '400',
+                        'title' => 'Invalid data',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/signup',
+                        'home' => 'http://api.example.com/home',
+                    ],
+                ],
+                'POST',
+                [
+                    'type' => 'users',
+                    'attributes' => [
+                        'username' => 'gustavo',
+                        'email' => 'gus.sup@channelweb.it',
+                    ],
+                ],
+            ],
+            'missing email' => [
+                400,
+                [
+                    'error' => [
+                        'status' => '400',
+                        'title' => 'Invalid data',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/signup',
+                        'home' => 'http://api.example.com/home',
+                    ],
+                ],
+                'POST',
+                [
+                    'type' => 'users',
+                    'attributes' => [
+                        'username' => 'gustavo',
+                        'password' => 'supporto',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test /signup endpoint
+     *
+     * @param int $expected The expected status code
+     * @param string $method The HTTP method
+     * @param array $data The payload to send
+     * @return void
+     *
+     * @dataProvider signupProvider
+     * @covers ::signup()
+     */
+    public function testSignup($statusCode, $expected, $method, $data)
+    {
+        $this->configRequestHeaders($method);
+        $methodName = strtolower($method);
+        $this->$methodName('/signup', json_encode(compact('data')));
+
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode($statusCode);
+        $this->assertContentType('application/vnd.api+json');
+
+        if ($statusCode === 202) {
+            static::assertNull($result);
+        } else {
+            static::assertArrayNotHasKey('data', $result);
+            static::assertArrayHasKey('links', $result);
+            static::assertArrayHasKey('error', $result);
+            static::assertEquals($expected['links'], $result['links']);
+            static::assertArraySubset($expected['error'], $result['error']);
+            static::assertArrayHasKey('title', $result['error']);
+            static::assertNotEmpty($result['error']['title']);
+        }
+    }
+}

--- a/plugins/BEdita/API/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Error/ExceptionRendererTest.php
@@ -65,7 +65,7 @@ class ExceptionRendererTest extends TestCase
     }
 
     /**
-     * Data provider for `testIsHtmlToSend` test case.
+     * Data provider for `testErrorDetails` test case.
      *
      * @return array
      */
@@ -84,7 +84,21 @@ class ExceptionRendererTest extends TestCase
             'detailArray' => [
                 ['title' => 'new title', 'detail' => [['field' => ['cause' => 'err detail']]]],
                 'new title',
-                " 'field' :  [cause] err detail"
+                '[0.field.cause]: err detail. '
+            ],
+            'detailArray2' => [
+                [
+                    'title' => 'new title',
+                    'detail' => [
+                        'field' => ['cause' => 'err detail'],
+                        'nestedFields' => [
+                            'field2' => ['cause2' => 'err detail2'],
+                            'field3' => ['cause3' => 'err detail3'],
+                        ]
+                    ]
+                ],
+                'new title',
+                '[field.cause]: err detail. [nestedFields.field2.cause2]: err detail2. [nestedFields.field3.cause3]: err detail3. '
             ]
         ];
     }

--- a/plugins/BEdita/Core/src/Mailer/UserMailer.php
+++ b/plugins/BEdita/Core/src/Mailer/UserMailer.php
@@ -20,7 +20,6 @@ use Cake\ORM\TableRegistry;
 
 /**
  * Mailer class to send notifications to users
- * [Temporary dummy implementation]
  *
  * @since 4.0.0
  */
@@ -30,12 +29,12 @@ class UserMailer extends Mailer
      * Welcome message
      *
      * @param array $options Email options: 'to' (recipient)
-     * @return void
+     * @return $this
      * @codeCoverageIgnore
      */
     public function welcome($options)
     {
-        $this
+        return $this
             ->setTemplate('BEdita/Core.welcome')
             ->setLayout('BEdita/Core.default')
             ->setTo($options['to'])
@@ -50,7 +49,7 @@ class UserMailer extends Mailer
      * - `activationUrl` the activation url to follow
      *
      * @param array $options Email options
-     * @return void
+     * @return $this
      * @throws \LogicException When missing some required parameter
      */
     public function signup(array $options)
@@ -81,7 +80,7 @@ class UserMailer extends Mailer
             'appName' => $appName
         ]);
 
-        $this->setTemplate('BEdita/Core.signup')
+        return $this->setTemplate('BEdita/Core.signup')
             ->setLayout('BEdita/Core.default')
             ->setEmailFormat('both')
             ->setTo($user->email)

--- a/plugins/BEdita/Core/src/Mailer/UserMailer.php
+++ b/plugins/BEdita/Core/src/Mailer/UserMailer.php
@@ -51,6 +51,7 @@ class UserMailer extends Mailer
      *
      * @param array $options Email options
      * @return void
+     * @throws \LogicException When missing some required parameter
      */
     public function signup(array $options)
     {

--- a/plugins/BEdita/Core/src/Mailer/UserMailer.php
+++ b/plugins/BEdita/Core/src/Mailer/UserMailer.php
@@ -13,7 +13,10 @@
 
 namespace BEdita\Core\Mailer;
 
+use BEdita\Core\Model\Action\GetObjectAction;
+use BEdita\Core\State\CurrentApplication;
 use Cake\Mailer\Mailer;
+use Cake\ORM\TableRegistry;
 
 /**
  * Mailer class to send notifications to users
@@ -37,5 +40,50 @@ class UserMailer extends Mailer
             ->setLayout('BEdita/Core.default')
             ->setTo($options['to'])
             ->setSubject('Welcome!');
+    }
+
+    /**
+     * Signup message.
+     *
+     * It requires `$options['params']` with:
+     * - `userId` the user id to send signup email
+     * - `activationUrl` the activation url to follow
+     *
+     * @param array $options Email options
+     * @return void
+     */
+    public function signup(array $options)
+    {
+        if (empty($options['params']['userId'])) {
+            throw new \LogicException(__d('bedita', 'Parameter "{0}" missing', ['params.userId']));
+        }
+
+        if (empty($options['params']['activationUrl'])) {
+            throw new \LogicException(__d('bedita', 'Parameter "{0}" missing', ['params.activationUrl']));
+        }
+
+        $users = TableRegistry::get('Users');
+        $action = new GetObjectAction(['table' => $users]);
+        $user = $action(['primaryKey' => $options['params']['userId']]);
+
+        if (empty($user->email)) {
+            throw new \LogicException(__d('bedita', 'User email missing'));
+        }
+
+        $currentApplication = CurrentApplication::getApplication();
+        $appName = ($currentApplication !== null) ? $currentApplication->name : 'BEdita';
+        $subject = __d('bedita', '{0} registration', [$appName]);
+
+        $this->set([
+            'user' => $user,
+            'activationUrl' => $options['params']['activationUrl'],
+            'appName' => $appName
+        ]);
+
+        $this->setTemplate('BEdita/Core.signup')
+            ->setLayout('BEdita/Core.default')
+            ->setEmailFormat('both')
+            ->setTo($user->email)
+            ->setSubject($subject);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Action/SaveEntityAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SaveEntityAction.php
@@ -47,8 +47,10 @@ class SaveEntityAction extends BaseAction
      */
     public function execute(array $data = [])
     {
-        $entity = $this->Table->patchEntity($data['entity'], $data['data']);
-        $success = $this->Table->save($entity);
+        $entityOptions = !empty($data['entityOptions']) ? (array)$data['entityOptions'] : [];
+        $saveOptions = !empty($data['saveOptions']) ? (array)$data['saveOptions'] : [];
+        $entity = $this->Table->patchEntity($data['entity'], $data['data'], $entityOptions);
+        $success = $this->Table->save($entity, $saveOptions);
 
         if ($success === false) {
             $errors = $entity->getErrors();

--- a/plugins/BEdita/Core/src/Model/Action/SaveEntityAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SaveEntityAction.php
@@ -16,6 +16,7 @@ namespace BEdita\Core\Model\Action;
 use Cake\Log\LogTrait;
 use Cake\Network\Exception\BadRequestException;
 use Cake\Network\Exception\InternalErrorException;
+use Cake\Utility\Hash;
 
 /**
  * Command to save an entity.
@@ -47,8 +48,8 @@ class SaveEntityAction extends BaseAction
      */
     public function execute(array $data = [])
     {
-        $entityOptions = !empty($data['entityOptions']) ? (array)$data['entityOptions'] : [];
-        $saveOptions = !empty($data['saveOptions']) ? (array)$data['saveOptions'] : [];
+        $entityOptions = (array)Hash::get($data, 'entityOptions');
+        $saveOptions = (array)Hash::get($data, 'saveOptions');
         $entity = $this->Table->patchEntity($data['entity'], $data['data'], $entityOptions);
         $success = $this->Table->save($entity, $saveOptions);
 

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -117,18 +117,24 @@ class SignupUserAction extends BaseAction
      * @param array $context The validation context
      * @return bool
      */
-    public function isValidUrl($value, $context)
+    public function isValidUrl($value, array $context = [])
     {
+        // check for a valid scheme (https://, myapp://,...)
         $regex = '/(?<scheme>^[a-z][a-z0-9+\-.]*:\/\/).*/';
         if (!preg_match($regex, $value, $matches)) {
             return false;
         }
 
+        // if scheme is not an URL protocol then it's a custom url (myapp://) => ok
         if (!preg_match('/^(https?|ftps?|sftp|file|news|gopher:\/\/)/', $matches['scheme'])) {
             return true;
         }
 
-        $provider = $context['providers']['default'];
+        if (!empty($context['providers']['default'])) {
+            $provider = $context['providers']['default'];
+        } else {
+            $provider = (new Validator())->getProvider('default');
+        }
 
         return $provider->url($value, true, $context);
     }

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Model\Action;
+
+use BEdita\Core\Model\Entity\AsyncJob;
+use BEdita\Core\Model\Entity\User;
+use BEdita\Core\Utility\LoggedUser;
+use Cake\I18n\Time;
+use Cake\Mailer\MailerAwareTrait;
+use Cake\Network\Exception\BadRequestException;
+use Cake\Network\Exception\InternalErrorException;
+use Cake\Network\Exception\SocketException;
+use Cake\ORM\TableRegistry;
+use Cake\Validation\Validator;
+
+/**
+ * Command to signup a user.
+ *
+ * @since 4.0.0
+ */
+class SignupUserAction extends BaseAction
+{
+    use MailerAwareTrait;
+
+    /**
+     * The UsersTable table
+     *
+     * @var \BEdita\Core\Model\Table\UsersTable
+     */
+    protected $Users = null;
+
+    /**
+     * The AsynJobs table
+     *
+     * @var \BEdita\Core\Model\Table\AsyncJobsTable
+     */
+    protected $AsyncJobs = null;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function initialize(array $config)
+    {
+        $this->Users = TableRegistry::get('Users');
+        $this->AsyncJobs = TableRegistry::get('AsyncJobs');
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws \Cake\Netowrk\Exception\BadRequestException When validation of `$data['urlOptions']` fails
+     */
+    public function execute(array $data = [])
+    {
+        $data['urlOptions'] = (!empty($data['urlOptions']) && is_array($data['urlOptions'])) ? $data['urlOptions'] : [];
+        $errors = $this->validate($data['urlOptions']);
+        if (!empty($errors)) {
+            throw new BadRequestException([
+                'title' => __d('bedita', 'Invalid data'),
+                'detail' => $errors,
+            ]);
+        }
+
+        return $this->Users->connection()->transactional(function () use ($data) {
+            $user = $this->createUser($data['data']);
+            $job = $this->createSignupJob($user);
+            $this->sendMail($user, $job, $data['urlOptions']);
+
+            return compact('user', 'job');
+        });
+    }
+
+    /**
+     * Validate data.
+     *
+     * It needs to validate some data that don't concern the User entity
+     * as `activation_url` and `redirect_url`
+     *
+     * @param array $data The data to validate
+     * @return array
+     */
+    protected function validate(array $data)
+    {
+        $validator = new Validator();
+        $validator->setProvider('signup', $this);
+
+        $validator
+            ->requirePresence('activation_url')
+            ->add('activation_url', 'customUrl', [
+                'rule' => 'isValidUrl',
+                'provider' => 'signup',
+            ])
+
+            ->add('redirect_url', 'customUrl', [
+                'rule' => 'isValidUrl',
+                'provider' => 'signup',
+            ]);
+
+        return $validator->errors($data);
+    }
+
+    /**
+     * Checks that a value is a valid URL or custom url as myapp://
+     *
+     * @param string $value The url to check
+     * @param array $context The validation context
+     * @return bool
+     */
+    public function isValidUrl($value, $context)
+    {
+        $regex = '/(?<scheme>^[a-z][a-z0-9+\-.]*:\/\/).*/';
+        if (!preg_match($regex, $value, $matches)) {
+            return false;
+        }
+
+        if (!preg_match('/^(https?|ftps?|sftp|file|news|gopher:\/\/)/', $matches['scheme'])) {
+            return true;
+        }
+
+        $provider = $context['providers']['default'];
+
+        return $provider->url($value, true, $context);
+    }
+
+    /**
+     * Create a new user with status draft.
+     *
+     * The user is validated using 'signup' validation.
+     *
+     * @param array $data The data to save
+     * @return mixed
+     */
+    protected function createUser(array $data)
+    {
+        if (!LoggedUser::getUser()) {
+            LoggedUser::setUser(['id' => 1]);
+        }
+
+        $data = ['status' => 'draft'] + $data;
+        $action = new SaveEntityAction(['table' => $this->Users]);
+
+        return $action([
+            'entity' => $this->Users->newEntity(),
+            'data' => $data,
+            'entityOptions' => [
+                'validate' => 'signup',
+            ]
+        ]);
+    }
+
+    /**
+     * Create the signup async job
+     *
+     * @param User $user The user created
+     * @return mixed
+     */
+    protected function createSignupJob(User $user)
+    {
+        $action = new SaveEntityAction(['table' => $this->AsyncJobs]);
+
+        return $action([
+            'entity' => $this->AsyncJobs->newEntity(),
+            'data' => [
+                'service' => 'signup',
+                'payload' => [
+                    'user_id' => $user->id,
+                ],
+                'scheduled_from' => new Time('1 day'),
+                'priority' => 1,
+            ]
+        ]);
+    }
+
+    /**
+     * Send confirmation email to user
+     *
+     * @param User $user The user
+     * @param AsyncJob $job The referred async job
+     * @param array $urlOptions The options used to build activation url
+     * @return void
+     * @throws \Exception When sending email throws an exception different from \Cake\Network\Exception\SocketException
+     */
+    protected function sendMail(User $user, AsyncJob $job, array $urlOptions = [])
+    {
+        try {
+            $options = [
+                'params' => [
+                    'userId' => $user->id,
+                    'activationUrl' => $this->getActivationUrl($job, $urlOptions),
+                ]
+            ];
+            $this->getMailer('BEdita/Core.User')->send('signup', [$options]);
+        } catch (SocketException $e) {
+            // @todo insert async job to retry sending email
+        } catch (\Exception $e) {
+            throw $e;
+        }
+    }
+
+    /**
+     * Return the signup activation url
+     *
+     * @param AsyncJob $job The async job entity
+     * @param array $urlOptions The options used to build activation url
+     * @return string
+     */
+    protected function getActivationUrl(AsyncJob $job, array $urlOptions)
+    {
+        $baseUrl = $urlOptions['activation_url'];
+        $redirectUrl = empty($urlOptions['redirect_url']) ? '' : '&redirect_url=' . rawurlencode($urlOptions['redirect_url']);
+        $baseUrl .= (strpos($baseUrl, '?') === false) ? '?' : '&';
+
+        return sprintf('%sid=%s%s', $baseUrl, $job->uuid, $redirectUrl);
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -112,6 +112,31 @@ class UsersTable extends Table
     }
 
     /**
+     * Signup validation
+     *
+     * @param \Cake\Validation\Validator $validator The validator
+     * @return \Cake\Validation\Validator
+     * @codeCoverageIgnore
+     */
+    public function validationSignup(Validator $validator)
+    {
+        $validator = $this->validationDefault($validator);
+
+        $validator
+            ->email('email')
+            ->requirePresence('email')
+            ->add('email', 'unique', ['rule' => 'validateUnique', 'provider' => 'table'])
+
+            ->requirePresence('password_hash')
+            ->notEmpty('password_hash')
+
+            ->requirePresence('status')
+            ->equals('status', 'draft');
+
+        return $validator;
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @codeCoverageIgnore

--- a/plugins/BEdita/Core/src/Template/Email/html/signup.ctp
+++ b/plugins/BEdita/Core/src/Template/Email/html/signup.ctp
@@ -1,0 +1,11 @@
+<p><?= __d('bedita', 'Dear {0},', [$user->username]) ?></p>
+<p>
+    <?= __d('bedita', 'thank you for registering to {0}.', [$appName]) ?>
+    <br>
+    <?= __d('bedita', 'To confirm your registration, please follow this link:') ?>
+</p>
+
+<p><?= $this->Html->link($activationUrl, $activationUrl, ['target' => '_blank']); ?></p>
+
+<p></p>
+<p><?= __d('bedita', 'Regards') ?></p>

--- a/plugins/BEdita/Core/src/Template/Email/text/signup.ctp
+++ b/plugins/BEdita/Core/src/Template/Email/text/signup.ctp
@@ -1,0 +1,12 @@
+<?= __d('bedita', 'Dear {0},', [$user->username]) ?>
+
+
+<?= __d('bedita', 'thank you for registering to {0}.', [$appName]) ?>
+
+<?= __d('bedita', 'To confirm your registration, please follow this link:') ?>
+
+
+<?= $activationUrl ?>
+
+
+<?= __d('bedita', 'Regards') ?>

--- a/plugins/BEdita/Core/src/Template/Layout/Email/html/default.ctp
+++ b/plugins/BEdita/Core/src/Template/Layout/Email/html/default.ctp
@@ -1,0 +1,1 @@
+<?= $this->fetch('content') ?>

--- a/plugins/BEdita/Core/src/Template/Layout/Email/text/default.ctp
+++ b/plugins/BEdita/Core/src/Template/Layout/Email/text/default.ctp
@@ -1,0 +1,1 @@
+<?= $this->fetch('content') ?>

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTest.php
@@ -44,6 +44,7 @@ class UserMailerTest extends TestCase
         'plugin.BEdita/Core.object_types',
         'plugin.BEdita/Core.roles',
         'plugin.BEdita/Core.external_auth',
+        'plugin.BEdita/Core.auth_providers',
         'plugin.BEdita/Core.relations',
         'plugin.BEdita/Core.relation_types',
     ];

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTest.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Mailer;
+
+use Cake\Mailer\Email;
+use Cake\Mailer\MailerAwareTrait;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * @coversDefaultClass \BEdita\Core\Mailer\UserMailer
+ */
+class UserMailerTest extends TestCase
+{
+    use MailerAwareTrait;
+
+    /**
+     * The Email instance
+     *
+     * @var \Cake\Mailer\Email
+     */
+    protected $Email;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.profiles',
+        'plugin.BEdita/Core.users',
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.roles',
+        'plugin.BEdita/Core.external_auth',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        $this->Email = new Email('test');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        $this->Email = null;
+    }
+
+    /**
+     * Provider for `testSignup()`
+     *
+     * @return array
+     */
+    public function signupProvider()
+    {
+        return [
+            'ok' => [
+                true,
+                [
+                    'params' => [
+                        'userId' => 5,
+                        'activationUrl' => 'http://example.com',
+                    ]
+                ],
+            ],
+            'missing userId' => [
+                new \LogicException('Parameter "params.userId" missing'),
+                [
+                    'params' => [
+                        'activationUrl' => 'http://example.com',
+                    ]
+                ],
+            ],
+            'missing activationUrl' => [
+                new \LogicException('Parameter "params.activationUrl" missing'),
+                [
+                    'params' => [
+                        'userId' => 5,
+                    ]
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test signup
+     *
+     * @param mixed $expected
+     * @param array $options
+     * @return void
+     *
+     * @dataProvider signupProvider
+     * @covers ::signup()
+     */
+    public function testSignup($expected, $options)
+    {
+        if ($expected instanceof \Exception) {
+            $this->expectException(get_class($expected));
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+        $result = $this->getMailer('BEdita/Core.User', $this->Email)->send('signup', [$options]);
+
+        static::assertEquals($expected, (bool)$result);
+    }
+
+    /**
+     * Test fail sending email to user without email
+     *
+     * @return void
+     *
+     * @covers ::signup()
+     */
+    public function testSignupMissingUserEmail()
+    {
+        $Users = TableRegistry::get('Users');
+        $user = $Users->get(5);
+        $user->email = null;
+        $Users->save($user);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('User email missing');
+
+        $options = [
+            'params' => [
+                'userId' => 5,
+                'activationUrl' => 'http://example.com',
+            ],
+        ];
+
+        $this->getMailer('BEdita/Core.User', $this->Email)->send('signup', [$options]);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -172,4 +172,19 @@ class SignupUserActionTest extends TestCase
             ],
         ]);
     }
+
+    /**
+     * Test `isValidUrl()` not with validation (without context)
+     *
+     * @return void
+     */
+    public function testIsValidUrlWithoutContext()
+    {
+        $action = new SignupUserAction();
+        $result = $action->isValidUrl('https://example.com');
+        $this->assertTrue($result);
+
+        $result = $action->isValidUrl('https://examplecom');
+        $this->assertFalse($result);
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Action;
+
+use BEdita\Core\Model\Action\SignupUserAction;
+use BEdita\Core\Model\Entity\AsyncJob;
+use BEdita\Core\Model\Entity\User;
+use Cake\Mailer\Email;
+use Cake\Network\Exception\BadRequestException;
+use Cake\Network\Exception\InternalErrorException;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * @covers \BEdita\Core\Model\Action\SignupUserAction
+ */
+class SignupUserActionTest extends TestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.profiles',
+        'plugin.BEdita/Core.users',
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.async_jobs',
+        'plugin.BEdita/Core.roles',
+        'plugin.BEdita/Core.external_auth',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
+    ];
+
+    /**
+     * Provider for `testExecute()`
+     *
+     * @return void
+     */
+    public function executeProvider()
+    {
+        return [
+            'ok' => [
+                true,
+                [
+                    'data' => [
+                        'username' => 'testsignup',
+                        'password_hash' => 'testsignup',
+                        'email' => 'test.signup@example.com',
+                    ],
+                    'urlOptions' => [
+                        'activation_url' => 'http://sample.com?confirm=true',
+                        'redirect_url' => 'http://sample.com/ok',
+                    ],
+                ]
+            ],
+            'ok custom url' => [
+                true,
+                [
+                    'data' => [
+                        'username' => 'testsignup',
+                        'password_hash' => 'testsignup',
+                        'email' => 'test.signup@example.com',
+                    ],
+                    'urlOptions' => [
+                        'activation_url' => 'myapp://activate',
+                        'redirect_url' => 'myapp://',
+                    ],
+                ]
+            ],
+            'missing activation_url' => [
+                new BadRequestException(),
+                [
+                    'data' => [
+                        'username' => 'testsignup',
+                        'password_hash' => 'testsignup',
+                        'email' => 'test.signup@example.com',
+                    ],
+                ]
+            ],
+            'activation url invalid' => [
+                new BadRequestException(),
+                [
+                    'data' => [
+                        'username' => 'testsignup',
+                        'password_hash' => 'testsignup',
+                        'email' => 'test.signup@example.com',
+                    ],
+                    'urlOptions' => [
+                        'activation_url' => '/activate',
+                    ],
+                ]
+            ],
+            'activation url invalid 2' => [
+                new BadRequestException(),
+                [
+                    'data' => [
+                        'username' => 'testsignup',
+                        'password_hash' => 'testsignup',
+                        'email' => 'test.signup@example.com',
+                    ],
+                    'urlOptions' => [
+                        'activation_url' => 'https://activate',
+                    ],
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * Test command execution.
+     *
+     * @return void
+     *
+     * @dataProvider executeProvider
+     */
+    public function testExecute($expected, $data)
+    {
+        Email::dropTransport('default');
+        Email::setConfigTransport('default', [
+            'className' => 'Debug'
+        ]);
+
+        if ($expected instanceof \Exception) {
+            $this->expectException(get_class($expected));
+        }
+
+        $action = new SignupUserAction();
+        $result = $action($data);
+
+        static::assertTrue((bool)$result);
+        static::assertInstanceOf(User::class, $result['user']);
+        static::assertInstanceOf(AsyncJob::class, $result['job']);
+    }
+
+    /**
+     * Test execute when exception different from SocketException was raised
+     *
+     * @return void
+     */
+    public function testExceptionSendMail()
+    {
+        $this->expectException(InternalErrorException::class);
+
+        $mock = $this->getMockBuilder(SignupUserAction::class)
+            ->setMethods(['getMailer'])
+            ->getMock();
+
+        $mock->method('getMailer')->will($this->throwException(new InternalErrorException));
+
+        $mock([
+            'data' => [
+                'username' => 'testsignup',
+                'password_hash' => 'testsignup',
+                'email' => 'test.signup@example.com',
+            ],
+            'urlOptions' => [
+                'activation_url' => 'http://sample.com?confirm=true',
+            ],
+        ]);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -40,6 +40,7 @@ class SignupUserActionTest extends TestCase
         'plugin.BEdita/Core.async_jobs',
         'plugin.BEdita/Core.roles',
         'plugin.BEdita/Core.external_auth',
+        'plugin.BEdita/Core.auth_providers',
         'plugin.BEdita/Core.relations',
         'plugin.BEdita/Core.relation_types',
     ];

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -305,7 +305,6 @@ class UsersTableTest extends TestCase
      *
      * @return void
      * @dataProvider validationSignupProvider
-     * @covers ::validateUrl()
      */
     public function testValidationSignup($expected, array $data)
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -250,4 +250,75 @@ class UsersTableTest extends TestCase
 
         static::assertSame($expected, $actual);
     }
+
+    /**
+     * Data provider for `testValidationSignup` test case.
+     *
+     * @return array
+     */
+    public function validationSignupProvider()
+    {
+        return [
+            'valid' => [
+                true,
+                [
+                    'username' => 'some_unique_value',
+                    'password_hash' => 'password',
+                    'email' => 'my@email.com',
+                    'status' => 'draft',
+                ],
+            ],
+            'wrong status' => [
+                false,
+                [
+                    'username' => 'some_unique_value',
+                    'password_hash' => 'password',
+                    'email' => 'my@email.com',
+                    'status' => 'on',
+                ],
+            ],
+            'missing status' => [
+                false,
+                [
+                    'username' => 'some_unique_value',
+                    'password_hash' => 'password',
+                    'email' => 'my@email.com',
+                ],
+            ],
+            'missing password' => [
+                false,
+                [
+                    'username' => 'some_unique_value',
+                    'password_hash' => null,
+                    'email' => 'my@email.com',
+                    'status' => 'draft',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test validation signup.
+     *
+     * @param bool $expected Expected result.
+     * @param array $data Data to be validated.
+     *
+     * @return void
+     * @dataProvider validationSignupProvider
+     * @covers ::validateUrl()
+     */
+    public function testValidationSignup($expected, array $data)
+    {
+        $user = $this->Users->newEntity();
+        $this->Users->patchEntity($user, $data, ['validate' => 'signup']);
+        $user->type = 'users';
+
+        $error = (bool)$user->errors();
+        $this->assertEquals($expected, !$error);
+
+        if ($expected) {
+            $success = $this->Users->save($user);
+            $this->assertTrue((bool)$success);
+        }
+    }
 }


### PR DESCRIPTION
The PR add addtional step to #1203 

After this PR a user can partially signup :smile: 

* a user with status `draft` will be created
* a job is added to `async_jobs`
* a confirmation email is send to the user

### Considerations

1. If no error occurs the response will be a `202 Accepted` with no body but I don't know if it's correct.
2. At the moment trying to signup a user with existing `username` or `email` responds with a `400 Bad Request` instead of `409 Conflict`. 