### PR TITLE
Restore temporarily disabled build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,9 +78,9 @@ jobs:
     - stage: complete
       php: 5.6
       env: "DB=mysql DB_VERSION=5.7 db_dsn='mysql://root@localhost/bedita_test'"
-    # - stage: complete
-    #   php: 7.0
-    #   env: "DB=pgsql DB_VERSION=9.6 db_dsn='postgres://postgres@127.0.0.1/bedita_test'"
+    - stage: complete
+      php: 7.0
+      env: "DB=pgsql DB_VERSION=9.6 db_dsn='postgres://postgres@127.0.0.1/bedita_test'"
     - stage: complete
       php: 7.1
       env: "DB=mysql DB_VERSION=5.6 db_dsn='mysql://root@localhost/bedita_test'"


### PR DESCRIPTION
This PR fixes #1332.

The mysterious problem seems to be solved. I didn't do absolutely nothing but re-enable the disabled build. Was it because of the aliens? the CIA? the templars? I guess we'll never ever know.