### PR TITLE
Update `.gitattributes` for `git archive` command

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -41,3 +41,15 @@
 *.mo binary
 *.pdf binary
 *.phar binary
+
+# Remove files for archives generated using `git archive`
+.github export-ignore
+plugins/BEdita/API/postman export-ignore
+plugins/BEdita/API/spec export-ignore
+tests export-ignore
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.scrutinizer.yml export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
This PR updates `.gitattributes` file to exclude useless files from zipballs and tarballs generated using `git archive` command.

Please note, however, that installed vendors _are not_ included in these archives. This is both good and bad: it is good because dependencies **MUST** be installed using Composer, that is able to detect which package version should be installed based on the characteristics of the system it runs on; it is bad because if somebody uses a zipball or a tarball, they probably don't have Composer installed on their system.

Anyways:
- `git archive -o myfile.zip HEAD` generates a ZIP archive of the current tree
- `git archive -o myfile.tar HEAD` generates a TAR archive of the current tree