### PR TITLE
Include relations in object types cache

### DIFF
--- a/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
@@ -70,10 +70,6 @@ class RelationsBehavior extends Behavior
         if (!($objectType instanceof ObjectType)) {
             $objectType = $table->get($objectType);
         }
-        $table->loadInto(
-            $objectType,
-            ['LeftRelations.RightObjectTypes', 'RightRelations.LeftObjectTypes']
-        );
 
         $this->objectType = $objectType;
 

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
@@ -29,7 +29,6 @@ use Cake\Utility\Inflector;
  * @property string $plugin
  * @property string $model
  * @property string $table
- * @property array $associations
  * @property string[] $relations
  * @property \BEdita\Core\Model\Entity\ObjectEntity[] $objects
  * @property \BEdita\Core\Model\Entity\Relation[] $left_relations

--- a/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
@@ -197,10 +197,13 @@ class ObjectTypesTable extends Table
             $primaryKey = $allTypes[$primaryKey];
         }
 
-        $options += [
-            'key' => 'id_' . $primaryKey,
-            'cache' => self::CACHE_CONFIG,
-        ];
+        if (empty($options)) {
+            $options = [
+                'key' => 'id_' . $primaryKey,
+                'cache' => self::CACHE_CONFIG,
+                'contain' => ['LeftRelations.RightObjectTypes', 'RightRelations.LeftObjectTypes'],
+            ];
+        }
 
         return parent::get($primaryKey, $options);
     }

--- a/plugins/BEdita/Core/src/Model/Table/RelationTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationTypesTable.php
@@ -105,7 +105,7 @@ class RelationTypesTable extends Table
 
         $ids = array_unique([$entity->get($property), $entity->getOriginal($property)]);
         foreach ($ids as $id) {
-            Cache::delete('id_' . $id, ObjectTypesTable::CACHE_CONFIG);
+            Cache::delete(ObjectTypesTable::getCacheKey($id), ObjectTypesTable::CACHE_CONFIG);
         }
     }
 
@@ -119,6 +119,6 @@ class RelationTypesTable extends Table
     public function afterDelete(Event $event, Entity $entity)
     {
         $property = $this->association('ObjectTypes')->getForeignKey();
-        Cache::delete('id_' . $entity->get($property), ObjectTypesTable::CACHE_CONFIG);
+        Cache::delete(ObjectTypesTable::getCacheKey($entity->get($property)), ObjectTypesTable::CACHE_CONFIG);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/RelationTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationTypesTable.php
@@ -15,9 +15,6 @@
 namespace BEdita\Core\Model\Table;
 
 use Cake\Cache\Cache;
-use Cake\Database\Expression\QueryExpression;
-use Cake\Event\Event;
-use Cake\ORM\Entity;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
@@ -55,12 +52,12 @@ class RelationTypesTable extends Table
         $this->belongsTo('Relations', [
             'foreignKey' => 'relation_id',
             'joinType' => 'INNER',
-            'className' => 'Relations'
+            'className' => 'Relations',
         ]);
         $this->belongsTo('ObjectTypes', [
             'foreignKey' => 'object_type_id',
             'joinType' => 'INNER',
-            'className' => 'ObjectTypes'
+            'className' => 'ObjectTypes',
         ]);
     }
 
@@ -96,59 +93,20 @@ class RelationTypesTable extends Table
     /**
      * Invalidate object types cache after updating a relation's object type.
      *
-     * @param \Cake\Event\Event $event Triggered event.
-     * @param \Cake\ORM\Entity $entity Subject entity.
      * @return void
      */
-    public function afterSave(Event $event, Entity $entity)
+    public function afterSave()
     {
-        $objectTypeId = $this->ObjectTypes->getForeignKey();
-        $relationId = $this->Relations->getForeignKey();
-
-        $ids = $this
-            ->find('list', [
-                'keyField' => $objectTypeId,
-                'valueField' => $objectTypeId,
-            ])
-            ->where(function (QueryExpression $exp) use ($entity, $relationId) {
-                return $exp->in($relationId, [$entity->get($relationId), $entity->getOriginal($relationId)]);
-            })
-            ->toArray();
-        $ids[] = $entity->get($objectTypeId);
-        $ids[] = $entity->getOriginal($objectTypeId);
-
-        $ids = array_unique($ids);
-        foreach ($ids as $id) {
-            Cache::delete(ObjectTypesTable::getCacheKey($id), ObjectTypesTable::CACHE_CONFIG);
-        }
+        Cache::clear(false, ObjectTypesTable::CACHE_CONFIG);
     }
 
     /**
      * Invalidate object types cache after deleting a relation's object type.
      *
-     * @param \Cake\Event\Event $event Triggered event.
-     * @param \Cake\ORM\Entity $entity Subject entity.
      * @return void
      */
-    public function afterDelete(Event $event, Entity $entity)
+    public function afterDelete()
     {
-        $objectTypeId = $this->ObjectTypes->getForeignKey();
-        $relationId = $this->Relations->getForeignKey();
-
-        $ids = $this
-            ->find('list', [
-                'keyField' => $objectTypeId,
-                'valueField' => $objectTypeId,
-            ])
-            ->where([
-                $relationId => $entity->get($relationId),
-            ])
-            ->toArray();
-        $ids[] = $entity->get($objectTypeId);
-
-        $ids = array_unique($ids);
-        foreach ($ids as $id) {
-            Cache::delete(ObjectTypesTable::getCacheKey($id), ObjectTypesTable::CACHE_CONFIG);
-        }
+        Cache::clear(false, ObjectTypesTable::CACHE_CONFIG);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
@@ -17,8 +17,6 @@ use BEdita\Core\ORM\Rule\IsUniqueAmongst;
 use Cake\Cache\Cache;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\TableSchema;
-use Cake\Event\Event;
-use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
@@ -175,22 +173,20 @@ class RelationsTable extends Table
     /**
      * Invalidate object types cache after updating a relation.
      *
-     * @param \Cake\Event\Event $event Triggered event.
-     * @param \Cake\ORM\Entity $entity Subject entity.
      * @return void
      */
-    public function afterSave(Event $event, Entity $entity)
+    public function afterSave()
     {
-        $ids = $this->LeftObjectTypes->junction()
-            ->find('list', [
-                'keyField' => $this->LeftObjectTypes->getTargetForeignKey(),
-                'valueField' => $this->LeftObjectTypes->getTargetForeignKey(),
-            ])
-            ->where([
-                $this->LeftObjectTypes->getForeignKey() => $entity->id,
-            ]);
-        foreach ($ids as $id) {
-            Cache::delete(ObjectTypesTable::getCacheKey($id), ObjectTypesTable::CACHE_CONFIG);
-        }
+        Cache::clear(false, ObjectTypesTable::CACHE_CONFIG);
+    }
+
+    /**
+     * Invalidate object types cache after deleting a relation.
+     *
+     * @return void
+     */
+    public function afterDelete()
+    {
+        Cache::clear(false, ObjectTypesTable::CACHE_CONFIG);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
@@ -190,7 +190,7 @@ class RelationsTable extends Table
                 $this->LeftObjectTypes->getForeignKey() => $entity->id,
             ]);
         foreach ($ids as $id) {
-            Cache::delete('id_' . $id, ObjectTypesTable::CACHE_CONFIG);
+            Cache::delete(ObjectTypesTable::getCacheKey($id), ObjectTypesTable::CACHE_CONFIG);
         }
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
@@ -331,14 +331,14 @@ class ObjectTypesTableTest extends TestCase
     {
         $entity = $this->ObjectTypes->get('document');
 
-        static::assertNotFalse(Cache::read('id_1', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
 
         $entity = $this->ObjectTypes->patchEntity($entity, ['singular' => 'foo', 'name' => 'foos']);
         $this->ObjectTypes->save($entity);
 
-        static::assertFalse(Cache::read('id_1', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
     }
@@ -354,13 +354,13 @@ class ObjectTypesTableTest extends TestCase
     {
         $entity = $this->ObjectTypes->get('document');
 
-        static::assertNotFalse(Cache::read('id_1', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
 
         $this->ObjectTypes->delete($entity);
 
-        static::assertFalse(Cache::read('id_1', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
     }
@@ -435,5 +435,20 @@ class ObjectTypesTableTest extends TestCase
 
         static::assertArrayHasKey('LeftRelations', $contain);
         static::assertArrayHasKey('RightRelations', $contain);
+    }
+
+    /**
+     * Test `getCacheKey` static method.
+     *
+     * @return void
+     *
+     * @covers ::getCacheKey()
+     */
+    public function testGetCacheKey()
+    {
+        $expected = 'id_99_rel';
+        $result = ObjectTypesTable::getCacheKey(99);
+
+        static::assertSame($expected, $result);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
@@ -330,8 +330,12 @@ class ObjectTypesTableTest extends TestCase
     public function testInvalidateCacheAfterSave()
     {
         $entity = $this->ObjectTypes->get('document');
+        $this->ObjectTypes->get(2);
+        $this->ObjectTypes->get(5);
 
         static::assertNotFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_2_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_5_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
 
@@ -339,6 +343,8 @@ class ObjectTypesTableTest extends TestCase
         $this->ObjectTypes->save($entity);
 
         static::assertFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('id_2_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_5_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
     }
@@ -353,14 +359,20 @@ class ObjectTypesTableTest extends TestCase
     public function testInvalidateCacheAfterDelete()
     {
         $entity = $this->ObjectTypes->get('document');
+        $this->ObjectTypes->get(2);
+        $this->ObjectTypes->get(5);
 
         static::assertNotFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_2_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_5_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
 
         $this->ObjectTypes->delete($entity);
 
         static::assertFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('id_2_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_5_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
@@ -344,7 +344,7 @@ class ObjectTypesTableTest extends TestCase
 
         static::assertFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('id_2_rel', ObjectTypesTable::CACHE_CONFIG));
-        static::assertNotFalse(Cache::read('id_5_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('id_5_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
     }
@@ -372,7 +372,7 @@ class ObjectTypesTableTest extends TestCase
 
         static::assertFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('id_2_rel', ObjectTypesTable::CACHE_CONFIG));
-        static::assertNotFalse(Cache::read('id_5_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('id_5_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
     }
@@ -447,20 +447,5 @@ class ObjectTypesTableTest extends TestCase
 
         static::assertArrayHasKey('LeftRelations', $contain);
         static::assertArrayHasKey('RightRelations', $contain);
-    }
-
-    /**
-     * Test `getCacheKey` static method.
-     *
-     * @return void
-     *
-     * @covers ::getCacheKey()
-     */
-    public function testGetCacheKey()
-    {
-        $expected = 'id_99_rel';
-        $result = ObjectTypesTable::getCacheKey(99);
-
-        static::assertSame($expected, $result);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
@@ -15,6 +15,8 @@ namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use BEdita\Core\Model\Table\ObjectTypesTable;
 use Cake\Cache\Cache;
+use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\ORM\Association\HasMany;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -84,11 +86,11 @@ class ObjectTypesTableTest extends TestCase
     {
         $this->ObjectTypes->initialize([]);
 
-        $this->assertEquals('object_types', $this->ObjectTypes->getTable());
-        $this->assertEquals('id', $this->ObjectTypes->getPrimaryKey());
-        $this->assertEquals('name', $this->ObjectTypes->getDisplayField());
+        static::assertEquals('object_types', $this->ObjectTypes->getTable());
+        static::assertEquals('id', $this->ObjectTypes->getPrimaryKey());
+        static::assertEquals('name', $this->ObjectTypes->getDisplayField());
 
-        $this->assertInstanceOf('\Cake\ORM\Association\HasMany', $this->ObjectTypes->Objects);
+        static::assertInstanceOf(HasMany::class, $this->ObjectTypes->Objects);
     }
 
     /**
@@ -176,7 +178,7 @@ class ObjectTypesTableTest extends TestCase
         $this->ObjectTypes->patchEntity($objectType, $data);
 
         $success = $this->ObjectTypes->save($objectType);
-        $this->assertEquals($expected, (bool)$success);
+        static::assertEquals($expected, (bool)$success);
     }
 
     /**
@@ -278,11 +280,11 @@ class ObjectTypesTableTest extends TestCase
                 'Documents',
             ],
             'missingId' => [
-                false,
+                new RecordNotFoundException('Record not found in table "object_types"'),
                 99,
             ],
             'missingType' => [
-                false,
+                new RecordNotFoundException('Record not found in table "object_types"'),
                 'missing_type',
             ],
         ];
@@ -300,13 +302,22 @@ class ObjectTypesTableTest extends TestCase
      */
     public function testGet($expected, $primaryKey)
     {
-        if (!$expected) {
-            $this->expectException('\Cake\Datasource\Exception\RecordNotFoundException');
+        if ($expected instanceof \Exception) {
+            $this->expectException(get_class($expected));
+            static::expectExceptionMessage($expected->getMessage());
         }
 
         $entity = $this->ObjectTypes->get($primaryKey);
 
-        $this->assertEquals($expected, $entity->toArray());
+        static::assertEquals($expected, $entity->toArray());
+        static::assertTrue($entity->has('left_relations'));
+        static::assertTrue($entity->has('right_relations'));
+        foreach ($entity->left_relations as $relation) {
+            static::assertTrue($relation->has('right_object_types'));
+        }
+        foreach ($entity->right_relations as $relation) {
+            static::assertTrue($relation->has('left_object_types'));
+        }
     }
 
     /**
@@ -320,16 +331,16 @@ class ObjectTypesTableTest extends TestCase
     {
         $entity = $this->ObjectTypes->get('document');
 
-        $this->assertNotFalse(Cache::read('id_1', ObjectTypesTable::CACHE_CONFIG));
-        $this->assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
-        $this->assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_1', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
 
         $entity = $this->ObjectTypes->patchEntity($entity, ['singular' => 'foo', 'name' => 'foos']);
         $this->ObjectTypes->save($entity);
 
-        $this->assertFalse(Cache::read('id_1', ObjectTypesTable::CACHE_CONFIG));
-        $this->assertFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
-        $this->assertFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('id_1', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
     }
 
     /**
@@ -343,15 +354,15 @@ class ObjectTypesTableTest extends TestCase
     {
         $entity = $this->ObjectTypes->get('document');
 
-        $this->assertNotFalse(Cache::read('id_1', ObjectTypesTable::CACHE_CONFIG));
-        $this->assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
-        $this->assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_1', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
 
         $this->ObjectTypes->delete($entity);
 
-        $this->assertFalse(Cache::read('id_1', ObjectTypesTable::CACHE_CONFIG));
-        $this->assertFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
-        $this->assertFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('id_1', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationTypesTableTest.php
@@ -140,8 +140,8 @@ class RelationTypesTableTest extends TestCase
         $this->RelationTypes->ObjectTypes->get('document');
         $this->RelationTypes->ObjectTypes->get(5);
 
-        static::assertNotFalse(Cache::read('id_1', ObjectTypesTable::CACHE_CONFIG));
-        static::assertNotFalse(Cache::read('id_5', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_5_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
 
@@ -149,8 +149,8 @@ class RelationTypesTableTest extends TestCase
         $entity->object_type = $this->RelationTypes->ObjectTypes->get(5);
         $this->RelationTypes->save($entity);
 
-        static::assertFalse(Cache::read('id_1', ObjectTypesTable::CACHE_CONFIG));
-        static::assertFalse(Cache::read('id_5', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('id_5_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
     }
@@ -166,14 +166,14 @@ class RelationTypesTableTest extends TestCase
     {
         $this->RelationTypes->ObjectTypes->get('document');
 
-        static::assertNotFalse(Cache::read('id_1', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
 
         $entity = $this->RelationTypes->get([1, 1, 'left']);
         $this->RelationTypes->delete($entity);
 
-        static::assertFalse(Cache::read('id_1', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationTypesTableTest.php
@@ -154,8 +154,8 @@ class RelationTypesTableTest extends TestCase
         static::assertFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('id_2_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('id_5_rel', ObjectTypesTable::CACHE_CONFIG));
-        static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
-        static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
     }
 
     /**
@@ -182,8 +182,8 @@ class RelationTypesTableTest extends TestCase
 
         static::assertFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('id_2_rel', ObjectTypesTable::CACHE_CONFIG));
-        static::assertNotFalse(Cache::read('id_5_rel', ObjectTypesTable::CACHE_CONFIG));
-        static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
-        static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('id_5_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationTypesTableTest.php
@@ -138,9 +138,11 @@ class RelationTypesTableTest extends TestCase
     public function testInvalidateCacheAfterSave()
     {
         $this->RelationTypes->ObjectTypes->get('document');
+        $this->RelationTypes->ObjectTypes->get(2);
         $this->RelationTypes->ObjectTypes->get(5);
 
         static::assertNotFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_2_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('id_5_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
@@ -150,6 +152,7 @@ class RelationTypesTableTest extends TestCase
         $this->RelationTypes->save($entity);
 
         static::assertFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('id_2_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('id_5_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
@@ -165,8 +168,12 @@ class RelationTypesTableTest extends TestCase
     public function testInvalidateCacheAfterDelete()
     {
         $this->RelationTypes->ObjectTypes->get('document');
+        $this->RelationTypes->ObjectTypes->get(2);
+        $this->RelationTypes->ObjectTypes->get(5);
 
         static::assertNotFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_2_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_5_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
 
@@ -174,6 +181,8 @@ class RelationTypesTableTest extends TestCase
         $this->RelationTypes->delete($entity);
 
         static::assertFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('id_2_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_5_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
@@ -196,8 +196,8 @@ class RelationsTableTest extends TestCase
         $this->Relations->LeftObjectTypes->get('document');
         $this->Relations->LeftObjectTypes->get(2);
 
-        static::assertNotFalse(Cache::read('id_1', ObjectTypesTable::CACHE_CONFIG));
-        static::assertNotFalse(Cache::read('id_2', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_2_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
 
@@ -205,8 +205,8 @@ class RelationsTableTest extends TestCase
         $entity = $this->Relations->patchEntity($entity, ['description' => 'My brand new description']);
         $this->Relations->save($entity);
 
-        static::assertFalse(Cache::read('id_1', ObjectTypesTable::CACHE_CONFIG));
-        static::assertFalse(Cache::read('id_2', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('id_2_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
     }
@@ -223,16 +223,16 @@ class RelationsTableTest extends TestCase
         $this->Relations->LeftObjectTypes->get('document');
         $this->Relations->LeftObjectTypes->get(2);
 
-        static::assertNotFalse(Cache::read('id_1', ObjectTypesTable::CACHE_CONFIG));
-        static::assertNotFalse(Cache::read('id_2', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertNotFalse(Cache::read('id_2_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
 
         $entity = $this->Relations->get(1);
         $this->Relations->delete($entity);
 
-        static::assertFalse(Cache::read('id_1', ObjectTypesTable::CACHE_CONFIG));
-        static::assertFalse(Cache::read('id_2', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('id_2_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
@@ -207,8 +207,8 @@ class RelationsTableTest extends TestCase
 
         static::assertFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('id_2_rel', ObjectTypesTable::CACHE_CONFIG));
-        static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
-        static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
     }
 
     /**
@@ -216,7 +216,7 @@ class RelationsTableTest extends TestCase
      *
      * @return void
      *
-     * @coversNothing
+     * @covers ::afterDelete()
      */
     public function testInvalidateCacheAfterDelete()
     {
@@ -233,7 +233,7 @@ class RelationsTableTest extends TestCase
 
         static::assertFalse(Cache::read('id_1_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('id_2_rel', ObjectTypesTable::CACHE_CONFIG));
-        static::assertNotFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
-        static::assertNotFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
+        static::assertFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
     }
 }


### PR DESCRIPTION
This PR fixes #1226 by including information about relations in object types cache.

In complex scenarios, where relations are being navigated in depth, we are currently performing the same query over and over to find out which relations are attached to the current object type. In such scenarios this PR might significantly reduce the amount of queries being performed — a simple test in a very complex scenario lowered the amount of queries by almost 75%. 😱 