### PR TITLE
Search roles, object_types, applications...

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -200,84 +200,72 @@ class FilterQueryStringTest extends IntegrationTestCase
     }
 
     /**
-     * Test finder of objects by query string.
+     * Data provider for `testSearchFilter` test case.
      *
-     * @return void
-     *
-     * @coversNothing
+     * @return array
      */
-    public function testFindQuery()
+    public function searchFilterProvider()
     {
-        $expected = ['2', '3', '9', '10'];
-        $this->configRequestHeaders();
-
-        $this->get('/objects?filter[query]=here');
-        $result = json_decode((string)$this->_response->getBody(), true);
-
-        $this->assertResponseCode(200);
-        $this->assertContentType('application/vnd.api+json');
-
-        static::assertArrayHasKey('data', $result);
-        static::assertEquals($expected, Hash::extract($result['data'], '{n}.id'), '', 0, 10, true);
+        return [
+            'here' => [
+                '/objects?filter[query]=here',
+                [
+                    '2',
+                    '3',
+                    '9',
+                    '10',
+                ],
+            ],
+            'locations' => [
+                '/locations?filter[query]=bologna',
+                [
+                    '8',
+                ],
+            ],
+            'users' => [
+                '/users?filter[query]=second',
+                [
+                    '5',
+                ],
+            ],
+            'here2' => [
+                '/objects?q=here',
+                [
+                    '2',
+                    '3',
+                    '9',
+                    '10',
+                ],
+            ],
+            'roles' => [
+                '/roles?q=first',
+                [
+                    '1',
+                ],
+            ],
+            'object_types' => [
+                '/model/object_types?filter[query]=profile',
+                [
+                    '3',
+                ],
+            ],
+        ];
     }
 
     /**
-     * Test finder of locations by query string.
+     * Test finder of objects by search string using `filter[query]` or `q`.
      *
      * @return void
+     * @param string $url Url string.
+     * @param array $expected Expected result.
      *
+     * @dataProvider searchFilterProvider
      * @coversNothing
      */
-    public function testFindQueryLocations()
+    public function testSearchFilter($url, $expected)
     {
-        $expected = [8];
         $this->configRequestHeaders();
-
-        $this->get('/locations?filter[query]=bologna');
-        $result = json_decode((string)$this->_response->getBody(), true);
-
-        $this->assertResponseCode(200);
-        $this->assertContentType('application/vnd.api+json');
-
-        static::assertArrayHasKey('data', $result);
-        static::assertEquals($expected, Hash::extract($result['data'], '{n}.id'), '', 0, 10, true);
-    }
-
-    /**
-     * Test finder of users by query string.
-     *
-     * @return void
-     *
-     * @coversNothing
-     */
-    public function testFindQueryUsers()
-    {
-        $expected = [5];
-        $this->configRequestHeaders();
-
-        $this->get('/users?filter[query]=second');
-        $result = json_decode((string)$this->_response->getBody(), true);
-
-        $this->assertResponseCode(200);
-        $this->assertContentType('application/vnd.api+json');
-
-        static::assertArrayHasKey('data', $result);
-        static::assertEquals($expected, Hash::extract($result['data'], '{n}.id'), '', 0, 10, true);
-    }
-
-    /**
-     * Test finder of objects by query string using shorthand `?q=` query parameter.
-     *
-     * @return void
-     *
-     * @coversNothing
-     */
-    public function testFindQueryAlias()
-    {
-        $expected = ['2', '3', '9', '10'];
-        $this->configRequestHeaders();
-
-        $this->get('/objects?q=here');
+        $this->get($url);
         $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->assertResponseCode(200);

--- a/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
@@ -61,6 +61,12 @@ class ApplicationsTable extends Table
 
         $this->setDisplayField('name');
         $this->addBehavior('Timestamp');
+        $this->addBehavior('BEdita/Core.Searchable', [
+            'fields' => [
+                'name' => 10,
+                'description' => 5,
+            ],
+        ]);
 
         $this->hasMany('EndpointPermissions', [
             'dependent' => true,

--- a/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
@@ -121,6 +121,13 @@ class ObjectTypesTable extends Table
             'left' => 'tree_left',
             'right' => 'tree_right',
         ]);
+        $this->addBehavior('BEdita/Core.Searchable', [
+            'fields' => [
+                'name' => 10,
+                'singular' => 10,
+                'description' => 5,
+            ],
+        ]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/RolesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RolesTable.php
@@ -67,6 +67,12 @@ class RolesTable extends Table
         $this->hasMany('EndpointPermissions', [
             'dependent' => true,
         ]);
+        $this->addBehavior('BEdita/Core.Searchable', [
+            'fields' => [
+                'name' => 10,
+                'description' => 5,
+            ],
+        ]);
     }
 
     /**


### PR DESCRIPTION
This PR adds search capability to some resources endpoints.

- `Searchable` behavior has been added to those resources.
- search filter integration test has been updated

now you can:
 - `GET /roles?q=first`
 - `GET /model/object_types?filter[query]=profile`