### PR TITLE
Fix relations save operations after CakePHP 3.4.8 release 😒

### DIFF
--- a/plugins/BEdita/Core/src/Model/Action/AddRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/AddRelatedObjectsAction.php
@@ -86,7 +86,7 @@ class AddRelatedObjectsAction extends UpdateRelatedObjectsAction
             return $action->execute(compact('entity', 'relatedEntities'));
         }
 
-        $relatedEntities = $this->prepareRelatedEntities($relatedEntities);
+        $relatedEntities = $this->prepareRelatedEntities($relatedEntities, $entity);
 
         return $this->Association->getConnection()->transactional(function () use ($entity, $relatedEntities) {
             $relatedEntities = $this->diff($entity, $relatedEntities);

--- a/plugins/BEdita/Core/src/Model/Action/SetRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SetRelatedObjectsAction.php
@@ -95,7 +95,7 @@ class SetRelatedObjectsAction extends UpdateRelatedObjectsAction
             return $action->execute(compact('entity', 'relatedEntities'));
         }
 
-        $relatedEntities = $this->prepareRelatedEntities($relatedEntities);
+        $relatedEntities = $this->prepareRelatedEntities($relatedEntities, $entity);
 
         $diff = $this->diff($entity, $relatedEntities);
 


### PR DESCRIPTION
This PR fixes an issue that arose after the release of CakePHP 3.4.8, in cakephp/cakephp#10665.

Relationships were not saved anymore due to the primary key of the ObjectRelation entity being completely erased in order to avoid issues with relations being saved more than once. Unfortunately this does not take into account a scenario like ours where a discriminator column `relation_id` is part of the primary key, and is used to distinguish between several kinds of associations between the very same objects.

Since our scenario is quite uncommon, it's probably better to fix it in our homeland rather than opening a PR to CakePHP core, which might add complexity that's not needed by most users.