### PR TITLE
Status endpoint accepts everything

### DIFF
--- a/plugins/BEdita/API/src/Controller/StatusController.php
+++ b/plugins/BEdita/API/src/Controller/StatusController.php
@@ -13,6 +13,8 @@
 namespace BEdita\API\Controller;
 
 use BEdita\Core\Utility\System;
+use Cake\Event\Event;
+use Cake\Network\Request;
 
 /**
  * Controller for `/status` endpoint.
@@ -21,6 +23,36 @@ use BEdita\Core\Utility\System;
  */
 class StatusController extends AppController
 {
+
+    /**
+     * {@inheritDoc}
+     */
+    public function initialize()
+    {
+        if (!$this->request->is('jsonapi')) {
+            Request::addDetector('json', function (Request $request) {
+                return true;
+            });
+        }
+
+        parent::initialize();
+
+        $this->Auth->getAuthorize('BEdita/API.Endpoint')->setConfig('defaultAuthorized', true);
+        if ($this->JsonApi) {
+            $this->JsonApi->setConfig('checkMediaType', false);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function afterFilter(Event $event)
+    {
+        // Restore default detector
+        Request::addDetector('json', ['accept' => ['application/json'], 'param' => '_ext', 'value' => 'json']);
+
+        return parent::afterFilter($event);
+    }
 
     /**
      * Show system status info

--- a/plugins/BEdita/API/tests/TestCase/Controller/StatusControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/StatusControllerTest.php
@@ -26,6 +26,8 @@ class StatusControllerTest extends IntegrationTestCase
      * @return void
      *
      * @covers ::index()
+     * @covers ::initialize()
+     * @covers ::afterFilter()
      */
     public function testIndex()
     {

--- a/plugins/BEdita/API/tests/TestCase/Controller/StatusControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/StatusControllerTest.php
@@ -47,5 +47,14 @@ class StatusControllerTest extends IntegrationTestCase
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
         $this->assertEquals($expected, $result);
+
+        // test with */* content type
+        $this->configRequestHeaders('GET', ['Accept' => '*/*']);
+        $this->get('/status');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/json');
+        $this->assertEquals($expected, $result);
     }
 }


### PR DESCRIPTION
In order to use `/status` to monitor API strict check on `Accept` HTTP header has to be removed.

If no json or json api header or acceptable html header is provided a  default `application/json` response is provided

`Request::addDetector` is used fo that purpose, a restore action in `afterFilter` mainly for unit tests