### PR TITLE
Console memory limit and mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,23 @@
+Alberto Pagliarini <batopa@gmail.com>
+Alberto Pagliarini <batopa@gmail.com> batopa
+Alberto Pagliarini <batopa@gmail.com> <a.pagliarini@channelweb.it>
+qwerg <glob.andrea@gmail.com>
+qwerg <glob.andrea@gmail.com> andrea
+Dante Di Domenico <d.didomenico@channelweb.it>
+Dante Di Domenico <d.didomenico@channelweb.it> <dante@didoda.com>
+Edoardo Cavazza <edoardo.cavazza@chialab.it>
+Edoardo Cavazza <edoardo.cavazza@chialab.it> Edoardo
+Edoardo Cavazza <edoardo.cavazza@chialab.it> <info@edoardocavazza.com>
+Edoardo Cavazza <edoardo.cavazza@chialab.it> <edo.cava@gmail.com>
+manuelzane <zane@costrutto.com>
+manuelzane <zane@costrutto.com> <zane@chialab.it>
+Niki Corradetti <n.corradetti@channelweb.it>
+Niki Corradetti <n.corradetti@channelweb.it> niki
+Niki Corradetti <n.corradetti@channelweb.it> nikazzio
+Stefano Rosanelli <stefano.rosanelli@gmail.com>
+Stefano Rosanelli <stefano.rosanelli@gmail.com> stefanorosanelli
+Paolo Cuffiani <paolo.cuffiani@chialab.it>
+Paolo Cuffiani <paolo.cuffiani@chialab.it> <me@fquff.io>
+Paolo Cuffiani <paolo.cuffiani@chialab.it> <paolo.cuffiani@gmail.com>
+vallo87 <mazzai.valerio@googlemail.com>
+vallo87 <mazzai.valerio@googlemail.com> <pascal87>

--- a/cake/console/cake
+++ b/cake/console/cake
@@ -28,6 +28,6 @@ done
 LIB=$(dirname -- "$LIB")/
 APP=`pwd`
 
-exec php -q "$LIB"cake.php -working "$APP" "$@"
+exec php -d "memory_limit=-1" -q "$LIB"cake.php -working "$APP" "$@"
 
 exit;


### PR DESCRIPTION
This PR adds two very minor features:

1) The ability to launch `./cake.sh` without worrying about memory limits
2) Mailmap to consolidate contribution statistics — `git shortlog -sne` now merges contributions made by `Gustavo Supporto <gustavo.supporto@channelweb.it>` and `gustavo <gustavo@localhost>`, instead of displaying two separate contributors.