### PR TITLE
Honour `useImmutable` preference in `DateTimeType`

### DIFF
--- a/plugins/BEdita/Core/src/Database/Type/DateTimeType.php
+++ b/plugins/BEdita/Core/src/Database/Type/DateTimeType.php
@@ -14,8 +14,6 @@
 namespace BEdita\Core\Database\Type;
 
 use Cake\Database\Type\DateTimeType as CakeDateTimeType;
-use Cake\I18n\Time;
-use DateTimeInterface;
 
 /**
  * Custom DateTimeType class with simplified marshal
@@ -38,17 +36,20 @@ class DateTimeType extends CakeDateTimeType
      */
     public function marshal($value)
     {
-        if ($value instanceof DateTimeInterface) {
+        if ($value instanceof \DateTimeInterface) {
             return $value;
         }
 
-        if (preg_match('/^\d{4}(-\d\d(-\d\d([T ]\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?)?$/i', $value)) {
-            $value = Time::parse($value);
+        if (is_string($value) && preg_match('/^\d{4}(-\d\d(-\d\d([T ]\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?)?$/i', $value)) {
+            /* @var \Cake\I18n\Time|\Cake\I18n\FrozenTime $value */
+            $value = call_user_func([$this->getDateTimeClassName(), 'parse'], $value);
             if ($value->getTimezone()->getName() === 'Z') {
                 $value = $value->setTimezone('UTC');
             }
+
+            return $value;
         }
 
-        return $value;
+        return null;
     }
 }

--- a/plugins/BEdita/Core/src/Model/Entity/DateRange.php
+++ b/plugins/BEdita/Core/src/Model/Entity/DateRange.php
@@ -13,7 +13,6 @@
 
 namespace BEdita\Core\Model\Entity;
 
-use Cake\I18n\Time;
 use Cake\ORM\Entity;
 
 /**
@@ -21,8 +20,8 @@ use Cake\ORM\Entity;
  *
  * @property int $id
  * @property int $object_id
- * @property \Cake\I18n\Time $start_date
- * @property \Cake\I18n\Time|null $end_date
+ * @property \DateTimeInterface $start_date
+ * @property \DateTimeInterface|null $end_date
  * @property array $params
  *
  * @property \BEdita\Core\Model\Entity\ObjectEntity $object
@@ -127,7 +126,7 @@ class DateRange extends Entity
                 continue;
             }
 
-            $last->start_date = $last->start_date->min($current->start_date);
+            $last->start_date = min($last->start_date, $current->start_date);
             if ($last->end_date === null || ($current->end_date !== null && $last->end_date < $current->end_date)) {
                 $last->end_date = $current->end_date;
             }
@@ -208,7 +207,10 @@ class DateRange extends Entity
             $dateRange = clone $dateRange1;
 
             while (($dateRange2 = current($array2)) !== false) {
-                if ($dateRange->end_date === null && $dateRange2->end_date === null && $dateRange->start_date->eq($dateRange2->start_date)) {
+                if ($dateRange->end_date === null
+                    && $dateRange2->end_date === null
+                    && $dateRange->start_date->getTimestamp() === $dateRange2->start_date->getTimestamp()
+                ) {
                     // Unit sets match. Discard range.
                     $dateRange = null;
                     next($array2);
@@ -264,7 +266,7 @@ class DateRange extends Entity
      * @return void
      * @throws \LogicException Throws an exception if a malformed Date Range is encountered.
      */
-    public static function checkWellFormed(... $dateRanges)
+    public static function checkWellFormed(...$dateRanges)
     {
         $getType = function ($var) {
             if (!is_object($var)) {
@@ -275,21 +277,21 @@ class DateRange extends Entity
         };
 
         foreach ($dateRanges as $dateRange) {
-            if (!($dateRange instanceof static)) {
+            if (!($dateRange instanceof self)) {
                 throw new \LogicException(
                     __d('bedita', 'Invalid Date Range entity class: expected "{0}", got "{1}"', static::class, $getType($dateRange))
                 );
             }
 
-            if (!($dateRange->start_date instanceof Time)) {
+            if (!($dateRange->start_date instanceof \DateTimeInterface)) {
                 throw new \LogicException(
-                    __d('bedita', 'Invalid "{0}": expected "{1}", got "{2}"', 'start_date', Time::class, $getType($dateRange->start_date))
+                    __d('bedita', 'Invalid "{0}": expected "{1}", got "{2}"', 'start_date', \DateTimeInterface::class, $getType($dateRange->start_date))
                 );
             }
 
-            if (!($dateRange->end_date instanceof Time) && $dateRange->end_date !== null) {
+            if (!($dateRange->end_date instanceof \DateTimeInterface) && $dateRange->end_date !== null) {
                 throw new \LogicException(
-                    __d('bedita', 'Invalid "{0}": expected "{1}", got "{2}"', 'end_date', Time::class, $getType($dateRange->end_date))
+                    __d('bedita', 'Invalid "{0}": expected "{1}", got "{2}"', 'end_date', \DateTimeInterface::class, $getType($dateRange->end_date))
                 );
             }
         }

--- a/plugins/BEdita/Core/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -26,39 +26,61 @@ class DateTimeTypeTest extends TestCase
 {
 
     /**
-     * Data provider for `testMarshal`
+     * Data provider for `testMarshalSuccess`.
+     *
+     * @return array
      */
-    public function marshalProvider()
+    public function marshalSuccessProvider()
     {
         return [
-            'success' => [
-                [
-                    '2017-03-01 12:12:12',
-                    '2017-12-31T23:59:59Z',
-                    '2018-01-01',
-                    '2018-01-01 11:22',
-                    '2017-01-01T11:22:33',
-                    '2017-01-01 11:22:33',
-                    '2017-01-01T11:22:33',
-                    '2017-01-01 11:22:33Z',
-                    '2017-04-01T11:22:33+10:00',
-                    '2017-01-01T19:20:30.45+01:00',
-                ],
-                true
+            [
+                '2017-03-01 12:12:12',
+                '2017-03-01 12:12:12',
             ],
-            'fail' => [
-                [
-                    '20170301121212',
-                    '2017 1 1',
-                    '05 march 2017',
-                ],
-                false
+            [
+                '2017-12-31T23:59:59Z',
+                '2017-12-31T23:59:59Z',
+            ],
+            [
+                '2018-01-01',
+                '2018-01-01',
+            ],
+            [
+                '2018-01-01 11:22',
+                '2018-01-01 11:22',
+            ],
+            [
+                '2017-01-01T11:22:33',
+                '2017-01-01T11:22:33',
+            ],
+            [
+                '2017-01-01 11:22:33',
+                '2017-01-01 11:22:33',
+            ],
+            [
+                '2017-01-01T11:22:33',
+                '2017-01-01T11:22:33',
+            ],
+            [
+                '2017-01-01 11:22:33Z',
+                '2017-01-01 11:22:33Z',
+            ],
+            [
+                '2017-04-01T11:22:33+10:00',
+                '2017-04-01T11:22:33+10:00',
+            ],
+            [
+                '2017-01-01T19:20:30.45+01:00',
+                '2017-01-01T19:20:30.45+01:00',
             ],
             'datetime' => [
-                [
-                    new DateTime(),
-                ],
-                false
+                new DateTime('2000-01-01 00:00:00'),
+                new DateTime('2000-01-01 00:00:00'),
+            ],
+            'success immutable' => [
+                '2017-03-01 12:12:12',
+                '2017-03-01 12:12:12',
+                true,
             ],
         ];
     }
@@ -66,20 +88,69 @@ class DateTimeTypeTest extends TestCase
     /**
      * Test `marshal` method
      *
+     * @param \DateTimeInterface|string $expected Expected result
+     * @param mixed $input Input data to be marshaled.
+     * @param bool $useImmutable Should immutable datetime objects be used?
      * @return void
-     * @dataProvider marshalProvider
+     *
+     * @dataProvider marshalSuccessProvider
      * @covers ::marshal
      */
-    public function testMarshal($dates, $success)
+    public function testMarshalSuccess($expected, $input, $useImmutable = false)
     {
         $dateTimeType = new DateTimeType();
-        foreach ($dates as $date) {
-            $result = $dateTimeType->marshal($date);
-            if ($success) {
-                $this->assertEquals(Time::parse($date)->toUnixString(), $result->toUnixString());
-            } else {
-                $this->assertEquals($date, $result);
-            }
+        if ($useImmutable) {
+            $dateTimeType->useImmutable();
         }
+
+        $result = $dateTimeType->marshal($input);
+        if (is_string($expected)) {
+            static::assertInstanceOf($dateTimeType->getDateTimeClassName(), $result);
+            $expected = Time::parse($expected);
+        }
+        static::assertSame($expected->getTimestamp(), $result->getTimestamp());
+    }
+
+    /**
+     * Data provider for `testMarshalFailure`.
+     *
+     * @return array
+     */
+    public function marshalFailureProvider()
+    {
+        return [
+            [
+                '20170301121212',
+            ],
+            [
+                '2017 1 1',
+            ],
+            [
+                '05 march 2017',
+            ],
+            [
+                [1, 2, 3],
+            ],
+            [
+                new \stdClass(),
+            ],
+        ];
+    }
+
+    /**
+     * Test `marshal` method with invalid input
+     *
+     * @param mixed $input Input data to be marshaled.
+     * @return void
+     *
+     * @dataProvider marshalFailureProvider
+     * @covers ::marshal
+     */
+    public function testMarshalFailure($input)
+    {
+        $dateTimeType = new DateTimeType();
+        $result = $dateTimeType->marshal($input);
+
+        static::assertNull($result);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/DateRangeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/DateRangeTest.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Test\TestCase\Model\Entity;
 
 use BEdita\Core\Model\Entity\DateRange;
+use Cake\I18n\FrozenTime;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -679,7 +680,7 @@ class DateRangeTest extends TestCase
                 false,
             ],
             'invalid start date' => [
-                new \LogicException('Invalid "start_date": expected "Cake\I18n\Time", got "NULL"'),
+                new \LogicException('Invalid "start_date": expected "DateTimeInterface", got "NULL"'),
                 [
                     [
                         'start_date' => null,
@@ -688,13 +689,14 @@ class DateRangeTest extends TestCase
                 ],
             ],
             'invalid end date' => [
-                new \LogicException('Invalid "end_date": expected "Cake\I18n\Time", got "string"'),
+                new \LogicException('Invalid "end_date": expected "DateTimeInterface", got "string"'),
                 [
-                    [
-                        'start_date' => '2017-01-01',
+                    new DateRange([
+                        'start_date' => new FrozenTime(),
                         'end_date' => 'better than yesterday, worse than tomorrow',
-                    ],
+                    ]),
                 ],
+                false,
             ],
             'ok' => [
                 true,


### PR DESCRIPTION
This PR fixes a minor issues with `DateTimeType`.

Regardless of the preference expressed in `bootstrap.php`, mutable date time objects are employed.

We should honour user's preference and use `FrozenTime` instead of `Time` if user prefers so.