### PR TITLE
Allow timestamps when marshaling DateTime fields

### DIFF
--- a/plugins/BEdita/Core/src/Database/Type/DateTimeType.php
+++ b/plugins/BEdita/Core/src/Database/Type/DateTimeType.php
@@ -36,6 +36,9 @@ class DateTimeType extends CakeDateTimeType
      */
     public function marshal($value)
     {
+        if (is_string($value) || is_numeric($value)) {
+            $value = parent::marshal($value);
+        }
         if ($value instanceof \DateTimeInterface) {
             return $value;
         }

--- a/plugins/BEdita/Core/src/Database/Type/DateTimeType.php
+++ b/plugins/BEdita/Core/src/Database/Type/DateTimeType.php
@@ -36,9 +36,6 @@ class DateTimeType extends CakeDateTimeType
      */
     public function marshal($value)
     {
-        if (is_string($value) || is_numeric($value)) {
-            $value = parent::marshal($value);
-        }
         if ($value instanceof \DateTimeInterface) {
             return $value;
         }
@@ -49,10 +46,8 @@ class DateTimeType extends CakeDateTimeType
             if ($value->getTimezone()->getName() === 'Z') {
                 $value = $value->setTimezone('UTC');
             }
-
-            return $value;
         }
 
-        return null;
+        return $value;
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -120,7 +120,7 @@ class DateTimeTypeTest extends TestCase
     {
         return [
             [
-                '20170301121212',
+                '@20170301121212',
             ],
             [
                 '2017 1 1',

--- a/plugins/BEdita/Core/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -120,7 +120,7 @@ class DateTimeTypeTest extends TestCase
     {
         return [
             [
-                '@20170301121212',
+                '20170301121212',
             ],
             [
                 '2017 1 1',
@@ -151,6 +151,6 @@ class DateTimeTypeTest extends TestCase
         $dateTimeType = new DateTimeType();
         $result = $dateTimeType->marshal($input);
 
-        static::assertNull($result);
+        static::assertSame($input, $result);
     }
 }


### PR DESCRIPTION
This PR fixes a regression introduced (by me) in #1251.

This regression causes timestamps (e.g. `time()`) not to be marshaled correctly when using BEdita's DateTimeType. This, for instance, causes DebugKit to raise an error, since it uses `REQUEST_TIME` server variable to set `requested_at` field, but that value is marshaled as `null`, and a SQL constraint fails, since that column isn't nullable in the datasource.

Sorry about that. 😞 