### PR TITLE
Project.name config

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -410,6 +410,15 @@ return [
     ],
 
     /**
+     * Project information.
+     *
+     * - `name` public name of the project, short expression recommended like `MyProject`, `Nope v1`
+     */
+    'Project' => [
+        'name' => 'BEdita 4',
+    ],
+
+    /**
      * Signup settings.
      *
      * - `requireActivation` - boolean (default: true) - Are new users required to verify their contact method

--- a/plugins/BEdita/API/src/Controller/HomeController.php
+++ b/plugins/BEdita/API/src/Controller/HomeController.php
@@ -13,6 +13,7 @@
 namespace BEdita\API\Controller;
 
 use BEdita\Core\Utility\LoggedUser;
+use Cake\Core\Configure;
 use Cake\Http\ServerRequest;
 use Cake\ORM\TableRegistry;
 use Cake\Routing\Router;
@@ -92,8 +93,9 @@ class HomeController extends AppController
                 ],
             ];
         }
+        $project = Configure::read('Project');
 
-        $this->set('_meta', compact('resources'));
+        $this->set('_meta', compact('resources', 'project'));
         $this->set('_serialize', []);
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
@@ -14,6 +14,7 @@ namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
 use BEdita\Core\Utility\LoggedUser;
+use Cake\Core\Configure;
 use Cake\Utility\Hash;
 
 /**
@@ -33,6 +34,7 @@ class HomeControllerTest extends IntegrationTestCase
      */
     public function testIndex()
     {
+        $project = Configure::read('Project');
         $expected = [
             'links' => [
                 'self' => 'http://api.example.com/home',
@@ -236,6 +238,7 @@ class HomeControllerTest extends IntegrationTestCase
                         ],
                     ],
                 ],
+                'project' => $project,
             ],
         ];
 

--- a/plugins/BEdita/Core/src/Mailer/UserMailer.php
+++ b/plugins/BEdita/Core/src/Mailer/UserMailer.php
@@ -14,7 +14,7 @@
 namespace BEdita\Core\Mailer;
 
 use BEdita\Core\Model\Entity\User;
-use BEdita\Core\State\CurrentApplication;
+use Cake\Core\Configure;
 use Cake\Mailer\Mailer;
 
 /**
@@ -164,8 +164,8 @@ class UserMailer extends Mailer
      */
     protected function getProjectName()
     {
-        $currentApplication = CurrentApplication::getApplication();
+        $name = Configure::read('Project.name');
 
-        return ($currentApplication !== null) ? $currentApplication->name : 'BEdita';
+        return ($name !== null) ? $name : 'BEdita';
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTest.php
@@ -352,8 +352,6 @@ class UserMailerTest extends TestCase
      */
     public function testGetProjectName($expected, $configured)
     {
-        $current = Configure::read('Project.name');
-
         Configure::write('Project.name', $configured);
 
         $this->getMailer('BEdita/Core.User', $this->Email)->send('welcome', [
@@ -367,8 +365,5 @@ class UserMailerTest extends TestCase
         $viewVars = $this->Email->getViewVars();
         static::assertArrayHasKey('projectName', $viewVars);
         static::assertEquals($expected, $viewVars['projectName']);
-
-        // restore conf
-        Configure::write('Project.name', $current);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTest.php
@@ -14,7 +14,7 @@
 namespace BEdita\Core\Test\TestCase\Mailer;
 
 use BEdita\Core\Model\Entity\Application;
-use BEdita\Core\State\CurrentApplication;
+use Cake\Core\Configure;
 use Cake\Mailer\Email;
 use Cake\Mailer\MailerAwareTrait;
 use Cake\ORM\TableRegistry;
@@ -331,12 +331,11 @@ class UserMailerTest extends TestCase
         return [
             'default' => [
                 'BEdita',
+                null,
             ],
-            'custom app name' => [
+            'custom name' => [
                 'Superunknown :(',
-                new Application([
-                    'name' => 'Superunknown :('
-                ])
+                'Superunknown :('
             ],
         ];
     }
@@ -345,17 +344,17 @@ class UserMailerTest extends TestCase
      * Test `getProjectName()`
      *
      * @param string $expected The project name expected
-     * @param \BEdita\Core\Model\Entity\Application $application The application entity
+     * @param string $configured The project name to put in configuration
      * @return void
      *
      * @dataProvider getProjectNameProvider
      * @covers ::getProjectName()
      */
-    public function testGetProjectName($expected, $application = null)
+    public function testGetProjectName($expected, $configured)
     {
-        if ($application instanceof Application) {
-            CurrentApplication::setApplication($application);
-        }
+        $current = Configure::read('Project.name');
+
+        Configure::write('Project.name', $configured);
 
         $this->getMailer('BEdita/Core.User', $this->Email)->send('welcome', [
             [
@@ -368,5 +367,8 @@ class UserMailerTest extends TestCase
         $viewVars = $this->Email->getViewVars();
         static::assertArrayHasKey('projectName', $viewVars);
         static::assertEquals($expected, $viewVars['projectName']);
+
+        // restore conf
+        Configure::write('Project.name', $current);
     }
 }


### PR DESCRIPTION
This PR adds a `Project` configuration key to contain project information.

`Project.name` will be used in email subjects to users as default.