### PR TITLE
Add error code

### DIFF
--- a/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
@@ -101,16 +101,18 @@ class JsonApiComponent extends Component
      * @param int $status HTTP error code.
      * @param string $title Brief description of error.
      * @param string $detail Long description of error
+     * @param string $code Application specific error code.
      * @param array|null $meta Additional metadata about error.
      * @return void
      */
-    public function error($status, $title, $detail, array $meta = null)
+    public function error($status, $title, $detail = null, $code = null, array $meta = null)
     {
         $controller = $this->getController();
 
         $status = (string)$status;
+        $code = (string)$code;
 
-        $error = compact('status', 'title', 'detail', 'meta');
+        $error = compact('status', 'title', 'detail', 'code', 'meta');
         $error = array_filter($error);
 
         $controller->set('_error', $error);

--- a/plugins/BEdita/API/src/Error/ExceptionRenderer.php
+++ b/plugins/BEdita/API/src/Error/ExceptionRenderer.php
@@ -141,7 +141,7 @@ class ExceptionRenderer extends CakeExceptionRenderer
         }
 
         $errorAttributes = $error->getAttributes();
-        if (empty($errorAttributes['code'])) {
+        if (empty($errorAttributes['code']) || !is_scalar($errorAttributes['code'])) {
             return '';
         }
 

--- a/plugins/BEdita/API/src/Error/ExceptionRenderer.php
+++ b/plugins/BEdita/API/src/Error/ExceptionRenderer.php
@@ -43,9 +43,10 @@ class ExceptionRenderer extends CakeExceptionRenderer
     {
         $isDebug = Configure::read('debug');
 
-        $code = $this->_code($this->error);
-        $message = $this->_message($this->error, $code);
+        $status = $this->_code($this->error);
+        $title = $this->_message($this->error, $status);
         $detail = $this->errorDetail($this->error);
+        $code = $this->appErrorCode($this->error);
         $trace = null;
         if ($isDebug) {
             $trace = explode("\n", $this->_unwrap($this->error)->getTraceAsString());
@@ -54,7 +55,7 @@ class ExceptionRenderer extends CakeExceptionRenderer
         if ($this->isHtmlToSend()) {
             $this->setupView();
             $this->controller->set('method', $this->controller->request->getMethod());
-            $this->controller->set('responseBody', $this->jsonError($code, $message, $trace));
+            $this->controller->set('responseBody', $this->jsonError($status, $title, $detail, $code, $trace));
 
             return parent::render();
         }
@@ -66,7 +67,7 @@ class ExceptionRenderer extends CakeExceptionRenderer
             'checkMediaType' => $this->controller->request->is('jsonapi'),
         ]);
 
-        $this->controller->JsonApi->error($code, $message, $detail, array_filter(compact('trace')));
+        $this->controller->JsonApi->error($status, $title, $detail, $code, array_filter(compact('trace')));
         $this->controller->RequestHandler->renderAs($this->controller, 'jsonapi');
 
         return parent::render();
@@ -75,9 +76,9 @@ class ExceptionRenderer extends CakeExceptionRenderer
     /**
      * {@inheritDoc}
      */
-    protected function _message(\Exception $error, $code)
+    protected function _message(\Exception $error, $status)
     {
-        $message = parent::_message($error, $code);
+        $message = parent::_message($error, $status);
         if (empty($message) && $error instanceof CakeException) {
             $errorAttributes = $error->getAttributes();
             if (!empty($errorAttributes['title'])) {
@@ -125,6 +126,26 @@ class ExceptionRenderer extends CakeExceptionRenderer
         }
 
         return $res;
+    }
+
+    /**
+     * Application specific error code.
+     *
+     * @param \Exception $error Exception.
+     * @return string Error code
+     */
+    protected function appErrorCode(\Exception $error)
+    {
+        if (!$error instanceof CakeException) {
+            return '';
+        }
+
+        $errorAttributes = $error->getAttributes();
+        if (empty($errorAttributes['code'])) {
+            return '';
+        }
+
+        return (string)$errorAttributes['code'];
     }
 
     /**
@@ -186,7 +207,7 @@ class ExceptionRenderer extends CakeExceptionRenderer
     /**
      * {@inheritDoc}
      */
-    protected function _template(\Exception $exception, $method, $code)
+    protected function _template(\Exception $exception, $method, $status)
     {
         return $this->template = 'error';
     }
@@ -194,19 +215,18 @@ class ExceptionRenderer extends CakeExceptionRenderer
     /**
      * Build json error string for HTML error display
      *
-     * @param string $code Error code
-     * @param string $message Error message
+     * @param string $status HTTP error code
+     * @param string $title Error message
+     * @param string $detail Longer description of error
+     * @param string $code Application error code
      * @param array|null $trace Error stacktrace
      * @return string JSON error
      */
-    public function jsonError($code, $message, $trace)
+    public function jsonError($status, $title, $detail, $code, $trace)
     {
+        $meta = array_filter(compact('trace'));
         $res = [
-            'error' => [
-                'status' => $code,
-                'title' => $message,
-                'meta' => array_filter(compact('trace'))
-            ]
+            'error' => array_filter(compact('status', 'title', 'detail', 'code', 'meta'))
         ];
 
         return json_encode($res);

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
@@ -246,6 +246,7 @@ class JsonApiComponentTest extends TestCase
             'status' => '500',
             'title' => 'Example error',
             'detail' => 'Example description',
+            'code' => 'my-code',
             'meta' => [
                 'key' => 'Example metadata',
             ],
@@ -254,7 +255,7 @@ class JsonApiComponentTest extends TestCase
         $controller = new Controller();
         $component = new JsonApiComponent(new ComponentRegistry($controller), []);
 
-        $component->error(500, 'Example error', 'Example description', ['key' => 'Example metadata']);
+        $component->error(500, 'Example error', 'Example description', 'my-code', ['key' => 'Example metadata']);
 
         $this->assertEquals($expected, $controller->viewVars['_error']);
     }

--- a/plugins/BEdita/API/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Error/ExceptionRendererTest.php
@@ -99,7 +99,17 @@ class ExceptionRendererTest extends TestCase
                 ],
                 'new title',
                 '[field.cause]: err detail. [nestedFields.field2.cause2]: err detail2. [nestedFields.field3.cause3]: err detail3. '
-            ]
+            ],
+            'code' => [
+                ['title' => 'err title', 'code' => 'err-code'],
+                'err title',
+                null,
+                'err-code',
+            ],
+            'badCode' => [
+                ['title' => 'err title', 'code' => ['err-code']],
+                'err title',
+            ],
         ];
     }
 
@@ -109,14 +119,16 @@ class ExceptionRendererTest extends TestCase
      * @param string $errorMessage Expected error message.
      * @param string $title Expected error title.
      * @param string $detail Additional details.
+     * @param string $code Error code.
      * @return void
      *
      * @dataProvider errDetailsProvider
      * @covers ::render()
      * @covers ::_message()
      * @covers ::errorDetail()
+     * @covers ::appErrorCode()
      */
-    public function testErrorDetails($errorMessage, $title, $detail = '')
+    public function testErrorDetails($errorMessage, $title, $detail = '', $code = '')
     {
         $renderer = new ExceptionRenderer(new NotFoundException($errorMessage));
         $renderer->controller->request->env('HTTP_ACCEPT', 'application/json');
@@ -126,6 +138,13 @@ class ExceptionRendererTest extends TestCase
         $this->assertEquals($title, $responseBody['error']['title']);
         if ($detail) {
             $this->assertEquals($detail, $responseBody['error']['detail']);
+        } else {
+            $this->assertArrayNotHasKey('detail', $responseBody['error']);
+        }
+        if ($code) {
+            $this->assertEquals($code, $responseBody['error']['code']);
+        } else {
+            $this->assertArrayNotHasKey('code', $responseBody['error']);
         }
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Error/ExceptionRendererTest.php
@@ -322,13 +322,12 @@ class ExceptionRendererTest extends TestCase
         $this->assertArrayHasKey('error', $responseBody);
         $this->assertArrayHasKey('status', $responseBody['error']);
         $this->assertArrayHasKey('title', $responseBody['error']);
-        $this->assertArrayHasKey('meta', $responseBody['error']);
         $this->assertEquals(404, $responseBody['error']['status']);
         $this->assertEquals('test html', $responseBody['error']['title']);
-
         if (!$debug) {
-            $this->assertEmpty($responseBody['error']['meta']);
+            $this->assertArrayNotHasKey('meta', $responseBody['error']);
         } else {
+            $this->assertArrayHasKey('meta', $responseBody['error']);
             $this->assertNotEmpty($responseBody['error']['meta']);
             $this->assertArrayHasKey('trace', $responseBody['error']['meta']);
             $this->assertNotEmpty($responseBody['error']['meta']['trace']);


### PR DESCRIPTION
This PR solves #1237 

Throwing any Exception extending `CakeException` we can now add a `'code'` element that will be displayed in JSON API error output together with `status`, `title` and `detail`

An exception like:
```php
            throw new BadRequestException([
                'title' => 'bad request',
                'detail' => 'this was bad',
                'code' => 'error_code',
            ]);
```

will display:
```json
"error": {
   "status" : "400",
   "title": "bad request",
   "detail": "this was bad",
   "code": "error_code"
}
```