### PR TITLE
Allow base64-encoded uploads

### DIFF
--- a/plugins/BEdita/Core/src/Model/Entity/Stream.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Stream.php
@@ -148,8 +148,7 @@ class Stream extends Entity implements JsonApiSerializable
             return null;
         }
 
-        $stream = new ZendStream('php://temp', 'wb+');
-        $stream->attach($readStream);
+        $stream = new ZendStream($readStream, 'r');
 
         return $this->_properties['contents'] = $stream;
     }
@@ -196,8 +195,7 @@ class Stream extends Entity implements JsonApiSerializable
 
         // Stream.
         rewind($resource);
-        $stream = new ZendStream('php://temp', 'wb+');
-        $stream->attach($resource);
+        $stream = new ZendStream($resource, 'r');
 
         return $stream;
     }


### PR DESCRIPTION
This PR allows clients to upload files using base64-encoded payloads instead of raw binary streams.

Clients that wish to upload a base64-encoded payload **MUST** include the header `Content-Transfer-Encoding: base64` in their request.

This feature is available _only_ for `POST /streams/upload/:fileName` endpoint.