### PR TITLE
Fix wrong field alias with query string search on deeply-inherited tables

### DIFF
--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -124,7 +124,7 @@ class ObjectsController extends ResourcesController
                 );
         } else {
             // List existing entities.
-            $filter = $this->request->getQuery('filter');
+            $filter = (array)$this->request->getQuery('filter') + array_filter(['query' => $this->request->getQuery('q')]);
             $include = $this->request->getQuery('include');
             $contain = $include ? $this->prepareInclude($include) : [];
 
@@ -192,7 +192,7 @@ class ObjectsController extends ResourcesController
         $relatedId = $this->request->getParam('related_id');
 
         $association = $this->findAssociation($relationship);
-        $filter = $this->request->getQuery('filter');
+        $filter = (array)$this->request->getQuery('filter') + array_filter(['query' => $this->request->getQuery('q')]);
 
         $action = new ListRelatedObjectsAction(compact('association'));
         $query = $action(['primaryKey' => $relatedId, 'filter' => $filter]);
@@ -230,7 +230,7 @@ class ObjectsController extends ResourcesController
 
             case 'GET':
             default:
-                $filter = $this->request->getQuery('filter');
+                $filter = (array)$this->request->getQuery('filter') + array_filter(['query' => $this->request->getQuery('q')]);
 
                 $action = new ListRelatedObjectsAction(compact('association'));
                 $data = $action(['primaryKey' => $id, 'list' => true, 'filter' => $filter]);

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -177,7 +177,7 @@ abstract class ResourcesController extends AppController
                 );
         } else {
             // List existing entities.
-            $filter = $this->request->getQuery('filter');
+            $filter = (array)$this->request->getQuery('filter') + array_filter(['query' => $this->request->getQuery('q')]);
             $include = $this->request->getQuery('include');
             $contain = $include ? $this->prepareInclude($include) : [];
 
@@ -256,7 +256,7 @@ abstract class ResourcesController extends AppController
         $relatedId = $this->request->getParam('related_id');
 
         $association = $this->findAssociation($relationship);
-        $filter = $this->request->getQuery('filter');
+        $filter = (array)$this->request->getQuery('filter') + array_filter(['query' => $this->request->getQuery('q')]);
 
         $action = new ListAssociatedAction(compact('association'));
         $query = $action->execute(['primaryKey' => $relatedId, 'filter' => $filter]);
@@ -301,7 +301,7 @@ abstract class ResourcesController extends AppController
 
             case 'GET':
             default:
-                $filter = $this->request->getQuery('filter');
+                $filter = (array)$this->request->getQuery('filter') + array_filter(['query' => $this->request->getQuery('q')]);
 
                 $action = new ListAssociatedAction(compact('association'));
                 $data = $action(['primaryKey' => $id, 'list' => true, 'filter' => $filter]);

--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -240,4 +240,26 @@ class FilterQueryStringTest extends IntegrationTestCase
         static::assertArrayHasKey('data', $result);
         static::assertEquals($expected, Hash::extract($result['data'], '{n}.id'), '', 0, 10, true);
     }
+
+    /**
+     * Test finder of users by query string.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testFindQueryUsers()
+    {
+        $expected = [5];
+        $this->configRequestHeaders();
+
+        $this->get('/users?filter[query]=second');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        static::assertArrayHasKey('data', $result);
+        static::assertEquals($expected, Hash::extract($result['data'], '{n}.id'), '', 0, 10, true);
+    }
 }

--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -262,4 +262,26 @@ class FilterQueryStringTest extends IntegrationTestCase
         static::assertArrayHasKey('data', $result);
         static::assertEquals($expected, Hash::extract($result['data'], '{n}.id'), '', 0, 10, true);
     }
+
+    /**
+     * Test finder of objects by query string using shorthand `?q=` query parameter.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testFindQueryAlias()
+    {
+        $expected = [2, 3, 9];
+        $this->configRequestHeaders();
+
+        $this->get('/objects?q=here');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        static::assertArrayHasKey('data', $result);
+        static::assertEquals($expected, Hash::extract($result['data'], '{n}.id'), '', 0, 10, true);
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
@@ -159,8 +159,25 @@ class SearchableBehavior extends Behavior
             ]);
         }
 
+        $table = $this->getTable();
+        $tables = array_reverse(
+            array_merge(
+                [$table],
+                ($table instanceof InheritanceTable) ? $table->inheritedTables() : []
+            )
+        );
+        $aliasField = function ($field) use ($tables) {
+            /* @var \Cake\ORM\Table $table */
+            foreach ($tables as $table) {
+                if ($table->hasField($field, false)) {
+                    return $table->aliasField($field);
+                }
+            }
+
+            return $field;
+        };
         $fields = array_map( // Alias fields to avoid ambiguities.
-            [$this->getTable(), 'aliasField'],
+            $aliasField,
             array_keys($this->getFields())
         );
 

--- a/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
@@ -160,12 +160,7 @@ class SearchableBehavior extends Behavior
         }
 
         $table = $this->getTable();
-        $tables = array_reverse(
-            array_merge(
-                [$table],
-                ($table instanceof InheritanceTable) ? $table->inheritedTables() : []
-            )
-        );
+        $tables = array_reverse(($table instanceof InheritanceTable) ? $table->inheritedTables() : []);
         $aliasField = function ($field) use ($tables) {
             /* @var \Cake\ORM\Table $table */
             foreach ($tables as $table) {
@@ -174,7 +169,7 @@ class SearchableBehavior extends Behavior
                 }
             }
 
-            return $field;
+            return $this->getTable()->aliasField($field);
         };
         $fields = array_map( // Alias fields to avoid ambiguities.
             $aliasField,


### PR DESCRIPTION
This PR is basically an ugly workaround to alias fields the right way.

Visiting `GET /users?filter[query]=gustavo` now causes a 500 Internal Server Error because some fields are improperly aliased with `Profiles` instead of `Objects`. This happens for any table inheritance chain deeper than two levels.

Not any more! Thanks to this ugly PR, you shall be able to correctly search for Gustavo. (Hint: he's at the toilet.)