### PR TITLE
Docker image 🐳

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+/.idea/
+/.git/
+/.vagrant/
+/.vscode/
+/logs/
+/tmp/
+/vendor/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,8 @@
-/.idea/
-/.git/
-/.vagrant/
-/.vscode/
-/config/app.php
-/logs/
-/tmp/
-/vendor/
+.idea
+.git
+.vagrant
+.vscode
+config/app.php
+logs
+tmp
+vendor

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 /.git/
 /.vagrant/
 /.vscode/
+/config/app.php
 /logs/
 /tmp/
 /vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM chialab/php:7.1-apache
+MAINTAINER dev@chialab.io
+
+# Install Wait-for-it and configure PHP
+RUN curl -o /wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh \
+    && chmod +x /wait-for-it.sh \
+    && echo "[PHP]\noutput_buffering = 4096\nmemory_limit = -1" > /usr/local/etc/php/php.ini
+
+# Copy files
+COPY . /var/www/html
+
+ARG DEBUG
+ENV DEBUG ${DEBUG:-false}
+
+# Install libraries
+WORKDIR /var/www/html
+RUN if [ ! "$DEBUG" = "true" ]; then export COMPOSER_ARGS='--no-dev'; fi \
+    && composer install $COMPOSER_ARGS --optimize-autoloader --no-interaction --quiet
+
+ENV LOG_DEBUG_URL="console:///?stream=php://stdout" \
+    LOG_ERROR_URL="console:///?stream=php://stderr" \
+    DATABASE_URL="sqlite:////var/www/html/bedita.sqlite"
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD ["apache2-foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM chialab/php:7.1-apache
+ARG PHP_VERSION=7.1
+FROM chialab/php:${PHP_VERSION}-apache
 MAINTAINER dev@chialab.io
 
 # Install Wait-for-it and configure PHP
@@ -14,6 +15,7 @@ ENV DEBUG ${DEBUG:-false}
 
 # Install libraries
 WORKDIR /var/www/html
+VOLUME /var/www/webroot/files
 RUN if [ ! "$DEBUG" = "true" ]; then export COMPOSER_ARGS='--no-dev'; fi \
     && composer install $COMPOSER_ARGS --optimize-autoloader --no-interaction --quiet
 
@@ -23,5 +25,7 @@ ENV LOG_DEBUG_URL="console:///?stream=php://stdout" \
 
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
+HEALTHCHECK --interval=30s --timeout=3s --start-period=1m \
+    CMD curl -f http://localhost/status || exit 1
 
 CMD ["apache2-foreground"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -eo pipefail
+shopt -s nullglob
+
+if [ ! -z "${DATABASE_URL}" ]; then
+    DATABASE_HOST=$(php -r "echo parse_url(getenv('DATABASE_URL'), PHP_URL_HOST) . ':' . parse_url(getenv('DATABASE_URL'), PHP_URL_PORT);")
+    if [ "$DATABASE_HOST" != ":" ]; then
+        /wait-for-it.sh ${DATABASE_HOST} -s -t 0 -- echo '=====> Database Ready'
+    fi
+    bin/cake migrations migrate -p BEdita/Core
+    bin/cake migrations seed -p BEdita/Core --seed InitialSeed
+
+    chmod -R a+rwX tmp
+    chmod -R a+rwX logs
+
+    DATABASE_VENDOR=$(php -r "echo explode('://', getenv('DATABASE_URL'))[0];")
+    echo "=====> Vendor: ${DATABASE_VENDOR}"
+    if [ "$DATABASE_VENDOR" = "sqlite" ]; then
+        DATABASE_PATH=$(php -r "echo substr(parse_url(preg_replace('/^([\\w\\\\\\]+)/', 'file', getenv('DATABASE_URL')), PHP_URL_PATH), 1);")
+        echo "=====> Path: ${DATABASE_PATH}"
+        chmod a+rwx logs ${DATABASE_PATH}
+    fi
+fi
+
+exec "$@"


### PR DESCRIPTION
This PR introduces `Dockerfile` for BEdita base app.

## Building the image

The image can be built launching this command from the repository root:

```bash
docker build -t bedita/bedita:4.0.0-alpha .
```

This will create a new Docker image on top of `chialab/php:7.1-apache` installing BEdita and its dependencies.

A different PHP version can be specified using build arguments:

```bash
docker build -t bedita/bedita:4.0.0-alpha --build-arg PHP_VERSION=7.0 .
```

### Debug image

An image built for development purposes can be built using build arguments:

```bash
docker build -t bedita/bedita:4-cactus --build-arg DEBUG=true .
```

## Running the container

The container can be launched launching this command from any working directory after the image has been successfully built:

```bash
docker run -p 8080:80 bedita/bedita:4.0.0-alpha
```

This will launch a BEdita instance that uses SQLite as its storage backend. It should become available at http://localhost:8080/home almost instantly.

### Using PostgreSQL or MySQL via linked containers

Other database backends can be used with BEdita by launching the database server in a separate Docker container.

A MySQL 5.7 server can be launched in a container launching this command:

```bash
docker run -d --name mysql \
  --env MYSQL_ROOT_PASSWORD=root \
  --env MYSQL_DATABASE=bedita \
  --env MYSQL_USER=bedita \
  --env MYSQL_PASSWORD=bedita \
  mysql:5.7
```

Then, a BEdita instance can be configured to use MySQL as its backend launching this command:

```bash
docker run -d --name=bedita \
  --env DATABASE_URL=mysql://bedita:bedita@mysql:3306/bedita \
  -p 8080:80 --link mysql:mysql \
  bedita/bedita:4.0.0-alpha
```

The BEdita container will automatically wait until MySQL container becomes available, then will run connect to it, launch required schema migrations, and start the Web server. The application should become available at http://localhost:8080/home in a matter of few seconds. However, depending on the responsiveness of MySQL container, this might take longer.

## Logging

Logs are written to stdout and sterr, so that they can be inspected via `docker logs`. This is considered a common practice for Docker containers, and there are tools that can collect and ingest logs written this way. However, `LOG_ERROR_URL` and `LOG_DEBUG_URL` can be overwritten at container launch via `--env` flag to send logs to a different destination. For instance, one might want to launch a Logstash container, link it to BEdita container, and send BEdita logs to Logstash.