### PR TITLE
Custom element event calendar

### DIFF
--- a/bedita-app/config/bedita.cfg.php.sample
+++ b/bedita-app/config/bedita.cfg.php.sample
@@ -349,3 +349,13 @@ $config['objectCakeCache'] = true;
 //      'publications' => true, // stats about publications
 //      'editors' => true, // status about content editors
 // );
+
+/**
+ * Custom event calendar dates element.
+ * - name is the element name
+ * - options can be used to use an element of plugged module
+ */
+// $config['eventsCalendarDatesElement'] = array(
+//     'name' => 'form_event_calendar_dates',
+//     'options' => array('plugin' => 'timelines'),
+// );

--- a/bedita-app/views/events/inc/form.tpl
+++ b/bedita-app/views/events/inc/form.tpl
@@ -11,8 +11,12 @@
 	{include file="../inc/form_properties.tpl" comments=true}
 
 	{$view->element('form_previews')}
-	
-	{$view->element('form_calendar_dates')}
+
+	{if !empty($conf->eventsCalendarDatesElement)}
+		{$view->element($conf->eventsCalendarDatesElement.name, $conf->eventsCalendarDatesElement.options)}
+	{else}
+		{$view->element('form_calendar_dates')}
+	{/if}
 	
 	{assign_associative var="params" title="Event Locations"}
 	{$view->element('form_geotag', $params)}

--- a/bedita-app/webroot/js/module.events.js
+++ b/bedita-app/webroot/js/module.events.js
@@ -13,7 +13,9 @@ $(document).ready(function(){
             timeFormat: 'G:i'
         }
 
-    	$('.timeStart, .timeEnd', '.daterow').timepicker(timePickerOptions);
+        if ($.fn.timepicker) {
+            $('.timeStart, .timeEnd', '.daterow').timepicker(timePickerOptions);
+        }
 
         var numDates = $('.daterow').length;
 


### PR DESCRIPTION
This PR fixes #1376

Configuration is present in `bedita.cfg.php.sample`

```php
$config['eventsCalendarDatesElement'] = array(
    'name' => 'form_event_calendar_dates',
    'options' => array('plugin' => 'plugin_name'),
);
``
