### PR TITLE
Allow custom JSON input

### DIFF
--- a/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
@@ -52,6 +52,7 @@ class JsonApiComponent extends Component
         'checkMediaType' => true,
         'resourceTypes' => null,
         'clientGeneratedIds' => false,
+        'customJsonInput' => false,
     ];
 
     /**
@@ -83,6 +84,10 @@ class JsonApiComponent extends Component
             $json = json_decode($json, true);
             if (json_last_error() || !is_array($json) || !isset($json['data'])) {
                 throw new \InvalidArgumentException('Invalid JSON');
+            }
+            // avoid JSON-API parsing on application/json with 'customJsonInput' true
+            if ($this->config('contentType') === 'json' && $this->config('customJsonInput')) {
+                return $json;
             }
 
             return JsonApi::parseData((array)$json['data']);

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
@@ -309,6 +309,29 @@ class JsonApiComponentTest extends TestCase
     }
 
     /**
+     * Test `parseInput()` method with custom JSON
+     *
+     * @return void
+     *
+     * @covers ::parseInput()
+     */
+    public function testCustomParseInput()
+    {
+        $config = [
+            'contentType' => 'json',
+            'customJsonInput' => true,
+        ];
+        $component = new JsonApiComponent(new ComponentRegistry(new Controller()), $config);
+
+        $input = '{"data":{"key1":"value1","key2":"value2"}}';
+        $result = $component->parseInput($input);
+
+        $expected = ['data' => ['key1' => 'value1', 'key2' => 'value2']];
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * Data provider for `testAllowedResourceTypes` test case.
      *
      * @return array


### PR DESCRIPTION
This PR add custom JSON input in situations where JSON-API input makes no sense.

Simplest way to activate it is ovverride controller `initialize` like this: 
```php
public function initialize()
    {
        parent::initialize();
        $this->JsonApi->setConfig('customJsonInput', true);
    }
```

`JsonApiComponent::parseInput()` will then allow custom json input if `application/json` is used as request content type

