### PR TITLE
Message loader for custom domains

### DIFF
--- a/plugins/BEdita/Core/config/bootstrap.php
+++ b/plugins/BEdita/Core/config/bootstrap.php
@@ -39,7 +39,7 @@ Type::set('timestamp', new DateTimeType());
 /**
  * Set loader for translation domain "bedita".
  */
-I18n::translators()->registerLoader('dockbooking', function($name, $locale) {
+I18n::translators()->registerLoader('bedita', function($name, $locale) {
     return new MessagesFileLoader($name, $locale, 'po', ['BEdita/Core', 'BEdita/API']);
 });
 

--- a/plugins/BEdita/Core/config/bootstrap.php
+++ b/plugins/BEdita/Core/config/bootstrap.php
@@ -39,7 +39,7 @@ Type::set('timestamp', new DateTimeType());
 /**
  * Set loader for translation domain "bedita".
  */
-I18n::translators()->registerLoader('bedita', function($name, $locale) {
+I18n::translators()->registerLoader('bedita', function ($name, $locale) {
     return new MessagesFileLoader($name, $locale, 'po', ['BEdita/Core', 'BEdita/API']);
 });
 

--- a/plugins/BEdita/Core/config/bootstrap.php
+++ b/plugins/BEdita/Core/config/bootstrap.php
@@ -2,11 +2,12 @@
 
 use BEdita\Core\Configure\Engine\DatabaseConfig;
 use BEdita\Core\Database\Type\DateTimeType;
+use BEdita\Core\I18n\MessagesFileLoader;
 use BEdita\Core\ORM\Locator\TableLocator;
-use BEdita\Core\Utility\LoggedUser;
 use Cake\Core\Configure;
 use Cake\Core\Configure\Engine\IniConfig;
 use Cake\Database\Type;
+use Cake\I18n\I18n;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -34,5 +35,12 @@ if (!Configure::configured('ini')) {
  */
 Type::set('datetime', new DateTimeType());
 Type::set('timestamp', new DateTimeType());
+
+/**
+ * Set loader for translation domain "bedita".
+ */
+I18n::translators()->registerLoader('dockbooking', function($name, $locale) {
+    return new MessagesFileLoader($name, $locale, 'po', ['BEdita/Core', 'BEdita/API']);
+});
 
 Configure::load('BEdita/Core.bedita', 'ini');

--- a/plugins/BEdita/Core/src/I18n/MessagesFileLoader.php
+++ b/plugins/BEdita/Core/src/I18n/MessagesFileLoader.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\I18n;
+
+use Cake\Core\Plugin;
+use Cake\I18n\MessagesFileLoader as BaseLoader;
+use Locale;
+
+/**
+ * Loader for translation messages.
+ *
+ * @see \Cake\I18n\MessagesFileLoader
+ *
+ * @since 4.0.0
+ */
+class MessagesFileLoader extends BaseLoader
+{
+
+    /**
+     * List of plugins where lookup should happen for the given domain.
+     *
+     * @var string[]
+     */
+    protected $plugins = [];
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param string[] $plugins Additional plugins to look up in for translations.
+     */
+    public function __construct($name, $locale, $extension = 'po', array $plugins = [])
+    {
+        parent::__construct($name, $locale, $extension);
+
+        $this->plugins = $plugins;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function translationsFolders()
+    {
+        $searchPaths = parent::translationsFolders();
+
+        $locale = Locale::parseLocale($this->_locale) + ['region' => null];
+        $folders = [
+            implode('_', [$locale['language'], $locale['region']]),
+            $locale['language']
+        ];
+        foreach ($this->plugins as $pluginName) {
+            if (Plugin::loaded($pluginName)) {
+                $basePath = Plugin::classPath($pluginName) . 'Locale' . DIRECTORY_SEPARATOR;
+                foreach ($folders as $folder) {
+                    $searchPaths[] = $basePath . $folder . DIRECTORY_SEPARATOR;
+                }
+            }
+        }
+
+        return $searchPaths;
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/I18n/MessagesFileLoaderTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/I18n/MessagesFileLoaderTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\I18n;
+
+use BEdita\Core\I18n\MessagesFileLoader;
+use Cake\Core\Plugin;
+use Cake\TestSuite\TestCase;
+
+/**
+ * @coversDefaultClass \BEdita\Core\I18n\MessagesFileLoader
+ */
+class MessagesFileLoaderTest extends TestCase
+{
+
+    /**
+     * Test constructor.
+     *
+     * @return void
+     *
+     * @covers ::__construct()
+     */
+    public function testConstruct()
+    {
+        $plugins = ['BEdita/Core'];
+
+        $loader = new MessagesFileLoader('bedita', 'it_IT', 'po', $plugins);
+
+        static::assertAttributeSame($plugins, 'plugins', $loader);
+    }
+
+    /**
+     * Test getter of search paths.
+     *
+     * @return void
+     *
+     * @covers ::translationsFolders()
+     */
+    public function testTranslationsFolders()
+    {
+        $expected = [
+            Plugin::classPath('BEdita/Core') . 'Locale' . DS . 'it_IT' . DS,
+            Plugin::classPath('BEdita/Core') . 'Locale' . DS . 'it' . DS,
+        ];
+        $plugins = ['BEdita/Core', 'MissingPlugin'];
+
+        $loader = new MessagesFileLoader('bedita', 'it_IT', 'po', $plugins);
+        $searchPaths = $loader->translationsFolders();
+
+        foreach ($expected as $path) {
+            static::assertContains($path, $searchPaths);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a custom message loader that will look into the specified list of plugins for message translations.

For instance, we might want to put translations for messages under the domain `bedita` into multiple plugins ("BEdita/Core" and "BEdita/API").