### PR TITLE
Finder for my objects

### DIFF
--- a/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
@@ -118,7 +118,7 @@ class ApplicationsTable extends Table
      * @param array $options Options array. It requires an `apiKey` key.
      * @return \Cake\ORM\Query
      */
-    public function findApiKey(Query $query, array $options)
+    protected function findApiKey(Query $query, array $options)
     {
         if (empty($options['apiKey']) || !is_string($options['apiKey'])) {
             throw new \BadMethodCallException('Required option "apiKey" must be a not empty string');

--- a/plugins/BEdita/Core/src/Model/Table/AuthProvidersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/AuthProvidersTable.php
@@ -113,7 +113,7 @@ class AuthProvidersTable extends Table
      * @param \Cake\ORM\Query $query Query object.
      * @return \Cake\ORM\Query
      */
-    public function findAuthenticate(Query $query)
+    protected function findAuthenticate(Query $query)
     {
         return $query->formatResults(function (ResultSetInterface $results) {
             return $results

--- a/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
@@ -122,7 +122,7 @@ class DateRangesTable extends Table
      * @return \Cake\ORM\Query
      * @throws \BEdita\Core\Exception\BadFilterException
      */
-    public function findDateRanges(Query $query, array $options)
+    protected function findDateRanges(Query $query, array $options)
     {
         $options = array_intersect_key($options, array_flip(['start_date', 'end_date']));
         $options = array_combine(

--- a/plugins/BEdita/Core/src/Model/Table/EndpointPermissionsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/EndpointPermissionsTable.php
@@ -95,7 +95,7 @@ class EndpointPermissionsTable extends Table
      * @param array $options Additional options.
      * @return \Cake\ORM\Query
      */
-    public function findByEndpoint(Query $query, array $options)
+    protected function findByEndpoint(Query $query, array $options)
     {
         $field = $this->aliasField($this->Endpoints->getForeignKey());
         $ids = array_filter((array)Hash::get($options, 'endpointIds', []));
@@ -132,7 +132,7 @@ class EndpointPermissionsTable extends Table
      * @param array $options Additional options.
      * @return \Cake\ORM\Query
      */
-    public function findByApplication(Query $query, array $options)
+    protected function findByApplication(Query $query, array $options)
     {
         $field = $this->aliasField($this->Applications->getForeignKey());
         $id = Hash::get($options, 'applicationId');
@@ -169,7 +169,7 @@ class EndpointPermissionsTable extends Table
      * @param array $options Additional options.
      * @return \Cake\ORM\Query
      */
-    public function findByRole(Query $query, array $options)
+    protected function findByRole(Query $query, array $options)
     {
         $field = $this->aliasField($this->Roles->getForeignKey());
         $ids = array_filter((array)Hash::get($options, 'roleIds', []));

--- a/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
@@ -210,10 +210,9 @@ class ObjectTypesTable extends Table
      *
      * @param \Cake\Event\Event $event Triggered event.
      * @param \Cake\Datasource\EntityInterface $entity Subject entity.
-     * @param \ArrayObject $options Additional options.
      * @return void
      */
-    public function afterSave(Event $event, EntityInterface $entity, \ArrayObject $options)
+    public function afterSave(Event $event, EntityInterface $entity)
     {
         Cache::delete('id_' . $entity->id, self::CACHE_CONFIG);
         if ($entity->dirty('name')) {
@@ -229,10 +228,9 @@ class ObjectTypesTable extends Table
      *
      * @param \Cake\Event\Event $event Triggered event.
      * @param \Cake\Datasource\EntityInterface $entity Subject entity.
-     * @param \ArrayObject $options Additional options.
      * @return void
      */
-    public function afterDelete(Event $event, EntityInterface $entity, \ArrayObject $options)
+    public function afterDelete(Event $event, EntityInterface $entity)
     {
         Cache::delete('id_' . $entity->id, self::CACHE_CONFIG);
         Cache::delete('map', self::CACHE_CONFIG);

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -15,6 +15,7 @@ namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Model\Entity\ObjectEntity;
 use BEdita\Core\Model\Validation\ObjectsValidator;
+use BEdita\Core\Utility\LoggedUser;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\TableSchema;
 use Cake\ORM\Query;
@@ -146,7 +147,7 @@ class ObjectsTable extends Table
      * @param array $options Array of acceptable object types.
      * @return \Cake\ORM\Query
      */
-    public function findType(Query $query, array $options)
+    protected function findType(Query $query, array $options)
     {
         foreach ($options as &$type) {
             $type = $this->ObjectTypes->get($type)->id;
@@ -169,12 +170,25 @@ class ObjectsTable extends Table
      * @param array $options Array of acceptable date range conditions.
      * @return \Cake\ORM\Query
      */
-    public function findDateRanges(Query $query, array $options)
+    protected function findDateRanges(Query $query, array $options)
     {
         return $query
             ->distinct([$this->aliasField($this->getPrimaryKey())])
             ->innerJoinWith('DateRanges', function (Query $query) use ($options) {
                 return $query->find('dateRanges', $options);
             });
+    }
+
+    /**
+     * Finder for my objects (i.e.: user created by logged-in user)
+     *
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @return \Cake\ORM\Query
+     */
+    protected function findMine(Query $query)
+    {
+        return $query->where(function (QueryExpression $exp) {
+            return $exp->eq($this->aliasField($this->CreatedByUser->getForeignKey()), LoggedUser::id());
+        });
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -15,6 +15,8 @@ namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Model\Validation\UsersValidator;
 use BEdita\Core\ORM\Inheritance\Table;
+use BEdita\Core\Utility\LoggedUser;
+use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
@@ -198,6 +200,19 @@ class UsersTable extends Table
             }
 
             return $query;
+        });
+    }
+
+    /**
+     * Finder for my users. This only returns the currently logged in user.
+     *
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @return \Cake\ORM\Query
+     */
+    protected function findMine(Query $query)
+    {
+        return $query->where(function (QueryExpression $exp) {
+            return $exp->eq($this->aliasField((string)$this->getPrimaryKey()), LoggedUser::id());
         });
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -50,6 +50,7 @@ class ObjectsTableTest extends TestCase
     public function tearDown()
     {
         unset($this->Objects);
+        LoggedUser::resetUser();
 
         parent::tearDown();
     }
@@ -244,5 +245,26 @@ class ObjectsTableTest extends TestCase
         static::assertCount(1, $object->date_ranges);
         static::assertSame(1, $this->Objects->DateRanges->find()->where(['object_id' => $object->id])->count());
         static::assertSame(0, $this->Objects->DateRanges->find()->where(['object_id IS' => null])->count());
+    }
+
+    /**
+     * Test finder for my objects.
+     *
+     * @return void
+     *
+     * @covers ::findMine()
+     */
+    public function testFindMine()
+    {
+        $expected = $this->Objects->find()
+            ->find('list', ['keyField' => 'id', 'valueField' => 'id'])
+            ->where(['created_by' => 1])
+            ->toArray();
+
+        $result = $this->Objects->find('mine')
+            ->find('list', ['keyField' => 'id', 'valueField' => 'id'])
+            ->toArray();
+
+        static::assertEquals($expected, $result);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
@@ -41,6 +41,9 @@ class RolesTableTest extends TestCase
         'plugin.BEdita/Core.object_types',
         'plugin.BEdita/Core.relations',
         'plugin.BEdita/Core.relation_types',
+        'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.profiles',
+        'plugin.BEdita/Core.users',
         'plugin.BEdita/Core.roles',
         'plugin.BEdita/Core.roles_users',
     ];

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
+use BEdita\Core\Utility\LoggedUser;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -41,6 +42,7 @@ class RolesTableTest extends TestCase
         'plugin.BEdita/Core.relations',
         'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.roles',
+        'plugin.BEdita/Core.roles_users',
     ];
 
     /**
@@ -49,7 +51,9 @@ class RolesTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
+
         $this->Roles = TableRegistry::get('Roles');
+        LoggedUser::setUser(['id' => 1]);
     }
 
     /**
@@ -58,6 +62,7 @@ class RolesTableTest extends TestCase
     public function tearDown()
     {
         unset($this->Roles);
+        LoggedUser::resetUser();
 
         parent::tearDown();
     }
@@ -119,12 +124,32 @@ class RolesTableTest extends TestCase
         $role = $this->Roles->newEntity();
         $this->Roles->patchEntity($role, $data);
 
-        $error = (bool)$role->errors();
-        $this->assertEquals($expected, !$error);
+        $error = (bool)$role->getErrors();
+        static::assertEquals($expected, !$error);
 
         if ($expected) {
             $success = $this->Roles->save($role);
-            $this->assertTrue((bool)$success);
+            static::assertTrue((bool)$success);
         }
+    }
+
+    /**
+     * Test finder for my objects.
+     *
+     * @return void
+     *
+     * @covers ::findMine()
+     */
+    public function testFindMine()
+    {
+        $expected = [
+            1 => 1,
+        ];
+
+        $result = $this->Roles->find('mine')
+            ->find('list', ['keyField' => 'id', 'valueField' => 'id'])
+            ->toArray();
+
+        static::assertEquals($expected, $result);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -320,4 +320,24 @@ class UsersTableTest extends TestCase
             $this->assertTrue((bool)$success);
         }
     }
+
+    /**
+     * Test finder for my objects.
+     *
+     * @return void
+     *
+     * @covers ::findMine()
+     */
+    public function testFindMine()
+    {
+        $expected = [
+            1 => 1,
+        ];
+
+        $result = $this->Users->find('mine')
+            ->find('list', ['keyField' => 'id', 'valueField' => 'id'])
+            ->toArray();
+
+        static::assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
This PR implements several `findMine` custom finders.

These finders should be used by a logged user to filter results by "property".

Examples:
- `GET /objects?filter[mine]` will return only objects created by the user
- `GET /users?filter[mine]` will return only the current user (my user is the user I'm logged in with, right? 🙃 )
- `GET /roles?filter[mine]` will return only roles associated to the current user (my roles are the role I am associated to)

Models that inherit from Objects can declare their own `findMine` finder to customize logic, when needed. For instance, an hypothetical "Animals" object model might want to return only Animals that are related to the current user via some custom relation, even if they haven't been created by the user.

This finder _might_ be used in the future to enforce security policies on endpoint permissions when permission is `mine`.