### PR TITLE
Allow JSON configuration to help automated systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /composer.lock
 /composer.local.json
 /config/app.php
+/config/app.json
 /coverage/*
 /docs/*
 /index.html

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -55,6 +55,7 @@ use BEdita\Core\Plugin;
 use Cake\Cache\Cache;
 use Cake\Console\ConsoleErrorHandler;
 use Cake\Core\Configure;
+use Cake\Core\Configure\Engine\JsonConfig;
 use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Database\Type;
 use Cake\Datasource\ConnectionManager;
@@ -77,6 +78,13 @@ try {
     Configure::load('app', 'default', false);
 } catch (\Exception $e) {
     exit($e->getMessage() . "\n");
+}
+
+try {
+    Configure::config('json', new JsonConfig());
+    Configure::load('app', 'json');
+} catch (\Exception $e) {
+    // Do not halt if `app.json` is missing.
 }
 
 /*


### PR DESCRIPTION
This PR adds `config/app.json` to the list of files ignored by Git, and attempts to load the file on application bootstrap.

This basically makes it possible to add an `app.json` file to add pieces of configuration when bootstrapping the application. This makes it easier to manage BEdita configuration using automated systems such as Ansible, Puppet, Chef, etc.