### PR TITLE
Several fixes

### DIFF
--- a/plugins/BEdita/API/src/Auth/JwtAuthenticate.php
+++ b/plugins/BEdita/API/src/Auth/JwtAuthenticate.php
@@ -14,7 +14,6 @@
 namespace BEdita\API\Auth;
 
 use Cake\Auth\BaseAuthenticate;
-use Cake\Core\Configure;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Network\Exception\UnauthorizedException;
@@ -111,7 +110,7 @@ class JwtAuthenticate extends BaseAuthenticate
      * Get user record based on info available in JWT.
      *
      * @param \Cake\Http\ServerRequest $request The request object.
-     * @param \Cake\Network\Response $response Response object.
+     * @param \Cake\Http\Response $response Response object.
      * @return array|false User record array or false on failure.
      */
     public function authenticate(ServerRequest $request, Response $response)
@@ -205,10 +204,6 @@ class JwtAuthenticate extends BaseAuthenticate
 
             return (array)$payload;
         } catch (\Exception $e) {
-            if (Configure::read('debug')) {
-                throw $e;
-            }
-
             $this->error = $e;
         }
 

--- a/plugins/BEdita/Core/src/Model/Entity/DateRange.php
+++ b/plugins/BEdita/Core/src/Model/Entity/DateRange.php
@@ -118,11 +118,11 @@ class DateRange extends Entity
 
         // Merge items.
         $result = [];
-        $last = array_shift($dateRanges);
+        $last = clone array_shift($dateRanges);
         while (($current = array_shift($dateRanges)) !== null) {
             if ($last->isBefore($current) && $last->end_date < $current->start_date) {
                 $result[] = $last;
-                $last = $current;
+                $last = clone $current;
 
                 continue;
             }
@@ -174,6 +174,21 @@ class DateRange extends Entity
      *
      * **Warning**: this method does **not** take `params` into account.
      *
+     * ### Example
+     *
+     * ```php
+     * $array1 = [new DateRange(['start_date' => new Time('2017-01-01 00:00:00'), 'end_date' => new Time('2017-01-31 12:59:59')])];
+     * $array2 = [new DateRange(['start_date' => new Time('2017-01-10 00:00:00'), 'end_date' => new Time('2017-01-19 12:59:59')])];
+     *
+     * $diff = DateRange::diff($array1, $array2);
+     *
+     * // $diff will now be equivalent to:
+     * $diff = [
+     *     new DateRange(['start_date' => new Time('2017-01-10 00:00:00'), 'end_date' => new Time('2017-01-10 00:00:00')]),
+     *     new DateRange(['start_date' => new Time('2017-01-19 12:59:59'), 'end_date' => new Time('2017-01-19 12:59:59')]),
+     * ];
+     * ```
+     *
      * @param \BEdita\Core\Model\Entity\DateRange[] $array1 First set of Date Ranges.
      * @param \BEdita\Core\Model\Entity\DateRange[] $array2 Second set of Date Ranges.
      * @return \BEdita\Core\Model\Entity\DateRange[]
@@ -193,7 +208,7 @@ class DateRange extends Entity
             $dateRange = clone $dateRange1;
 
             while (($dateRange2 = current($array2)) !== false) {
-                if ($dateRange->end_date === null && $dateRange2->end_date === null && $dateRange->start_date == $dateRange2->start_date) {
+                if ($dateRange->end_date === null && $dateRange2->end_date === null && $dateRange->start_date->eq($dateRange2->start_date)) {
                     // Unit sets match. Discard range.
                     $dateRange = null;
                     next($array2);

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -37,14 +37,6 @@ use Cake\ORM\Table;
  * @method \BEdita\Core\Model\Entity\ObjectEntity[] patchEntities($entities, array $data, array $options = [])
  * @method \BEdita\Core\Model\Entity\ObjectEntity findOrCreate($search, callable $callback = null, $options = [])
  *
- * @method \BEdita\Core\Model\Entity\ObjectEntity get($primaryKey, $options = [])
- * @method \BEdita\Core\Model\Entity\ObjectEntity newEntity($data = null, array $options = [])
- * @method \BEdita\Core\Model\Entity\ObjectEntity[] newEntities(array $data, array $options = [])
- * @method \BEdita\Core\Model\Entity\ObjectEntity|bool save(\Cake\Datasource\EntityInterface $entity, $options = [])
- * @method \BEdita\Core\Model\Entity\ObjectEntity patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
- * @method \BEdita\Core\Model\Entity\ObjectEntity[] patchEntities($entities, array $data, array $options = [])
- * @method \BEdita\Core\Model\Entity\ObjectEntity findOrCreate($search, callable $callback = null, $options = [])
- *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @mixin \BEdita\Core\Model\Behavior\UserModifiedBehavior
  * @mixin \BEdita\Core\Model\Behavior\RelationsBehavior

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/DateRangeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/DateRangeTest.php
@@ -443,6 +443,12 @@ class DateRangeTest extends TestCase
 
         $result = DateRange::normalize($dateRanges);
 
+        foreach ($dateRanges as $dateRange) {
+            foreach ($result as $item) {
+                static::assertNotSame($dateRange, $item);
+            }
+        }
+
         $expected = json_decode(json_encode($expected), true);
         $result = json_decode(json_encode($result), true);
 


### PR DESCRIPTION
This PR fixes some minor issues:

- remove duplicate `@method` annotations in ObjectsTable
- do not re-throw exception on invalid JWT token when debug is on, causing 500 error responses where 401 would be more appropriate
- fix problem where `DateRange` static methods were modifying entities in-place instead of cloning them — after calling `DateRange::diff($a, $b)`, `$a` resulted in a modified set
- add example to `DateRange::diff()` method's doc block