### PR TITLE
Composer: code sniffer proper setup and launch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "bedita/bedita",
     "type": "project",
     "description": "BEdita API-first content management server app",
-    "homepage": "http://bedita.com",
+    "homepage": "https://www.bedita.com",
     "license": "LGPL-3.0",
     "support": {
         "source": "https://github.com/bedita/bedita",
@@ -17,7 +17,7 @@
         {
             "name": "ChannelWeb s.r.l.",
             "email": "info@channelweb.it",
-            "homepage": "http://www.channelweb.it"
+            "homepage": "https://www.channelweb.it"
         }
     ],
     "require": {
@@ -53,11 +53,21 @@
         "post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump",
         "check": [
             "@test",
+            "@cs-setup",
             "@cs-check"
         ],
-        "cs-check": "phpcs --colors -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
-        "cs-fix": "phpcbf --colors --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
-        "test": "phpunit --colors=always"
+        "cs-check": " vendor/bin/phpcs --colors -n -p --extensions=php --ignore=/Migrations/,/Seeds/ ./config ./src ./tests ./plugins/*/*/config ./plugins/*/*/src ./plugins/*/*/tests",
+        "cs-fix": "vendor/bin/phpcbf --colors --extensions=php --ignore=/Migrations/,/Seeds/ ./config ./src ./tests ./plugins/*/*/config ./plugins/*/*/src ./plugins/*/*/tests",
+        "cs-setup": [
+            "vendor/bin/phpcs --config-set installed_paths vendor/cakephp/cakephp-codesniffer",
+            "vendor/bin/phpcs --config-set default_standard CakePHP",
+            "vendor/bin/phpcs --config-set colors 1"
+        ],
+        "test": "vendor/bin/phpunit --colors=always",
+        "update-dev": [
+            "@composer update",
+            "@cs-setup"
+        ]
     },
     "extra": {
         "merge-plugin": {


### PR DESCRIPTION
This PR introduces some minor changes to `composer,json`

- new `cs-setup` script to set CakePHP codesniffer rules as default
- new `update-dev` script to launch `composer update` followed by `cs-setup`
- `cs-check` and `cs-fix` have been updated to use same rules as in Travis/CI

To try them simply invoke:
 - `composer run-script cs-setup`
 - `composer run-script update-dev`
and so on...
