### PR TITLE
Docker update: CORS, API KEY and admin user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,15 @@ VOLUME /var/www/webroot/files
 RUN if [ ! "$DEBUG" = "true" ]; then export COMPOSER_ARGS='--no-dev'; fi \
     && composer install $COMPOSER_ARGS --optimize-autoloader --no-interaction --quiet
 
+# Activate headers module
+RUN a2enmod headers
+
+# Set CORS headers in .htaccess
+RUN echo "Header Set Access-Control-Allow-Origin \"*\"" >> /var/www/html/webroot/.htaccess \
+    && echo "Header Set Access-Control-Allow-Headers \"content-type, origin, x-api-key, x-requested-with, authorization\"" >> /var/www/html/webroot/.htaccess \
+    && echo "Header Set Access-Control-Allow-Methods \"PUT, GET, POST, PATCH, DELETE, OPTIONS\"" >> /var/www/html/webroot/.htaccess
+
+
 ENV LOG_DEBUG_URL="console:///?stream=php://stdout" \
     LOG_ERROR_URL="console:///?stream=php://stderr" \
     DATABASE_URL="sqlite:////var/www/html/bedita.sqlite"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,6 +10,14 @@ if [ ! -z "${DATABASE_URL}" ]; then
     bin/cake migrations migrate -p BEdita/Core
     bin/cake migrations seed -p BEdita/Core --seed InitialSeed
 
+    if [ ! -z "${BEDITA_API_KEY}" ]; then
+        bin/cake migrations seed -p BEdita/Core --seed ApplicationFromEnvSeed
+    fi
+
+    if [[ ! -z "${BEDITA_ADMIN_USR}" && ! -z "${BEDITA_ADMIN_PWD}" ]]; then
+        bin/cake migrations seed -p BEdita/Core --seed AdminFromEnvSeed
+    fi
+
     chmod -R a+rwX tmp
     chmod -R a+rwX logs
 

--- a/plugins/BEdita/Core/config/Seeds/AdminFromEnvSeed.php
+++ b/plugins/BEdita/Core/config/Seeds/AdminFromEnvSeed.php
@@ -1,0 +1,30 @@
+<?php
+use Cake\Auth\WeakPasswordHasher;
+use Migrations\AbstractSeed;
+
+/**
+ * Updates main admin user from env vars:
+ *  - 'username' => BEDITA_ADMIN_USR
+ *  - 'password' => BEDITA_ADMIN_PWD
+ */
+class AdminFromEnvSeed extends AbstractSeed
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function run()
+    {
+        $username = getenv('BEDITA_ADMIN_USR');
+        $password = getenv('BEDITA_ADMIN_PWD');
+        if (empty($username) || empty($password)) {
+            echo "Mandatory environment variables missing: BEDITA_ADMIN_USR, BEDITA_ADMIN_PWD\n";
+            echo 'No data seeded!';
+
+            return -1;
+        }
+
+        $hash = (new WeakPasswordHasher(['hashType' => 'md5']))->hash($password);
+        $query = sprintf("UPDATE users set username='%s', password_hash='%s' WHERE id=1", $username, $hash);
+        $this->query($query);
+    }
+}

--- a/plugins/BEdita/Core/config/Seeds/ApplicationFromEnvSeed.php
+++ b/plugins/BEdita/Core/config/Seeds/ApplicationFromEnvSeed.php
@@ -1,0 +1,37 @@
+<?php
+use Migrations\AbstractSeed;
+
+/**
+ * Create new application from env vars:
+ *  - 'api_key' => BEDITA_API_KEY
+ *  - 'name' => BEDITA_APP_NAME (optional)
+ */
+class ApplicationFromEnvSeed extends AbstractSeed
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function run()
+    {
+        $apiKey = getenv('BEDITA_API_KEY');
+        if (empty($apiKey)) {
+            echo "Mandatory environment variable missing: BEDITA_API_KEY\n";
+            echo 'No data seeded!';
+
+            return -1;
+        }
+        $appName = getenv('BEDITA_APP_NAME');
+
+        $row = [
+            'name' => $appName ? $appName : 'manager',
+            'api_key' => $apiKey,
+            'created' => date("Y-m-d H:i:s"),
+            'modified' => date("Y-m-d H:i:s"),
+            'enabled' => 1,
+        ];
+
+        $table = $this->table('applications');
+        $table->insert($row)->saveData();
+    }
+}


### PR DESCRIPTION
This PR add some features to the official docker image:

- **CORS** headers are set as default to allow operations from `bedita/manager` and other webapps

- initial **API KEY** setting is possible via environment variables `BEDITA_API_KEY` at runtime - launching an image with `--env BEDITA_API_KEY=########` - related application `name` may be set with optional  `BEDITA_APP_NAME` evironment variable

- default admin username and password may be modified with  `BEDITA_ADMIN_USR` and `BEDITA_ADMIN_PWD` environment variables

Docker run example:
```bash
docker run -p 8090:80 --env BEDITA_API_KEY=1029384756 --env BEDITA_APP_NAME=my-app --env BEDITA_ADMIN_USR=admin --env BEDITA_ADMIN_PWD=admin bedita4-image
``` 