### PR TITLE
Service 'plugin.name' notation

### DIFF
--- a/plugins/BEdita/Core/src/Job/ServiceRegistry.php
+++ b/plugins/BEdita/Core/src/Job/ServiceRegistry.php
@@ -49,11 +49,15 @@ class ServiceRegistry
             return static::$instances[$name];
         }
 
-        $className = Inflector::camelize($name);
-        $fullClassName = App::className($className, 'Job/Service', 'Service');
-        if ($fullClassName === false && strpos($className, '.') === false) {
-            $fullClassName = App::className('BEdita/Core.' . $className, 'Job/Service', 'Service');
+        $plugin = 'BEdita/Core.';
+        if (strpos($name, '.') !== false) {
+            list($plugin, $name) = explode('.', $name);
+            $plugin = Inflector::camelize($plugin) . '.';
         }
+
+        $className = $plugin . Inflector::camelize($name);
+        $fullClassName = App::className($className, 'Job/Service', 'Service');
+
         if ($fullClassName === false) {
             throw new \LogicException(__d('bedita', 'Unknown service "{0}"', [$name]));
         }

--- a/plugins/BEdita/Core/tests/TestCase/Job/ServiceRegistryTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/ServiceRegistryTest.php
@@ -69,6 +69,12 @@ class ServiceRegistryTest extends TestCase
         $result2 = ServiceRegistry::get('mail');
 
         static::assertSame($result, $result2);
+
+        // test dot notation
+        $result2 = ServiceRegistry::get('BEdita/Core.mail');
+
+        static::assertNotEmpty($result);
+        static::assertInstanceOf(JobService::class, $result);
     }
 
     /**


### PR DESCRIPTION
This is a trivial PR to enable `my_plugin.service` notation for services.

Since `Inflector::camelize('my_plugin.service')` gives `"MyPlugin.service"` instead of `"MyPlugin.Service"` this may cause failures.