### PR TITLE
Plain JSON for signup

### DIFF
--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -189,7 +189,7 @@ class LoginController extends AppController
      * If a valid token is passed actual change is perfomed, otherwise change is requested and token is
      * sent directly to user, tipically via email
      *
-     * @return \Cake\Http\Response|void
+     * @return \Cake\Http\Response|null
      */
     public function change()
     {
@@ -215,5 +215,7 @@ class LoginController extends AppController
         $this->set(compact('user'));
         $this->set('_serialize', ['user']);
         $this->set('_meta', $meta);
+
+        return null;
     }
 }

--- a/plugins/BEdita/API/src/Controller/SignupController.php
+++ b/plugins/BEdita/API/src/Controller/SignupController.php
@@ -33,11 +33,7 @@ class SignupController extends AppController
         parent::initialize();
         $this->Auth->getAuthorize('BEdita/API.Endpoint')->setConfig('defaultAuthorized', true);
 
-        if ($this->request->getParam('action') === 'signup' && $this->JsonApi) {
-            $this->JsonApi->setConfig('resourceTypes', ['users']);
-        }
-
-        if ($this->request->getParam('action') === 'activation' && $this->request->contentType() === 'application/json') {
+        if ($this->request->contentType() === 'application/json') {
             $this->RequestHandler->setConfig('inputTypeMap.json', ['json_decode', true], false);
         }
     }
@@ -52,18 +48,9 @@ class SignupController extends AppController
         $this->request->allowMethod('post');
 
         $data = $this->request->getData();
-        if (!empty($data['password'])) {
-            $data['password_hash'] = $data['password'];
-            unset($data['password']);
-        }
-
-        $urlOptions = $this->request->getData('_meta') ?: [];
 
         $action = new SignupUserAction();
-        $user = $action->execute([
-            'data' => $data,
-            'urlOptions' => $urlOptions
-        ]);
+        $user = $action->execute(compact('data'));
 
         $this->response = $this->response->withStatus(202);
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
@@ -217,7 +217,7 @@ class LoginControllerTest extends IntegrationTestCase
     /**
      * Create job for test
      *
-     * @return void
+     * @return \BEdita\Core\Model\Entity\AsyncJob
      */
     protected function createTestJob()
     {

--- a/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
@@ -85,15 +85,10 @@ class SignupControllerTest extends IntegrationTestCase
                 ],
                 'POST',
                 [
-                    'type' => 'users',
-                    'attributes' => [
-                        'username' => 'gustavo',
-                        'password' => 'supporto',
-                        'email' => 'gus.sup@channelweb.it',
-                    ],
-                    'meta' => [
-                        'activation_url' => 'http://example.com'
-                    ]
+                    'username' => 'gustavo',
+                    'password' => 'supporto',
+                    'email' => 'gus.sup@channelweb.it',
+                    'activation_url' => 'http://example.com',
                 ],
             ],
             'ok with activation_url and redirect_url' => [
@@ -113,16 +108,11 @@ class SignupControllerTest extends IntegrationTestCase
                 ],
                 'POST',
                 [
-                    'type' => 'users',
-                    'attributes' => [
-                        'username' => 'gustavo',
-                        'password' => 'supporto',
-                        'email' => 'gus.sup@channelweb.it',
-                    ],
-                    'meta' => [
-                        'activation_url' => 'http://example.com',
-                        'redirect_url' => 'myapp://'
-                    ]
+                    'username' => 'gustavo',
+                    'password' => 'supporto',
+                    'email' => 'gus.sup@channelweb.it',
+                    'activation_url' => 'http://example.com',
+                    'redirect_url' => 'myapp://',
                 ],
             ],
             'missing activation_url' => [
@@ -139,12 +129,9 @@ class SignupControllerTest extends IntegrationTestCase
                 ],
                 'POST',
                 [
-                    'type' => 'users',
-                    'attributes' => [
-                        'username' => 'gustavo',
-                        'password' => 'supporto',
-                        'email' => 'gus.sup@channelweb.it',
-                    ],
+                    'username' => 'gustavo',
+                    'password' => 'supporto',
+                    'email' => 'gus.sup@channelweb.it',
                 ],
             ],
             'missing username' => [
@@ -161,15 +148,10 @@ class SignupControllerTest extends IntegrationTestCase
                 ],
                 'POST',
                 [
-                    'type' => 'users',
-                    'attributes' => [
-                        'username' => '',
-                        'password' => 'supporto',
-                        'email' => 'gus.sup@channelweb.it',
-                    ],
-                    'meta' => [
-                        'activation_url' => 'http://example.com',
-                    ],
+                    'username' => '',
+                    'password' => 'supporto',
+                    'email' => 'gus.sup@channelweb.it',
+                    'activation_url' => 'http://example.com',
                 ],
             ],
             'missing password' => [
@@ -186,14 +168,9 @@ class SignupControllerTest extends IntegrationTestCase
                 ],
                 'POST',
                 [
-                    'type' => 'users',
-                    'attributes' => [
-                        'username' => 'gustavo',
-                        'email' => 'gus.sup@channelweb.it',
-                    ],
-                    'meta' => [
-                        'activation_url' => 'http://example.com',
-                    ],
+                    'username' => 'gustavo',
+                    'email' => 'gus.sup@channelweb.it',
+                    'activation_url' => 'http://example.com',
                 ],
             ],
             'missing email' => [
@@ -210,14 +187,9 @@ class SignupControllerTest extends IntegrationTestCase
                 ],
                 'POST',
                 [
-                    'type' => 'users',
-                    'attributes' => [
-                        'username' => 'gustavo',
-                        'password' => 'supporto',
-                    ],
-                    'meta' => [
-                        'activation_url' => 'http://example.com',
-                    ],
+                    'username' => 'gustavo',
+                    'password' => 'supporto',
+                    'activation_url' => 'http://example.com',
                 ],
             ],
         ];
@@ -237,9 +209,11 @@ class SignupControllerTest extends IntegrationTestCase
      */
     public function testSignup($statusCode, $expected, $method, $data)
     {
-        $this->configRequestHeaders($method);
+        $this->configRequestHeaders($method, [
+            'Content-Type' => 'application/json'
+        ]);
         $methodName = strtolower($method);
-        $this->$methodName('/signup', json_encode(compact('data')));
+        $this->$methodName('/signup', json_encode($data));
 
         $result = json_decode((string)$this->_response->getBody(), true);
 
@@ -397,19 +371,16 @@ class SignupControllerTest extends IntegrationTestCase
     public function testActivationOk()
     {
         // signup
-        $this->configRequestHeaders('POST');
+        $this->configRequestHeaders('POST', [
+            'Content-Type' => 'application/json'
+        ]);
         $data = [
-            'type' => 'users',
-            'attributes' => [
-                'username' => 'gustavo',
-                'password' => 'password',
-                'email' => 'gus.sup@channelweb.it',
-            ],
-            'meta' => [
-                'activation_url' => 'http://example.com',
-            ],
+            'username' => 'gustavo',
+            'password' => 'password',
+            'email' => 'gus.sup@channelweb.it',
+            'activation_url' => 'http://example.com',
         ];
-        $this->post('/signup', json_encode(compact('data')));
+        $this->post('/signup', json_encode($data));
 
         $asyncJob = TableRegistry::get('AsyncJobs')->find()
             ->order(['AsyncJobs.created' => 'DESC'])
@@ -438,19 +409,16 @@ class SignupControllerTest extends IntegrationTestCase
     public function testActivationConflict()
     {
         // signup
-        $this->configRequestHeaders('POST');
+        $this->configRequestHeaders('POST', [
+            'Content-Type' => 'application/json'
+        ]);
         $data = [
-            'type' => 'users',
-            'attributes' => [
-                'username' => 'gustavo',
-                'password' => 'password',
-                'email' => 'gus.sup@channelweb.it',
-            ],
-            'meta' => [
-                'activation_url' => 'http://example.com',
-            ],
+            'username' => 'gustavo',
+            'password' => 'password',
+            'email' => 'gus.sup@channelweb.it',
+            'activation_url' => 'http://example.com',
         ];
-        $this->post('/signup', json_encode(compact('data')));
+        $this->post('/signup', json_encode($data));
 
         $asyncJob = TableRegistry::get('AsyncJobs')->find()
             ->order(['AsyncJobs.created' => 'DESC'])

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -67,12 +67,11 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
      * {@inheritDoc}
      *
      * @return \BEdita\Core\Model\Entity\User
-     * @throws \Cake\Network\Exception\BadRequestException When validation of `$data['urlOptions']` fails
+     * @throws \Cake\Network\Exception\BadRequestException When validation of URL options fails
      */
     public function execute(array $data = [])
     {
-        $data['urlOptions'] = (!empty($data['urlOptions']) && is_array($data['urlOptions'])) ? $data['urlOptions'] : [];
-        $errors = $this->validate($data['urlOptions']);
+        $errors = $this->validate($data['data']);
         if (!empty($errors)) {
             throw new BadRequestException([
                 'title' => __d('bedita', 'Invalid data'),
@@ -84,7 +83,7 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
         $user = $this->createUser($data['data']);
         try {
             $job = $this->createSignupJob($user);
-            $activationUrl = $this->getActivationUrl($job, $data['urlOptions']);
+            $activationUrl = $this->getActivationUrl($job, $data['data']);
 
             $this->dispatchEvent('Auth.signup', [$user, $job, $activationUrl], $this->Users);
         } catch (\Exception $e) {

--- a/plugins/BEdita/Core/src/Model/Entity/User.php
+++ b/plugins/BEdita/Core/src/Model/Entity/User.php
@@ -20,6 +20,7 @@ use Cake\Auth\DefaultPasswordHasher;
  *
  * @property int $id
  * @property string $username
+ * @property string $password
  * @property string $password_hash
  * @property bool $blocked
  * @property \Cake\I18n\Time|\Cake\I18n\FrozenTime $last_login
@@ -68,6 +69,19 @@ class User extends Profile
         'external_auth',
         'deleted',
     ];
+
+    /**
+     * Password setter. This is an alias for `password_hash`.
+     *
+     * @param string $password Password to be hashed.
+     * @return null
+     */
+    protected function _setPassword($password)
+    {
+        $this->password_hash = $password;
+
+        return null;
+    }
 
     /**
      * Password setter.

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -76,10 +76,8 @@ class SignupUserActionTest extends TestCase
                 [
                     'data' => [
                         'username' => 'testsignup',
-                        'password_hash' => 'testsignup',
+                        'password' => 'testsignup',
                         'email' => 'test.signup@example.com',
-                    ],
-                    'urlOptions' => [
                         'activation_url' => 'http://sample.com?confirm=true',
                         'redirect_url' => 'http://sample.com/ok',
                     ],
@@ -90,10 +88,8 @@ class SignupUserActionTest extends TestCase
                 [
                     'data' => [
                         'username' => 'testsignup',
-                        'password_hash' => 'testsignup',
+                        'password' => 'testsignup',
                         'email' => 'test.signup@example.com',
-                    ],
-                    'urlOptions' => [
                         'activation_url' => 'myapp://activate',
                         'redirect_url' => 'myapp://',
                     ],
@@ -104,7 +100,7 @@ class SignupUserActionTest extends TestCase
                 [
                     'data' => [
                         'username' => 'testsignup',
-                        'password_hash' => 'testsignup',
+                        'password' => 'testsignup',
                         'email' => 'test.signup@example.com',
                     ],
                 ]
@@ -114,10 +110,8 @@ class SignupUserActionTest extends TestCase
                 [
                     'data' => [
                         'username' => 'testsignup',
-                        'password_hash' => 'testsignup',
+                        'password' => 'testsignup',
                         'email' => 'test.signup@example.com',
-                    ],
-                    'urlOptions' => [
                         'activation_url' => '/activate',
                     ],
                 ]
@@ -127,10 +121,8 @@ class SignupUserActionTest extends TestCase
                 [
                     'data' => [
                         'username' => 'testsignup',
-                        'password_hash' => 'testsignup',
+                        'password' => 'testsignup',
                         'email' => 'test.signup@example.com',
-                    ],
-                    'urlOptions' => [
                         'activation_url' => 'https://activate',
                     ],
                 ]
@@ -183,10 +175,8 @@ class SignupUserActionTest extends TestCase
         $data = [
             'data' => [
                 'username' => 'testsignup',
-                'password_hash' => 'testsignup',
+                'password' => 'testsignup',
                 'email' => 'test.signup@example.com',
-            ],
-            'urlOptions' => [
                 'activation_url' => 'http://sample.com?confirm=true',
                 'redirect_url' => 'http://sample.com/ok',
             ],
@@ -225,10 +215,8 @@ class SignupUserActionTest extends TestCase
         $data = [
             'data' => [
                 'username' => 'testsignup',
-                'password_hash' => 'testsignup',
+                'password' => 'testsignup',
                 'email' => 'test.signup@example.com',
-            ],
-            'urlOptions' => [
                 'activation_url' => 'http://sample.com?confirm=true',
                 'redirect_url' => 'http://sample.com/ok',
             ],

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActivationActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActivationActionTest.php
@@ -214,10 +214,8 @@ class SignupUserActivationActionTest extends TestCase
         $data = [
             'data' => [
                 'username' => 'testsignup',
-                'password_hash' => 'testsignup',
+                'password' => 'testsignup',
                 'email' => 'test.signup@example.com',
-            ],
-            'urlOptions' => [
                 'activation_url' => 'http://sample.com?confirm=true',
             ],
         ];

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/UserTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/UserTest.php
@@ -39,7 +39,9 @@ class UserTest extends TestCase
      * @var array
      */
     public $fixtures = [
+        'plugin.BEdita/Core.relations',
         'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.objects',
         'plugin.BEdita/Core.profiles',
         'plugin.BEdita/Core.users',
@@ -85,9 +87,9 @@ class UserTest extends TestCase
             throw new \InvalidArgumentException();
         }
 
-        $this->assertEquals(1, $user->id);
-        $this->assertFalse($user->blocked);
-        $this->assertEquals('patched_username', $user->username);
+        static::assertEquals(1, $user->id);
+        static::assertFalse($user->blocked);
+        static::assertEquals('patched_username', $user->username);
     }
 
     /**
@@ -103,12 +105,35 @@ class UserTest extends TestCase
             throw new \InvalidArgumentException();
         }
 
-        $this->assertNotEmpty($user->password_hash);
-        $this->assertArrayNotHasKey('password_hash', $user->toArray());
+        static::assertNotEmpty($user->password_hash);
+        static::assertArrayNotHasKey('password_hash', $user->toArray());
     }
 
     /**
      * Test setter method for `password`.
+     *
+     * @return void
+     * @covers ::_setPassword()
+     */
+    public function testSetPassword()
+    {
+        $user = $this->Users->get(1);
+
+        $data = [
+            'password' => 'myPassword',
+        ];
+        $user = $this->Users->patchEntity($user, $data);
+        if (!($user instanceof User)) {
+            throw new \InvalidArgumentException();
+        }
+
+        static::assertNull($user->password);
+        static::assertNotEquals('myPassword', $user->password_hash);
+        static::assertTrue((new DefaultPasswordHasher())->check('myPassword', $user->password_hash));
+    }
+
+    /**
+     * Test setter method for `password_hash`.
      *
      * @return void
      * @covers ::_setPasswordHash()
@@ -125,7 +150,7 @@ class UserTest extends TestCase
             throw new \InvalidArgumentException();
         }
 
-        $this->assertNotEquals('myPassword', $user->password_hash);
-        $this->assertTrue((new DefaultPasswordHasher())->check('myPassword', $user->password_hash));
+        static::assertNotEquals('myPassword', $user->password_hash);
+        static::assertTrue((new DefaultPasswordHasher())->check('myPassword', $user->password_hash));
     }
 }


### PR DESCRIPTION
This PR converts request data format for `POST /signup` from JSON API to plain JSON, in order to avoid some ambiguities such as where `meta.activation_url` should be placed in request data (either root-level or resource-level).