### PR TITLE
Issue/v4/1308 trash filter

### DIFF
--- a/plugins/BEdita/API/src/Controller/TrashController.php
+++ b/plugins/BEdita/API/src/Controller/TrashController.php
@@ -17,7 +17,6 @@ use BEdita\Core\Model\Action\GetObjectAction;
 use BEdita\Core\Model\Action\ListObjectsAction;
 use BEdita\Core\Model\Action\SaveEntityAction;
 use Cake\Network\Exception\ConflictException;
-use Cake\Network\Exception\InternalErrorException;
 
 /**
  * Controller for `/trash` endpoint.
@@ -98,7 +97,7 @@ class TrashController extends AppController
      *
      * @param int $id Object ID.
      * @return \Cake\Http\Response
-     * @throws \Cake\Network\Exception\InternalErrorException Throws an exception if an error occurs during deletion.
+     * @throws \Cake\ORM\Exception\PersistenceFailedException Throws an exception if an error occurs during deletion.
      */
     public function delete($id)
     {

--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -344,4 +344,63 @@ class FilterQueryStringTest extends IntegrationTestCase
         static::assertArrayHasKey('data', $result);
         static::assertEquals($expected, Hash::extract($result['data'], '{n}.id'), '', 0, 10, true);
     }
+
+    /**
+     * Data provider for `testTrashFilter` test case.
+     *
+     * @return array
+     */
+    public function trashFilterProvider()
+    {
+        return [
+            'simple' => [
+               'filter[type]=documents',
+               [
+                   '6',
+                   '7',
+               ],
+            ],
+            'exclude' => [
+               'filter[type][ne]=documents',
+               [
+               ],
+            ],
+            'query1' => [
+               'filter[query]=one',
+               [
+                   '6',
+               ],
+            ],
+            'query2' => [
+               'q=two',
+               [
+                   '7',
+               ],
+            ],
+        ];
+    }
+
+    /**
+     * Test filters on /trash endpoint.
+     *
+     * @param string $query Query string.
+     * @param array $expected Expected result.
+     * @return void
+     *
+     * @dataProvider trashFilterProvider
+     * @coversNothing
+     */
+    public function testTrashFilter($query, $expected)
+    {
+        $this->configRequestHeaders();
+
+        $this->get("/trash?$query");
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        static::assertArrayHasKey('data', $result);
+        static::assertEquals($expected, Hash::extract($result['data'], '{n}.id'), '', 0, 10, true);
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Action/DeleteEntityAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/DeleteEntityAction.php
@@ -43,11 +43,6 @@ class DeleteEntityAction extends BaseAction
      */
     public function execute(array $data = [])
     {
-        $success = $this->Table->delete($data['entity']);
-        if ($success === false) {
-            throw new InternalErrorException(__d('bedita', 'Hard delete failed'));
-        }
-
-        return $success;
+        return $this->Table->deleteOrFail($data['entity']);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Action/DeleteEntityAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/DeleteEntityAction.php
@@ -13,6 +13,8 @@
 
 namespace BEdita\Core\Model\Action;
 
+use Cake\Network\Exception\InternalErrorException;
+
 /**
  * Command to delete an entity.
  *
@@ -41,6 +43,11 @@ class DeleteEntityAction extends BaseAction
      */
     public function execute(array $data = [])
     {
-        return $this->Table->delete($data['entity']);
+        $success = $this->Table->delete($data['entity']);
+        if ($success === false) {
+            throw new InternalErrorException(__d('bedita', 'Hard delete failed'));
+        }
+
+        return $success;
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteEntityActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteEntityActionTest.php
@@ -55,25 +55,4 @@ class DeleteEntityActionTest extends TestCase
         static::assertTrue($result);
         static::assertFalse($table->exists(['id' => 1]));
     }
-
-    /**
-     * Test command execution with delete error.
-     *
-     * @return void
-     *
-     * @expectedException \Cake\Network\Exception\InternalErrorException
-     * @covers ::execute()
-     */
-    public function testDeleteErrors()
-    {
-        $entity = TableRegistry::get('FakeAnimals')->get(1);
-
-        $table = $this->getMockBuilder(Table::class)
-            ->getMock();
-        $table->method('delete')
-            ->will(static::returnValue(false));
-
-        $action = new DeleteEntityAction(compact('table'));
-        $action(compact('entity'));
-    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteEntityActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteEntityActionTest.php
@@ -14,11 +14,14 @@
 namespace BEdita\Core\Test\TestCase\Model\Action;
 
 use BEdita\Core\Model\Action\DeleteEntityAction;
+use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
 /**
- * @covers \BEdita\Core\Model\Action\DeleteEntityAction
+ * {@see \BEdita\Core\Model\Action\DeleteEntityAction} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Model\Action\DeleteEntityAction
  */
 class DeleteEntityActionTest extends TestCase
 {
@@ -36,6 +39,9 @@ class DeleteEntityActionTest extends TestCase
      * Test command execution.
      *
      * @return void
+
+     * @covers ::initialize()
+     * @covers ::execute()
      */
     public function testExecute()
     {
@@ -48,5 +54,26 @@ class DeleteEntityActionTest extends TestCase
 
         static::assertTrue($result);
         static::assertFalse($table->exists(['id' => 1]));
+    }
+
+    /**
+     * Test command execution with delete error.
+     *
+     * @return void
+     *
+     * @expectedException \Cake\Network\Exception\InternalErrorException
+     * @covers ::execute()
+     */
+    public function testDeleteErrors()
+    {
+        $entity = TableRegistry::get('FakeAnimals')->get(1);
+
+        $table = $this->getMockBuilder(Table::class)
+            ->getMock();
+        $table->method('delete')
+            ->will(static::returnValue(false));
+
+        $action = new DeleteEntityAction(compact('table'));
+        $action(compact('entity'));
     }
 }


### PR DESCRIPTION
This PR fixes #1308

* in `TrahController` actions are used instead of `Table` calls
* a new integration test was added
* on hard delete failure in `DeleteEntityAction` now an exception is thrown, and related test was updated 