### PR TITLE
Custom uname generator

### DIFF
--- a/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
@@ -77,8 +77,8 @@ class UniqueNameBehavior extends Behavior
             $uname = $this->generateUniqueName($entity);
         }
         $count = 0;
-        while ($this->uniqueNameExists($uname, $entity->get('id')
-            && ($count++ < self::UNAME_MAX_REGENERATE))) {
+        while ($this->uniqueNameExists($uname, $entity->get('id'))
+            && ($count++ < self::UNAME_MAX_REGENERATE)) {
             $uname = $this->generateUniqueName($entity, true);
         }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
@@ -139,7 +139,16 @@ class UniqueNameBehaviorTest extends TestCase
                 [
                     'sourceField' => 'name',
                 ],
-            ]
+            ],
+            'generator' => [
+                'RandomName',
+                'John Doe',
+                [
+                    'generator' => function ($entity) {
+                        return str_shuffle($entity->get('username'));
+                    }
+                ]
+            ],
         ];
     }
 
@@ -160,8 +169,8 @@ class UniqueNameBehaviorTest extends TestCase
         $user = $Users->newEntity();
         $Users->patchEntity($user, compact('username', 'name'));
         $behavior = $Users->behaviors()->get('UniqueName');
-        $uname1 = $behavior->generateUniqueName($user, $config);
-        $uname2 = $behavior->generateUniqueName($user, $config, true);
+        $uname1 = $behavior->generateUniqueName($user, false, $config);
+        $uname2 = $behavior->generateUniqueName($user, true, $config);
 
         $this->assertNotEquals($uname1, $uname2);
     }
@@ -267,7 +276,7 @@ class UniqueNameBehaviorTest extends TestCase
     public function testUniqueNameFromValue($value, $expected, $cfg, $regenerate)
     {
         $behavior = TableRegistry::get('Objects')->behaviors()->get('UniqueName');
-        $result = $behavior->uniqueNameFromValue($value, $cfg, $regenerate);
+        $result = $behavior->uniqueNameFromValue($value, $regenerate, $cfg);
 
         if ($regenerate) {
             $cfg = array_merge($behavior->config(), $cfg);


### PR DESCRIPTION
This PR adds a custom unique name generator using callable items

In a table class you may define a custom function like this:
```php
        $this->addBehavior('BEdita/Core.UniqueName', [
            'generator' => function ($entity) {
                return str_shuffle($entity->get('title'));
            }
        ]);
```