### PR TITLE
Default application and remove/disable controls

### DIFF
--- a/plugins/BEdita/Core/config/Migrations/20171027164507_DefaultApplication.php
+++ b/plugins/BEdita/Core/config/Migrations/20171027164507_DefaultApplication.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+use BEdita\Core\Model\Table\ApplicationsTable;
+use Migrations\AbstractMigration;
+
+/**
+ * Create a default application if missing.
+ *
+ * @since 4.0.0
+ */
+class DefaultApplication extends AbstractMigration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function up()
+    {
+        $appRow = $this->fetchAll("SELECT id FROM applications where id=1");
+        if (!empty($appRow)) {
+            return 0;
+        }
+
+        $this->table('applications')
+            ->insert([
+                [
+                    'id' => 1,
+                    'name' => 'default-app',
+                    'api_key' => ApplicationsTable::generateApiKey(),
+                    'description' => 'Default application',
+                    'created' => date('Y-m-d H:i:s'),
+                    'modified' => date('Y-m-d H:i:s'),
+                    'enabled' => 1,
+                ]
+            ])
+            ->save();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function down()
+    {
+    }
+}
+

--- a/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
@@ -96,7 +96,7 @@ class ApplicationsTable extends Table
     /**
      * Generate the api key on application creation.
      *
-     * If applications is DEFAULT_APPLICATION or current invoking application and `enabled` to false
+     * If applications is DEFAULT_APPLICATION or current invoking application and `enabled` is `false`
      * raise an ImmutableResourceException
      *
      * @param \Cake\Event\Event $event The event dispatched

--- a/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
@@ -13,6 +13,8 @@
 
 namespace BEdita\Core\Model\Table;
 
+use BEdita\Core\Exception\ImmutableResourceException;
+use BEdita\Core\State\CurrentApplication;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\ORM\Query;
@@ -31,6 +33,13 @@ use Cake\Validation\Validator;
  */
 class ApplicationsTable extends Table
 {
+    /**
+     * Default application id
+     *
+     * @var int
+     */
+    const DEFAULT_APPLICATION = 1;
+
     /**
      * {@inheritDoc}
      *
@@ -85,7 +94,10 @@ class ApplicationsTable extends Table
     }
 
     /**
-     * Generate the api key on application creation
+     * Generate the api key on application creation.
+     *
+     * If applications is DEFAULT_APPLICATION or current invoking application and `enabled` to false
+     * raise an ImmutableResourceException
      *
      * @param \Cake\Event\Event $event The event dispatched
      * @param \Cake\Datasource\EntityInterface $entity The entity to save
@@ -93,11 +105,14 @@ class ApplicationsTable extends Table
      */
     public function beforeSave(Event $event, EntityInterface $entity)
     {
-        if (!$entity->isNew() || $entity->has('api_key')) {
-            return;
+        if (!$entity->isNew() && $entity->enabled == false &&
+            in_array($entity->id, [static::DEFAULT_APPLICATION, CurrentApplication::getApplicationId()])) {
+            throw new ImmutableResourceException(__d('bedita', 'Could not disable "Application" {0}', $entity->id));
         }
 
-        $entity->set('api_key', static::generateApiKey());
+        if ($entity->isNew() && !$entity->has('api_key')) {
+            $entity->set('api_key', static::generateApiKey());
+        }
     }
 
     /**
@@ -128,5 +143,20 @@ class ApplicationsTable extends Table
                 $this->aliasField('api_key') => $options['apiKey'],
                 $this->aliasField('enabled') => true,
             ]);
+    }
+
+    /**
+     * Before delete checks: if applications is DEFAULT_APPLICATION or current raise a ImmutableResourceException
+     *
+     * @param \Cake\Event\Event $event The beforeSave event that was fired
+     * @param \Cake\Datasource\EntityInterface $entity the entity that is going to be saved
+     * @return void
+     * @throws \BEdita\Core\Exception\ImmutableResourceException if entity is not deletable
+     */
+    public function beforeDelete(Event $event, EntityInterface $entity)
+    {
+        if (in_array($entity->id, [static::DEFAULT_APPLICATION, CurrentApplication::getApplicationId()])) {
+            throw new ImmutableResourceException(__d('bedita', 'Could not delete "Application" {0}', $entity->id));
+        }
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
@@ -102,6 +102,7 @@ class ApplicationsTable extends Table
      * @param \Cake\Event\Event $event The event dispatched
      * @param \Cake\Datasource\EntityInterface $entity The entity to save
      * @return void
+     * @throws \BEdita\Core\Exception\ImmutableResourceException if entity is not disableable
      */
     public function beforeSave(Event $event, EntityInterface $entity)
     {

--- a/plugins/BEdita/Core/src/Shell/BeditaShell.php
+++ b/plugins/BEdita/Core/src/Shell/BeditaShell.php
@@ -147,7 +147,21 @@ class BeditaShell extends Shell
         $this->adminUser();
         $this->hr();
 
+        $this->info('Default API KEY is: ' . $this->defaultApiKey());
+
         return true;
+    }
+
+    /**
+     * Display default application api key
+     *
+     * @return string Default application api key
+     */
+    protected function defaultApiKey()
+    {
+        $application = TableRegistry::get('Applications')->get(1);
+
+        return !empty($application) ? $application->get('api_key') : '';
     }
 
     /**

--- a/plugins/BEdita/Core/src/State/CurrentApplication.php
+++ b/plugins/BEdita/Core/src/State/CurrentApplication.php
@@ -91,10 +91,10 @@ class CurrentApplication
     /**
      * Static wrapper around {@see self::set()}.
      *
-     * @param \BEdita\Core\Model\Entity\Application $application Application instance.
+     * @param \BEdita\Core\Model\Entity\Application|null $application Application instance.
      * @return void
      */
-    public static function setApplication(Application $application)
+    public static function setApplication(Application $application = null)
     {
         static::getInstance()->set($application);
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ApplicationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ApplicationsTableTest.php
@@ -39,7 +39,6 @@ class ApplicationsTableTest extends TestCase
      */
     public $currentApplication;
 
-
     /**
      * Fixtures
      *


### PR DESCRIPTION
This PR introduces a default application with id 1 via migrations.

Some new constraints are introduced:
- default application and current application in use cannot be removed
- default application and current application cannot be disabled
