### PR TITLE
Add garbage collection for refresh_token

### DIFF
--- a/bedita-app/controllers/api_base_controller.php
+++ b/bedita-app/controllers/api_base_controller.php
@@ -1989,7 +1989,7 @@ abstract class ApiBaseController extends FrontendController {
             }
             $data = array(
                 'access_token' => $token,
-                'expires_in' => $this->ApiAuth->config['expiresIn'],
+                'expires_in' => $this->ApiAuth->config['JWT']['expiresIn'],
                 'refresh_token' => $refreshToken
             );
         } elseif ($grantType == 'refresh_token') {
@@ -2004,7 +2004,7 @@ abstract class ApiBaseController extends FrontendController {
 
             $data = array(
                 'access_token' => $token,
-                'expires_in' => $this->ApiAuth->config['expiresIn'],
+                'expires_in' => $this->ApiAuth->config['JWT']['expiresIn'],
                 'refresh_token' => $params['refresh_token']
             );
         } else {


### PR DESCRIPTION
This PR fixes #1385 

After this PR the `refresh_token` expire time is configurable via `api.auth.refreshTokenExpiresIn`. Default is set to `1 month`.
Every time a renew is performed the `hash_jobs.expired` field related to `refresh_token` will be updated.

In order to clean `hash_jobs` table from expired/unused `refresh_token` a garbage collection method `ApiAuthComponent::gc()` has been introduced and called every time an `access_token` is generated i.e. when user tries to authenticate or to renew an expired `access_token`.
