### PR TITLE
User data in signup response

### DIFF
--- a/plugins/BEdita/API/src/Controller/SignupController.php
+++ b/plugins/BEdita/API/src/Controller/SignupController.php
@@ -37,7 +37,7 @@ class SignupController extends AppController
     /**
      * Signup action.
      *
-     * @return \Cake\Http\Response
+     * @return void
      */
     public function signup()
     {
@@ -53,11 +53,14 @@ class SignupController extends AppController
         $urlOptions += ['activation_url' => Router::url(['_name' => 'api:signup'], true)];
 
         $action = new SignupUserAction();
-        $action([
+        $user = $action->execute([
             'data' => $data,
             'urlOptions' => $urlOptions
         ]);
 
-        return $this->response->withStatus(202);
+        $this->response = $this->response->withStatus(202);
+
+        $this->set('data', $user);
+        $this->set('_serialize', ['data']);
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
@@ -14,7 +14,6 @@ namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
 use Cake\Mailer\Email;
-use Cake\ORM\TableRegistry;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\SignupController
@@ -55,7 +54,19 @@ class SignupControllerTest extends IntegrationTestCase
             ],
             'ok' => [
                 202,
-                null,
+                [
+                    'data' => [
+                        'type' => 'users',
+                        'attributes' => [
+                            'username' => 'gustavo',
+                            'email' => 'gus.sup@channelweb.it',
+                        ],
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/signup',
+                        'home' => 'http://api.example.com/home',
+                    ],
+                ],
                 'POST',
                 [
                     'type' => 'users',
@@ -68,7 +79,19 @@ class SignupControllerTest extends IntegrationTestCase
             ],
             'ok with activation_url' => [
                 202,
-                null,
+                [
+                    'data' => [
+                        'type' => 'users',
+                        'attributes' => [
+                            'username' => 'gustavo',
+                            'email' => 'gus.sup@channelweb.it',
+                        ],
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/signup',
+                        'home' => 'http://api.example.com/home',
+                    ],
+                ],
                 'POST',
                 [
                     'type' => 'users',
@@ -84,7 +107,19 @@ class SignupControllerTest extends IntegrationTestCase
             ],
             'ok with activation_url and redirect_url' => [
                 202,
-                null,
+                [
+                    'data' => [
+                        'type' => 'users',
+                        'attributes' => [
+                            'username' => 'gustavo',
+                            'email' => 'gus.sup@channelweb.it',
+                        ],
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/signup',
+                        'home' => 'http://api.example.com/home',
+                    ],
+                ],
                 'POST',
                 [
                     'type' => 'users',
@@ -169,7 +204,8 @@ class SignupControllerTest extends IntegrationTestCase
     /**
      * Test /signup endpoint
      *
-     * @param int $expected The expected status code
+     * @param int $statusCode Expected status code.
+     * @param int $expected The expected content
      * @param string $method The HTTP method
      * @param array $data The payload to send
      * @return void
@@ -194,7 +230,11 @@ class SignupControllerTest extends IntegrationTestCase
         $this->assertContentType('application/vnd.api+json');
 
         if ($statusCode === 202) {
-            static::assertNull($result);
+            static::assertArrayNotHasKey('error', $result);
+            static::assertArrayHasKey('links', $result);
+            static::assertArrayHasKey('data', $result);
+            static::assertEquals($expected['links'], $result['links']);
+            static::assertArraySubset($expected['data'], $result['data']);
         } else {
             static::assertArrayNotHasKey('data', $result);
             static::assertArrayHasKey('links', $result);

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -57,6 +57,7 @@ class SignupUserAction extends BaseAction
     /**
      * {@inheritDoc}
      *
+     * @return \BEdita\Core\Model\Entity\User
      * @throws \Cake\Network\Exception\BadRequestException When validation of `$data['urlOptions']` fails
      */
     public function execute(array $data = [])
@@ -70,13 +71,15 @@ class SignupUserAction extends BaseAction
             ]);
         }
 
-        return $this->Users->getConnection()->transactional(function () use ($data) {
+        $userId = $this->Users->getConnection()->transactional(function () use ($data) {
             $user = $this->createUser($data['data']);
             $job = $this->createSignupJob($user);
             $this->sendMail($user, $job, $data['urlOptions']);
 
-            return compact('user', 'job');
+            return $user->id;
         });
+
+        return (new GetObjectAction(['table' => $this->Users]))->execute(['primaryKey' => $userId]);
     }
 
     /**
@@ -143,7 +146,7 @@ class SignupUserAction extends BaseAction
      * The user is validated using 'signup' validation.
      *
      * @param array $data The data to save
-     * @return mixed
+     * @return \BEdita\Core\Model\Entity\User
      */
     protected function createUser(array $data)
     {
@@ -167,7 +170,7 @@ class SignupUserAction extends BaseAction
      * Create the signup async job
      *
      * @param User $user The user created
-     * @return mixed
+     * @return \BEdita\Core\Model\Entity\AsyncJob
      */
     protected function createSignupJob(User $user)
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -14,12 +14,10 @@
 namespace BEdita\Core\Test\TestCase\Model\Action;
 
 use BEdita\Core\Model\Action\SignupUserAction;
-use BEdita\Core\Model\Entity\AsyncJob;
 use BEdita\Core\Model\Entity\User;
 use Cake\Mailer\Email;
 use Cake\Network\Exception\BadRequestException;
 use Cake\Network\Exception\InternalErrorException;
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -48,7 +46,7 @@ class SignupUserActionTest extends TestCase
     /**
      * Provider for `testExecute()`
      *
-     * @return void
+     * @return array
      */
     public function executeProvider()
     {
@@ -142,8 +140,7 @@ class SignupUserActionTest extends TestCase
         $result = $action($data);
 
         static::assertTrue((bool)$result);
-        static::assertInstanceOf(User::class, $result['user']);
-        static::assertInstanceOf(AsyncJob::class, $result['job']);
+        static::assertInstanceOf(User::class, $result);
     }
 
     /**
@@ -161,7 +158,7 @@ class SignupUserActionTest extends TestCase
 
         $mock->method('getMailer')->will($this->throwException(new InternalErrorException));
 
-        $mock([
+        $mock->execute([
             'data' => [
                 'username' => 'testsignup',
                 'password_hash' => 'testsignup',


### PR DESCRIPTION
After a `POST /signup` request, user data is present in response.