### PR TITLE
Basic analytics middleware

### DIFF
--- a/plugins/BEdita/API/src/Event/CommonEventHandler.php
+++ b/plugins/BEdita/API/src/Event/CommonEventHandler.php
@@ -12,6 +12,7 @@
  */
 namespace BEdita\API\Event;
 
+use BEdita\API\Middleware\AnalyticsMiddleware;
 use BEdita\API\Middleware\CorsMiddleware;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Core\Configure;
@@ -61,10 +62,12 @@ class CommonEventHandler implements EventListenerInterface
      */
     public function buildMiddlewareStack(Event $event, MiddlewareQueue $middleware)
     {
-        $middleware->insertBefore(
-            ErrorHandlerMiddleware::class,
-            new CorsMiddleware(Configure::read('CORS'))
-        );
+        $middleware
+            ->prepend(new AnalyticsMiddleware())
+            ->insertBefore(
+                ErrorHandlerMiddleware::class,
+                new CorsMiddleware(Configure::read('CORS'))
+            );
     }
 
     /**

--- a/plugins/BEdita/API/src/Middleware/AnalyticsMiddleware.php
+++ b/plugins/BEdita/API/src/Middleware/AnalyticsMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -12,12 +12,14 @@
  */
 namespace BEdita\API\Middleware;
 
+use BEdita\Core\State\CurrentApplication;
+use BEdita\Core\Utility\LoggedUser;
+use Cake\Core\Configure;
 use Cake\Http\Response;
 use Cake\Log\Log;
-use Cake\Log\LogTrait;
-use Cake\Network\CorsBuilder;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
 
 /**
  * Middleware to trace analytics data
@@ -26,14 +28,26 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class AnalyticsMiddleware
 {
-    use LogTrait;
-
     /**
      * Request start time
      *
      * @var float
      */
     protected $startTime = null;
+
+    /**
+     * Analytics data
+     *
+     * @var array
+     */
+    protected $data = [];
+
+    /**
+     * Registered callbacks fo analytics extensions
+     *
+     * @var array
+     */
+    protected static $callbacks = [];
 
     /**
      * Configure analytics logger if not configured yet
@@ -43,15 +57,83 @@ class AnalyticsMiddleware
     public function __construct()
     {
         $this->startTime = microtime(true);
+        if (defined('TIME_START')) {
+            $this->startTime = TIME_START;
+        }
+
         if (!in_array('analytics', Log::configured())) {
             Log::config('analytics', [
-                'className' => 'Cake\Log\Engine\FileLog',
+                'className' => 'File',
                 'path' => LOGS,
-                'levels' => ['info'],
                 'scopes' => ['analytics'],
-                'file' => 'analyitics',
+                'file' => 'analytics',
             ]);
         }
+    }
+
+    /**
+     * Getter for $startTime
+     *
+     * @return float
+     * @codeCoverageIgnore
+     */
+    public function getStartTime()
+    {
+        return $this->startTime;
+    }
+
+    /**
+     * Getter for $data
+     *
+     * @return float
+     * @codeCoverageIgnore
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * Register new analytics extension callback
+     *
+     * @param mixed $newCallback Callback to register
+     * @return void
+     */
+    public static function registerCallback($newCallback)
+    {
+        if (!is_callable($newCallback)) {
+            Log::warning('Bad callback ' . print_r($newCallback, true));
+
+            return;
+        }
+        static::$callbacks[] = $newCallback;
+    }
+
+    /**
+     * Get analytics custom data from registered callbacks
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request.
+     * @param \Psr\Http\Message\ResponseInterface $response The response.
+     * @return array
+     */
+    protected function readCallbackData(ServerRequestInterface $request, ResponseInterface $response)
+    {
+        if (empty(static::$callbacks)) {
+            return [];
+        }
+
+        $res = [];
+        $params = [$request, $response];
+        foreach (static::$callbacks as $call) {
+            try {
+                $values = call_user_func_array($call, $params);
+                $res[] = $values;
+            } catch (Throwable $t) {
+                Log::error('Error calling callback ' . print_r($call, true));
+            }
+        }
+
+        return $res;
     }
 
     /**
@@ -65,10 +147,23 @@ class AnalyticsMiddleware
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
     {
         $response = $next($request, $response);
-        $end = microtime(true);
 
-        $message = sprintf('Request time for %s: %f seconds', (string)$request->getUri(), $end - $this->startTime);
-        $this->log($message, 'info', ['analytics']);
+        /**
+         * TODO: add custom application error code
+         */
+        $this->data = [
+            'r' => $request->getEnv('REQUEST_TIME'),
+            'a' => CurrentApplication::getApplicationId(),
+            'usr' => LoggedUser::id(),
+            'm' => $request->getMethod(),
+            'url' => $request->getUri()->getPath(),
+            'q' => $request->getUri()->getQuery(),
+            's' => $response->getStatusCode(),
+            'x' => $this->readCallBackData($request, $response),
+            'e' => round(microtime(true) - $this->startTime, 4, PHP_ROUND_HALF_EVEN),
+        ];
+
+        Log::info(json_encode($this->data), 'analytics');
 
         return $response;
     }

--- a/plugins/BEdita/API/src/Middleware/AnalyticsMiddleware.php
+++ b/plugins/BEdita/API/src/Middleware/AnalyticsMiddleware.php
@@ -19,7 +19,6 @@ use Cake\Http\Response;
 use Cake\Log\Log;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Throwable;
 
 /**
  * Middleware to trace analytics data
@@ -43,7 +42,7 @@ class AnalyticsMiddleware
     protected $data = [];
 
     /**
-     * Registered callbacks fo analytics extensions
+     * Registered callbacks for custom analytics data
      *
      * @var array
      */
@@ -85,7 +84,7 @@ class AnalyticsMiddleware
     /**
      * Getter for $data
      *
-     * @return float
+     * @return array
      * @codeCoverageIgnore
      */
     public function getData()
@@ -125,12 +124,7 @@ class AnalyticsMiddleware
         $res = [];
         $params = [$request, $response];
         foreach (static::$callbacks as $call) {
-            try {
-                $values = call_user_func_array($call, $params);
-                $res[] = $values;
-            } catch (Throwable $t) {
-                Log::error('Error calling callback ' . print_r($call, true));
-            }
+            $res[] = call_user_func_array($call, $params);
         }
 
         return $res;

--- a/plugins/BEdita/API/src/Middleware/AnalyticsMiddleware.php
+++ b/plugins/BEdita/API/src/Middleware/AnalyticsMiddleware.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Middleware;
+
+use Cake\Http\Response;
+use Cake\Log\Log;
+use Cake\Log\LogTrait;
+use Cake\Network\CorsBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Middleware to trace analytics data
+ *
+ * @since 4.0.0
+ */
+class AnalyticsMiddleware
+{
+    use LogTrait;
+
+    /**
+     * Request start time
+     *
+     * @var float
+     */
+    protected $startTime = null;
+
+    /**
+     * Configure analytics logger if not configured yet
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->startTime = microtime(true);
+        if (!in_array('analytics', Log::configured())) {
+            Log::config('analytics', [
+                'className' => 'Cake\Log\Engine\FileLog',
+                'path' => LOGS,
+                'levels' => ['info'],
+                'scopes' => ['analytics'],
+                'file' => 'analyitics',
+            ]);
+        }
+    }
+
+    /**
+     * The middleware action.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request.
+     * @param \Psr\Http\Message\ResponseInterface $response The response.
+     * @param callable $next The next middleware to call.
+     * @return \Psr\Http\Message\ResponseInterface A response.
+     */
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
+    {
+        $response = $next($request, $response);
+        $end = microtime(true);
+
+        $message = sprintf('Request time for %s: %f seconds', (string)$request->getUri(), $end - $this->startTime);
+        $this->log($message, 'info', ['analytics']);
+
+        return $response;
+    }
+}

--- a/plugins/BEdita/API/tests/TestCase/Event/CommonEventHandlerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Event/CommonEventHandlerTest.php
@@ -13,6 +13,7 @@
 namespace BEdita\API\Test\TestCase\Event;
 
 use BEdita\API\Event\CommonEventHandler;
+use BEdita\API\Middleware\AnalyticsMiddleware;
 use BEdita\API\Middleware\CorsMiddleware;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
@@ -67,9 +68,10 @@ class CommonEventHandlerTest extends TestCase
 
         $event = new Event('Server.buildMiddleware', null, ['middleware' => $middleware]);
         EventManager::instance()->dispatch($event);
-        static::assertCount(2, $middleware);
-        static::assertInstanceOf(CorsMiddleware::class, $middleware->get(0));
-        static::assertInstanceOf(ErrorHandlerMiddleware::class, $middleware->get(1));
+        static::assertCount(3, $middleware);
+        static::assertInstanceOf(AnalyticsMiddleware::class, $middleware->get(0));
+        static::assertInstanceOf(CorsMiddleware::class, $middleware->get(1));
+        static::assertInstanceOf(ErrorHandlerMiddleware::class, $middleware->get(2));
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Middleware/AnalyticsMiddlewareTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Middleware/AnalyticsMiddlewareTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Test\TestCase\Middleware;
+
+use BEdita\API\Middleware\AnalyticsMiddleware;
+use Cake\Http\Response;
+use Cake\Http\ServerRequestFactory;
+use Cake\Log\Log;
+use Cake\TestSuite\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * {@see \BEdita\API\Middleware\AnalyticsMiddleware} Test Case
+ *
+ * @coversDefaultClass \BEdita\API\Middleware\AnalyticsMiddleware
+ */
+class AnalyticsMiddlewareTest extends TestCase
+{
+    /**
+     * Test __invoke method response
+     *
+     * @return void
+     *
+     * @covers ::__invoke()
+     * @covers ::__construct()
+     */
+    public function testAnalytics()
+    {
+        $server = [
+            'REQUEST_URI' => '/home',
+            'REQUEST_METHOD' => 'GET',
+            'HTTP_ACCEPT' => 'application/json',
+            'HTTP_ORIGIN' => 'http://api.example.com',
+        ];
+
+        $request = ServerRequestFactory::fromGlobals($server);
+        $response = new Response();
+        $next = function ($req, $res) {
+            return $res;
+        };
+        Log::drop('analytics');
+        $middleware = new AnalyticsMiddleware();
+        $middleware($request, $response, $next);
+
+        static::assertNotEmpty($middleware->getData());
+    }
+
+    /**
+     * Data provider for `testCallback`
+     *
+     * @return void
+     */
+    public function callbackProvider()
+    {
+        return [
+            'empty' => [
+                'undefined',
+                [],
+            ],
+            'badFunction' => [
+                function (array $data) {
+                    return 'result';
+                },
+                [],
+            ],
+            'simple' => [
+                function (ServerRequestInterface $request, Response $response) {
+                    return 'result';
+                },
+                ['result'],
+            ],
+        ];
+    }
+
+    /**
+     * Test callback methods
+     *
+     * @return void
+     *
+     * @dataProvider callbackProvider
+     * @covers ::registerCallback()
+     * @covers ::readCallbackData()
+     */
+    public function testCallback($callback, $expected)
+    {
+        $server = [
+            'REQUEST_URI' => '/home',
+            'REQUEST_METHOD' => 'GET',
+            'HTTP_ACCEPT' => 'application/json',
+            'HTTP_ORIGIN' => 'http://api.example.com',
+        ];
+
+        $request = ServerRequestFactory::fromGlobals($server);
+        $response = new Response();
+        $next = function ($req, $res) {
+            return $res;
+        };
+
+        AnalyticsMiddleware::registerCallback($callback);
+        $middleware = new AnalyticsMiddleware();
+
+        $middleware($request, $response, $next);
+
+        $data = $middleware->getData();
+        static::assertNotEmpty($data);
+        static::assertArrayHasKey('x', $data);
+        static::assertEquals($data['x'], $expected);
+    }
+}

--- a/plugins/BEdita/API/tests/TestCase/Middleware/AnalyticsMiddlewareTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Middleware/AnalyticsMiddlewareTest.php
@@ -110,4 +110,58 @@ class AnalyticsMiddlewareTest extends TestCase
         static::assertArrayHasKey('x', $data);
         static::assertEquals($data['x'], $expected);
     }
+
+
+    /**
+     * Data provider for `testCallback`
+     *
+     * @return void
+     */
+    public function errorCodeProvider()
+    {
+        return [
+            'empty' => [
+                '{"error":{"status":"401","title":"Expired token","code":"be_token_expired"}}',
+                401,
+                'be_token_expired',
+            ],
+            'simple' => [
+                '{"error":{"status":"404","title":"Not Found"}}',
+                404,
+                null,
+            ],
+            'data' => [
+                '{"data":{}}',
+                200,
+                null,
+            ],
+        ];
+    }
+
+    /**
+     * Test getAppErrorCode() method
+     *
+     * @return void
+     *
+     * @dataProvider errorCodeProvider
+     * @covers ::getAppErrorCode()
+     */
+    public function testAppErrorCode($body, $status, $expected)
+    {
+        $request = ServerRequestFactory::fromGlobals();
+        $response = new Response();
+        $response = $response->withStatus($status)->withStringBody($body);
+        $next = function ($req, $res) {
+            return $res;
+        };
+
+        $middleware = new AnalyticsMiddleware();
+        $middleware($request, $response, $next);
+
+        $data = $middleware->getData();
+        static::assertNotEmpty($data);
+        static::assertArrayHasKey('c', $data);
+        static::assertEquals($data['c'], $expected);
+    }
+
 }

--- a/plugins/BEdita/API/tests/TestCase/Middleware/AnalyticsMiddlewareTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Middleware/AnalyticsMiddlewareTest.php
@@ -67,12 +67,6 @@ class AnalyticsMiddlewareTest extends TestCase
                 'undefined',
                 [],
             ],
-            'badFunction' => [
-                function (array $data) {
-                    return 'result';
-                },
-                [],
-            ],
             'simple' => [
                 function (ServerRequestInterface $request, Response $response) {
                     return 'result';

--- a/plugins/BEdita/API/tests/TestCase/Middleware/AnalyticsMiddlewareTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Middleware/AnalyticsMiddlewareTest.php
@@ -159,5 +159,4 @@ class AnalyticsMiddlewareTest extends TestCase
         static::assertArrayHasKey('c', $data);
         static::assertEquals($data['c'], $expected);
     }
-
 }

--- a/plugins/BEdita/Core/src/State/CurrentApplication.php
+++ b/plugins/BEdita/Core/src/State/CurrentApplication.php
@@ -35,13 +35,34 @@ class CurrentApplication
     protected $application = null;
 
     /**
-     * Set current application.
+     * Get current application.
      *
      * @return \BEdita\Core\Model\Entity\Application|null
      */
     public function get()
     {
         return $this->application;
+    }
+
+    /**
+     * Get current application id.
+     * Null if no application is set.
+     *
+     * @return int|null
+     */
+    public function id()
+    {
+        return $this->application ? $this->application->id : null;
+    }
+
+    /**
+     * Static wrapper around {@see self::id()}.
+     *
+     * @return \BEdita\Core\Model\Entity\Application|null
+     */
+    public static function getApplicationId()
+    {
+        return static::getInstance()->id();
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/State/CurrentApplicationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/State/CurrentApplicationTest.php
@@ -80,6 +80,24 @@ class CurrentApplicationTest extends TestCase
     }
 
     /**
+     * Test `getApplicationId` method.
+     *
+     * @return void
+     *
+     * @covers ::id()
+     * @covers ::getApplicationId()
+     */
+    public function testGetApplicationId()
+    {
+        static::assertNull(null, CurrentApplication::getApplicationId());
+
+        $application = $this->Applications->get(1);
+        CurrentApplication::setApplication($application);
+
+        static::assertSame(1, CurrentApplication::getApplicationId());
+    }
+
+    /**
      * Test `setApplication` method.
      *
      * @return void


### PR DESCRIPTION
This PR fixes #1315

Basic analytics system via middleware has been implemented.

Analytics data are simply stored as default in `logs/analytics.log` using a JSON encoded format.
Destination may be changed using `Log::config('analytics')` settings.

Created JSON provides this structure:
```json
{
    "r" : "request timestamp",
    "a" : "application id or null",
    "usr" :  "logged user id or null",
    "m" :  "HTTP method",
    "url" : "requeste URL",
    "q" : "query string",
    "s" : "HTTP response status code",
    "c" : "application error code or null",
    "x" : "custom data via events",
    "e" : "elapsed time"
}
``` 

Custom data may be added from plugins implementing event listeners for **'Analytics.custom'** event.
Event method expected signature is `(Event $e, ServerRequestInterface $request, ResponseInterface $response)` 
Returned data will then be added to `"x"` array.
