### PR TITLE
Add mail preview for password recovery message

### DIFF
--- a/plugins/BEdita/Core/src/Mailer/Preview/UserMailerPreview.php
+++ b/plugins/BEdita/Core/src/Mailer/Preview/UserMailerPreview.php
@@ -17,7 +17,7 @@ use Cake\Utility\Text;
 use DebugKit\Mailer\MailPreview;
 
 /**
- * Mail preview for UserMailer
+ * Mail preview for user mailer.
  *
  * @property \BEdita\Core\Model\Table\UsersTable $Users
  *

--- a/plugins/BEdita/Core/src/Mailer/Preview/UserMailerPreview.php
+++ b/plugins/BEdita/Core/src/Mailer/Preview/UserMailerPreview.php
@@ -13,10 +13,13 @@
 
 namespace BEdita\Core\Mailer\Preview;
 
+use Cake\Utility\Text;
 use DebugKit\Mailer\MailPreview;
 
 /**
  * Mail preview for UserMailer
+ *
+ * @property \BEdita\Core\Model\Table\UsersTable $Users
  *
  * @since 4.0.0
  * @codeCoverageIgnore
@@ -26,58 +29,78 @@ class UserMailerPreview extends MailPreview
     /**
      * Preview of Welcome message.
      *
-     * @return \BEdita\Core\Mailer\UserMailer
+     * @return \Cake\Mailer\Email
      */
     public function welcome()
     {
         $user = $this->getUser();
-
         $options = [
-            'params' => [
-                'user' => $user
-            ]
+            'params' => compact('user'),
         ];
 
-        return $this->getMailer('BEdita/Core.User')
-            ->welcome($options);
+        /* @var \BEdita\Core\Mailer\UserMailer $mailer */
+        $mailer = $this->getMailer('BEdita/Core.User');
+
+        return $mailer->welcome($options);
     }
 
     /**
      * Preview of Signup message.
      *
-     * @return \BEdita\Core\Mailer\UserMailer
+     * @return \Cake\Mailer\Email
      */
     public function signup()
     {
-        $user = $this->getUser();
-
         $options = [
             'params' => [
-                'user' => $user,
-                'activationUrl' => 'https://example.com'
-            ]
+                'user' => $this->getUser(),
+                'changeUrl' => 'https://example.org/activate?code=' . Text::uuid(),
+            ],
         ];
 
-        return $this->getMailer('BEdita/Core.User')
-            ->signup($options);
+        /* @var \BEdita\Core\Mailer\UserMailer $mailer */
+        $mailer = $this->getMailer('BEdita/Core.User');
+
+        return $mailer->signup($options);
     }
 
     /**
-     * Get last user adding email if empty
+     * Preview of Password recovery message.
+     *
+     * @return \Cake\Mailer\Email
+     */
+    public function changeRequest()
+    {
+        $options = [
+            'params' => [
+                'user' => $this->getUser(),
+                'changeUrl' => 'https://example.org/recover?code=' . Text::uuid(),
+            ],
+        ];
+
+        /* @var \BEdita\Core\Mailer\UserMailer $mailer */
+        $mailer = $this->getMailer('BEdita/Core.User');
+
+        return $mailer->changeRequest($options);
+    }
+
+    /**
+     * Create mock user.
      *
      * @return \BEdita\Core\Model\Entity\User
      */
     protected function getUser()
     {
         $this->loadModel('Users');
-        $user = $this->Users
-            ->find()
-            ->order(['id' => 'DESC'])
-            ->first();
 
-        if (!$user->email) {
-            $user->email = 'gustavo@bedita.com';
-        }
+        $user = $this->Users->newEntity([
+            'name' => 'Gustavo',
+            'surname' => 'Supporto',
+            'title' => 'Gustavo Supporto',
+            'email' => 'gustavo.supporto@example.org',
+            'username' => 'gustavo_supporto',
+        ]);
+        $user->type = 'users';
 
         return $user;
     }

--- a/plugins/BEdita/Core/src/Mailer/UserMailer.php
+++ b/plugins/BEdita/Core/src/Mailer/UserMailer.php
@@ -106,7 +106,7 @@ class UserMailer extends Mailer
      * - `changeUrl` the change url to follow
      *
      * @param array $options Email options
-     * @return $this
+     * @return \Cake\Mailer\Email
      * @throws \LogicException When missing some required parameter
      */
     public function changeRequest(array $options)


### PR DESCRIPTION
This PR adds a mailer preview for email sent after a password recovery request.

It also includes a minor fix to docblock `@return` annotation. Excluding this, all other changes are in a class used for development purposes, hence no tests are present.