### PR TITLE
Api key via query string

### DIFF
--- a/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
+++ b/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
@@ -170,7 +170,7 @@ class EndpointAuthorize extends BaseAuthorize
         if ($this->application === null) {
             $apiKey = $this->request->getHeaderLine($this->_config['apiKeyHeaderName']);
             if (empty($apiKey)) {
-                $apiKey = $this->request->getQuery($this->_config['apiKeyQueryString']);
+                $apiKey = strval($this->request->getQuery($this->_config['apiKeyQueryString']));
             }
             if (empty($apiKey) && empty($this->_config['blockAnonymousApps'])) {
                 return null;

--- a/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
+++ b/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
@@ -140,8 +140,7 @@ class EndpointAuthorize extends BaseAuthorize
     protected function unauthenticate()
     {
         $controller = $this->_registry->getController();
-
-        return $controller
+        $controller
             ->Auth->getAuthenticate('BEdita/API.Jwt')
             ->unauthenticated($controller->request, $controller->response);
     }
@@ -170,8 +169,8 @@ class EndpointAuthorize extends BaseAuthorize
         $this->application = CurrentApplication::getApplication();
         if ($this->application === null) {
             $apiKey = $this->request->getHeaderLine($this->_config['apiKeyHeaderName']);
-            if (empty($apiKey)) {
-                $apiKey = strval($this->request->getQuery($this->_config['apiKeyQueryString']));
+            if (empty($apiKey) && $this->_config['apiKeyQueryString'] !== null) {
+                $apiKey = (string)$this->request->getQuery($this->_config['apiKeyQueryString']);
             }
             if (empty($apiKey) && empty($this->_config['blockAnonymousApps'])) {
                 return null;

--- a/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
+++ b/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
@@ -135,12 +135,13 @@ class EndpointAuthorize extends BaseAuthorize
      * Perform user unauthentication to return 401 Unauthorized
      * instead of 403 Forbidden
      *
-     * @return void
+     * @return mixed
      */
     protected function unauthenticate()
     {
         $controller = $this->_registry->getController();
-        $controller
+
+        return $controller
             ->Auth->getAuthenticate('BEdita/API.Jwt')
             ->unauthenticated($controller->request, $controller->response);
     }

--- a/plugins/BEdita/API/tests/TestCase/Auth/EndpointAuthorizeTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/EndpointAuthorizeTest.php
@@ -64,6 +64,7 @@ class EndpointAuthorizeTest extends TestCase
                 [
                     'HTTP_X_CUSTOM_HEADER' => API_KEY,
                 ],
+                [],
                 [
                     'apiKeyHeaderName' => 'X-Custom-Header',
                 ],
@@ -77,6 +78,7 @@ class EndpointAuthorizeTest extends TestCase
             'missing API key' => [
                 new ForbiddenException('Missing API key'),
                 [],
+                [],
                 [
                     'blockAnonymousApps' => true,
                 ],
@@ -84,6 +86,20 @@ class EndpointAuthorizeTest extends TestCase
             'anonymous application' => [
                 null,
                 [],
+            ],
+            'query string api key' => [
+                1,
+                [],
+                [
+                    'api_key' => API_KEY,
+                ],
+            ],
+            'query string failure' => [
+                new ForbiddenException('Invalid API key'),
+                [],
+                [
+                    'api_key' => 'this API key is invalid!',
+                ]
             ],
         ];
     }
@@ -93,13 +109,14 @@ class EndpointAuthorizeTest extends TestCase
      *
      * @param int|\Exception $expected Expected application ID.
      * @param array $environment Request headers.
+     * @param array $query Request query strings.
      * @param array $config Configuration.
      * @return void
      *
      * @dataProvider getApplicationProvider()
      * @covers ::getApplication()
      */
-    public function testGetApplication($expected, array $environment, array $config = [])
+    public function testGetApplication($expected, array $environment, array $query = [], array $config = [])
     {
         if ($expected instanceof \Exception) {
             static::expectException(get_class($expected));
@@ -108,7 +125,7 @@ class EndpointAuthorizeTest extends TestCase
 
         CurrentApplication::getInstance()->set(null);
         $authorize = new EndpointAuthorize(new ComponentRegistry(), $config);
-        $request = new ServerRequest(compact('environment'));
+        $request = new ServerRequest(compact('environment', 'query'));
 
         $authorize->authorize([], $request);
 


### PR DESCRIPTION
Although generally not recommended in some situations passing `api_key` in query string can be useful or necessary: for instance in `webhooks` like method calls where you have poor or no control over request headers.

Probably this possibility should be application dependent.

Minor refactor on `$this->endpoint` and `$this->application` included + improved coverage.