### PR TITLE
feat: force debug true in test bootstrap

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -46,3 +46,4 @@ Configure::write('Filesystem', [
         'baseUrl' => 'https://static.example.org/files',
     ],
 ]);
+Configure::write('debug', true);


### PR DESCRIPTION
This PR provides `debug = true`, when launching `vendors/bin/phpunit`
