### PR TITLE
Fix missing boundary when sending emails asynchronously

### DIFF
--- a/plugins/BEdita/Core/src/Mailer/Email.php
+++ b/plugins/BEdita/Core/src/Mailer/Email.php
@@ -54,4 +54,15 @@ class Email extends CakeEmail
 
         return $contents;
     }
+
+    /**
+     * Get boundary used by a mail.
+     *
+     * @param \Cake\Mailer\Email $email Email instance.
+     * @return string|null
+     */
+    public static function getBoundary(CakeEmail $email)
+    {
+        return $email->_boundary;
+    }
 }

--- a/plugins/BEdita/Core/src/Mailer/Transport/AsyncJobsTransport.php
+++ b/plugins/BEdita/Core/src/Mailer/Transport/AsyncJobsTransport.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Mailer\Transport;
 
+use BEdita\Core\Mailer\Email as BeditaEmail;
 use Cake\Mailer\AbstractTransport;
 use Cake\Mailer\Email;
 use Cake\Network\Email\DebugTransport;
@@ -53,6 +54,7 @@ class AsyncJobsTransport extends AbstractTransport
 
         $payload = $email->jsonSerialize();
         $payload += [
+            '_boundary' => BeditaEmail::getBoundary($email),
             '_message' => $email->message(),
             '_htmlMessage' => $email->message(Email::MESSAGE_HTML),
             '_textMessage' => $email->message(Email::MESSAGE_TEXT),

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/EmailTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/EmailTest.php
@@ -137,4 +137,31 @@ class EmailTest extends TestCase
         static::assertArrayHasKey('message', $result);
         static::assertSame($expected['message'], $result['message']);
     }
+
+    /**
+     * Test getter for boundary.
+     *
+     * @return void
+     *
+     * @covers ::getBoundary()
+     */
+    public function testGetBoundary()
+    {
+        $email = new Email();
+        $email->setTo('evermannella@example.org');
+        $email->message('This is the message');
+        $email->addAttachments([
+            'test.txt' => [
+                'data' => 'Some text attachment',
+                'mimetype' => 'text/plain',
+            ],
+        ]);
+        $email->setTransport('test');
+        $email->send();
+
+        $boundary = Email::getBoundary($email);
+
+        static::assertNotNull($boundary);
+        static::assertAttributeSame($boundary, '_boundary', $email);
+    }
 }


### PR DESCRIPTION
When sending a multipart email using the AsyncJobs mail transport, the email is rejected by the SMTP server due to the boundary being missing:

```
...
Content-Type: multipart/alternative; boundary=""
...
```

This PR fixes this bug.