### PR TITLE
Write operations on custom properties

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -225,6 +225,8 @@ class ObjectsControllerTest extends IntegrationTestCase
                         'lang' => 'eng',
                         'publish_start' => null,
                         'publish_end' => null,
+                        'another_username' => 'synapse', // custom property
+                        'another_email' => 'synapse@example.org', // custom property
                     ],
                     'meta' => [
                         'locked' => false,

--- a/plugins/BEdita/API/tests/TestCase/Controller/PropertiesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/PropertiesControllerTest.php
@@ -51,10 +51,10 @@ class PropertiesControllerTest extends IntegrationTestCase
             ],
             'meta' => [
                 'pagination' => [
-                    'count' => 6,
+                    'count' => 7,
                     'page' => 1,
                     'page_count' => 1,
-                    'page_items' => 6,
+                    'page_items' => 7,
                     'page_size' => 20,
                 ],
             ],
@@ -183,6 +183,27 @@ class PropertiesControllerTest extends IntegrationTestCase
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/properties/6',
+                    ],
+                ],
+                [
+                    'id' => '7',
+                    'type' => 'properties',
+                    'attributes' => [
+                        'name' => 'disabled_property',
+                        'multiple' => false,
+                        'options_list' => null,
+                        'description' => 'Disabled property example',
+                        'property_type_name' => 'string',
+                        'object_type_name' => 'users',
+                        'label' => null,
+                        'list_view' => true,
+                    ],
+                    'meta' => [
+                        'created' => '2017-09-05T11:10:00+00:00',
+                        'modified' => '2017-09-05T11:10:00+00:00',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/properties/7',
                     ],
                 ],
             ],
@@ -346,7 +367,7 @@ class PropertiesControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertHeader('Location', 'http://api.example.com/properties/7');
+        $this->assertHeader('Location', 'http://api.example.com/properties/8');
         $this->assertTrue(TableRegistry::get('Properties')->exists(['name' => 'yet_another_body']));
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
@@ -143,8 +143,8 @@ class UsersControllerTest extends IntegrationTestCase
                         'publish_start' => null,
                         'publish_end' => null,
                         'username' => 'second user',
-                        'another_username' => null, // custom property
-                        'another_email' => null, // custom property
+                        'another_username' => 'synapse', // custom property
+                        'another_email' => 'synapse@example.org', // custom property
                     ],
                     'meta' => [
                         'locked' => false,

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Model\Behavior;
 
+use Cake\Collection\CollectionInterface;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Event\Event;
@@ -27,6 +28,7 @@ use Cake\ORM\TableRegistry;
  */
 class CustomPropertiesBehavior extends Behavior
 {
+
     /**
      * {@inheritDoc}
      */
@@ -43,9 +45,33 @@ class CustomPropertiesBehavior extends Behavior
     protected $available = null;
 
     /**
+     * {@inheritDoc}
+     */
+    public function initialize(array $config)
+    {
+        parent::initialize($config);
+
+        $table = $this->getTable();
+        if (!$table->hasBehavior('ObjectType')) {
+            $table->addBehavior('BEdita/Core.ObjectType');
+        }
+    }
+
+    /**
+     * Getter for object type.
+     *
+     * @param array $args Method arguments.
+     * @return \BEdita\Core\Model\Entity\ObjectType
+     */
+    protected function objectType(...$args)
+    {
+        return $this->getTable()->behaviors()->call('objectType', $args);
+    }
+
+    /**
      * Get available properties for object type
      *
-     * @return array
+     * @return \BEdita\Core\Model\Entity\Property[]
      */
     public function getAvailable()
     {
@@ -53,21 +79,21 @@ class CustomPropertiesBehavior extends Behavior
             return $this->available;
         }
 
+        // @todo Add cache for properties.
         try {
-            $objectType = TableRegistry::get('ObjectTypes')->get($this->getTable()->getAlias());
-        } catch (RecordNotFoundException $ex) {
-            return $this->available = [];
+            $objectType = $this->objectType($this->getTable()->getAlias());
+        } catch (RecordNotFoundException $e) {
+            return [];
+        }
+        if (!$objectType->has('properties')) {
+            //TableRegistry::get('ObjectTypes')->loadInto($objectType, ['Properties']);
+            $objectType->properties = TableRegistry::get('Properties')
+                ->find()
+                ->where(['object_type_id' => $objectType->id])
+                ->all();
         }
 
-        // @todo add cache for properties
-        $props = TableRegistry::get('Properties')->find()
-                ->where([
-                    'object_type_id' => $objectType->id,
-                    'enabled' => 1,
-                ])
-                ->all();
-
-        $this->available = $props->indexBy('name')->toArray();
+        $this->available = collection($objectType->properties)->indexBy('name')->toArray();
 
         return $this->available;
     }
@@ -85,13 +111,13 @@ class CustomPropertiesBehavior extends Behavior
     /**
      * Set custom properties keys as main properties
      *
-     * @param \Cake\Event\Event $event The beforeFind event that was fired.
-     * @param \Cake\ORM\Query $query Query
+     * @param \Cake\Event\Event $event Fired event.
+     * @param \Cake\ORM\Query $query Query object instance.
      * @return void
      */
     public function beforeFind(Event $event, Query $query)
     {
-        $query->formatResults(function ($results) {
+        $query->formatResults(function (CollectionInterface $results) {
             return $results->map(function ($row) {
                 return $this->promoteProperties($row);
             });
@@ -99,7 +125,19 @@ class CustomPropertiesBehavior extends Behavior
     }
 
     /**
-     * Promote the properties in configuration `field` to first citizen property.
+     * Set custom properties in their dedicated field.
+     *
+     * @param \Cake\Event\Event $event Fired event.
+     * @param \Cake\Datasource\EntityInterface $entity Entity.
+     * @return void
+     */
+    public function beforeSave(Event $event, EntityInterface $entity)
+    {
+        $this->demoteProperties($entity);
+    }
+
+    /**
+     * Promote the properties in configured `field` to first-class citizen properties.
      * Missing properties in `$entity` but available will be filled with default values.
      *
      * @param \Cake\Datasource\EntityInterface|array $entity The entity or the array to work on
@@ -107,11 +145,11 @@ class CustomPropertiesBehavior extends Behavior
      */
     protected function promoteProperties($entity)
     {
-        if ((!is_array($entity) && !($entity instanceof EntityInterface)) || !$this->isFieldSet($entity)) {
+        $field = $this->getConfig('field');
+        if ((!is_array($entity) && !($entity instanceof EntityInterface)) || !$this->isFieldSet($entity, $field)) {
             return $entity;
         }
 
-        $field = $this->getConfig('field');
         if (empty($entity[$field]) || !is_array($entity[$field])) {
             $entity[$field] = [];
         }
@@ -122,7 +160,11 @@ class CustomPropertiesBehavior extends Behavior
         }
 
         $customProps = $entity[$field];
-        unset($entity[$field]);
+        if ($entity instanceof EntityInterface) {
+            $entity->setHidden([$field], true);
+        } else {
+            unset($entity[$field]);
+        }
 
         if (is_array($entity)) {
             return array_merge($entity, $customProps);
@@ -134,21 +176,52 @@ class CustomPropertiesBehavior extends Behavior
     }
 
     /**
-     * Check if configured field containing custom properties is set in `$entity`.
-     * For "set" is intended that it is present in `$entity` with any value.
+     * Send custom properties back to where they came from.
      *
-     * @param \Cake\Datasource\EntityInterface|array $entity The entity or the array to check
-     * @return bool
+     * @param \Cake\Datasource\EntityInterface $entity Entity being saved.
+     * @return void
      */
-    protected function isFieldSet($entity)
+    protected function demoteProperties(EntityInterface $entity)
     {
         $field = $this->getConfig('field');
+        $value = (array)$entity->get($field);
 
+        $dirty = false;
+        $available = $this->getAvailable();
+        foreach ($available as $property) {
+            $propertyName = $property->name;
+            if (!$this->isFieldSet($entity, $propertyName) || !$entity->isDirty($propertyName)) {
+                continue;
+            }
+
+            $dirty = true;
+            $value[$propertyName] = $entity->get($propertyName);
+        }
+
+        $entity->set($field, $value);
+        $entity->setDirty($field, $dirty);
+    }
+
+    /**
+     * Check if configured field containing custom properties is set in `$entity`.
+     *
+     * A field is considered "set" if it is present in `$entity` with any value, including `NULL`.
+     *
+     * @param \Cake\Datasource\EntityInterface|array $entity The entity or the array to check.
+     * @param string $field The field being looked for.
+     * @return bool
+     */
+    protected function isFieldSet($entity, $field)
+    {
         $allProperties = $entity;
         if ($entity instanceof EntityInterface) {
-            $allProperties = clone $entity;
-            $allProperties->setHidden([]);
-            $allProperties = $allProperties->toArray();
+            $hidden = $entity->getHidden();
+            try {
+                $entity->setHidden([]);
+                $allProperties = $entity->toArray();
+            } finally {
+                $entity->setHidden($hidden);
+            }
         }
 
         return array_key_exists($field, $allProperties);

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -86,10 +86,12 @@ class CustomPropertiesBehavior extends Behavior
             return [];
         }
         if (!$objectType->has('properties')) {
-            //TableRegistry::get('ObjectTypes')->loadInto($objectType, ['Properties']);
             $objectType->properties = TableRegistry::get('Properties')
                 ->find()
-                ->where(['object_type_id' => $objectType->id])
+                ->where([
+                    'object_type_id' => $objectType->id,
+                    'enabled' => 1,
+                ])
                 ->all();
         }
 

--- a/plugins/BEdita/Core/src/Model/Behavior/ObjectTypeBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/ObjectTypeBehavior.php
@@ -11,13 +11,6 @@
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
 
-/**
- * Created by PhpStorm.
- * User: paolo
- * Date: 02/09/17
- * Time: 12:02
- */
-
 namespace BEdita\Core\Model\Behavior;
 
 use BEdita\Core\Model\Entity\ObjectType;

--- a/plugins/BEdita/Core/src/Model/Behavior/ObjectTypeBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/ObjectTypeBehavior.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+/**
+ * Created by PhpStorm.
+ * User: paolo
+ * Date: 02/09/17
+ * Time: 12:02
+ */
+
+namespace BEdita\Core\Model\Behavior;
+
+use BEdita\Core\Model\Entity\ObjectType;
+use Cake\ORM\Behavior;
+use Cake\ORM\TableRegistry;
+
+/**
+ * Object type behavior.
+ *
+ * @since 4.0.0
+ */
+class ObjectTypeBehavior extends Behavior
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_defaultConfig = [
+        'table' => 'ObjectTypes',
+        'implementedMethods' => [
+            'objectType' => 'objectType',
+        ],
+    ];
+
+    /**
+     * Object type instance.
+     *
+     * @var \BEdita\Core\Model\Entity\ObjectType
+     */
+    protected $objectType;
+
+    /**
+     * Getter/setter for object type.
+     *
+     * @param \BEdita\Core\Model\Entity\ObjectType|string|int|null $objectType Object type entity, name or ID.
+     * @return \BEdita\Core\Model\Entity\ObjectType|null
+     */
+    public function objectType($objectType = null)
+    {
+        if ($objectType === null) {
+            return $this->objectType;
+        }
+
+        if (!($objectType instanceof ObjectType)) {
+            $objectType = TableRegistry::get($this->getConfig('table'))
+                ->get($objectType);
+        }
+
+        return $this->objectType = $objectType;
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
@@ -13,7 +13,6 @@
 
 namespace BEdita\Core\Model\Behavior;
 
-use BEdita\Core\Model\Entity\ObjectType;
 use BEdita\Core\ORM\Association\RelatedTo;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\ORM\Behavior;
@@ -30,20 +29,11 @@ class RelationsBehavior extends Behavior
      * {@inheritDoc}
      */
     protected $_defaultConfig = [
-        'objectType' => null,
         'implementedMethods' => [
-            'objectType' => 'objectType',
             'setupRelations' => 'setupRelations',
             'getRelations' => 'getRelations',
         ],
     ];
-
-    /**
-     * Object type instance.
-     *
-     * @var \BEdita\Core\Model\Entity\ObjectType
-     */
-    protected $objectType;
 
     /**
      * {@inheritDoc}
@@ -52,29 +42,23 @@ class RelationsBehavior extends Behavior
     {
         parent::initialize($config);
 
+        $table = $this->getTable();
+        if (!$table->hasBehavior('ObjectType')) {
+            $table->addBehavior('BEdita/Core.ObjectType');
+        }
+
         $this->setupRelations();
     }
 
     /**
-     * Getter/setter for object type.
+     * Getter for object type.
      *
-     * @param \BEdita\Core\Model\Entity\ObjectType|string|int|null $objectType Object type entity, name or ID.
-     * @return \BEdita\Core\Model\Entity\ObjectType|null
+     * @param array $args Method arguments.
+     * @return \BEdita\Core\Model\Entity\ObjectType
      */
-    public function objectType($objectType = null)
+    protected function objectType(...$args)
     {
-        if ($objectType === null) {
-            return $this->objectType;
-        }
-
-        $table = TableRegistry::get('ObjectTypes');
-        if (!($objectType instanceof ObjectType)) {
-            $objectType = $table->get($objectType);
-        }
-
-        $this->objectType = $objectType;
-
-        return $this->objectType;
+        return $this->getTable()->behaviors()->call('objectType', $args);
     }
 
     /**
@@ -111,7 +95,7 @@ class RelationsBehavior extends Behavior
     public function setupRelations($objectType = null)
     {
         if ($objectType === null) {
-            $objectType = $this->getConfig('objectType') ?: $this->getTable()->getAlias();
+            $objectType = $this->getTable()->getAlias();
         }
 
         try {
@@ -196,10 +180,10 @@ class RelationsBehavior extends Behavior
      */
     public function getRelations()
     {
-        $relations = collection($this->objectType->left_relations)
+        $relations = collection($this->objectType()->left_relations)
             ->indexBy('name')
             ->append(
-                collection($this->objectType->right_relations)
+                collection($this->objectType()->right_relations)
                     ->indexBy('inverse_name')
             );
 

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
@@ -36,6 +36,7 @@ use Cake\Utility\Inflector;
  * @property \BEdita\Core\Model\Entity\ObjectEntity[] $objects
  * @property \BEdita\Core\Model\Entity\Relation[] $left_relations
  * @property \BEdita\Core\Model\Entity\Relation[] $right_relations
+ * @property \BEdita\Core\Model\Entity\Property[] $properties
  */
 class ObjectType extends Entity implements JsonApiSerializable
 {

--- a/plugins/BEdita/Core/tests/Fixture/ObjectsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ObjectsFixture.php
@@ -102,6 +102,7 @@ class ObjectsFixture extends TestFixture
             'lang' => 'eng',
             'created_by' => 1,
             'modified_by' => 1,
+            'custom_props' => '{"another_username":"synapse","another_email":"synapse@example.org"}',
         ],
         [
             'object_type_id' => 1,

--- a/plugins/BEdita/Core/tests/Fixture/PropertiesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/PropertiesFixture.php
@@ -94,5 +94,18 @@ class PropertiesFixture extends TestFixture
             'label' => null,
             'list_view' => true
         ],
+        [
+            'name' => 'disabled_property',
+            'property_type_id' => 1,
+            'object_type_id' => 3,
+            'multiple' => 0,
+            'options_list' => null,
+            'created' => '2017-09-05 11:10:00',
+            'modified' => '2017-09-05 11:10:00',
+            'description' => 'Disabled property example',
+            'enabled' => 0,
+            'label' => null,
+            'list_view' => true
+        ],
     ];
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
@@ -294,6 +294,11 @@ class CustomPropertiesBehaviorTest extends TestCase
         $table->patchEntity($entity, $data);
         $table->save($entity);
 
-        static::assertSame($expected, $entity->get('custom_props'));
+        $result = $entity->get('custom_props');
+
+        ksort($expected);
+        ksort($result);
+
+        static::assertSame($expected, $result);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
@@ -270,6 +270,18 @@ class CustomPropertiesBehaviorTest extends TestCase
                 1,
                 'Users',
             ],
+            'disabledProperty' => [
+                [
+                    'another_username' => 'gustavo',
+                    'another_email' => null,
+                ],
+                [
+                    'another_username' => 'gustavo',
+                    'disabled_property' => 'do not write it!',
+                ],
+                1,
+                'Users',
+            ],
         ];
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
@@ -41,6 +41,24 @@ class CustomPropertiesBehaviorTest extends TestCase
     ];
 
     /**
+     * Test initialization.
+     *
+     * @return void
+     *
+     * @covers ::initialize()
+     */
+    public function testInitialize()
+    {
+        $table = TableRegistry::get('FakeObjects', [
+            'className' => Table::class,
+        ]);
+        static::assertFalse($table->hasBehavior('BEdita/Core.ObjectType'));
+
+        $table->addBehavior('BEdita/Core.CustomProperties');
+        static::assertTrue($table->hasBehavior('ObjectType'));
+    }
+
+    /**
      * Data provider for testGetAvailable()
      *
      * @return array
@@ -54,20 +72,23 @@ class CustomPropertiesBehaviorTest extends TestCase
             ],
             'userProp' => [
                 ['another_username', 'another_email'],
-                'Users'
-            ]
+                'Users',
+            ],
         ];
     }
 
     /**
      * Test get available properties
      *
+     * @param array $expected Expected result.
+     * @param string $tableName Table name.
      * @return void
      *
      * @covers ::getAvailable()
+     * @covers ::objectType()
      * @dataProvider getAvailableProvider
      */
-    public function testGetAvailable($expected, $tableName)
+    public function testGetAvailable(array $expected, $tableName)
     {
         $table = TableRegistry::get($tableName);
         $behavior = $table->behaviors()->get('CustomProperties');
@@ -91,7 +112,7 @@ class CustomPropertiesBehaviorTest extends TestCase
      *
      * @covers ::getAvailable()
      */
-    public function testGetAvailableTypeNotfound()
+    public function testGetAvailableTypeNotFound()
     {
         // test try/catch failure on `objectType` load
         $Relations = TableRegistry::get('Relations');
@@ -134,7 +155,63 @@ class CustomPropertiesBehaviorTest extends TestCase
     }
 
     /**
+     * Data provider for `testBeforeFind` test case.
+     *
+     * @return array
+     */
+    public function beforeFindProvider()
+    {
+        return [
+            'simple' => [
+                ['another_username', 'another_email'],
+                1,
+                'Users',
+            ],
+            'no hydration' => [
+                ['another_username', 'another_email'],
+                1,
+                'Users',
+                false,
+            ],
+            'empty' => [
+                [],
+                9,
+                'Events',
+            ],
+        ];
+    }
+    /**
      * Test setting of priority before entity is saved.
+     *
+     * @param string[] $expectedProperties List of expected properties.
+     * @param int $id Entity ID.
+     * @param string $table Table.
+     * @param bool $hydrate Should hydration be enabled?
+     * @return void
+     *
+     * @dataProvider beforeFindProvider()
+     * @covers ::beforeFind()
+     * @covers ::promoteProperties()
+     * @covers ::isFieldSet()
+     */
+    public function testBeforeFind(array $expectedProperties, $id, $table, $hydrate = true)
+    {
+        $result = TableRegistry::get($table)->find()
+            ->where(compact('id'))
+            ->enableHydration($hydrate)
+            ->first();
+        if ($hydrate) {
+            $result = $result->toArray();
+        }
+
+        static::assertArrayNotHasKey('custom_props', $result);
+        foreach ($expectedProperties as $property) {
+            static::assertArrayHasKey($property, $result);
+        }
+    }
+
+    /**
+     * Test that no errors are triggered if results aren't neither entities nor arrays.
      *
      * @return void
      *
@@ -142,37 +219,81 @@ class CustomPropertiesBehaviorTest extends TestCase
      * @covers ::promoteProperties()
      * @covers ::isFieldSet()
      */
-    public function testBeforeFind()
+    public function testBeforeFindOtherType()
     {
-        $table = TableRegistry::get('Users');
-        $user = $table->get(1);
+        $result = TableRegistry::get('Objects')
+            ->find('list')
+            ->find('type', ['documents'])
+            ->toArray();
 
-        static::assertFalse($user->isDirty());
-
-        $result = $user->toArray();
-        static::assertArrayHasKey('another_username', $result);
-        static::assertArrayHasKey('another_email', $result);
-        static::assertArrayNotHasKey('custom_props', $result);
-
-        // no hydration
-        $result = $table->find()
-            ->where(['id' => 1])
-            ->enableHydration(false)
-            ->first();
-
-        static::assertArrayHasKey('another_username', $result);
-        static::assertArrayHasKey('another_email', $result);
-        static::assertArrayNotHasKey('custom_props', $result);
-
-        // test empty `custom_props`
-        $table = TableRegistry::get('Events');
-        $event = $table->get(9);
-        $result = $event->toArray();
         static::assertNotEmpty($result);
-        static::assertArrayNotHasKey('custom_props', $result);
+    }
 
-        // test `promoteProperties` case `$entity` is not an entity ora array
-        $result = TableRegistry::get('Objects')->find('list')->find('type', ['documents'])->toArray();
-        static::assertNotEmpty($result);
+    /**
+     * Data provider for `testBeforeSave` test case.
+     *
+     * @return array
+     */
+    public function beforeSaveProvider()
+    {
+        return [
+            'simple' => [
+                [
+                    'another_username' => 'gustavo',
+                    'another_email' => null,
+                ],
+                [
+                    'another_username' => 'gustavo',
+                ],
+                1,
+                'Users',
+            ],
+            'overwrite' => [
+                [
+                    'another_username' => 'synapse',
+                    'another_email' => 'gustavo@example.org',
+                ],
+                [
+                    'another_email' => 'gustavo@example.org',
+                ],
+                5,
+                'Users',
+            ],
+            'empty' => [
+                [
+                    'another_username' => null,
+                    'another_email' => null,
+                ],
+                [
+                    'password' => 'hohoho',
+                ],
+                1,
+                'Users',
+            ],
+        ];
+    }
+
+    /**
+     * Test correct save of custom properties.
+     *
+     * @param array $expected Expected result.
+     * @param array $data Data.
+     * @param int $id Entity ID.
+     * @param string $table Table.
+     * @return void
+     *
+     * @dataProvider beforeSaveProvider()
+     * @covers ::beforeSave()
+     * @covers ::demoteProperties()
+     */
+    public function testBeforeSave(array $expected, array $data, $id, $table)
+    {
+        $table = TableRegistry::get($table);
+        $entity = $table->get($id);
+
+        $table->patchEntity($entity, $data);
+        $table->save($entity);
+
+        static::assertSame($expected, $entity->get('custom_props'));
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectTypeBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectTypeBehaviorTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Behavior;
+
+use BEdita\Core\Model\Entity\ObjectType;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * @coversDefaultClass \BEdita\Core\Model\Behavior\ObjectTypeBehavior
+ */
+class ObjectTypeBehaviorTest extends TestCase
+{
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
+        'plugin.BEdita/Core.objects',
+    ];
+
+    /**
+     * Data provider for `testObjectType` test case.
+     *
+     * @return array
+     */
+    public function objectTypeProvider()
+    {
+        return [
+            'getter' => [
+                'documents',
+                'Documents',
+            ],
+            'setter' => [
+                'documents',
+                'Documents',
+                1,
+            ],
+            'setter by name' => [
+                'documents',
+                'Documents',
+                'document',
+            ],
+        ];
+    }
+
+    /**
+     * Test `objectType` getter/setter.
+     *
+     * @param string|string $expected Expected result.
+     * @param string $table Table.
+     * @param int|string|null $objectType Object type being set.
+     * @return void
+     *
+     * @dataProvider objectTypeProvider()
+     * @covers ::objectType()
+     */
+    public function testObjectType($expected, $table, $objectType = null)
+    {
+        $table = TableRegistry::get($table);
+        if (!$table->hasBehavior('ObjectType')) {
+            $table->addBehavior('BEdita/Core.ObjectType');
+        }
+        $behavior = $table->behaviors()->get('ObjectType');
+
+        static::assertTrue($table->behaviors()->hasMethod('objectType'));
+
+        $objectType = $table->behaviors()->call('objectType', [$objectType]);
+
+        if ($expected === null) {
+            static::assertNull($objectType);
+            static::assertAttributeSame(null, 'objectType', $behavior);
+        } else {
+            static::assertInstanceOf(ObjectType::class, $objectType);
+            static::assertAttributeInstanceOf(ObjectType::class, 'objectType', $behavior);
+            static::assertSame($expected, $objectType->name);
+        }
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/RelationsBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/RelationsBehaviorTest.php
@@ -58,6 +58,10 @@ class RelationsBehaviorTest extends TestCase
         $Profiles = TableRegistry::get('Profiles');
         $Locations = TableRegistry::get('Locations');
 
+        static::assertTrue($Documents->hasBehavior('ObjectType'));
+        static::assertTrue($Profiles->hasBehavior('ObjectType'));
+        static::assertTrue($Locations->hasBehavior('ObjectType'));
+
         static::assertSame(1, $Documents->objectType()->id);
         static::assertSame(2, $Profiles->objectType()->id);
 


### PR DESCRIPTION
This PR resolves #1340.

Custom properties are now gently moved to `custom_props` when the entity is saved.

A new `ObjectTypeBehavior` was introduced as a place to share common logic for `RelationsBehavior` and `CustomPropertiesBehavior` — and possibly more behaviours to come.