### PR TITLE
Unauthorized on invalid or expired JWT

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -63,14 +63,14 @@ return [
      *   The salt value is also used as the encryption key.
      *   You should treat it as extremely sensitive data.
      * - jwt - Duration and algorithm for JSON Web Tokens.
-     *   By default, `duration` is `'+2 hours'`, and `algorithm` is `'HS256'`.
+     *   By default, `duration` is `'+20 minutes'`, and `algorithm` is `'HS256'`.
      * - blockAnonymousApps - Are anonymous applications (i.e. requests without an api key) forbidden?
      * - blockAnonymousUsers - Are unauthenticated users requests blocked by default?
      */
     'Security' => [
         'salt' => env('SECURITY_SALT', '__SALT__'),
         // 'jwt' => [
-        //     'duration' => '+2 hours',
+        //     'duration' => '+20 minutes',
         //     'algorithm' => 'HS256',
         // ],
         // 'blockAnonymousApps' => true,

--- a/plugins/BEdita/API/src/Auth/JwtAuthenticate.php
+++ b/plugins/BEdita/API/src/Auth/JwtAuthenticate.php
@@ -128,6 +128,10 @@ class JwtAuthenticate extends BaseAuthenticate
     {
         $payload = $this->getPayload($request);
 
+        if (!empty($this->error)) {
+            throw new UnauthorizedException($this->error->getMessage());
+        }
+
         if (!$this->_config['queryDatasource'] && !isset($payload['sub'])) {
             return $payload;
         }

--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -189,7 +189,7 @@ class LoginController extends AppController
      * If a valid token is passed actual change is perfomed, otherwise change is requested and token is
      * sent directly to user, tipically via email
      *
-     * @return \Cake\Http\Response|void
+     * @return \Cake\Http\Response|null
      */
     public function change()
     {
@@ -215,5 +215,7 @@ class LoginController extends AppController
         $this->set(compact('user'));
         $this->set('_serialize', ['user']);
         $this->set('_meta', $meta);
+
+        return null;
     }
 }

--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -141,7 +141,7 @@ class LoginController extends AppController
     protected function jwtTokens(array $user)
     {
         $algorithm = Configure::read('Security.jwt.algorithm') ?: 'HS256';
-        $duration = Configure::read('Security.jwt.duration') ?: '+2 hours';
+        $duration = Configure::read('Security.jwt.duration') ?: '+20 minutes';
         $currentUrl = Router::reverse($this->request, true);
         $claims = [
             'iss' => Router::fullBaseUrl(),

--- a/plugins/BEdita/API/tests/TestCase/Auth/JwtAuthenticateTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/JwtAuthenticateTest.php
@@ -17,10 +17,10 @@ use BEdita\API\Auth\JwtAuthenticate;
 use Cake\Auth\WeakPasswordHasher;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
-use Cake\Core\Configure;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\I18n\Time;
+use Cake\Network\Exception\UnauthorizedException;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Security;
 use Firebase\JWT\JWT;
@@ -159,6 +159,7 @@ class JwtAuthenticateTest extends TestCase
         $renewToken = JWT::encode(['sub' => 1], Security::salt());
 
         $invalidToken = JWT::encode(['aud' => 'http://example.org'], Security::salt());
+        $expiredToken = JWT::encode(['exp' => time() - 10], Security::salt());
 
         return [
             'default' => [
@@ -203,7 +204,7 @@ class JwtAuthenticateTest extends TestCase
                 new ServerRequest(),
             ],
             'invalidToken' => [
-                false,
+                new UnauthorizedException('Invalid audience'),
                 [],
                 new ServerRequest([
                     'params' => [
@@ -218,13 +219,20 @@ class JwtAuthenticateTest extends TestCase
                     ],
                 ]),
             ],
+            'expiredToken' => [
+                new UnauthorizedException('Expired token'),
+                [],
+                new ServerRequest([
+                    'environment' => ['HTTP_AUTHORIZATION' => 'Bearer ' . $expiredToken],
+                ]),
+            ],
         ];
     }
 
     /**
      * Test `getUser` method.
      *
-     * @param array|false $expected Expected result.
+     * @param array|false|\Exception $expected Expected result.
      * @param array $config Configuration.
      * @param \Cake\Http\ServerRequest $request Request.
      * @return void
@@ -237,7 +245,11 @@ class JwtAuthenticateTest extends TestCase
      */
     public function testAuthenticate($expected, array $config, ServerRequest $request)
     {
-        Configure::write('debug', false);
+        if ($expected instanceof \Exception) {
+            $this->expectException(get_class($expected));
+            $this->expectExceptionCode($expected->getCode());
+            $this->expectExceptionMessage($expected->getMessage());
+        }
 
         $auth = new JwtAuthenticate(new ComponentRegistry(), $config);
 
@@ -278,8 +290,6 @@ class JwtAuthenticateTest extends TestCase
      */
     public function testUnauthenticatedWithInternalErrorMessage()
     {
-        Configure::write('debug', false);
-
         $request = new ServerRequest([
             'params' => [
                 'plugin' => 'BEdita/API',


### PR DESCRIPTION
This PR fixes an issue where a user with an invalid JWT (expired or invalid due to other causes) was considered an anonymous users. This caused problems to clients relying on a 401 response being returned to know whether the token had to be renewed.

Now, requests are considered anonymous only if NO token is passed at all. If a token is supplied, and it happens to be invalid, a 401 response is returned.

Also, default duration of authentication tokens has been decreased from 2 hours to 20 minutes. This better fits to JWT best practices, that suggest tokens to be short-lived, and rather have high refresh rates to better handle invalidation and stuff.