### PR TITLE
Type filter enhance

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -284,4 +284,61 @@ class FilterQueryStringTest extends IntegrationTestCase
         static::assertArrayHasKey('data', $result);
         static::assertEquals($expected, Hash::extract($result['data'], '{n}.id'), '', 0, 10, true);
     }
+
+    /**
+     * Data provider for `testTypeFilter` test case.
+     *
+     * @return array
+     */
+    public function typeFilterProvider()
+    {
+        return [
+            'simple' => [
+               'filter[type]=users',
+               [
+                   1,
+                   5
+               ]
+            ],
+            'exclude' => [
+               'filter[type][ne]=documents',
+               [
+                   1,
+                   4,
+                   5,
+                   8,
+                   9
+               ]
+            ],
+            'multi' => [
+               'filter[type][]=events&filter[type][]=locations',
+               [
+                   8,
+                   9
+               ]
+            ],
+        ];
+    }
+
+    /**
+     * Test `filter[type]` query string.
+     *
+     * @return void
+     *
+     * @dataProvider typeFilterProvider
+     * @coversNothing
+     */
+    public function testTypeFilter($query, $expected)
+    {
+        $this->configRequestHeaders();
+
+        $this->get("/objects?$query");
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        static::assertArrayHasKey('data', $result);
+        static::assertEquals($expected, Hash::extract($result['data'], '{n}.id'), '', 0, 10, true);
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -15,6 +15,7 @@ namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Model\Entity\ObjectEntity;
 use BEdita\Core\Model\Validation\ObjectsValidator;
+use BEdita\Core\ORM\QueryFilterTrait;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\TableSchema;
@@ -46,6 +47,8 @@ use Cake\ORM\Table;
  */
 class ObjectsTable extends Table
 {
+
+    use QueryFilterTrait;
 
     /**
      * {@inheritDoc}
@@ -153,14 +156,9 @@ class ObjectsTable extends Table
             $type = $this->ObjectTypes->get($type)->id;
         }
         unset($type);
+        $field = $this->aliasField($this->ObjectTypes->getForeignKey());
 
-        return $query
-            ->where(function (QueryExpression $exp) use ($options) {
-                return $exp->in(
-                    $this->aliasField($this->ObjectTypes->getForeignKey()),
-                    $options
-                );
-            });
+        return $this->fieldsFilter($query, [$field => $options]);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -28,6 +28,9 @@ class ObjectsTableTest extends TestCase
     public $fixtures = [
         'plugin.BEdita/Core.object_types',
         'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
+        'plugin.BEdita/Core.object_relations',
         'plugin.BEdita/Core.profiles',
         'plugin.BEdita/Core.users',
         'plugin.BEdita/Core.date_ranges',
@@ -166,6 +169,16 @@ class ObjectsTableTest extends TestCase
                 ],
                 ['document', 'profiles'],
             ],
+            'exclude' => [
+                [
+                    1 => 'Mr. First User',
+                    4 => 'Gustavo Supporto profile',
+                    5 => 'Miss Second User',
+                    8 => 'The Two Towers',
+                    9 => 'first event',
+                ],
+                ['ne' => 'documents'],
+            ],
             'missing' => [
                 false,
                 ['document', 'profiles', 0],
@@ -232,6 +245,8 @@ class ObjectsTableTest extends TestCase
         if (!$object) {
             static::fail('Unable to save object');
         }
+        $object = $this->Objects->get($object->id, ['contain' => ['DateRanges']]);
+        static::assertCount(1, $object->date_ranges);
 
         $data['date_ranges'][0]['start_date'] = date('Y-m-d');
         $object = $this->Objects->patchEntity($object, $data);


### PR DESCRIPTION
This PR adds additional options to  `filter[type]` query string filter using `QueryFilterTrait::fieldsFilter`

For instance is now possible a filter like `?filter[type][ne]=documents`: get all objects not of type `documents`
 
