### PR TITLE
Trigger events on user signup, activation or password recovery

### DIFF
--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -14,11 +14,15 @@
 namespace BEdita\Core\Test\TestCase\Model\Action;
 
 use BEdita\Core\Model\Action\SignupUserAction;
+use BEdita\Core\Model\Entity\AsyncJob;
 use BEdita\Core\Model\Entity\User;
 use Cake\Core\Configure;
+use Cake\Event\Event;
+use Cake\Event\EventManager;
 use Cake\Mailer\Email;
 use Cake\Network\Exception\BadRequestException;
 use Cake\Network\Exception\InternalErrorException;
+use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -45,6 +49,19 @@ class SignupUserActionTest extends TestCase
         'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.object_relations',
     ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        Email::dropTransport('default');
+        Email::setConfigTransport('default', [
+            'className' => 'Debug',
+        ]);
+    }
 
     /**
      * Provider for `testExecute()`
@@ -132,14 +149,20 @@ class SignupUserActionTest extends TestCase
      */
     public function testExecute($expected, array $data)
     {
-        Email::dropTransport('default');
-        Email::setConfigTransport('default', [
-            'className' => 'Debug'
-        ]);
-
         if ($expected instanceof \Exception) {
             $this->expectException(get_class($expected));
         }
+
+        $eventDispatched = 0;
+        EventManager::instance()->on('Auth.signup', function (...$arguments) use (&$eventDispatched) {
+            $eventDispatched++;
+
+            static::assertCount(4, $arguments);
+            static::assertInstanceOf(Event::class, $arguments[0]);
+            static::assertInstanceOf(User::class, $arguments[1]);
+            static::assertInstanceOf(AsyncJob::class, $arguments[2]);
+            static::assertTrue(is_string($arguments[3]));
+        });
 
         $action = new SignupUserAction();
         $result = $action($data);
@@ -147,6 +170,7 @@ class SignupUserActionTest extends TestCase
         static::assertTrue((bool)$result);
         static::assertInstanceOf(User::class, $result);
         static::assertSame('draft', $result->status);
+        static::assertSame(1, $eventDispatched, 'Event not dispatched');
     }
 
     /**
@@ -168,35 +192,37 @@ class SignupUserActionTest extends TestCase
             ],
         ];
 
-        Email::dropTransport('default');
-        Email::setConfigTransport('default', [
-            'className' => 'Debug',
-        ]);
         Configure::write('Signup.requireActivation', false);
+
+        $eventDispatched = 0;
+        EventManager::instance()->on('Auth.signup', function (...$arguments) use (&$eventDispatched) {
+            $eventDispatched++;
+
+            static::assertCount(4, $arguments);
+            static::assertInstanceOf(Event::class, $arguments[0]);
+            static::assertInstanceOf(User::class, $arguments[1]);
+            static::assertInstanceOf(AsyncJob::class, $arguments[2]);
+            static::assertTrue(is_string($arguments[3]));
+        });
 
         $action = new SignupUserAction();
         $result = $action($data);
 
         static::assertInstanceOf(User::class, $result);
         static::assertSame('on', $result->status);
+        static::assertSame(1, $eventDispatched, 'Event not dispatched');
     }
 
     /**
      * Test execute when exception was raised sending email
      *
      * @return void
+     *
+     * @expectedException \Cake\Network\Exception\InternalErrorException
      */
     public function testExceptionSendMail()
     {
-        $this->expectException(InternalErrorException::class);
-
-        $mock = $this->getMockBuilder(SignupUserAction::class)
-            ->setMethods(['getMailer'])
-            ->getMock();
-
-        $mock->method('getMailer')->will($this->throwException(new InternalErrorException));
-
-        $mock->execute([
+        $data = [
             'data' => [
                 'username' => 'testsignup',
                 'password_hash' => 'testsignup',
@@ -204,7 +230,24 @@ class SignupUserActionTest extends TestCase
             ],
             'urlOptions' => [
                 'activation_url' => 'http://sample.com?confirm=true',
+                'redirect_url' => 'http://sample.com/ok',
             ],
-        ]);
+        ];
+
+        $eventDispatched = 0;
+        EventManager::instance()->on('Auth.signup', function () use (&$eventDispatched) {
+            $eventDispatched++;
+
+            throw new InternalErrorException;
+        });
+
+        $action = new SignupUserAction();
+
+        try {
+            $action($data);
+        } finally {
+            static::assertSame(1, $eventDispatched, 'Event not dispatched');
+            static::assertFalse(TableRegistry::get('Users')->exists(['username' => 'testsignup']));
+        }
     }
 }


### PR DESCRIPTION
This PR resolves #1263 and adds the documented events, so that developers can attach their listeners and hook into the flow.