### PR TITLE
Introduce /model base endpoint

### DIFF
--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -23,12 +23,14 @@ Router::plugin(
     ],
     function (RouteBuilder $routes) {
         $resourcesControllers = [
-            'object_types',
-            'properties',
-            'relations',
             'roles',
             'streams',
             'users',
+        ];
+        $modelingControllers = [
+            'object_types',
+            'properties',
+            'relations',
         ];
         $routes->setRouteClass(InflectedRoute::class);
 
@@ -107,6 +109,29 @@ Router::plugin(
             '/streams/upload/:fileName',
             ['controller' => 'Streams', 'action' => 'upload'],
             ['_name' => 'streams:upload', 'pass' => ['fileName']]
+        );
+
+        // Modeling.
+        $modelingControllers = implode('|', $modelingControllers);
+        $routes->connect(
+            '/model/:controller',
+            ['action' => 'index'],
+            ['_name' => 'model:index', 'controller' => $modelingControllers]
+        );
+        $routes->connect(
+            '/model/:controller/:id',
+            ['action' => 'resource'],
+            ['_name' => 'model:resource', 'pass' => ['id'], 'controller' => $modelingControllers]
+        );
+        $routes->connect(
+            '/model/:controller/:related_id/:relationship',
+            ['action' => 'related'],
+            ['_name' => 'model:related', 'controller' => $modelingControllers]
+        );
+        $routes->connect(
+            '/model/:controller/:id/relationships/:relationship',
+            ['action' => 'relationships'],
+            ['_name' => 'model:relationships', 'controller' => $modelingControllers]
         );
 
         // Resources.

--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -30,6 +30,7 @@ Router::plugin(
         $modelingControllers = [
             'object_types',
             'properties',
+            'property_types',
             'relations',
         ];
         $routes->setRouteClass(InflectedRoute::class);

--- a/plugins/BEdita/API/postman/BE4.postman_collection.json
+++ b/plugins/BEdita/API/postman/BE4.postman_collection.json
@@ -717,7 +717,7 @@
 						}
 					],
 					"request": {
-						"url": "{{be4Url}}/object_types",
+						"url": "{{be4Url}}/model/object_types",
 						"method": "GET",
 						"header": [
 							{
@@ -775,7 +775,7 @@
 						}
 					],
 					"request": {
-						"url": "{{be4Url}}/object_types",
+						"url": "{{be4Url}}/model/object_types",
 						"method": "POST",
 						"header": [
 							{
@@ -839,7 +839,7 @@
 						}
 					],
 					"request": {
-						"url": "{{be4Url}}/object_types/{{objectTypeName}}",
+						"url": "{{be4Url}}/model/object_types/{{objectTypeName}}",
 						"method": "GET",
 						"header": [
 							{
@@ -893,7 +893,7 @@
 						}
 					],
 					"request": {
-						"url": "{{be4Url}}/object_types/{{objectTypeId}}",
+						"url": "{{be4Url}}/model/object_types/{{objectTypeId}}",
 						"method": "PATCH",
 						"header": [
 							{
@@ -4170,7 +4170,7 @@
 						}
 					],
 					"request": {
-						"url": "{{be4Url}}/object_types/{{objectTypeName}}",
+						"url": "{{be4Url}}/model/object_types/{{objectTypeName}}",
 						"method": "DELETE",
 						"header": [
 							{

--- a/plugins/BEdita/API/spec/be4.yaml
+++ b/plugins/BEdita/API/spec/be4.yaml
@@ -49,7 +49,7 @@ definitions:
     UserParam: { properties: { data: { required: [id, type], properties: { id: { type: integer }, type: { type: string, enum: [users] } } } } }
     404Response: { type: object, properties: { error: { type: object, properties: { status: { type: integer, enum: ['404'] }, title: { type: string, enum: ['Not Found'] } } }, links: { type: object, properties: { self: { type: string }, home: { type: string } } } } }
     Home200Response: { properties: { links: { properties: { self: { type: string }, home: { type: string } } }, meta: { properties: { resources: { $ref: '#/definitions/MetaResources' } } } } }
-    MetaResources: { properties: { /objects: { $ref: '#/definitions/Resource' }, /users: { $ref: '#/definitions/Resource' }, /roles: { $ref: '#/definitions/Resource' }, /object_types: { $ref: '#/definitions/Resource' }, /status: { $ref: '#/definitions/Resource' } } }
+    MetaResources: { properties: { /objects: { $ref: '#/definitions/Resource' }, /users: { $ref: '#/definitions/Resource' }, /roles: { $ref: '#/definitions/Resource' }, /model/object_types: { $ref: '#/definitions/Resource' }, /status: { $ref: '#/definitions/Resource' } } }
     Resource: { properties: { href: { type: string }, hints: { $ref: '#/definitions/Hint' } } }
     Hint: { properties: { allow: { type: array, items: { type: string } }, formats: { type: array, items: { type: string } } } }
     Relantionship: { properties: { roles: { $ref: '#/definitions/RelationShipRole' } } }

--- a/plugins/BEdita/API/spec/home.yaml
+++ b/plugins/BEdita/API/spec/home.yaml
@@ -49,7 +49,7 @@ definitions:
         $ref: '#/definitions/Resource'
       '/roles':
         $ref: '#/definitions/Resource'
-      '/object_types':
+      '/model/object_types':
         $ref: '#/definitions/Resource'
       '/status':
         $ref: '#/definitions/Resource'

--- a/plugins/BEdita/API/src/Controller/AdminController.php
+++ b/plugins/BEdita/API/src/Controller/AdminController.php
@@ -32,6 +32,11 @@ class AdminController extends ResourcesController
     public $modelClass = null;
 
     /**
+     * {@inheritDoc}
+     */
+    protected $_routeNamePrefix = 'api:admin';
+
+    /**
      * Resource name, one of `$this->config('allowedResources')`
      */
     public $resourceName = null;
@@ -76,7 +81,7 @@ class AdminController extends ResourcesController
     {
         return Router::url(
             [
-                '_name' => 'api:admin:resource',
+                '_name' => $this->_routeNamePrefix . ':resource',
                 'item' => $this->resourceName,
                 'id' => $id,
                 'controller' => $this->name,

--- a/plugins/BEdita/API/src/Controller/AdminController.php
+++ b/plugins/BEdita/API/src/Controller/AdminController.php
@@ -34,7 +34,7 @@ class AdminController extends ResourcesController
     /**
      * {@inheritDoc}
      */
-    protected $_routeNamePrefix = 'api:admin';
+    protected $routeNamePrefix = 'api:admin';
 
     /**
      * Resource name, one of `$this->config('allowedResources')`
@@ -81,7 +81,7 @@ class AdminController extends ResourcesController
     {
         return Router::url(
             [
-                '_name' => $this->_routeNamePrefix . ':resource',
+                '_name' => $this->routeNamePrefix . ':resource',
                 'item' => $this->resourceName,
                 'id' => $id,
                 'controller' => $this->name,

--- a/plugins/BEdita/API/src/Controller/HomeController.php
+++ b/plugins/BEdita/API/src/Controller/HomeController.php
@@ -37,9 +37,9 @@ class HomeController extends AppController
      */
     protected $defaultEndpoints = [
         '/auth' => ['GET', 'POST'],
-        '/object_types' => 'ALL',
+        '/admin' => 'ALL',
+        '/model' => 'ALL',
         '/objects' => 'ALL',
-        '/relations' => 'ALL',
         '/roles' => 'ALL',
         '/signup' => ['POST'],
         '/status' => ['GET'],

--- a/plugins/BEdita/API/src/Controller/ObjectTypesController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectTypesController.php
@@ -29,7 +29,7 @@ class ObjectTypesController extends ResourcesController
     /**
      * {@inheritDoc}
      */
-    protected $_routeNamePrefix = 'api:model';
+    protected $routeNamePrefix = 'api:model';
 
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/API/src/Controller/ObjectTypesController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectTypesController.php
@@ -13,7 +13,7 @@
 namespace BEdita\API\Controller;
 
 /**
- * Controller for `/model/model/object_types` endpoint.
+ * Controller for `/model/object_types` endpoint.
  *
  * @since 4.0.0
  *

--- a/plugins/BEdita/API/src/Controller/ObjectTypesController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectTypesController.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -13,7 +13,7 @@
 namespace BEdita\API\Controller;
 
 /**
- * Controller for `/object_types` endpoint.
+ * Controller for `/model/model/object_types` endpoint.
  *
  * @since 4.0.0
  *
@@ -25,6 +25,11 @@ class ObjectTypesController extends ResourcesController
      * {@inheritDoc}
      */
     public $modelClass = 'ObjectTypes';
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_routeNamePrefix = 'api:model';
 
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/API/src/Controller/PropertiesController.php
+++ b/plugins/BEdita/API/src/Controller/PropertiesController.php
@@ -13,7 +13,7 @@
 namespace BEdita\API\Controller;
 
 /**
- * Controller for `/properties` endpoint.
+ * Controller for `/model/properties` endpoint.
  *
  * @since 4.0.0
  *
@@ -26,6 +26,11 @@ class PropertiesController extends ResourcesController
      * {@inheritDoc}
      */
     public $modelClass = 'Properties';
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_routeNamePrefix = 'api:model';
 
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/API/src/Controller/PropertiesController.php
+++ b/plugins/BEdita/API/src/Controller/PropertiesController.php
@@ -30,7 +30,7 @@ class PropertiesController extends ResourcesController
     /**
      * {@inheritDoc}
      */
-    protected $_routeNamePrefix = 'api:model';
+    protected $routeNamePrefix = 'api:model';
 
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/API/src/Controller/PropertyTypesController.php
+++ b/plugins/BEdita/API/src/Controller/PropertyTypesController.php
@@ -30,7 +30,7 @@ class PropertyTypesController extends ResourcesController
     /**
      * {@inheritDoc}
      */
-    protected $_routeNamePrefix = 'api:model';
+    protected $routeNamePrefix = 'api:model';
 
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/API/src/Controller/PropertyTypesController.php
+++ b/plugins/BEdita/API/src/Controller/PropertyTypesController.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Controller;
+
+/**
+ * Controller for `/model/property_types` endpoint.
+ *
+ * @since 4.0.0
+ *
+ * @property \BEdita\Core\Model\Table\PropertyTypesTable $PropertyTypes
+ */
+class PropertyTypesController extends ResourcesController
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public $modelClass = 'PropertyTypes';
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_routeNamePrefix = 'api:model';
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_defaultConfig = [
+        'allowedAssociations' => [
+            'properties' => ['properties'],
+        ],
+    ];
+}

--- a/plugins/BEdita/API/src/Controller/RelationsController.php
+++ b/plugins/BEdita/API/src/Controller/RelationsController.php
@@ -29,7 +29,7 @@ class RelationsController extends ResourcesController
     /**
      * {@inheritDoc}
      */
-    protected $_routeNamePrefix = 'api:model';
+    protected $routeNamePrefix = 'api:model';
 
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/API/src/Controller/RelationsController.php
+++ b/plugins/BEdita/API/src/Controller/RelationsController.php
@@ -13,7 +13,7 @@
 namespace BEdita\API\Controller;
 
 /**
- * Controller for `/relations` endpoint.
+ * Controller for `/model/relations` endpoint.
  *
  * @since 4.0.0
  *
@@ -25,6 +25,11 @@ class RelationsController extends ResourcesController
      * {@inheritDoc}
      */
     public $modelClass = 'Relations';
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_routeNamePrefix = 'api:model';
 
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -66,6 +66,13 @@ abstract class ResourcesController extends AppController
     protected $Table;
 
     /**
+     * Prefix used in `_name` creating route urls
+     *
+     * @var string
+     */
+    protected $_routeNamePrefix = 'api:resources';
+
+    /**
      * {@inheritDoc}
      */
     public function initialize()
@@ -199,7 +206,7 @@ abstract class ResourcesController extends AppController
     {
         return Router::url(
             [
-                '_name' => 'api:resources:resource',
+                '_name' => $this->_routeNamePrefix . ':resource',
                 'controller' => $this->name,
                 'id' => $id,
             ],
@@ -387,7 +394,7 @@ abstract class ResourcesController extends AppController
 
         return Router::url(
             [
-                '_name' => 'api:resources:index',
+                '_name' => $this->_routeNamePrefix . ':index',
                 'controller' => $destinationEntity['type'],
             ],
             true

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -70,7 +70,7 @@ abstract class ResourcesController extends AppController
      *
      * @var string
      */
-    protected $_routeNamePrefix = 'api:resources';
+    protected $routeNamePrefix = 'api:resources';
 
     /**
      * {@inheritDoc}
@@ -206,7 +206,7 @@ abstract class ResourcesController extends AppController
     {
         return Router::url(
             [
-                '_name' => $this->_routeNamePrefix . ':resource',
+                '_name' => $this->routeNamePrefix . ':resource',
                 'controller' => $this->name,
                 'id' => $id,
             ],
@@ -394,7 +394,7 @@ abstract class ResourcesController extends AppController
 
         return Router::url(
             [
-                '_name' => $this->_routeNamePrefix . ':index',
+                '_name' => $this->routeNamePrefix . ':index',
                 'controller' => $destinationEntity['type'],
             ],
             true

--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -187,7 +187,7 @@ class FilterQueryStringTest extends IntegrationTestCase
     {
         $this->configRequestHeaders();
 
-        $this->get('/object_types?filter[by_relation][name]=test');
+        $this->get('/model/object_types?filter[by_relation][name]=test');
         $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->assertResponseCode(200);

--- a/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
@@ -178,8 +178,8 @@ class HomeControllerTest extends IntegrationTestCase
                             ]
                         ],
                     ],
-                    '/relations' => [
-                        'href' => 'http://api.example.com/relations',
+                    '/model' => [
+                        'href' => 'http://api.example.com/model',
                         'hints' => [
                             'allow' => [
                                 'GET', 'POST', 'PATCH', 'DELETE'
@@ -189,12 +189,12 @@ class HomeControllerTest extends IntegrationTestCase
                                 'application/vnd.api+json'
                             ],
                             'display' => [
-                                'label' => 'Relations',
+                                'label' => 'Model',
                             ]
                         ],
                     ],
-                    '/object_types' => [
-                        'href' => 'http://api.example.com/object_types',
+                    '/admin' => [
+                        'href' => 'http://api.example.com/admin',
                         'hints' => [
                             'allow' => [
                                 'GET', 'POST', 'PATCH', 'DELETE'
@@ -204,7 +204,7 @@ class HomeControllerTest extends IntegrationTestCase
                                 'application/vnd.api+json'
                             ],
                             'display' => [
-                                'label' => 'ObjectTypes',
+                                'label' => 'Admin',
                             ]
                         ],
                     ],

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectTypesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectTypesControllerTest.php
@@ -43,9 +43,9 @@ class ObjectTypesControllerTest extends IntegrationTestCase
     {
         $expected = [
             'links' => [
-                'self' => 'http://api.example.com/object_types',
-                'first' => 'http://api.example.com/object_types',
-                'last' => 'http://api.example.com/object_types',
+                'self' => 'http://api.example.com/model/object_types',
+                'first' => 'http://api.example.com/model/object_types',
+                'last' => 'http://api.example.com/model/object_types',
                 'prev' => null,
                 'next' => null,
                 'home' => 'http://api.example.com/home',
@@ -81,25 +81,25 @@ class ObjectTypesControllerTest extends IntegrationTestCase
                         ],
                     ],
                     'links' => [
-                        'self' => 'http://api.example.com/object_types/1',
+                        'self' => 'http://api.example.com/model/object_types/1',
                     ],
                     'relationships' => [
                         'properties' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/1/relationships/properties',
-                                'related' => 'http://api.example.com/object_types/1/properties',
+                                'self' => 'http://api.example.com/model/object_types/1/relationships/properties',
+                                'related' => 'http://api.example.com/model/object_types/1/properties',
                             ],
                         ],
                         'left_relations' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/1/relationships/left_relations',
-                                'related' => 'http://api.example.com/object_types/1/left_relations',
+                                'self' => 'http://api.example.com/model/object_types/1/relationships/left_relations',
+                                'related' => 'http://api.example.com/model/object_types/1/left_relations',
                             ]
                         ],
                         'right_relations' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/1/relationships/right_relations',
-                                'related' => 'http://api.example.com/object_types/1/right_relations',
+                                'self' => 'http://api.example.com/model/object_types/1/relationships/right_relations',
+                                'related' => 'http://api.example.com/model/object_types/1/right_relations',
                             ]
                         ],
                     ],
@@ -124,25 +124,25 @@ class ObjectTypesControllerTest extends IntegrationTestCase
                         ],
                     ],
                     'links' => [
-                        'self' => 'http://api.example.com/object_types/2',
+                        'self' => 'http://api.example.com/model/object_types/2',
                     ],
                     'relationships' => [
                         'properties' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/2/relationships/properties',
-                                'related' => 'http://api.example.com/object_types/2/properties',
+                                'self' => 'http://api.example.com/model/object_types/2/relationships/properties',
+                                'related' => 'http://api.example.com/model/object_types/2/properties',
                             ],
                         ],
                         'left_relations' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/2/relationships/left_relations',
-                                'related' => 'http://api.example.com/object_types/2/left_relations',
+                                'self' => 'http://api.example.com/model/object_types/2/relationships/left_relations',
+                                'related' => 'http://api.example.com/model/object_types/2/left_relations',
                             ]
                         ],
                         'right_relations' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/2/relationships/right_relations',
-                                'related' => 'http://api.example.com/object_types/2/right_relations',
+                                'self' => 'http://api.example.com/model/object_types/2/relationships/right_relations',
+                                'related' => 'http://api.example.com/model/object_types/2/right_relations',
                             ]
                         ],
                     ],
@@ -165,25 +165,25 @@ class ObjectTypesControllerTest extends IntegrationTestCase
                         'relations' => [],
                     ],
                     'links' => [
-                        'self' => 'http://api.example.com/object_types/3',
+                        'self' => 'http://api.example.com/model/object_types/3',
                     ],
                     'relationships' => [
                         'properties' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/3/relationships/properties',
-                                'related' => 'http://api.example.com/object_types/3/properties',
+                                'self' => 'http://api.example.com/model/object_types/3/relationships/properties',
+                                'related' => 'http://api.example.com/model/object_types/3/properties',
                             ],
                         ],
                         'left_relations' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/3/relationships/left_relations',
-                                'related' => 'http://api.example.com/object_types/3/left_relations',
+                                'self' => 'http://api.example.com/model/object_types/3/relationships/left_relations',
+                                'related' => 'http://api.example.com/model/object_types/3/left_relations',
                             ]
                         ],
                         'right_relations' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/3/relationships/right_relations',
-                                'related' => 'http://api.example.com/object_types/3/right_relations',
+                                'self' => 'http://api.example.com/model/object_types/3/relationships/right_relations',
+                                'related' => 'http://api.example.com/model/object_types/3/right_relations',
                             ]
                         ],
                     ],
@@ -206,25 +206,25 @@ class ObjectTypesControllerTest extends IntegrationTestCase
                         'relations' => [],
                     ],
                     'links' => [
-                        'self' => 'http://api.example.com/object_types/4',
+                        'self' => 'http://api.example.com/model/object_types/4',
                     ],
                     'relationships' => [
                         'properties' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/4/relationships/properties',
-                                'related' => 'http://api.example.com/object_types/4/properties',
+                                'self' => 'http://api.example.com/model/object_types/4/relationships/properties',
+                                'related' => 'http://api.example.com/model/object_types/4/properties',
                             ],
                         ],
                         'left_relations' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/4/relationships/left_relations',
-                                'related' => 'http://api.example.com/object_types/4/left_relations',
+                                'self' => 'http://api.example.com/model/object_types/4/relationships/left_relations',
+                                'related' => 'http://api.example.com/model/object_types/4/left_relations',
                             ]
                         ],
                         'right_relations' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/4/relationships/right_relations',
-                                'related' => 'http://api.example.com/object_types/4/right_relations',
+                                'self' => 'http://api.example.com/model/object_types/4/relationships/right_relations',
+                                'related' => 'http://api.example.com/model/object_types/4/right_relations',
                             ]
                         ],
                     ],
@@ -250,25 +250,25 @@ class ObjectTypesControllerTest extends IntegrationTestCase
                         ],
                     ],
                     'links' => [
-                        'self' => 'http://api.example.com/object_types/5',
+                        'self' => 'http://api.example.com/model/object_types/5',
                     ],
                     'relationships' => [
                         'properties' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/5/relationships/properties',
-                                'related' => 'http://api.example.com/object_types/5/properties',
+                                'self' => 'http://api.example.com/model/object_types/5/relationships/properties',
+                                'related' => 'http://api.example.com/model/object_types/5/properties',
                             ],
                         ],
                         'left_relations' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/5/relationships/left_relations',
-                                'related' => 'http://api.example.com/object_types/5/left_relations',
+                                'self' => 'http://api.example.com/model/object_types/5/relationships/left_relations',
+                                'related' => 'http://api.example.com/model/object_types/5/left_relations',
                             ]
                         ],
                         'right_relations' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/5/relationships/right_relations',
-                                'related' => 'http://api.example.com/object_types/5/right_relations',
+                                'self' => 'http://api.example.com/model/object_types/5/relationships/right_relations',
+                                'related' => 'http://api.example.com/model/object_types/5/right_relations',
                             ]
                         ],
                     ],
@@ -291,25 +291,25 @@ class ObjectTypesControllerTest extends IntegrationTestCase
                         'relations' => [],
                     ],
                     'links' => [
-                        'self' => 'http://api.example.com/object_types/6',
+                        'self' => 'http://api.example.com/model/object_types/6',
                     ],
                     'relationships' => [
                         'properties' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/6/relationships/properties',
-                                'related' => 'http://api.example.com/object_types/6/properties',
+                                'self' => 'http://api.example.com/model/object_types/6/relationships/properties',
+                                'related' => 'http://api.example.com/model/object_types/6/properties',
                             ],
                         ],
                         'left_relations' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/6/relationships/left_relations',
-                                'related' => 'http://api.example.com/object_types/6/left_relations',
+                                'self' => 'http://api.example.com/model/object_types/6/relationships/left_relations',
+                                'related' => 'http://api.example.com/model/object_types/6/left_relations',
                             ]
                         ],
                         'right_relations' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/6/relationships/right_relations',
-                                'related' => 'http://api.example.com/object_types/6/right_relations',
+                                'self' => 'http://api.example.com/model/object_types/6/relationships/right_relations',
+                                'related' => 'http://api.example.com/model/object_types/6/right_relations',
                             ]
                         ],
                     ],
@@ -332,25 +332,25 @@ class ObjectTypesControllerTest extends IntegrationTestCase
                         'relations' => [],
                     ],
                     'links' => [
-                        'self' => 'http://api.example.com/object_types/7',
+                        'self' => 'http://api.example.com/model/object_types/7',
                     ],
                     'relationships' => [
                         'properties' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/7/relationships/properties',
-                                'related' => 'http://api.example.com/object_types/7/properties',
+                                'self' => 'http://api.example.com/model/object_types/7/relationships/properties',
+                                'related' => 'http://api.example.com/model/object_types/7/properties',
                             ],
                         ],
                         'left_relations' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/7/relationships/left_relations',
-                                'related' => 'http://api.example.com/object_types/7/left_relations',
+                                'self' => 'http://api.example.com/model/object_types/7/relationships/left_relations',
+                                'related' => 'http://api.example.com/model/object_types/7/left_relations',
                             ]
                         ],
                         'right_relations' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/7/relationships/right_relations',
-                                'related' => 'http://api.example.com/object_types/7/right_relations',
+                                'self' => 'http://api.example.com/model/object_types/7/relationships/right_relations',
+                                'related' => 'http://api.example.com/model/object_types/7/right_relations',
                             ]
                         ],
                     ],
@@ -359,7 +359,7 @@ class ObjectTypesControllerTest extends IntegrationTestCase
         ];
 
         $this->configRequestHeaders();
-        $this->get('/object_types');
+        $this->get('/model/object_types');
         $result = json_decode((string)$this->_response->getBody(), true);
 
         /*
@@ -388,9 +388,9 @@ class ObjectTypesControllerTest extends IntegrationTestCase
     {
         $expected = [
             'links' => [
-                'self' => 'http://api.example.com/object_types',
-                'first' => 'http://api.example.com/object_types',
-                'last' => 'http://api.example.com/object_types',
+                'self' => 'http://api.example.com/model/object_types',
+                'first' => 'http://api.example.com/model/object_types',
+                'last' => 'http://api.example.com/model/object_types',
                 'prev' => null,
                 'next' => null,
                 'home' => 'http://api.example.com/home',
@@ -411,7 +411,7 @@ class ObjectTypesControllerTest extends IntegrationTestCase
         TableRegistry::get('ObjectTypes')->deleteAll([]);
 
         $this->configRequestHeaders();
-        $this->get('/object_types');
+        $this->get('/model/object_types');
         $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->assertResponseCode(200);
@@ -431,7 +431,7 @@ class ObjectTypesControllerTest extends IntegrationTestCase
     {
         $expected = [
             'links' => [
-                'self' => 'http://api.example.com/object_types/1',
+                'self' => 'http://api.example.com/model/object_types/1',
                 'home' => 'http://api.example.com/home',
             ],
             'data' => [
@@ -457,20 +457,20 @@ class ObjectTypesControllerTest extends IntegrationTestCase
                 'relationships' => [
                     'properties' => [
                         'links' => [
-                            'self' => 'http://api.example.com/object_types/1/relationships/properties',
-                            'related' => 'http://api.example.com/object_types/1/properties',
+                            'self' => 'http://api.example.com/model/object_types/1/relationships/properties',
+                            'related' => 'http://api.example.com/model/object_types/1/properties',
                         ],
                     ],
                     'left_relations' => [
                         'links' => [
-                            'self' => 'http://api.example.com/object_types/1/relationships/left_relations',
-                            'related' => 'http://api.example.com/object_types/1/left_relations',
+                            'self' => 'http://api.example.com/model/object_types/1/relationships/left_relations',
+                            'related' => 'http://api.example.com/model/object_types/1/left_relations',
                         ],
                     ],
                     'right_relations' => [
                         'links' => [
-                            'self' => 'http://api.example.com/object_types/1/relationships/right_relations',
-                            'related' => 'http://api.example.com/object_types/1/right_relations',
+                            'self' => 'http://api.example.com/model/object_types/1/relationships/right_relations',
+                            'related' => 'http://api.example.com/model/object_types/1/right_relations',
                         ],
                     ],
                 ],
@@ -478,7 +478,7 @@ class ObjectTypesControllerTest extends IntegrationTestCase
         ];
 
         $this->configRequestHeaders();
-        $this->get('/object_types/1');
+        $this->get('/model/object_types/1');
         $result = json_decode((string)$this->_response->getBody(), true);
 
         /*
@@ -507,7 +507,7 @@ class ObjectTypesControllerTest extends IntegrationTestCase
     {
         $expected = [
             'links' => [
-                'self' => 'http://api.example.com/object_types/99',
+                'self' => 'http://api.example.com/model/object_types/99',
                 'home' => 'http://api.example.com/home',
             ],
             'error' => [
@@ -516,7 +516,7 @@ class ObjectTypesControllerTest extends IntegrationTestCase
         ];
 
         $this->configRequestHeaders();
-        $this->get('/object_types/99');
+        $this->get('/model/object_types/99');
         $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->assertResponseCode(404);
@@ -555,11 +555,11 @@ class ObjectTypesControllerTest extends IntegrationTestCase
         ];
 
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
-        $this->post('/object_types', json_encode(compact('data')));
+        $this->post('/model/object_types', json_encode(compact('data')));
 
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertHeader('Location', 'http://api.example.com/object_types/8');
+        $this->assertHeader('Location', 'http://api.example.com/model/object_types/8');
         $this->assertTrue(TableRegistry::get('ObjectTypes')->exists(['singular' => 'my_object_type']));
     }
 
@@ -583,7 +583,7 @@ class ObjectTypesControllerTest extends IntegrationTestCase
         $count = TableRegistry::get('ObjectTypes')->find()->count();
 
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
-        $this->post('/object_types', json_encode(compact('data')));
+        $this->post('/model/object_types', json_encode(compact('data')));
 
         $this->assertResponseCode(400);
         $this->assertContentType('application/vnd.api+json');
@@ -609,7 +609,7 @@ class ObjectTypesControllerTest extends IntegrationTestCase
         ];
 
         $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
-        $this->patch('/object_types/1', json_encode(compact('data')));
+        $this->patch('/model/object_types/1', json_encode(compact('data')));
 
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
@@ -643,7 +643,7 @@ class ObjectTypesControllerTest extends IntegrationTestCase
         ];
 
         $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
-        $this->patch('/object_types/2', json_encode(compact('data')));
+        $this->patch('/model/object_types/2', json_encode(compact('data')));
 
         $this->assertResponseCode(409);
         $this->assertContentType('application/vnd.api+json');
@@ -662,7 +662,7 @@ class ObjectTypesControllerTest extends IntegrationTestCase
     public function testDelete()
     {
         $this->configRequestHeaders('DELETE', $this->getUserAuthHeader());
-        $this->delete('/object_types/1');
+        $this->delete('/model/object_types/1');
 
         $this->assertResponseCode(204);
         $this->assertContentType('application/vnd.api+json');

--- a/plugins/BEdita/API/tests/TestCase/Controller/PropertiesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/PropertiesControllerTest.php
@@ -42,9 +42,9 @@ class PropertiesControllerTest extends IntegrationTestCase
     {
         $expected = [
             'links' => [
-                'self' => 'http://api.example.com/properties',
-                'first' => 'http://api.example.com/properties',
-                'last' => 'http://api.example.com/properties',
+                'self' => 'http://api.example.com/model/properties',
+                'first' => 'http://api.example.com/model/properties',
+                'last' => 'http://api.example.com/model/properties',
                 'prev' => null,
                 'next' => null,
                 'home' => 'http://api.example.com/home',
@@ -77,7 +77,7 @@ class PropertiesControllerTest extends IntegrationTestCase
                         'modified' => '2016-12-31T23:09:23+00:00',
                     ],
                     'links' => [
-                        'self' => 'http://api.example.com/properties/1',
+                        'self' => 'http://api.example.com/model/properties/1',
                     ],
                 ],
                 [
@@ -98,7 +98,7 @@ class PropertiesControllerTest extends IntegrationTestCase
                         'modified' => '2016-12-31T23:09:23+00:00',
                     ],
                     'links' => [
-                        'self' => 'http://api.example.com/properties/2',
+                        'self' => 'http://api.example.com/model/properties/2',
                     ],
                 ],
                 [
@@ -119,7 +119,7 @@ class PropertiesControllerTest extends IntegrationTestCase
                         'modified' => '2016-12-31T23:09:23+00:00',
                     ],
                     'links' => [
-                        'self' => 'http://api.example.com/properties/3',
+                        'self' => 'http://api.example.com/model/properties/3',
                     ],
                 ],
                 [
@@ -140,7 +140,7 @@ class PropertiesControllerTest extends IntegrationTestCase
                         'modified' => '2016-12-31T23:09:23+00:00',
                     ],
                     'links' => [
-                        'self' => 'http://api.example.com/properties/4',
+                        'self' => 'http://api.example.com/model/properties/4',
                     ],
                 ],
                 [
@@ -161,7 +161,7 @@ class PropertiesControllerTest extends IntegrationTestCase
                         'modified' => '2016-12-31T23:09:23+00:00',
                     ],
                     'links' => [
-                        'self' => 'http://api.example.com/properties/5',
+                        'self' => 'http://api.example.com/model/properties/5',
                     ],
                 ],
                 [
@@ -182,7 +182,7 @@ class PropertiesControllerTest extends IntegrationTestCase
                         'modified' => '2016-12-31T23:09:23+00:00',
                     ],
                     'links' => [
-                        'self' => 'http://api.example.com/properties/6',
+                        'self' => 'http://api.example.com/model/properties/6',
                     ],
                 ],
                 [
@@ -203,14 +203,14 @@ class PropertiesControllerTest extends IntegrationTestCase
                         'modified' => '2017-09-05T11:10:00+00:00',
                     ],
                     'links' => [
-                        'self' => 'http://api.example.com/properties/7',
+                        'self' => 'http://api.example.com/model/properties/7',
                     ],
                 ],
             ],
         ];
 
         $this->configRequestHeaders();
-        $this->get('/properties');
+        $this->get('/model/properties');
         $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->assertResponseCode(200);
@@ -230,9 +230,9 @@ class PropertiesControllerTest extends IntegrationTestCase
     {
         $expected = [
             'links' => [
-                'self' => 'http://api.example.com/properties',
-                'first' => 'http://api.example.com/properties',
-                'last' => 'http://api.example.com/properties',
+                'self' => 'http://api.example.com/model/properties',
+                'first' => 'http://api.example.com/model/properties',
+                'last' => 'http://api.example.com/model/properties',
                 'prev' => null,
                 'next' => null,
                 'home' => 'http://api.example.com/home',
@@ -252,7 +252,7 @@ class PropertiesControllerTest extends IntegrationTestCase
         TableRegistry::get('Properties')->deleteAll([]);
 
         $this->configRequestHeaders();
-        $this->get('/properties');
+        $this->get('/model/properties');
         $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->assertResponseCode(200);
@@ -272,7 +272,7 @@ class PropertiesControllerTest extends IntegrationTestCase
     {
         $expected = [
             'links' => [
-                'self' => 'http://api.example.com/properties/1',
+                'self' => 'http://api.example.com/model/properties/1',
                 'home' => 'http://api.example.com/home',
             ],
             'data' => [
@@ -296,7 +296,7 @@ class PropertiesControllerTest extends IntegrationTestCase
         ];
 
         $this->configRequestHeaders();
-        $this->get('/properties/1');
+        $this->get('/model/properties/1');
         $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->assertResponseCode(200);
@@ -316,7 +316,7 @@ class PropertiesControllerTest extends IntegrationTestCase
     {
         $expected = [
             'links' => [
-                'self' => 'http://api.example.com/properties/999999',
+                'self' => 'http://api.example.com/model/properties/999999',
                 'home' => 'http://api.example.com/home',
             ],
             'error' => [
@@ -325,7 +325,7 @@ class PropertiesControllerTest extends IntegrationTestCase
         ];
 
         $this->configRequestHeaders();
-        $this->get('/properties/999999');
+        $this->get('/model/properties/999999');
         $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->assertResponseCode(404);
@@ -363,11 +363,11 @@ class PropertiesControllerTest extends IntegrationTestCase
         ];
 
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
-        $this->post('/properties', json_encode(compact('data')));
+        $this->post('/model/properties', json_encode(compact('data')));
 
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertHeader('Location', 'http://api.example.com/properties/8');
+        $this->assertHeader('Location', 'http://api.example.com/model/properties/8');
         $this->assertTrue(TableRegistry::get('Properties')->exists(['name' => 'yet_another_body']));
     }
 
@@ -391,7 +391,7 @@ class PropertiesControllerTest extends IntegrationTestCase
         $count = TableRegistry::get('Properties')->find()->count();
 
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
-        $this->post('/properties', json_encode(compact('data')));
+        $this->post('/model/properties', json_encode(compact('data')));
 
         $this->assertResponseCode(400);
         $this->assertContentType('application/vnd.api+json');
@@ -418,7 +418,7 @@ class PropertiesControllerTest extends IntegrationTestCase
         ];
 
         $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
-        $this->patch('/properties/1', json_encode(compact('data')));
+        $this->patch('/model/properties/1', json_encode(compact('data')));
 
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
@@ -444,7 +444,7 @@ class PropertiesControllerTest extends IntegrationTestCase
         ];
 
         $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
-        $this->patch('/properties/2', json_encode(compact('data')));
+        $this->patch('/model/properties/2', json_encode(compact('data')));
 
         $this->assertResponseCode(409);
         $this->assertContentType('application/vnd.api+json');
@@ -463,7 +463,7 @@ class PropertiesControllerTest extends IntegrationTestCase
     public function testDelete()
     {
         $this->configRequestHeaders('DELETE', $this->getUserAuthHeader());
-        $this->delete('/properties/1');
+        $this->delete('/model/properties/1');
 
         $this->assertResponseCode(204);
         $this->assertContentType('application/vnd.api+json');

--- a/plugins/BEdita/API/tests/TestCase/Controller/PropertyTypesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/PropertyTypesControllerTest.php
@@ -1,0 +1,404 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Test\TestCase\Controller;
+
+use BEdita\API\TestSuite\IntegrationTestCase;
+use Cake\ORM\TableRegistry;
+
+/**
+ * @coversDefaultClass \BEdita\API\Controller\PropertyTypesController
+ */
+class PropertyTypesControllerTest extends IntegrationTestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.property_types',
+        'plugin.BEdita/Core.properties',
+    ];
+
+    /**
+     * Test index method.
+     *
+     * @return void
+     *
+     * @covers ::index()
+     * @covers ::initialize()
+     */
+    public function testIndex()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/model/property_types',
+                'first' => 'http://api.example.com/model/property_types',
+                'last' => 'http://api.example.com/model/property_types',
+                'prev' => null,
+                'next' => null,
+                'home' => 'http://api.example.com/home',
+            ],
+            'meta' => [
+                'pagination' => [
+                    'count' => 4,
+                    'page' => 1,
+                    'page_count' => 1,
+                    'page_items' => 4,
+                    'page_size' => 20,
+                ],
+            ],
+            'data' => [
+                [
+                    'id' => '1',
+                    'type' => 'property_types',
+                    'attributes' => [
+                        'name' => 'string',
+                        'params' => [
+                            'type' => 'string',
+                        ]
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/model/property_types/1',
+                    ],
+                    'relationships' => [
+                        'properties' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/model/property_types/1/properties',
+                                'self' => 'http://api.example.com/model/property_types/1/relationships/properties',
+                            ]
+                        ]
+                    ]
+                ],
+                [
+                    'id' => '2',
+                    'type' => 'property_types',
+                    'attributes' => [
+                        'name' => 'date',
+                        'params' => [
+                            'type' => 'string',
+                        ]
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/model/property_types/2',
+                    ],
+                    'relationships' => [
+                        'properties' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/model/property_types/2/properties',
+                                'self' => 'http://api.example.com/model/property_types/2/relationships/properties',
+                            ]
+                        ]
+                    ]
+                ],
+                [
+                    'id' => '3',
+                    'type' => 'property_types',
+                    'attributes' => [
+                        'name' => 'number',
+                        'params' => [
+                            'type' => 'number',
+                        ]
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/model/property_types/3',
+                    ],
+                    'relationships' => [
+                        'properties' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/model/property_types/3/properties',
+                                'self' => 'http://api.example.com/model/property_types/3/relationships/properties',
+                            ]
+                        ]
+                    ]
+                ],
+                [
+                    'id' => '4',
+                    'type' => 'property_types',
+                    'attributes' => [
+                        'name' => 'boolean',
+                        'params' => [
+                            'type' => 'boolean',
+                        ]
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/model/property_types/4',
+                    ],
+                    'relationships' => [
+                        'properties' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/model/property_types/4/properties',
+                                'self' => 'http://api.example.com/model/property_types/4/relationships/properties',
+                            ]
+                        ]
+                    ]
+                ],
+            ],
+        ];
+
+        $this->configRequestHeaders();
+        $this->get('/model/property_types');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test index method.
+     *
+     * @return void
+     *
+     * @covers ::resource()
+     * @covers ::initialize()
+     */
+    public function testEmpty()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/model/property_types',
+                'first' => 'http://api.example.com/model/property_types',
+                'last' => 'http://api.example.com/model/property_types',
+                'prev' => null,
+                'next' => null,
+                'home' => 'http://api.example.com/home',
+            ],
+            'meta' => [
+                'pagination' => [
+                    'count' => 0,
+                    'page' => 1,
+                    'page_count' => 1,
+                    'page_items' => 0,
+                    'page_size' => 20,
+                ],
+            ],
+            'data' => [],
+        ];
+
+        TableRegistry::get('PropertyTypes')->deleteAll([]);
+
+        $this->configRequestHeaders();
+        $this->get('/model/property_types');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test view method.
+     *
+     * @return void
+     *
+     * @covers ::resource()
+     * @covers ::initialize()
+     */
+    public function testSingle()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/model/property_types/1',
+                'home' => 'http://api.example.com/home',
+            ],
+            'data' => [
+                'id' => '1',
+                'type' => 'property_types',
+                'attributes' => [
+                    'name' => 'string',
+                    'params' => [
+                        'type' => 'string',
+                    ]
+                ],
+                'relationships' => [
+                    'properties' => [
+                        'links' => [
+                            'related' => 'http://api.example.com/model/property_types/1/properties',
+                            'self' => 'http://api.example.com/model/property_types/1/relationships/properties',
+                        ]
+                    ]
+                ],
+            ],
+        ];
+
+        $this->configRequestHeaders();
+        $this->get('/model/property_types/1');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test view method.
+     *
+     * @return void
+     *
+     * @covers ::resource()
+     * @covers ::initialize()
+     */
+    public function testMissing()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/model/property_types/999999',
+                'home' => 'http://api.example.com/home',
+            ],
+            'error' => [
+                'status' => '404',
+            ],
+        ];
+
+        $this->configRequestHeaders();
+        $this->get('/model/property_types/999999');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(404);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertArrayNotHasKey('data', $result);
+        $this->assertArrayHasKey('links', $result);
+        $this->assertArrayHasKey('error', $result);
+        $this->assertEquals($expected['links'], $result['links']);
+        $this->assertArraySubset($expected['error'], $result['error']);
+        $this->assertArrayHasKey('title', $result['error']);
+        $this->assertNotEmpty($result['error']['title']);
+    }
+
+    /**
+     * Test add method.
+     *
+     * @return void
+     *
+     * @covers ::index()
+     * @covers ::initialize()
+     * @covers ::resourceUrl()
+     */
+    public function testAdd()
+    {
+        $data = [
+            'type' => 'property_types',
+            'attributes' => [
+                'name' => 'gustavo',
+            ],
+        ];
+
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $this->post('/model/property_types', json_encode(compact('data')));
+
+        $this->assertResponseCode(201);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertHeader('Location', 'http://api.example.com/model/property_types/5');
+        $this->assertTrue(TableRegistry::get('PropertyTypes')->exists(['name' => 'gustavo']));
+    }
+
+    /**
+     * Test add method with invalid data.
+     *
+     * @return void
+     *
+     * @covers ::index()
+     * @covers ::initialize()
+     */
+    public function testInvalidAdd()
+    {
+        $data = [
+            'type' => 'property_types',
+            'attributes' => [
+                'some_property' => 'Some value',
+            ],
+        ];
+
+        $count = TableRegistry::get('PropertyTypes')->find()->count();
+
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $this->post('/model/property_types', json_encode(compact('data')));
+
+        $this->assertResponseCode(400);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertEquals($count, TableRegistry::get('PropertyTypes')->find()->count());
+    }
+
+    /**
+     * Test edit method.
+     *
+     * @return void
+     *
+     * @covers ::resource()
+     * @covers ::initialize()
+     */
+    public function testEdit()
+    {
+        $data = [
+            'id' => '1',
+            'type' => 'property_types',
+            'attributes' => [
+                'name' => 'string',
+                'params' => 'string',
+            ],
+        ];
+
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $this->patch('/model/property_types/1', json_encode(compact('data')));
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertEquals('string', TableRegistry::get('PropertyTypes')->get(1)->get('params'));
+    }
+
+    /**
+     * Test edit method with ID conflict.
+     *
+     * @return void
+     *
+     * @covers ::resource()
+     * @covers ::initialize()
+     */
+    public function testConflictEdit()
+    {
+        $data = [
+            'id' => '1',
+            'type' => 'property_types',
+            'attributes' => [
+                'name' => 'strong',
+            ],
+        ];
+
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $this->patch('/model/property_types/2', json_encode(compact('data')));
+
+        $this->assertResponseCode(409);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertEquals('string', TableRegistry::get('PropertyTypes')->get(1)->get('name'));
+        $this->assertEquals('date', TableRegistry::get('PropertyTypes')->get(2)->get('name'));
+    }
+
+    /**
+     * Test delete method.
+     *
+     * @return void
+     *
+     * @covers ::resource()
+     * @covers ::initialize()
+     */
+    public function testDelete()
+    {
+        $this->configRequestHeaders('DELETE', $this->getUserAuthHeader());
+        $this->delete('/model/property_types/1');
+
+        $this->assertResponseCode(204);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertFalse(TableRegistry::get('PropertyTypes')->exists(['id' => 1]));
+    }
+}

--- a/plugins/BEdita/API/tests/TestCase/Controller/RelationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/RelationsControllerTest.php
@@ -33,9 +33,9 @@ class RelationsControllerTest extends IntegrationTestCase
     {
         $expected = [
             'links' => [
-                'self' => 'http://api.example.com/relations',
-                'first' => 'http://api.example.com/relations',
-                'last' => 'http://api.example.com/relations',
+                'self' => 'http://api.example.com/model/relations',
+                'first' => 'http://api.example.com/model/relations',
+                'last' => 'http://api.example.com/model/relations',
                 'prev' => null,
                 'next' => null,
                 'home' => 'http://api.example.com/home',
@@ -62,19 +62,19 @@ class RelationsControllerTest extends IntegrationTestCase
                         'params' => null,
                     ],
                     'links' => [
-                        'self' => 'http://api.example.com/relations/1',
+                        'self' => 'http://api.example.com/model/relations/1',
                     ],
                     'relationships' => [
                         'left_object_types' => [
                             'links' => [
-                                'self' => 'http://api.example.com/relations/1/relationships/left_object_types',
-                                'related' => 'http://api.example.com/relations/1/left_object_types',
+                                'self' => 'http://api.example.com/model/relations/1/relationships/left_object_types',
+                                'related' => 'http://api.example.com/model/relations/1/left_object_types',
                             ],
                         ],
                         'right_object_types' => [
                             'links' => [
-                                'self' => 'http://api.example.com/relations/1/relationships/right_object_types',
-                                'related' => 'http://api.example.com/relations/1/right_object_types',
+                                'self' => 'http://api.example.com/model/relations/1/relationships/right_object_types',
+                                'related' => 'http://api.example.com/model/relations/1/right_object_types',
                             ],
                         ],
                     ],
@@ -103,19 +103,19 @@ class RelationsControllerTest extends IntegrationTestCase
                         ],
                     ],
                     'links' => [
-                        'self' => 'http://api.example.com/relations/2',
+                        'self' => 'http://api.example.com/model/relations/2',
                     ],
                     'relationships' => [
                         'left_object_types' => [
                             'links' => [
-                                'self' => 'http://api.example.com/relations/2/relationships/left_object_types',
-                                'related' => 'http://api.example.com/relations/2/left_object_types',
+                                'self' => 'http://api.example.com/model/relations/2/relationships/left_object_types',
+                                'related' => 'http://api.example.com/model/relations/2/left_object_types',
                             ],
                         ],
                         'right_object_types' => [
                             'links' => [
-                                'self' => 'http://api.example.com/relations/2/relationships/right_object_types',
-                                'related' => 'http://api.example.com/relations/2/right_object_types',
+                                'self' => 'http://api.example.com/model/relations/2/relationships/right_object_types',
+                                'related' => 'http://api.example.com/model/relations/2/right_object_types',
                             ],
                         ],
                     ],
@@ -124,7 +124,7 @@ class RelationsControllerTest extends IntegrationTestCase
         ];
 
         $this->configRequestHeaders();
-        $this->get('/relations');
+        $this->get('/model/relations');
         $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->assertResponseCode(200);
@@ -144,9 +144,9 @@ class RelationsControllerTest extends IntegrationTestCase
     {
         $expected = [
             'links' => [
-                'self' => 'http://api.example.com/relations',
-                'first' => 'http://api.example.com/relations',
-                'last' => 'http://api.example.com/relations',
+                'self' => 'http://api.example.com/model/relations',
+                'first' => 'http://api.example.com/model/relations',
+                'last' => 'http://api.example.com/model/relations',
                 'prev' => null,
                 'next' => null,
                 'home' => 'http://api.example.com/home',
@@ -166,7 +166,7 @@ class RelationsControllerTest extends IntegrationTestCase
         TableRegistry::get('Relations')->deleteAll([]);
 
         $this->configRequestHeaders();
-        $this->get('/relations');
+        $this->get('/model/relations');
         $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->assertResponseCode(200);
@@ -186,7 +186,7 @@ class RelationsControllerTest extends IntegrationTestCase
     {
         $expected = [
             'links' => [
-                'self' => 'http://api.example.com/relations/1',
+                'self' => 'http://api.example.com/model/relations/1',
                 'home' => 'http://api.example.com/home',
             ],
             'data' => [
@@ -203,14 +203,14 @@ class RelationsControllerTest extends IntegrationTestCase
                 'relationships' => [
                     'left_object_types' => [
                         'links' => [
-                            'self' => 'http://api.example.com/relations/1/relationships/left_object_types',
-                            'related' => 'http://api.example.com/relations/1/left_object_types',
+                            'self' => 'http://api.example.com/model/relations/1/relationships/left_object_types',
+                            'related' => 'http://api.example.com/model/relations/1/left_object_types',
                         ],
                     ],
                     'right_object_types' => [
                         'links' => [
-                            'self' => 'http://api.example.com/relations/1/relationships/right_object_types',
-                            'related' => 'http://api.example.com/relations/1/right_object_types',
+                            'self' => 'http://api.example.com/model/relations/1/relationships/right_object_types',
+                            'related' => 'http://api.example.com/model/relations/1/right_object_types',
                         ],
                     ],
                 ],
@@ -218,7 +218,7 @@ class RelationsControllerTest extends IntegrationTestCase
         ];
 
         $this->configRequestHeaders();
-        $this->get('/relations/1');
+        $this->get('/model/relations/1');
         $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->assertResponseCode(200);
@@ -239,7 +239,7 @@ class RelationsControllerTest extends IntegrationTestCase
     {
         $expected = [
             'links' => [
-                'self' => 'http://api.example.com/relations/99',
+                'self' => 'http://api.example.com/model/relations/99',
                 'home' => 'http://api.example.com/home',
             ],
             'error' => [
@@ -248,7 +248,7 @@ class RelationsControllerTest extends IntegrationTestCase
         ];
 
         $this->configRequestHeaders();
-        $this->get('/relations/99');
+        $this->get('/model/relations/99');
         $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->assertResponseCode(404);
@@ -288,7 +288,7 @@ class RelationsControllerTest extends IntegrationTestCase
         ];
 
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
-        $this->post('/relations', json_encode(compact('data')));
+        $this->post('/model/relations', json_encode(compact('data')));
 
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
@@ -298,7 +298,7 @@ class RelationsControllerTest extends IntegrationTestCase
             ->order(['id' => 'DESC'])
             ->first();
 
-        $this->assertHeader('Location', 'http://api.example.com/relations/' . $relation->id);
+        $this->assertHeader('Location', 'http://api.example.com/model/relations/' . $relation->id);
 
         $expected = array_merge(['id' => $relation->id], $data['attributes']);
         static::assertEquals($expected, $relation->toArray());
@@ -325,7 +325,7 @@ class RelationsControllerTest extends IntegrationTestCase
         $count = $Relations->find()->count();
 
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
-        $this->post('/relations', json_encode(compact('data')));
+        $this->post('/model/relations', json_encode(compact('data')));
 
         $this->assertResponseCode(400);
         $this->assertContentType('application/vnd.api+json');
@@ -351,7 +351,7 @@ class RelationsControllerTest extends IntegrationTestCase
         ];
 
         $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
-        $this->patch('/relations/1', json_encode(compact('data')));
+        $this->patch('/model/relations/1', json_encode(compact('data')));
 
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
@@ -383,7 +383,7 @@ class RelationsControllerTest extends IntegrationTestCase
         $expected = $Relations->get(1)->get('label');
 
         $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
-        $this->patch('/relations/2', json_encode(compact('data')));
+        $this->patch('/model/relations/2', json_encode(compact('data')));
 
         $this->assertResponseCode(409);
         $this->assertContentType('application/vnd.api+json');
@@ -401,7 +401,7 @@ class RelationsControllerTest extends IntegrationTestCase
     public function testDelete()
     {
         $this->configRequestHeaders('DELETE', $this->getUserAuthHeader());
-        $this->delete('/relations/1');
+        $this->delete('/model/relations/1');
 
         $this->assertResponseCode(204);
         $this->assertContentType('application/vnd.api+json');
@@ -421,13 +421,13 @@ class RelationsControllerTest extends IntegrationTestCase
     {
         $expected = [
             'links' => [
-                'self' => 'http://api.example.com/relations/1/left_object_types',
-                'first' => 'http://api.example.com/relations/1/left_object_types',
-                'last' => 'http://api.example.com/relations/1/left_object_types',
+                'self' => 'http://api.example.com/model/relations/1/left_object_types',
+                'first' => 'http://api.example.com/model/relations/1/left_object_types',
+                'last' => 'http://api.example.com/model/relations/1/left_object_types',
                 'prev' => null,
                 'next' => null,
                 'home' => 'http://api.example.com/home',
-                'available' => 'http://api.example.com/object_types',
+                'available' => 'http://api.example.com/model/object_types',
             ],
             'meta' => [
                 'pagination' => [
@@ -460,25 +460,25 @@ class RelationsControllerTest extends IntegrationTestCase
                         ],
                     ],
                     'links' => [
-                        'self' => 'http://api.example.com/object_types/1',
+                        'self' => 'http://api.example.com/model/object_types/1',
                     ],
                     'relationships' => [
                         'properties' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/1/relationships/properties',
-                                'related' => 'http://api.example.com/object_types/1/properties',
+                                'self' => 'http://api.example.com/model/object_types/1/relationships/properties',
+                                'related' => 'http://api.example.com/model/object_types/1/properties',
                             ],
                         ],
                         'left_relations' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/1/relationships/left_relations',
-                                'related' => 'http://api.example.com/object_types/1/left_relations',
+                                'self' => 'http://api.example.com/model/object_types/1/relationships/left_relations',
+                                'related' => 'http://api.example.com/model/object_types/1/left_relations',
                             ],
                         ],
                         'right_relations' => [
                             'links' => [
-                                'self' => 'http://api.example.com/object_types/1/relationships/right_relations',
-                                'related' => 'http://api.example.com/object_types/1/right_relations',
+                                'self' => 'http://api.example.com/model/object_types/1/relationships/right_relations',
+                                'related' => 'http://api.example.com/model/object_types/1/right_relations',
                             ],
                         ],
                     ],
@@ -487,7 +487,7 @@ class RelationsControllerTest extends IntegrationTestCase
         ];
 
         $this->configRequestHeaders();
-        $this->get('/relations/1/left_object_types');
+        $this->get('/model/relations/1/left_object_types');
         $result = json_decode((string)$this->_response->getBody(), true);
 
         /*

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiAdminTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiAdminTrait.php
@@ -27,13 +27,23 @@ trait JsonApiAdminTrait
 
     /**
      * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    protected function routeNamePrefix()
+    {
+        return 'api:admin';
+    }
+
+    /**
+     * {@inheritDoc}
      */
     protected function getLinks()
     {
         $table = TableRegistry::get($this->getSource());
         $primaryKey = $table->getPrimaryKey();
         $options = [
-            '_name' => 'api:admin:resource',
+            '_name' => $this->routeNamePrefix() . ':resource',
             'item' => $table->getTable(),
             'id' => $this->{$primaryKey},
         ];

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiModelTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiModelTrait.php
@@ -13,9 +13,6 @@
 
 namespace BEdita\Core\Model\Entity;
 
-use Cake\ORM\TableRegistry;
-use Cake\Routing\Router;
-
 /**
  * Trait for exposing useful properties required for JSON API response on `/model` resources.
  *

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiModelTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiModelTrait.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -13,19 +13,25 @@
 
 namespace BEdita\Core\Model\Entity;
 
-use BEdita\Core\Utility\JsonApiSerializable;
-use Cake\ORM\Entity;
+use Cake\ORM\TableRegistry;
+use Cake\Routing\Router;
 
 /**
- * Property Type Entity.
- *
- * @property string $name
- * @property string $params
+ * Trait for exposing useful properties required for JSON API response on `/model` resources.
  *
  * @since 4.0.0
  */
-class PropertyType extends Entity implements JsonApiSerializable
+trait JsonApiModelTrait
 {
+    use JsonApiTrait;
 
-    use JsonApiModelTrait;
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    protected function routeNamePrefix()
+    {
+        return 'api:model';
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
@@ -217,6 +217,16 @@ trait JsonApiTrait
     }
 
     /**
+     * Get prefix used for `_name` in routing urls creation.
+     *
+     * @return string
+     */
+    protected function routeNamePrefix()
+    {
+        return 'api:resources';
+    }
+
+    /**
      * Getter for `links`.
      *
      * @return array
@@ -225,7 +235,7 @@ trait JsonApiTrait
     {
         $self = Router::url(
             [
-                '_name' => 'api:resources:resource',
+                '_name' => $this->routeNamePrefix() . ':resource',
                 'controller' => $this->getType(),
                 'id' => $this->getId(),
             ],
@@ -281,7 +291,7 @@ trait JsonApiTrait
         foreach ($associations as $relationship) {
             $self = Router::url(
                 [
-                    '_name' => 'api:resources:relationships',
+                    '_name' => $this->routeNamePrefix() . ':relationships',
                     'controller' => $this->getType(),
                     'relationship' => $relationship,
                     'id' => $this->getId(),
@@ -290,7 +300,7 @@ trait JsonApiTrait
             );
             $related = Router::url(
                 [
-                    '_name' => 'api:resources:related',
+                    '_name' => $this->routeNamePrefix() . ':related',
                     'controller' => $this->getType(),
                     'relationship' => $relationship,
                     'related_id' => $this->getId(),

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
@@ -40,7 +40,7 @@ use Cake\Utility\Inflector;
  */
 class ObjectType extends Entity implements JsonApiSerializable
 {
-    use JsonApiTrait {
+    use JsonApiModelTrait {
         listAssociations as protected jsonApiListAssociations;
     }
 

--- a/plugins/BEdita/Core/src/Model/Entity/Property.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Property.php
@@ -42,7 +42,7 @@ use Cake\ORM\TableRegistry;
 class Property extends Entity implements JsonApiSerializable
 {
 
-    use JsonApiTrait;
+    use JsonApiModelTrait;
 
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/src/Model/Entity/Relation.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Relation.php
@@ -37,7 +37,7 @@ use Cake\Utility\Inflector;
 class Relation extends Entity implements JsonApiSerializable
 {
 
-    use JsonApiTrait;
+    use JsonApiModelTrait;
 
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/src/Model/Table/PropertyTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/PropertyTypesTable.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Model\Table;
 
+use Cake\Database\Schema\TableSchema;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
@@ -58,6 +59,18 @@ class PropertyTypesTable extends Table
             ->allowEmpty('params');
 
         return $validator;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    protected function _initializeSchema(TableSchema $schema)
+    {
+        $schema->setColumnType('params', 'json');
+
+        return $schema;
     }
 
     /**

--- a/plugins/BEdita/Core/tests/Fixture/PropertyTypesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/PropertyTypesFixture.php
@@ -31,15 +31,19 @@ class PropertyTypesFixture extends TestFixture
     public $records = [
         [
             'name' => 'string',
+            'params' => '{"type": "string"}'
         ],
         [
             'name' => 'date',
+            'params' => '{"type": "string"}'
         ],
         [
             'name' => 'number',
+            'params' => '{"type": "number"}'
         ],
         [
             'name' => 'boolean',
+            'params' => '{"type": "boolean"}'
         ],
     ];
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/PropertyTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/PropertyTypeTest.php
@@ -69,7 +69,7 @@ class PropertyTypeTest extends TestCase
     {
         $propertyType = $this->PropertyTypes->get(1);
         $this->assertEquals('string', $propertyType->name);
-        $this->assertNull($propertyType->params);
+        $this->assertEquals(['type' => 'string'], $propertyType->params);
 
         $data = [
             'name' => 'othername',


### PR DESCRIPTION
This PR solves #1348 

All *modeling* related endpoints are moved to `/model`, namely 
-  `/model/object_types`
- `/model/relations`
- `/model/properties`

Main code changes:
 * new routing URLs, pure resources urls are splitted in two groupd
 * `JsonApiModelTrait` introduced, similar to `JsonApiAdminTrait`
 * resource controller attribute `$_routeNamePrefix` added

Bonus track:
- `/model/property_types` was introduced
