### PR TITLE
Migration on core media types inheritance

### DIFF
--- a/plugins/BEdita/Core/config/Migrations/20171030185447_MediaTypesInheritance.php
+++ b/plugins/BEdita/Core/config/Migrations/20171030185447_MediaTypesInheritance.php
@@ -1,0 +1,50 @@
+<?php
+
+use Cake\ORM\Table;
+use Migrations\AbstractMigration;
+
+/**
+ * Add inheritance info to `videos`, `audio` and `files`.
+ *
+ */
+class MediaTypesInheritance extends AbstractMigration
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function up()
+    {
+        // Populate tree data. We'll be using a clean CakePHP table object to be able to use Tree behavior.
+        /* @var \Migrations\CakeAdapter $adapter */
+        $adapter = $this->getAdapter();
+        $table = new Table([
+            'table' => 'object_types',
+            'connection' => $adapter->getCakeConnection(),
+        ]);
+
+        $table->updateAll( // `videos`, `audio` and `files` inherit from `media`.
+            [
+                'parent_id' => $table->find()->where(['name' => 'media'])->firstOrFail()->id,
+            ],
+            [
+                'name IN' => ['videos', 'audio', 'files'],
+            ]
+        );
+
+        // Now let's fix NSM (nested-set model) left and right indexes from tree data.
+        $table->addBehavior('Tree', [
+            'left' => 'tree_left',
+            'right' => 'tree_right',
+        ]);
+        /* @var \Cake\ORM\Behavior\TreeBehavior $tree */
+        $tree = $table->behaviors()->get('Tree');
+        $tree->recover();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function down()
+    {
+    }
+}


### PR DESCRIPTION
This PR follows #1356 and #1361 => inheritance information was missing for media core types `videos`, `files` and `audio`
A simple migration fixes it
