### PR TITLE
Fix issue when obtaining a copy of query object not yet CTI-fixed

### DIFF
--- a/plugins/BEdita/Core/src/ORM/Inheritance/Query.php
+++ b/plugins/BEdita/Core/src/ORM/Inheritance/Query.php
@@ -306,4 +306,14 @@ class Query extends CakeQuery
 
         return $field;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function cleanCopy()
+    {
+        $this->triggerBeforeFind();
+
+        return parent::cleanCopy();
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/QueryTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/QueryTest.php
@@ -464,4 +464,35 @@ class QueryTest extends TestCase
         $sql = preg_replace('/(\s){2,}/', ' ', $sql);
         $this->assertEquals($expected, $sql);
     }
+
+    /**
+     * Test method to get clean copy of query object.
+     *
+     * @return void
+     *
+     * @covers ::cleanCopy()
+     */
+    public function testCleanCopy()
+    {
+        $expectedBefore = [
+            'FakeArticles' => [],
+        ];
+        $expectedAfter = [
+            'FakeMammals' => [
+                'FakeAnimals' => [
+                    'FakeArticles' => [],
+                ],
+            ],
+        ];
+
+        $query = $this->fakeFelines->find()
+            ->contain('FakeArticles');
+
+        static::assertSame($expectedBefore, $query->getEagerLoader()->contain());
+
+        $clone = $query->cleanCopy();
+
+        static::assertSame($expectedAfter, $query->getEagerLoader()->contain());
+        static::assertSame($expectedAfter, $clone->getEagerLoader()->contain());
+    }
 }


### PR DESCRIPTION
This PR resolves an issue caused by recent updates in CakePHP 3.4.7, that caused contained associations not to be properly fixed when a `count()` was performed on a query object _before_ it had been executed otherwise.