### PR TITLE
Group entity meta data in "relation" and "extra"

### DIFF
--- a/plugins/BEdita/API/src/Model/Action/UpdateAssociatedAction.php
+++ b/plugins/BEdita/API/src/Model/Action/UpdateAssociatedAction.php
@@ -114,7 +114,7 @@ class UpdateAssociatedAction extends BaseAction
                 );
             }
 
-            $meta = Hash::get($datum, '_meta');
+            $meta = Hash::get($datum, '_meta.relation');
             if (!$this->request->is('delete') && $association instanceof BelongsToMany && $meta !== null) {
                 $targetEntities[$id]->_joinData = $association->junction()->newEntity($meta);
             }

--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -125,9 +125,9 @@ class FilterQueryStringTest extends IntegrationTestCase
             $this->assertResponseCode(400);
         } else {
             $this->assertResponseCode(200);
-            static::assertEquals(count($expected), count($result['data']));
-            $resultDistance = Hash::extract($result['data'], '{n}.meta.distance');
-            static::assertEquals($expected, $resultDistance);
+            static::assertSame(count($expected), count($result['data']));
+            $resultDistance = Hash::extract($result['data'], '{n}.meta.extra.distance');
+            static::assertSame($expected, $resultDistance);
         }
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -797,9 +797,11 @@ class ObjectsControllerTest extends IntegrationTestCase
                         'published' => null,
                         'created_by' => 1,
                         'modified_by' => 1,
-                        'priority' => 1,
-                        'inv_priority' => 2,
-                        'params' => null,
+                        'relation' => [
+                            'priority' => 1,
+                            'inv_priority' => 2,
+                            'params' => null,
+                        ],
                     ],
                 ],
                 [
@@ -840,9 +842,11 @@ class ObjectsControllerTest extends IntegrationTestCase
                         'published' => null,
                         'created_by' => 1,
                         'modified_by' => 2,
-                        'priority' => 2,
-                        'inv_priority' => 1,
-                        'params' => null,
+                        'relation' => [
+                            'priority' => 2,
+                            'inv_priority' => 1,
+                            'params' => null,
+                        ],
                     ],
                 ],
             ],
@@ -902,9 +906,11 @@ class ObjectsControllerTest extends IntegrationTestCase
                         ],
                     ],
                     'meta' => [
-                        'priority' => 1,
-                        'inv_priority' => 2,
-                        'params' => null,
+                        'relation' => [
+                            'priority' => 1,
+                            'inv_priority' => 2,
+                            'params' => null,
+                        ],
                     ],
                 ],
                 [
@@ -928,9 +934,11 @@ class ObjectsControllerTest extends IntegrationTestCase
                         ],
                     ],
                     'meta' => [
-                        'priority' => 2,
-                        'inv_priority' => 1,
-                        'params' => null,
+                        'relation' => [
+                            'priority' => 2,
+                            'inv_priority' => 1,
+                            'params' => null,
+                        ],
                     ],
                 ],
             ],
@@ -1000,10 +1008,12 @@ class ObjectsControllerTest extends IntegrationTestCase
                         ],
                     ],
                     'meta' => [
-                        'priority' => 1,
-                        'inv_priority' => 2,
-                        'params' => [
-                            'gustavo' => 'supporto',
+                        'relation' => [
+                            'priority' => 1,
+                            'inv_priority' => 2,
+                            'params' => [
+                                'gustavo' => 'supporto',
+                            ],
                         ],
                     ],
                 ],
@@ -1019,10 +1029,12 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'id' => '4',
                 'type' => 'profiles',
                 'meta' => [
-                    'priority' => 1,
-                    'inv_priority' => 2,
-                    'params' => [
-                        'gustavo' => 'supporto',
+                    'relation' => [
+                        'priority' => 1,
+                        'inv_priority' => 2,
+                        'params' => [
+                            'gustavo' => 'supporto',
+                        ],
                     ],
                 ],
             ],
@@ -1065,10 +1077,12 @@ class ObjectsControllerTest extends IntegrationTestCase
                         ],
                     ],
                     'meta' => [
-                        'priority' => 1,
-                        'inv_priority' => 2,
-                        'params' => [
-                            'gustavo' => 'supporto',
+                        'relation' => [
+                            'priority' => 1,
+                            'inv_priority' => 2,
+                            'params' => [
+                                'gustavo' => 'supporto',
+                            ],
                         ],
                     ],
                 ],
@@ -1084,10 +1098,12 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'id' => '4',
                 'type' => 'profiles',
                 'meta' => [
-                    'priority' => 1,
-                    'inv_priority' => 2,
-                    'params' => [
-                        'gustavo' => 'supporto',
+                    'relation' => [
+                        'priority' => 1,
+                        'inv_priority' => 2,
+                        'params' => [
+                            'gustavo' => 'supporto',
+                        ],
                     ],
                 ],
             ],
@@ -1095,10 +1111,12 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'id' => '4',
                 'type' => 'profiles',
                 'meta' => [
-                    'priority' => 1,
-                    'inv_priority' => 2,
-                    'params' => [
-                        'gustavo' => 'supporto',
+                    'relation' => [
+                        'priority' => 1,
+                        'inv_priority' => 2,
+                        'params' => [
+                            'gustavo' => 'supporto',
+                        ],
                     ],
                 ],
             ],
@@ -1129,9 +1147,11 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'id' => '4',
                 'type' => 'profiles',
                 'meta' => [
-                    'priority' => 1,
-                    'inv_priority' => 2,
-                    'params' => null,
+                    'relation' => [
+                        'priority' => 1,
+                        'inv_priority' => 2,
+                        'params' => null,
+                    ],
                 ],
             ],
         ];
@@ -1238,10 +1258,12 @@ class ObjectsControllerTest extends IntegrationTestCase
                         ],
                     ],
                     'meta' => [
-                        'priority' => 1,
-                        'inv_priority' => 2,
-                        'params' => [
-                            'gustavo' => 'supporto',
+                        'relation' => [
+                            'priority' => 1,
+                            'inv_priority' => 2,
+                            'params' => [
+                                'gustavo' => 'supporto',
+                            ],
                         ],
                     ],
                 ],
@@ -1257,10 +1279,12 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'id' => '4',
                 'type' => 'profiles',
                 'meta' => [
-                    'priority' => 1,
-                    'inv_priority' => 2,
-                    'params' => [
-                        'gustavo' => 'supporto',
+                    'relation' => [
+                        'priority' => 1,
+                        'inv_priority' => 2,
+                        'params' => [
+                            'gustavo' => 'supporto',
+                        ],
                     ],
                 ],
             ],
@@ -1321,18 +1345,22 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'id' => '4',
                 'type' => 'profiles',
                 'meta' => [
-                    'priority' => 1,
-                    'inv_priority' => 2,
-                    'params' => null,
+                    'relation' => [
+                        'priority' => 1,
+                        'inv_priority' => 2,
+                        'params' => null,
+                    ],
                 ],
             ],
             [
                 'id' => '3',
                 'type' => 'documents',
                 'meta' => [
-                    'priority' => 2,
-                    'inv_priority' => 1,
-                    'params' => null,
+                    'relation' => [
+                        'priority' => 2,
+                        'inv_priority' => 1,
+                        'params' => null,
+                    ],
                 ],
             ],
         ];
@@ -1605,9 +1633,11 @@ class ObjectsControllerTest extends IntegrationTestCase
                         'published' => null,
                         'created_by' => 1,
                         'modified_by' => 1,
-                        'priority' => 1,
-                        'inv_priority' => 2,
-                        'params' => null,
+                        'relation' => [
+                            'priority' => 1,
+                            'inv_priority' => 2,
+                            'params' => null,
+                        ],
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/profiles/4',
@@ -1642,9 +1672,11 @@ class ObjectsControllerTest extends IntegrationTestCase
                         'published' => null,
                         'created_by' => 1,
                         'modified_by' => 2,
-                        'priority' => 2,
-                        'inv_priority' => 1,
-                        'params' => null,
+                        'relation' => [
+                            'priority' => 2,
+                            'inv_priority' => 1,
+                            'params' => null,
+                        ],
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/documents/3',

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
@@ -102,7 +102,7 @@ trait JsonApiTrait
      * @param string $property Property name.
      * @return mixed
      */
-    abstract public function get($property);
+    abstract public function &get($property);
 
     /**
      * Getter for `id`.

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
@@ -34,11 +34,25 @@ trait JsonApiTrait
 {
 
     /**
+     * Getter for entity's visible properties.
+     *
+     * @return string[]
+     */
+    abstract public function visibleProperties();
+
+    /**
      * Getter for entity's hidden properties.
      *
      * @return string[]
      */
     abstract public function getHidden();
+
+    /**
+     * Getter for entity's virtual properties.
+     *
+     * @return string[]
+     */
+    abstract public function getVirtual();
 
     /**
      * Getter for source model registry alias.
@@ -64,6 +78,31 @@ trait JsonApiTrait
      * @return bool
      */
     abstract public function isAccessible($property);
+
+    /**
+     * Extract properties from an entity.
+     *
+     * @param array $properties List of properties to extract
+     * @param bool $onlyDirty Return only dirty properties.
+     * @return array
+     */
+    abstract public function extract(array $properties, $onlyDirty = false);
+
+    /**
+     * Check if a property exists.
+     *
+     * @param string $property Property name.
+     * @return bool
+     */
+    abstract public function has($property);
+
+    /**
+     * Getter for a property.
+     *
+     * @param string $property Property name.
+     * @return mixed
+     */
+    abstract public function get($property);
 
     /**
      * Getter for `id`.

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -323,6 +323,105 @@ class JsonApiTraitTest extends TestCase
     }
 
     /**
+     * Test getter for meta fields.
+     *
+     * @return void
+     *
+     * @covers ::getMeta()
+     */
+    public function testGetMetaExtra()
+    {
+        $expected = [
+            'created',
+            'modified',
+            'unchangeable',
+            'extra',
+        ];
+        $expectedExtra = ['my_computed_field' => pi()];
+
+        $role = $this->Roles->get(1)
+            ->set('my_computed_field', pi())
+            ->jsonApiSerialize();
+
+        $meta = array_keys(Hash::get($role, 'meta', []));
+        $extra = Hash::get($role, 'meta.extra');
+
+        static::assertEquals($expected, $meta, '', 0, 10, true);
+        static::assertSame($expectedExtra, $extra);
+    }
+
+    /**
+     * Test getter for meta fields.
+     *
+     * @return void
+     *
+     * @covers ::getMeta()
+     */
+    public function testGetMetaEmptyJoinData()
+    {
+        $expected = [
+            'blocked',
+            'created',
+            'created_by',
+            'last_login',
+            'last_login_err',
+            'locked',
+            'modified',
+            'modified_by',
+            'num_login_err',
+            'published',
+        ];
+
+        $user = $this->Roles->get(1, ['contain' => ['Users']])
+            ->users[0]
+            ->jsonApiSerialize();
+
+        $meta = array_keys(Hash::get($user, 'meta', []));
+
+        static::assertEquals($expected, $meta, '', 0, 10, true);
+    }
+
+    /**
+     * Test getter for meta fields.
+     *
+     * @return void
+     *
+     * @covers ::getMeta()
+     */
+    public function testGetMetaJoinData()
+    {
+        $expected = [
+            'blocked',
+            'created',
+            'created_by',
+            'last_login',
+            'last_login_err',
+            'locked',
+            'modified',
+            'modified_by',
+            'num_login_err',
+            'published',
+            'relation',
+        ];
+        $expectedRelation = [
+            'id',
+            'role_id',
+            'user_id',
+        ];
+
+        $user = $this->Roles->get(1, ['contain' => ['Users']])
+            ->users[0];
+        $user->_joinData->setHidden([]);
+        $user = $user->jsonApiSerialize();
+
+        $meta = array_keys(Hash::get($user, 'meta', []));
+        $relation = array_keys(Hash::get($user, 'meta.relation', []));
+
+        static::assertEquals($expected, $meta, '', 0, 10, true);
+        static::assertEquals($expectedRelation, $relation, '', 0, 10, true);
+    }
+
+    /**
      * Data provider for `testJsonApiSerialize` test case.
      *
      * @return array


### PR DESCRIPTION
This PR resolves #1230 by introducing entities metadata sub-groups:

- relationship metadata is moved to `meta.relation` sub-group
- computed fields (including fields that have been added by custom finders, e.g. `distance`, added by `findGeo` for Locations) are moved to `meta.extra` sub-group

Since it would be hard to tell filter-added computed fields from other, I have merged `meta.filter` and `meta.extra`. If necessary, we can split them, but this would require additional entity-level configuration.

**NOTE**: relation metadata has been moved to `meta.relation` _both in read and write contexts_!!