### PR TITLE
CTI: pass _inherited option in beforeSave chain

### DIFF
--- a/plugins/BEdita/Core/src/ORM/Inheritance/InheritanceEventHandler.php
+++ b/plugins/BEdita/Core/src/ORM/Inheritance/InheritanceEventHandler.php
@@ -45,6 +45,8 @@ class InheritanceEventHandler implements EventListenerInterface
 
     /**
      * Save entities in inherited tables before saving entity on this table.
+     * A special `$options` key `_inherited` is set to true to let know
+     * to other listeners if the save action affects an inherited table.
      *
      * @param \Cake\Event\Event $event Dispatched event.
      * @param \Cake\Datasource\EntityInterface $entity Entity.
@@ -69,7 +71,7 @@ class InheritanceEventHandler implements EventListenerInterface
         }
 
         // Save parent entity.
-        $options = ['atomic' => false] + $options->getArrayCopy();
+        $options = ['atomic' => false, '_inherited' => true] + $options->getArrayCopy();
         $options['associated'] = array_diff_key(
             $options['associated'],
             array_flip(array_diff($table->associations()->keys(), $inheritedTable->associations()->keys()))

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/InheritanceEventHandlerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/InheritanceEventHandlerTest.php
@@ -319,10 +319,12 @@ class InheritanceEventHandlerTest extends TestCase
      */
     public function testBeforeSaveOptions()
     {
+        $eventDispatchedFelines = $eventDispatchedMammals = $eventDispatchedAnimals = 0;
         // Main table
         $this->fakeFelines->eventManager()->on(
             'Model.beforeSave',
-            function (Event $event, EntityInterface $entity, \ArrayObject $options) {
+            function (Event $event, EntityInterface $entity, \ArrayObject $options) use (&$eventDispatchedFelines) {
+                $eventDispatchedFelines++;
                 static::assertArrayNotHasKey('_inherited', $options);
                 static::assertTrue($options['atomic']);
             }
@@ -331,7 +333,8 @@ class InheritanceEventHandlerTest extends TestCase
         // Inherited table
         $this->fakeMammals->eventManager()->on(
             'Model.beforeSave',
-            function (Event $event, EntityInterface $entity, \ArrayObject $options) {
+            function (Event $event, EntityInterface $entity, \ArrayObject $options) use (&$eventDispatchedMammals) {
+                $eventDispatchedMammals++;
                 static::assertArrayHasKey('_inherited', $options);
                 static::assertTrue($options['_inherited']);
                 static::assertFalse($options['atomic']);
@@ -341,7 +344,8 @@ class InheritanceEventHandlerTest extends TestCase
         // Inherited table
         $this->fakeAnimals->eventManager()->on(
             'Model.beforeSave',
-            function (Event $event, EntityInterface $entity, \ArrayObject $options) {
+            function (Event $event, EntityInterface $entity, \ArrayObject $options) use (&$eventDispatchedAnimals) {
+                $eventDispatchedAnimals++;
                 static::assertArrayHasKey('_inherited', $options);
                 static::assertTrue($options['_inherited']);
                 static::assertFalse($options['atomic']);
@@ -355,6 +359,10 @@ class InheritanceEventHandlerTest extends TestCase
             'family' => 'Cats',
         ]);
         $result = $this->fakeFelines->save($feline);
+
+        static::assertSame(1, $eventDispatchedFelines);
+        static::assertSame(1, $eventDispatchedMammals);
+        static::assertSame(1, $eventDispatchedAnimals);
     }
 
     /**


### PR DESCRIPTION
This PR is **low priority** and is a **proposal** to know if `beforeSave` listener is called on main table or on inherited table in CTI scenario.

If you think that is useless feel free to discard it. :sweat_smile: 
