### PR TITLE
Allow `HEAD /status`

### DIFF
--- a/plugins/BEdita/API/src/Controller/StatusController.php
+++ b/plugins/BEdita/API/src/Controller/StatusController.php
@@ -13,6 +13,7 @@
 namespace BEdita\API\Controller;
 
 use BEdita\Core\Utility\System;
+use Cake\Core\Configure;
 
 /**
  * Controller for `/status` endpoint.
@@ -27,7 +28,7 @@ class StatusController extends AppController
      */
     public function initialize()
     {
-        if (!$this->request->is(['jsonapi', 'html'])) {
+        if (!$this->request->is('jsonapi') && ((!Configure::read('debug') && !Configure::read('Accept.html')) || !$this->request->is('html'))) {
             $this->request = $this->request->withHeader('Accept', 'application/json');
         }
 

--- a/plugins/BEdita/API/src/Controller/StatusController.php
+++ b/plugins/BEdita/API/src/Controller/StatusController.php
@@ -42,14 +42,20 @@ class StatusController extends AppController
     /**
      * Show system status info
      *
-     * @return void
+     * @return \Cake\Http\Response|null
      */
     public function index()
     {
-        $this->request->allowMethod('get');
+        $this->request->allowMethod(['get', 'head']);
+
+        if ($this->request->is('head')) {
+            return $this->response;
+        }
 
         $status = System::status();
         $this->set('_meta', compact('status'));
         $this->set('_serialize', []);
+
+        return null;
     }
 }

--- a/plugins/BEdita/API/src/Controller/StatusController.php
+++ b/plugins/BEdita/API/src/Controller/StatusController.php
@@ -13,8 +13,6 @@
 namespace BEdita\API\Controller;
 
 use BEdita\Core\Utility\System;
-use Cake\Event\Event;
-use Cake\Network\Request;
 
 /**
  * Controller for `/status` endpoint.
@@ -29,10 +27,8 @@ class StatusController extends AppController
      */
     public function initialize()
     {
-        if (!$this->request->is('jsonapi')) {
-            Request::addDetector('json', function (Request $request) {
-                return true;
-            });
+        if (!$this->request->is(['jsonapi', 'html'])) {
+            $this->request = $this->request->withHeader('Accept', 'application/json');
         }
 
         parent::initialize();
@@ -41,17 +37,6 @@ class StatusController extends AppController
         if ($this->JsonApi) {
             $this->JsonApi->setConfig('checkMediaType', false);
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function afterFilter(Event $event)
-    {
-        // Restore default detector
-        Request::addDetector('json', ['accept' => ['application/json'], 'param' => '_ext', 'value' => 'json']);
-
-        return parent::afterFilter($event);
     }
 
     /**

--- a/plugins/BEdita/API/src/Controller/StatusController.php
+++ b/plugins/BEdita/API/src/Controller/StatusController.php
@@ -28,7 +28,8 @@ class StatusController extends AppController
      */
     public function initialize()
     {
-        if (!$this->request->is('jsonapi') && ((!Configure::read('debug') && !Configure::read('Accept.html')) || !$this->request->is('html'))) {
+        $htmlRequest = (Configure::read('debug') || Configure::read('Accept.html')) && $this->request->is('html');
+        if (!$this->request->is('jsonapi') && !$htmlRequest) {
             $this->request = $this->request->withHeader('Accept', 'application/json');
         }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/StatusControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/StatusControllerTest.php
@@ -20,6 +20,7 @@ use BEdita\Core\Utility\System;
  */
 class StatusControllerTest extends IntegrationTestCase
 {
+
     /**
      * Test index method.
      *
@@ -27,18 +28,16 @@ class StatusControllerTest extends IntegrationTestCase
      *
      * @covers ::index()
      * @covers ::initialize()
-     * @covers ::afterFilter()
      */
     public function testIndex()
     {
-        $status = System::status();
         $expected = [
             'links' => [
                 'self' => 'http://api.example.com/status',
                 'home' => 'http://api.example.com/home',
             ],
             'meta' => [
-                'status' => $status
+                'status' => System::status(),
             ],
         ];
 
@@ -48,15 +47,53 @@ class StatusControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertEquals($expected, $result);
+        static::assertEquals($expected, $result);
+    }
 
-        // test with */* content type
+    /**
+     * Test index method with `Accept: * / *` header.
+     *
+     * @return void
+     *
+     * @covers ::index()
+     * @covers ::initialize()
+     */
+    public function testGenericContentType()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/status',
+                'home' => 'http://api.example.com/home',
+            ],
+            'meta' => [
+                'status' => System::status(),
+            ],
+        ];
+
         $this->configRequestHeaders('GET', ['Accept' => '*/*']);
         $this->get('/status');
         $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->assertResponseCode(200);
         $this->assertContentType('application/json');
-        $this->assertEquals($expected, $result);
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test `HEAD` request.
+     *
+     * @return void
+     *
+     * @covers ::index()
+     * @covers ::initialize()
+     */
+    public function testHeadRequest()
+    {
+        $this->configRequestHeaders('HEAD', ['Accept' => '*/*']);
+        $this->_sendRequest('/status', 'HEAD');
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/json');
+        $this->assertResponseEmpty();
     }
 }


### PR DESCRIPTION
This MR fixes a 405 Method Not Allowed error on `/status` endpoint when request method is HEAD instead of GET.

It also introduces a minor refactor to how requests are accepted even though they haven't a suitable `Accept` header: instead of overwriting the request detector, if a request would be rejected because of its `Accept` header, it is overwritten and set as `application/json`.