### PR TITLE
Insert `replace` in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,6 @@
     "require": {
         "php": ">=5.6.0",
         "cakephp/cakephp": "~3.5.2",
-        "mobiledetect/mobiledetectlib": "2.*",
-        "cakephp/migrations": "~1.7",
-        "cakephp/plugin-installer": "*",
         "wikimedia/composer-merge-plugin": "^1.4"
     },
     "require-dev": {
@@ -45,6 +42,10 @@
             "BEdita\\App\\Test\\": "tests",
             "Cake\\Test\\": "./vendor/cakephp/cakephp/tests"
         }
+    },
+    "replace": {
+        "bedita/core": "self.version",
+        "bedita/api": "self.version"
     },
     "scripts": {
         "post-install-cmd": "BEdita\\App\\Console\\Installer::postInstall",


### PR DESCRIPTION
This simple PR enables usage of `plugins` that depend on `bedita/core` and `bedita/api`

- a ["replace"](https://getcomposer.org/doc/04-schema.md#replace) section has been introduced
- some duplicate/unused required packages have been removed

With this PR you may safely use dependencies like this in your plugin's `composer.json` inside `plugins/MyPlugin`
```json
    "require": {
        "bedita/core": "dev-4-cactus",
        "bedita/api": "dev-4-cactus",
        "other/package": "...."
    },
 ```
and avoid ending up having `vendor/bedita/core` and `vendor/bedita/api` with some version mismatch in your main BEdita folder

But if you're on a branch !== `4-cactus` on the main BEdita folder this is not working at the moment: you may have to temporary remove `"bedita/core"` and `"bedita/api"` from your `composer.json` - or is there a better solution?

A dependency between `bedita/api` and `bedita/core` was not introduced for now just to avoid the aforementioned problem.
 