### PR TITLE
Dynamic /home response

### DIFF
--- a/plugins/BEdita/API/src/Controller/HomeController.php
+++ b/plugins/BEdita/API/src/Controller/HomeController.php
@@ -53,19 +53,7 @@ class HomeController extends AppController
     protected $defaultAllowUnlogged = [
         '/auth' => ['POST'],
         '/signup' => ['POST'],
-        '/status' => ['GET'],
         '/*' => ['GET'],
-    ];
-
-    /**
-     * Default blocked methods for unlogged users
-     * '/*' means: all other endpoints
-     *
-     * @var array
-     */
-    protected $defaultBlockUnlogged = [
-        '/auth' => ['GET'],
-        '/*' => ['POST', 'PATCH', 'DELETE'],
     ];
 
     /**
@@ -147,7 +135,7 @@ class HomeController extends AppController
     }
 
     /**
-     * Default unlogged use authorization on endpoint, without checking permissions
+     * Default unlogged authorization on endpoint method, without permissions check
      *
      * @param string $endpoint Endpoint URI
      * @param string $method HTTP method
@@ -156,12 +144,7 @@ class HomeController extends AppController
     protected function unloggedAuthorized($endpoint, $method)
     {
         $defaultAllow = Hash::get($this->defaultAllowUnlogged, $endpoint, $this->defaultAllowUnlogged['/*']);
-        if (in_array($method, $defaultAllow)) {
-            return true;
-        }
 
-        $defaultBlock = Hash::get($this->defaultBlockUnlogged, $endpoint, $this->defaultBlockUnlogged['/*']);
-
-        return !in_array($method, $defaultBlock);
+        return in_array($method, $defaultAllow);
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
@@ -29,6 +29,7 @@ class HomeControllerTest extends IntegrationTestCase
      * @covers ::index()
      * @covers ::objectTypesEndpoints()
      * @covers ::checkAuthorization()
+     * @covers ::unloggedAuthorized()
      */
     public function testIndex()
     {
@@ -39,6 +40,21 @@ class HomeControllerTest extends IntegrationTestCase
             ],
             'meta' => [
                 'resources' => [
+                    '/auth' => [
+                        'href' => 'http://api.example.com/auth',
+                        'hints' => [
+                            'allow' => [
+                                'GET', 'POST'
+                            ],
+                            'formats' => [
+                                'application/json',
+                                'application/vnd.api+json'
+                            ],
+                            'display' => [
+                                'label' => 'Auth',
+                            ]
+                        ],
+                    ],
                     '/documents' => [
                         'href' => 'http://api.example.com/documents',
                         'hints' => [
@@ -178,7 +194,7 @@ class HomeControllerTest extends IntegrationTestCase
                         'href' => 'http://api.example.com/status',
                         'hints' => [
                             'allow' => [
-                                'GET', 'POST', 'PATCH', 'DELETE'
+                                'GET'
                             ],
                             'formats' => [
                                 'application/json',
@@ -186,6 +202,21 @@ class HomeControllerTest extends IntegrationTestCase
                             ],
                             'display' => [
                                 'label' => 'Status',
+                            ]
+                        ],
+                    ],
+                    '/signup' => [
+                        'href' => 'http://api.example.com/signup',
+                        'hints' => [
+                            'allow' => [
+                                'POST'
+                            ],
+                            'formats' => [
+                                'application/json',
+                                'application/vnd.api+json'
+                            ],
+                            'display' => [
+                                'label' => 'Signup',
                             ]
                         ],
                     ],
@@ -227,6 +258,9 @@ class HomeControllerTest extends IntegrationTestCase
 
         $resetExpect = Hash::remove($expected, 'meta.resources.{*}.hints.allow');
         $resetExpect = Hash::insert($resetExpect, 'meta.resources.{*}.hints.allow', ['GET']);
+        $resetExpect = Hash::insert($resetExpect, 'meta.resources./auth.hints.allow', ['POST']);
+        $resetExpect = Hash::insert($resetExpect, 'meta.resources./signup.hints.allow', ['POST']);
+
         $this->assertEquals($resetExpect, $result);
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -13,6 +13,8 @@
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Utility\LoggedUser;
+use Cake\Utility\Hash;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\HomeController
@@ -25,6 +27,8 @@ class HomeControllerTest extends IntegrationTestCase
      * @return void
      *
      * @covers ::index()
+     * @covers ::objectTypesEndpoints()
+     * @covers ::checkAuthorization()
      */
     public function testIndex()
     {
@@ -47,7 +51,6 @@ class HomeControllerTest extends IntegrationTestCase
                             ],
                             'display' => [
                                 'label' => 'Documents',
-                                'color' => '#852a36'
                             ]
                         ],
                     ],
@@ -63,7 +66,6 @@ class HomeControllerTest extends IntegrationTestCase
                             ],
                             'display' => [
                                 'label' => 'Profiles',
-                                'color' => '#622635'
                             ]
                         ],
                     ],
@@ -79,7 +81,6 @@ class HomeControllerTest extends IntegrationTestCase
                             ],
                             'display' => [
                                 'label' => 'Objects',
-                                'color' => '#6103c1'
                             ]
                         ],
                     ],
@@ -95,7 +96,6 @@ class HomeControllerTest extends IntegrationTestCase
                             ],
                             'display' => [
                                 'label' => 'Users',
-                                'color' => '#032813'
                             ]
                         ],
                     ],
@@ -111,7 +111,6 @@ class HomeControllerTest extends IntegrationTestCase
                             ],
                             'display' => [
                                 'label' => 'News',
-                                'color' => '#63e1d8'
                             ]
                         ],
                     ],
@@ -127,7 +126,6 @@ class HomeControllerTest extends IntegrationTestCase
                             ],
                             'display' => [
                                 'label' => 'Locations',
-                                'color' => '#cc324f'
                             ]
                         ],
                     ],
@@ -143,7 +141,6 @@ class HomeControllerTest extends IntegrationTestCase
                             ],
                             'display' => [
                                 'label' => 'Events',
-                                'color' => '#44d1ab'
                             ]
                         ],
                     ],
@@ -159,7 +156,6 @@ class HomeControllerTest extends IntegrationTestCase
                             ],
                             'display' => [
                                 'label' => 'Roles',
-                                'color' => '#7b2bac'
                             ]
                         ],
                     ],
@@ -175,7 +171,6 @@ class HomeControllerTest extends IntegrationTestCase
                             ],
                             'display' => [
                                 'label' => 'ObjectTypes',
-                                'color' => '#6b2d02'
                             ]
                         ],
                     ],
@@ -191,7 +186,6 @@ class HomeControllerTest extends IntegrationTestCase
                             ],
                             'display' => [
                                 'label' => 'Status',
-                                'color' => '#88206a'
                             ]
                         ],
                     ],
@@ -207,13 +201,14 @@ class HomeControllerTest extends IntegrationTestCase
                             ],
                             'display' => [
                                 'label' => 'Trash',
-                                'color' => '#f45336'
                             ]
                         ],
                     ],
                 ],
             ],
         ];
+
+        LoggedUser::setUser(['id' => 1]);
 
         $this->configRequestHeaders();
         $this->get('/home');
@@ -222,5 +217,16 @@ class HomeControllerTest extends IntegrationTestCase
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
         $this->assertEquals($expected, $result);
+
+        LoggedUser::resetUser();
+        $this->configRequestHeaders();
+        $this->get('/home');
+        $result = json_decode((string)$this->_response->getBody(), true);
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        $resetExpect = Hash::remove($expected, 'meta.resources.{*}.hints.allow');
+        $resetExpect = Hash::insert($resetExpect, 'meta.resources.{*}.hints.allow', ['GET']);
+        $this->assertEquals($resetExpect, $result);
     }
 }


### PR DESCRIPTION
This PR solves #985 

`/home` response will now show complete endpoint list with actual allowed methods
 * an unlogged user is allowed to GET most endpoints, apart from `/auth` and `/signup`
 * a logged user is allowed to use all supported methods
 * additional check on endpoint permission is done to block some methods

@fquffio @didoda please check `HomeController::checkAuthorization` method, don't know if it's the correct way to do it...