### PR TITLE
 #1322 feat: admin endpoint only as administrator

### DIFF
--- a/plugins/BEdita/API/src/Controller/AdminController.php
+++ b/plugins/BEdita/API/src/Controller/AdminController.php
@@ -65,6 +65,9 @@ class AdminController extends ResourcesController
         if (isset($this->JsonApi)) {
             $this->JsonApi->setConfig('resourceTypes', [$this->resourceName]);
         }
+
+        $this->Auth->getAuthorize('BEdita/API.Endpoint')->setConfig('blockAnonymousUsers', true);
+        $this->Auth->getAuthorize('BEdita/API.Endpoint')->setConfig('administratorOnly', true);
     }
 
     /**

--- a/plugins/BEdita/API/src/Controller/AdminController.php
+++ b/plugins/BEdita/API/src/Controller/AdminController.php
@@ -66,7 +66,6 @@ class AdminController extends ResourcesController
             $this->JsonApi->setConfig('resourceTypes', [$this->resourceName]);
         }
 
-        $this->Auth->getAuthorize('BEdita/API.Endpoint')->setConfig('blockAnonymousUsers', true);
         $this->Auth->getAuthorize('BEdita/API.Endpoint')->setConfig('administratorOnly', true);
     }
 

--- a/plugins/BEdita/API/tests/IntegrationTest/AdminResourcesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/AdminResourcesTest.php
@@ -113,7 +113,7 @@ class AdminResourcesTest extends IntegrationTestCase
         $resourceId = substr($locationHeader, strrpos($locationHeader, '/') + 1);
 
         // VIEW
-        $this->configRequestHeaders();
+        $this->configRequestHeaders('GET', $authHeader);
         $this->get("$endpoint/$resourceId");
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');

--- a/plugins/BEdita/API/tests/TestCase/Controller/AdminControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AdminControllerTest.php
@@ -75,6 +75,13 @@ class AdminControllerTest extends IntegrationTestCase
         $result = json_decode((string)$this->_response->getBody(), true);
         static::assertResponseCode(401);
         static::assertContentType('application/vnd.api+json');
+        // GET /admin with user without administrator role
+        $authHeader = $this->getUserAuthHeader('second user', 'password2');
+        $this->configRequestHeaders('GET', $authHeader);
+        $this->get('/admin/applications');
+        $result = json_decode((string)$this->_response->getBody(), true);
+        static::assertResponseCode(403);
+        static::assertContentType('application/vnd.api+json');
         // GET /admin with authenticated user
         $authHeader = $this->getUserAuthHeader();
         $this->configRequestHeaders('GET', $authHeader);

--- a/plugins/BEdita/API/tests/TestCase/Controller/AdminControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AdminControllerTest.php
@@ -69,11 +69,17 @@ class AdminControllerTest extends IntegrationTestCase
                 ],
             ]
         ];
-
-        $this->configRequestHeaders();
+        // GET /admin with anonymous user
+        $this->configRequestHeaders('GET');
         $this->get('/admin/applications');
         $result = json_decode((string)$this->_response->getBody(), true);
-
+        static::assertResponseCode(401);
+        static::assertContentType('application/vnd.api+json');
+        // GET /admin with authenticated user
+        $authHeader = $this->getUserAuthHeader();
+        $this->configRequestHeaders('GET', $authHeader);
+        $this->get('/admin/applications');
+        $result = json_decode((string)$this->_response->getBody(), true);
         static::assertResponseCode(200);
         static::assertContentType('application/vnd.api+json');
         static::assertEquals($expected, $result['data']);

--- a/plugins/BEdita/Core/src/Model/Table/RolesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RolesTable.php
@@ -39,6 +39,13 @@ class RolesTable extends Table
 {
 
     /**
+     * Administrator role id
+     *
+     * @var int
+     */
+    const ADMIN_ROLE = 1;
+
+    /**
      * {@inheritDoc}
      *
      * @codeCoverageIgnore


### PR DESCRIPTION
This PR fixes #1322 

Only administrator users can call `/admin` endpoint: system raises 401 if user is anonymous or it's not an administrator.
