### PR TITLE
Accept `false` and `true` as boolen values in filters

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -348,6 +348,70 @@ class FilterQueryStringTest extends IntegrationTestCase
     }
 
     /**
+     * Data provider for `testFieldsFilter` test case.
+     *
+     * @return array
+     */
+    public function fieldsFilterProvider()
+    {
+        return [
+            'simple' => [
+                '/objects',
+                'filter[uname]=title-one',
+                [
+                   '2',
+                ],
+            ],
+            'boolean' => [
+                '/model/object_types',
+                'filter[is_abstract]=true',
+                [
+                   '1',
+                   '8',
+                ],
+            ],
+            'users' => [
+                '/users',
+                'filter[email]=second.user@example.com',
+                [
+                   '5',
+                ],
+            ],
+            'emptyRoles' => [
+                '/roles',
+                'filter[name]=gustavo',
+                [
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `filter[{field}]` query string.
+     *
+     * @param string $endpoint Endpoint.
+     * @param string $query Query string.
+     * @param array $expected Expected results ids.
+     * @return void
+     *
+     * @dataProvider fieldsFilterProvider
+     * @coversNothing
+     */
+    public function testFieldsFilter($endpoint, $query, $expected)
+    {
+        $this->configRequestHeaders();
+
+        $this->get("$endpoint?$query");
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        static::assertArrayHasKey('data', $result);
+        static::assertEquals($expected, Hash::extract($result['data'], '{n}.id'), '', 0, 10, true);
+    }
+
+    /**
      * Data provider for `testTrashFilter` test case.
      *
      * @return array

--- a/plugins/BEdita/Core/config/bootstrap.php
+++ b/plugins/BEdita/Core/config/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 use BEdita\Core\Configure\Engine\DatabaseConfig;
+use BEdita\Core\Database\Type\BoolType;
 use BEdita\Core\Database\Type\DateTimeType;
 use BEdita\Core\I18n\MessagesFileLoader;
 use BEdita\Core\ORM\Locator\TableLocator;
@@ -36,6 +37,11 @@ if (!Configure::configured('ini')) {
  */
 Type::set('datetime', new DateTimeType());
 Type::set('timestamp', new DateTimeType());
+
+/**
+ * Use custom BoolType
+ */
+Type::set('boolean', new BoolType());
 
 /**
  * Set loader for translation domain "bedita".

--- a/plugins/BEdita/Core/src/Database/Type/BoolType.php
+++ b/plugins/BEdita/Core/src/Database/Type/BoolType.php
@@ -22,7 +22,6 @@ use InvalidArgumentException;
  */
 class BoolType extends CakeBoolType
 {
-
     /**
      * Convert bool data into the database format.
      * `true` and `false` as strings are accepted, other strings are discarded
@@ -33,22 +32,13 @@ class BoolType extends CakeBoolType
      */
     public function toDatabase($value, Driver $driver)
     {
-        if ($value === true || $value === false || $value === null) {
-            return $value;
-        }
-
-        if (in_array($value, [1, 0, '1', '0'], true)) {
-            return (bool)$value;
-        }
-        if (is_string($value)) {
-            if (strtolower($value) === 'true') {
-                return true;
-            } elseif (strtolower($value) === 'false') {
-                return false;
-            } else {
-                return null;
+        try {
+            return parent::toDatabase($value, $driver);
+        } catch (InvalidArgumentException $e) {
+            if (is_string($value)) {
+                return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
             }
+            throw $e;
         }
-        throw new InvalidArgumentException('Cannot convert value to bool');
     }
 }

--- a/plugins/BEdita/Core/src/Database/Type/BoolType.php
+++ b/plugins/BEdita/Core/src/Database/Type/BoolType.php
@@ -24,7 +24,7 @@ class BoolType extends CakeBoolType
 {
     /**
      * Convert bool data into the database format.
-     * `true` and `false` as strings are accepted, other strings are discarded
+     * `true` and `false` as strings are accepted, other strings will cause an `InvalidArgumentException`
      *
      * @param mixed $value The value to convert.
      * @param \Cake\Database\Driver $driver The driver instance to convert with.
@@ -36,7 +36,10 @@ class BoolType extends CakeBoolType
             return parent::toDatabase($value, $driver);
         } catch (InvalidArgumentException $e) {
             if (is_string($value)) {
-                return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+                $value = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+                if ($value !== null) {
+                    return $value;
+                }
             }
             throw $e;
         }

--- a/plugins/BEdita/Core/src/Database/Type/BoolType.php
+++ b/plugins/BEdita/Core/src/Database/Type/BoolType.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Database\Type;
+
+use Cake\Database\Driver;
+use Cake\Database\Type\BoolType as CakeBoolType;
+use InvalidArgumentException;
+
+/**
+ * Custom BoolType class accepting also `true` and `false` as strings in input
+ */
+class BoolType extends CakeBoolType
+{
+
+    /**
+     * Convert bool data into the database format.
+     * `true` and `false` as strings are accepted, other strings are discarded
+     *
+     * @param mixed $value The value to convert.
+     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @return bool|null
+     */
+    public function toDatabase($value, Driver $driver)
+    {
+        if ($value === true || $value === false || $value === null) {
+            return $value;
+        }
+
+        if (in_array($value, [1, 0, '1', '0'], true)) {
+            return (bool)$value;
+        }
+        if (is_string($value)) {
+            if (strtolower($value) === 'true') {
+                return true;
+            } elseif (strtolower($value) === 'false') {
+                return false;
+            } else {
+                return null;
+            }
+        }
+        throw new InvalidArgumentException('Cannot convert value to bool');
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Database/Type/BoolTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Database/Type/BoolTypeTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Core\Test\TestCase\Database\Type;
+
+use BEdita\Core\Database\Type\BoolType;
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+
+/**
+ * {@see \BEdita\Core\Database\Type\BoolType} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Database\Type\BoolType
+ */
+class BoolTypeTest extends TestCase
+{
+    /**
+     * Data provider for `testToDatabase`.
+     *
+     * @return array
+     */
+    public function toDatabaseProvider()
+    {
+        return [
+            [
+                1,
+                true,
+            ],
+            [
+                0,
+                false,
+            ],
+            [
+                "1",
+                true,
+            ],
+            [
+                "0",
+                false,
+            ],
+            [
+                true,
+                true,
+            ],
+            [
+                false,
+                false,
+            ],
+            [
+                null,
+                null,
+            ],
+            [
+                "true",
+                true,
+            ],
+            [
+                "false",
+                false,
+            ],
+            [
+                "gustavo",
+                null,
+            ],
+            [
+                [1, 2, 3],
+                new InvalidArgumentException('Cannot convert value to bool'),
+            ]
+        ];
+    }
+
+    /**
+     * Test `toDatabase` method
+     *
+     * @param mixed $expected Expected result
+     * @param mixed $input Input data to be marshaled.
+     * @return void
+     *
+     * @dataProvider toDatabaseProvider
+     * @covers ::toDatabase()
+     */
+    public function testToDatabase($input, $expected)
+    {
+        if ($expected instanceof \Exception) {
+            $this->expectException(get_class($expected));
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+        $boolType = new BoolType();
+        $result = $boolType->toDatabase($input, ConnectionManager::get('default')->getDriver());
+
+        static::assertSame($expected, $result);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Database/Type/BoolTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Database/Type/BoolTypeTest.php
@@ -82,8 +82,8 @@ class BoolTypeTest extends TestCase
     /**
      * Test `toDatabase` method
      *
-     * @param mixed $expected Expected result
      * @param mixed $input Input data to be marshaled.
+     * @param mixed $expected Expected result
      * @return void
      *
      * @dataProvider toDatabaseProvider

--- a/plugins/BEdita/Core/tests/TestCase/Database/Type/BoolTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Database/Type/BoolTypeTest.php
@@ -70,7 +70,7 @@ class BoolTypeTest extends TestCase
             ],
             [
                 "gustavo",
-                null,
+                new InvalidArgumentException('Cannot convert value to bool'),
             ],
             [
                 [1, 2, 3],


### PR DESCRIPTION
This PR enables query field filters like:
-  `/model/object_types?filter[is_abstract]=true`
- `/objects?filter[locked]=false`

that currently return a `500 - Internal Error` (!!!), also with wrong values like  `/objects?filter[locked]=value`

A custom database `BoolType` has been added. 
There are other possible (and better) solutions of course...