### PR TITLE
Check `status` in cached objects

### DIFF
--- a/bedita-app/controllers/frontend_controller.php
+++ b/bedita-app/controllers/frontend_controller.php
@@ -1371,6 +1371,9 @@ abstract class FrontendController extends AppController {
         $obj = null;
         if ($this->BeObjectCache) {
             $obj = $this->BeObjectCache->read($obj_id, $bindings);
+            if (!empty($obj['status']) && !in_array($obj['status'], $this->status)) {
+                throw new BeditaNotFoundException(__('Content not found', true) . ' id: ' . $obj_id);
+            }
         }
 
         if (empty($obj)) {


### PR DESCRIPTION
This PR fixes cache status check in `loadObj()`

It may happen that an object cache with a not allowed `status` is saved, but there is no check in frontend object load.
