### PR TITLE
GET & PATCH /auth/user

### DIFF
--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -61,10 +61,20 @@ Router::plugin(
             ['controller' => 'Login', 'action' => 'change'],
             ['_name' => 'login:change']
         );
+        // GET /auth *deprecated* - to remove before `stable` relase
         $routes->connect(
             '/auth',
+            ['controller' => 'Login', 'action' => 'whoami', '_method' => 'GET']
+        );
+        $routes->connect(
+            '/auth/user',
             ['controller' => 'Login', 'action' => 'whoami', '_method' => 'GET'],
             ['_name' => 'login:whoami']
+        );
+        $routes->connect(
+            '/auth/user',
+            ['controller' => 'Login', 'action' => 'update', '_method' => 'PATCH'],
+            ['_name' => 'login:update']
         );
 
         // Admin.

--- a/plugins/BEdita/API/postman/BE4.postman_collection.json
+++ b/plugins/BEdita/API/postman/BE4.postman_collection.json
@@ -456,6 +456,124 @@
 						"description": "Perform actual credential change using secret hash"
 					},
 					"response": []
+				},
+				{
+					"name": "GET Auth user data",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"var schema = postman.getEnvironmentVariable(\"schemaBase\");",
+									"var responseJSON;",
+									"try {",
+									"    responseJSON = JSON.parse(responseBody); ",
+									"    if (responseCode.code === 200) {",
+									"        tests[\"Status equals 200\"] = true;",
+									"        tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';",
+									"        if (schema) {",
+									"            tests[\"Valid data\"] = tv4.validate(responseJSON, schema);",
+									"        } else {",
+									"            tests[\"Skip data validation\"] = true;",
+									"        }",
+									"    } else if (responseCode.code === 404) {",
+									"        tests[\"Status code is 404\"] = true;",
+									"        tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';",
+									"    }",
+									"} catch (e) {",
+									"    tests[\"Error in parsing response\"] = e;",
+									"}"
+								]
+							}
+						}
+					],
+					"request": {
+						"url": "{{be4Url}}/auth/user",
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.api+json",
+								"description": ""
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"description": ""
+							},
+							{
+								"key": "X-Api-Key",
+								"value": "{{apiKey}}",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"description": ""
+					},
+					"response": []
+				},
+				{
+					"name": "Modify auth user data",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"var schema = postman.getEnvironmentVariable(\"schemaPatch\");",
+									"var responseJSON;",
+									"try {",
+									"    responseJSON = JSON.parse(responseBody); ",
+									"    tests[\"Status code is 200\"] = responseCode.code === 200;",
+									"    tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';",
+									"    if (schema) {",
+									"        tests[\"Valid data\"] = tv4.validate(responseJSON, schema);",
+									"    } else {",
+									"        tests[\"Skip data validation\"] = true;",
+									"    }",
+									"} catch (e) {",
+									"    tests[\"Error in parsing response\"] = e;",
+									"}"
+								]
+							}
+						}
+					],
+					"request": {
+						"url": "{{be4Url}}/auth/user",
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"description": ""
+							},
+							{
+								"key": "Accept",
+								"value": "application/vnd.api+json",
+								"description": ""
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}",
+								"description": ""
+							},
+							{
+								"key": "X-Api-Key",
+								"value": "{{apiKey}}",
+								"description": ""
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"name\": \"Gustavo\"\n}"
+						},
+						"description": ""
+					},
+					"response": []
 				}
 			]
 		},

--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -197,6 +197,7 @@ class LoginController extends AppController
         $action = new SaveEntityAction(['table' => TableRegistry::get('Users')]);
         $action(compact('entity', 'data'));
 
+        // reload entity to cancel previous `setAccess` (otherwise `username` and `email` will appear in `meta`)
         $entity = $this->userEntity();
         $this->set(compact('entity'));
         $this->set('_serialize', ['entity']);

--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -195,8 +195,9 @@ class LoginController extends AppController
 
         $data = $this->request->getData();
         $action = new SaveEntityAction(['table' => TableRegistry::get('Users')]);
-        $entity = $action(compact('entity', 'data'));
+        $action(compact('entity', 'data'));
 
+        $entity = $this->userEntity();
         $this->set(compact('entity'));
         $this->set('_serialize', ['entity']);
     }

--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -190,17 +190,10 @@ class LoginController extends AppController
     {
         $this->request->allowMethod('patch');
 
-        $notAllowed = ['username', 'password', 'password_hash', 'email'];
-        $data = $this->request->getData();
-        if (!empty(array_intersect($notAllowed, array_keys($data)))) {
-            throw new BadRequestException([
-                'title' => __d('bedita', 'Bad input data'),
-                'detail' => sprintf('Fields not allowed: %s', implode(', ', $notAllowed)),
-            ]);
-        }
-
         $entity = $this->userEntity();
+        $entity->setAccess(['username', 'password', 'password_hash', 'email'], false);
 
+        $data = $this->request->getData();
         $action = new SaveEntityAction(['table' => TableRegistry::get('Users')]);
         $entity = $action(compact('entity', 'data'));
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
@@ -376,8 +376,8 @@ class LoginControllerTest extends IntegrationTestCase
 
         static::assertNotEmpty($result['data']);
         static::assertEquals(1, $result['data']['id']);
+        static::assertNotEquals($data['username'], $result['data']['attributes']['username']);
         // check password unchanged
         static::assertEquals($passwordHash, TableRegistry::get('Users')->get(1)->get('password_hash'));
-        static::assertNotEquals($data['username'], TableRegistry::get('Users')->get(1)->get('username'));
     }
 }


### PR DESCRIPTION
This PR fixes #1298

* `GET /auth/user` is now default endpoint to retrieve authenticated user data - `GET /auth` still working but deprecated

* `PATCH /auth/user` allows modification of user logged data with the exception of: `username`, `password`, `email` - not modifiable by logged user on this endpoint

Since no selection of  `type` or `id` is possible in this case and for consistency with other `LoginController` methods body data request format is plain JSON and not JSON API. 
This can be changed of course... 