### PR TITLE
`Fields` query string

### DIFF
--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -153,6 +153,7 @@ class ObjectsController extends ResourcesController
             $action = new ListObjectsAction(['table' => $this->Table, 'objectType' => $this->objectType]);
             $query = $action(compact('filter', 'contain'));
 
+            $this->set('_fields', $this->request->getQuery('fields', []));
             $data = $this->paginate($query);
         }
 
@@ -197,6 +198,7 @@ class ObjectsController extends ResourcesController
             $entity = $action(compact('entity', 'data'));
         }
 
+        $this->set('_fields', $this->request->getQuery('fields', []));
         $this->set(compact('entity'));
         $this->set('_serialize', ['entity']);
 
@@ -223,6 +225,7 @@ class ObjectsController extends ResourcesController
             $objects = $this->paginate($objects);
         }
 
+        $this->set('_fields', $this->request->getQuery('fields', []));
         $this->set(compact('objects'));
         $this->set('_serialize', ['objects']);
     }

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -180,6 +180,7 @@ abstract class ResourcesController extends AppController
             $action = new ListEntitiesAction(['table' => $this->Table]);
             $query = $action(compact('filter', 'contain'));
 
+            $this->set('_fields', $this->request->getQuery('fields', []));
             $data = $this->paginate($query);
         }
 
@@ -249,6 +250,7 @@ abstract class ResourcesController extends AppController
             $entity = $action(compact('entity', 'data'));
         }
 
+        $this->set('_fields', $this->request->getQuery('fields', []));
         $this->set(compact('entity'));
         $this->set('_serialize', ['entity']);
 
@@ -279,6 +281,7 @@ abstract class ResourcesController extends AppController
             $data = $this->paginate($data);
         }
 
+        $this->set('_fields', $this->request->getQuery('fields', []));
         $this->set(compact('data'));
         $this->set('_serialize', ['data']);
     }

--- a/plugins/BEdita/API/src/Utility/JsonApi.php
+++ b/plugins/BEdita/API/src/Utility/JsonApi.php
@@ -28,12 +28,13 @@ class JsonApi
      * Format single or multiple data items in JSON API format.
      *
      * @param \BEdita\Core\Utility\JsonApiSerializable|\BEdita\Core\Utility\JsonApiSerializable[] $items Items to be formatted.
+     * @param array $fields Selected fields to view in `attributes` and `meta`, if empty (default) all fields are serialized
      * @param array $included Array to be populated with included resources.
      * @return array
      * @throws \InvalidArgumentException Throws an exception if `$item` could not be converted to array, or
      *      if required key `id` is unset or empty.
      */
-    public static function formatData($items, array &$included = [])
+    public static function formatData($items, $fields = [], array &$included = [])
     {
         if ($items instanceof Query || $items instanceof CollectionInterface) {
             $items = $items->toList();
@@ -61,7 +62,7 @@ class JsonApi
                 ));
             }
 
-            $item = $item->jsonApiSerialize($options);
+            $item = $item->jsonApiSerialize($options, $fields);
             if (isset($item['included'])) {
                 $included = array_merge($included, $item['included']);
                 unset($item['included']);

--- a/plugins/BEdita/API/src/View/JsonApiView.php
+++ b/plugins/BEdita/API/src/View/JsonApiView.php
@@ -31,7 +31,7 @@ class JsonApiView extends JsonView
     /**
      * {@inheritDoc}
      */
-    protected $_specialVars = ['_serialize', '_jsonOptions', '_jsonp', '_error', '_links', '_meta'];
+    protected $_specialVars = ['_serialize', '_jsonOptions', '_jsonp', '_error', '_links', '_meta', '_fields'];
 
     /**
      * {@inheritDoc}
@@ -39,15 +39,16 @@ class JsonApiView extends JsonView
     protected function _dataToSerialize($serialize = true)
     {
         if (empty($this->viewVars['_error'])) {
+            $fields = empty($this->viewVars['_fields']) ? [] : explode(',', $this->viewVars['_fields']);
             $data = parent::_dataToSerialize($serialize) ?: [];
             if ($data) {
                 $included = [];
-                $data = JsonApi::formatData(reset($data), $included);
+                $data = JsonApi::formatData(reset($data), $fields, $included);
             }
             if (empty($included)) {
                 unset($included);
             } else {
-                $included = JsonApi::formatData($included);
+                $included = JsonApi::formatData($included, $fields);
             }
         } else {
             $error = $this->viewVars['_error'];

--- a/plugins/BEdita/API/tests/IntegrationTest/FieldsQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FieldsQueryStringTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Test\IntegrationTest;
+
+use BEdita\API\TestSuite\IntegrationTestCase;
+use Cake\Utility\Hash;
+
+/**
+ * Test Query String `fields`
+ */
+class FieldsQueryStringTest extends IntegrationTestCase
+{
+    /**
+     * Provider for `testFields`
+     *
+     * @return array
+     */
+    public function fieldsProvider()
+    {
+        return [
+            'simple' => [
+                '/documents?fields=title',
+                ['title'],
+                []
+            ],
+            'multi' => [
+                '/roles?fields=name,created',
+                ['name'],
+                ['created']
+            ],
+            'none' => [
+                '/users?fields=gustavo',
+                [],
+                []
+            ],
+            'single' => [
+                '/users/1?fields=username',
+                ['username'],
+                []
+            ],
+            'meta' => [
+                '/roles/1?fields=unchangeable',
+                [],
+                ['unchangeable'],
+            ],
+        ];
+    }
+
+    /**
+     * Test `fields` query string
+     *
+     * @param string $url Endpoint url to test
+     * @param array $attributes Expected response attributes
+     * @param array $meta Expected response meta
+     * @return void
+     *
+     * @dataProvider fieldsProvider
+     * @coversNothing
+     */
+    public function testFields($url, $attributes, $meta)
+    {
+        $this->configRequestHeaders();
+        $this->get($url);
+        $this->assertResponseCode(200);
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        // single result
+        if (!empty($result['data']['id'])) {
+            $resultAttr = [Hash::get($result, 'data.attributes', [])];
+            $resultMeta = [Hash::get($result, 'data.meta', [])];
+        } else {
+            $resultAttr = Hash::extract($result, 'data.{n}.attributes');
+            $resultMeta = Hash::extract($result, 'data.{n}.meta');
+        }
+
+        if (!empty($resultAttr)) {
+            foreach ($resultAttr as $r) {
+                static::assertEquals($attributes, array_keys($r));
+            }
+        } else {
+            static::assertEquals($attributes, array_keys($resultAttr));
+        }
+
+        if (!empty($resultMeta)) {
+            foreach ($resultMeta as $r) {
+                static::assertEquals($meta, array_keys($r));
+            }
+        } else {
+            static::assertEquals($meta, array_keys($resultMeta));
+        }
+    }
+}

--- a/plugins/BEdita/API/tests/IntegrationTest/SortQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/SortQueryStringTest.php
@@ -65,6 +65,7 @@ class SortQueryStringTest extends IntegrationTestCase
      * @return void
      *
      * @dataProvider sortProvider
+     * @coversNothing
      */
     public function testSort($expected, $endpoint, $sort)
     {

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
@@ -32,6 +32,13 @@ use Cake\Utility\Hash;
  */
 trait JsonApiTrait
 {
+    /**
+     * Selected fields in JSON API `attributes` and `meta` response.
+     * If empty all fields are shown.
+     *
+     * @var array
+     */
+    protected $_fields = [];
 
     /**
      * Getter for entity's visible properties.
@@ -125,6 +132,30 @@ trait JsonApiTrait
     }
 
     /**
+     * Setter for `_fields`.
+     *
+     * @return void
+     */
+    protected function setFields(array $fields)
+    {
+        $this->_fields = $fields;
+    }
+
+    /**
+     * Filter fields list depending on requested fields in $_fields
+     *
+     * @return array
+     */
+    protected function filterFields(array $fields)
+    {
+        if (empty($this->_fields)) {
+            return $fields;
+        }
+
+        return array_intersect($this->_fields, $fields);
+    }
+
+    /**
      * Getter for `attributes`.
      *
      * @return array
@@ -133,7 +164,7 @@ trait JsonApiTrait
     {
         $table = $this->getTable();
         $associations = static::listAssociations($table, $this->getHidden());
-        $visible = $this->visibleProperties();
+        $visible = $this->filterFields($this->visibleProperties());
 
         $properties = array_filter(
             array_diff($visible, (array)$table->getPrimaryKey(), $associations, ['_joinData', '_matchingData']),
@@ -152,7 +183,7 @@ trait JsonApiTrait
     {
         $table = $this->getTable();
         $associations = static::listAssociations($table, $this->getHidden());
-        $visible = $this->visibleProperties();
+        $visible = $this->filterFields($this->visibleProperties());
         $virtual = $this->getVirtual();
 
         $properties = array_filter(
@@ -319,12 +350,14 @@ trait JsonApiTrait
      * JSON API serializer.
      *
      * @param int $options Serializer options. Can be any combination of `JSONAPIOPT_*` constants defined in this class.
+     * @param array $fields Selected fields to view in `attributes` and `meta`, default empty => all fields are serialized
      * @return array
      */
-    public function jsonApiSerialize($options = 0)
+    public function jsonApiSerialize($options = 0, $fields = [])
     {
         $id = $this->getId();
         $type = $this->getType();
+        $this->setFields($fields);
 
         if (($options & JsonApiSerializable::JSONAPIOPT_EXCLUDE_ATTRIBUTES) === 0) {
             $attributes = $this->getAttributes();

--- a/plugins/BEdita/Core/src/Utility/JsonApiSerializable.php
+++ b/plugins/BEdita/Core/src/Utility/JsonApiSerializable.php
@@ -55,7 +55,8 @@ interface JsonApiSerializable
      * This method **MUST** return a resource object as per JSON API specifications.
      *
      * @param int $options Options for serializing. Can be any combination of `JSONAPIOPT_*` constants.
+     * @param array $fields Selected fields to view in `attributes` and `meta`, default empty => all fields are serialized
      * @return array
      */
-    public function jsonApiSerialize($options = 0);
+    public function jsonApiSerialize($options = 0, $fields = []);
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -466,7 +466,7 @@ class JsonApiTraitTest extends TestCase
      * @return void
      *
      * @covers ::jsonApiSerialize()
-     * @covers ::setFilter()
+     * @covers ::setFields()
      * @dataProvider jsonApiSerializeProvider()
      */
     public function testJsonApiSerialize($excludedKeys, $options)

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -120,6 +120,7 @@ class JsonApiTraitTest extends TestCase
      * @return void
      *
      * @covers ::getAttributes()
+     * @covers ::filterFields()
      */
     public function testGetAttributes()
     {
@@ -129,9 +130,12 @@ class JsonApiTraitTest extends TestCase
         ];
 
         $role = $this->Roles->get(1)->jsonApiSerialize();
-
         $attributes = array_keys($role['attributes']);
+        static::assertEquals($expected, $attributes);
 
+        // test with `fields`
+        $role = $this->Roles->get(1)->jsonApiSerialize(0, ['name', 'description']);
+        $attributes = array_keys($role['attributes']);
         static::assertEquals($expected, $attributes);
     }
 
@@ -288,6 +292,7 @@ class JsonApiTraitTest extends TestCase
      * @return void
      *
      * @covers ::getMeta()
+     * @covers ::filterFields()
      */
     public function testGetMeta()
     {
@@ -298,6 +303,13 @@ class JsonApiTraitTest extends TestCase
         ];
 
         $role = $this->Roles->get(1)->jsonApiSerialize();
+
+        $meta = array_keys(Hash::get($role, 'meta', []));
+
+        static::assertEquals($expected, $meta, '', 0, 10, true);
+
+        // test with `fields`
+        $role = $this->Roles->get(1)->jsonApiSerialize(0, ['created', 'modified', 'unchangeable']);
 
         $meta = array_keys(Hash::get($role, 'meta', []));
 
@@ -454,6 +466,7 @@ class JsonApiTraitTest extends TestCase
      * @return void
      *
      * @covers ::jsonApiSerialize()
+     * @covers ::setFilter()
      * @dataProvider jsonApiSerializeProvider()
      */
     public function testJsonApiSerialize($excludedKeys, $options)


### PR DESCRIPTION
This PR solves #861

`fields` query string is implemented: we can use a query like `?fields=title,body,created` to provide a comma separated string of elements of `attributes` and `meta` to display in response

I took the least efficient but simpler approach to handle query string in the view via `_fields` reserved key.
