### PR TITLE
Avoid unwanted TableLocator log

### DIFF
--- a/plugins/BEdita/Core/src/ORM/Locator/TableLocator.php
+++ b/plugins/BEdita/Core/src/ORM/Locator/TableLocator.php
@@ -28,13 +28,6 @@ class TableLocator extends CakeLocator
     use LogTrait;
 
     /**
-     * Aliases to exclude from loading as object type name
-     *
-     * @var array
-     */
-    protected $excludeAlias = ['_InverseAssociation'];
-
-    /**
      * Gets the table class name.
      *
      * @param string $alias The alias name you want to get.
@@ -59,13 +52,14 @@ class TableLocator extends CakeLocator
             return $className;
         }
 
-        if (!in_array($alias, $this->excludeAlias)) {
+        // aliases starting with `_` are reserved
+        if (substr($alias, 0, 1) !== '_') {
             try {
                 $objectTypes = $this->get('ObjectTypes');
                 $objectType = $objectTypes->get($alias);
                 $options['className'] = $objectType->table;
             } catch (\Exception $e) {
-                $this->log(sprintf('"%s" using alias %s', $e->getMessage(), $alias), 'warning');
+                $this->log(sprintf('%s using alias "%s"', $e->getMessage(), $alias), 'warning');
             }
         }
 

--- a/plugins/BEdita/Core/src/ORM/Locator/TableLocator.php
+++ b/plugins/BEdita/Core/src/ORM/Locator/TableLocator.php
@@ -28,6 +28,13 @@ class TableLocator extends CakeLocator
     use LogTrait;
 
     /**
+     * Aliases to exclude from loading as object type name
+     *
+     * @var array
+     */
+    protected $excludeAlias = ['_InverseAssociation'];
+
+    /**
      * Gets the table class name.
      *
      * @param string $alias The alias name you want to get.
@@ -52,12 +59,14 @@ class TableLocator extends CakeLocator
             return $className;
         }
 
-        try {
-            $objectTypes = $this->get('ObjectTypes');
-            $objectType = $objectTypes->get($alias);
-            $options['className'] = $objectType->table;
-        } catch (\Exception $e) {
-            $this->log($e->getMessage(), 'warning');
+        if (!in_array($alias, $this->excludeAlias)) {
+            try {
+                $objectTypes = $this->get('ObjectTypes');
+                $objectType = $objectTypes->get($alias);
+                $options['className'] = $objectType->table;
+            } catch (\Exception $e) {
+                $this->log(sprintf('"%s" using alias %s', $e->getMessage(), $alias), 'warning');
+            }
         }
 
         return App::className($options['className'], 'Model/Table', 'Table');

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/TableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/TableTest.php
@@ -594,8 +594,8 @@ class TableTest extends TestCase
         static::assertInstanceOf(Query::class, $this->fakeMammals->find('children', ['for' => 1, 'direct' => true]));
         static::assertInstanceOf(Query::class, $this->fakeFelines->find('children', ['for' => 1, 'direct' => true]));
 
-        static::assertTextNotContains('FakeAnimals', debug($this->fakeMammals->find('children', ['for' => 1, 'direct' => true])->sql()));
-        static::assertTextNotContains('FakeAnimals', debug($this->fakeFelines->find('children', ['for' => 1, 'direct' => true])->sql()));
+        static::assertTextNotContains('FakeAnimals', $this->fakeMammals->find('children', ['for' => 1, 'direct' => true])->sql());
+        static::assertTextNotContains('FakeAnimals', $this->fakeFelines->find('children', ['for' => 1, 'direct' => true])->sql());
     }
 
     /**


### PR DESCRIPTION
Quick & dirty way to remove unwaned error logs locading related objects.

There's surely a better way to do it :wink: 