### PR TITLE
Improve search

### DIFF
--- a/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
@@ -176,7 +176,7 @@ class SearchableBehavior extends Behavior
         // Concat all fields into a single, lower-cased string.
         $fields = [];
         foreach (array_keys($this->getFields()) as $field) {
-            $fields[] = new FunctionExpression('IFNULL', [
+            $fields[] = $query->func()->coalesce([
                 $aliasField($field) => 'identifier',
                 '',
             ]);

--- a/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
@@ -159,6 +159,7 @@ class SearchableBehavior extends Behavior
             ]);
         }
 
+        // Prepare fields aliasing function to avoid ambiguities.
         $table = $this->getTable();
         $tables = array_reverse(($table instanceof InheritanceTable) ? $table->inheritedTables() : []);
         $aliasField = function ($field) use ($tables) {
@@ -171,29 +172,30 @@ class SearchableBehavior extends Behavior
 
             return $this->getTable()->aliasField($field);
         };
-        $fields = array_map( // Alias fields to avoid ambiguities.
-            $aliasField,
-            array_keys($this->getFields())
-        );
+
+        // Concat all fields into a single, lower-cased string.
+        $fields = [];
+        foreach (array_keys($this->getFields()) as $field) {
+            $fields[] = new FunctionExpression('IFNULL', [
+                $aliasField($field) => 'identifier',
+                '',
+            ]);
+            $fields[] = ' '; // Add a spacer.
+        }
+        array_pop($fields); // Remove last spacer.
+        $field = new FunctionExpression('LOWER', [$query->func()->concat($fields)]);
 
         // Build query conditions.
         return $query
-            ->where(function (QueryExpression $exp) use ($fields, $words) {
-                $groups = [];
-                foreach ($fields as $field) {
-                    $groups[] = $exp->and_(function (QueryExpression $exp) use ($field, $words) {
-                        foreach ($words as $word) {
-                            $exp = $exp->like(
-                                new FunctionExpression('LOWER', [$field => 'identifier']),
-                                sprintf('%%%s%%', $word)
-                            );
-                        }
-
-                        return $exp;
-                    });
+            ->where(function (QueryExpression $exp) use ($field, $words) {
+                foreach ($words as $word) {
+                    $exp->like(
+                        $field,
+                        sprintf('%%%s%%', $word)
+                    );
                 }
 
-                return $exp->or_($groups);
+                return $exp;
             });
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
@@ -45,8 +45,10 @@ class SearchableBehaviorTest extends TestCase
         parent::setUp();
 
         TableRegistry::get('FakeMammals', ['className' => Table::class])
+            ->setDisplayField('name')
             ->extensionOf('FakeAnimals');
         TableRegistry::get('FakeFelines', ['className' => Table::class])
+            ->setDisplayField('name')
             ->extensionOf('FakeMammals');
     }
 
@@ -160,6 +162,13 @@ class SearchableBehaviorTest extends TestCase
             'two words' => [
                 [],
                 'koala eagle',
+            ],
+            'two words, different fields' => [
+                [
+                    1 => 'cat',
+                ],
+                'eutheria cat',
+                'FakeMammals',
             ],
             'bad type' => [
                 new BadFilterException([


### PR DESCRIPTION
This PR improves accuracy of `?filter[query]`. Search is now performed by concatenating all columns in which user is searching, and requiring presence of all terms in the resulting string.

For instance, an object with title "gustavo" and description "supporto", for search purposes is seen as the string "gustavo supporto".

This has a drawback, since it defies the purpose of indexing fields. However, some of the involved fields might not be indexed at all, therefore this should be an acceptable cost — I haven't run any benchmark, but I don't expect this to cause a significant deterioration of performances.