### PR TITLE
Remove `ApiKeys` config

### DIFF
--- a/plugins/BEdita/API/src/Controller/AppController.php
+++ b/plugins/BEdita/API/src/Controller/AppController.php
@@ -48,10 +48,6 @@ class AppController extends Controller
     {
         parent::initialize();
 
-        if (!$this->apiKeyCheck()) {
-            throw new ForbiddenException('No valid API KEY found');
-        }
-
         $this->response = $this->response->withHeader('X-BEdita-Version', Configure::read('BEdita.version'));
 
         $this->loadComponent('BEdita/API.Paginator', (array)Configure::read('Pagination'));
@@ -103,46 +99,6 @@ class AppController extends Controller
         }
 
         return null;
-    }
-
-    /**
-     * Check API KEY from request header.
-     * API KEYS are stored in configuration with this structure:
-     *
-     *  'ApiKeys' => [
-     *    'sdgwr89081023jfdklewRASdasdwdfswdr' => [
-     *      'label' => 'web app', // (optional)
-     *      'origin' => 'example.com', // (optional) could be '*'
-     *    ],
-     *    'w4nvwpq5028DDfwnrK2933293423nfnaa4' => [
-     *       ....
-     *    ],
-     *
-     * Check rules are:
-     *   - if no Api Keys are defined -> request is always accepted
-     *   - if one or more Api Keys are defined
-     *      - current X-Api-Key header value should be one of these keys
-     *      - if corresponding Key has an 'origin' request origin should match
-     *      - otherwise an error response is sent - HTTP 403
-     *
-     * @return bool True if check is passed, false otherwise
-     */
-    protected function apiKeyCheck()
-    {
-        $apiKeys = Configure::read('ApiKeys');
-        if (!empty($apiKeys)) {
-            $requestKey = $this->request->getHeaderLine('X-Api-Key');
-            if (!$requestKey || !isset($apiKeys[$requestKey])) {
-                return false;
-            }
-            $key = $apiKeys[$requestKey];
-            if (!empty($key['origin']) && $key['origin'] !== '*' &&
-                $key['origin'] !== $this->request->getHeaderLine('Origin')) {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/AppControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AppControllerTest.php
@@ -359,35 +359,6 @@ class AppControllerTest extends IntegrationTestCase
     }
 
     /**
-     * Test API KEY check rules.
-     *
-     * @param int $expectedCode Expected response code.
-     * @param array $apiKeyCfg API KEY configuration.
-     * @param string|null $apiKeyReq API KEY in request header.
-     * @param string|null $origin Request's "Origin" header.
-     * @return void
-     *
-     * @dataProvider apiKeysProvider
-     * @covers ::apiKeyCheck()
-     */
-    public function testApiKeys($expectedCode, $apiKeyCfg, $apiKeyReq = null, $origin = null)
-    {
-        Configure::write('ApiKeys', $apiKeyCfg);
-
-        $this->configRequest([
-            'headers' => [
-                'Accept' => 'application/vnd.api+json',
-                'Origin' => $origin,
-                'X-Api-Key' => $apiKeyReq,
-            ]
-        ]);
-
-        $this->get('/home');
-
-        $this->assertResponseCode($expectedCode);
-    }
-
-    /**
      * Test API meta info header.
      *
      * @return void

--- a/plugins/BEdita/API/tests/TestCase/Controller/AppControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AppControllerTest.php
@@ -99,6 +99,7 @@ class AppControllerTest extends IntegrationTestCase
      * @return void
      *
      * @dataProvider contentTypeProvider
+     * @covers ::beforeFilter()
      * @covers \BEdita\API\Controller\Component\JsonApiComponent::startup()
      * @covers \BEdita\API\Controller\Component\JsonApiComponent::beforeRender()
      * @covers \BEdita\API\Error\ExceptionRenderer::render()
@@ -304,58 +305,6 @@ class AppControllerTest extends IntegrationTestCase
         $this->assertResponseCode(500);
         $this->assertContentType('application/vnd.api+json');
         $this->assertResponseNotContains('<!DOCTYPE html>');
-    }
-
-    /**
-     * Data provider for `testApiKey` test case.
-     *
-     * @return array
-     */
-    public function apiKeysProvider()
-    {
-        return [
-            'apiKeyMissing' => [
-                403,
-                [
-                    'eqe12131231231231412414' => [
-                        'origin' => '*',
-                    ],
-                ],
-            ],
-            'apiKeyOk' => [
-                200,
-                [
-                    'eqe12131231231231412414' => [
-                        'origin' => '*',
-                    ],
-                ],
-                'eqe12131231231231412414',
-            ],
-            'noApiKey' => [
-                200,
-                [],
-            ],
-            'originOk' => [
-                200,
-                [
-                    'eqe12131231231231412414' => [
-                        'origin' => 'example.com',
-                    ],
-                ],
-                'eqe12131231231231412414',
-                'example.com'
-            ],
-            'originKo' => [
-                403,
-                [
-                    'eqe12131231231231412414' => [
-                        'origin' => 'example.com',
-                    ],
-                ],
-                'eqe12131231231231412414',
-                'otherdomain.com'
-            ],
-        ];
     }
 
     /**


### PR DESCRIPTION
Since `api_key` check si actually implemented in `EndpointAuthorize` the old API KEY configuration is not necessary anymore and potentially harmful.

Corresponding do paragrah https://bedita.readthedocs.io/en/4-cactus/configuration.html#apikeys will also be removed.
