### PR TITLE
JSON API `sparse fieldsets`

### DIFF
--- a/plugins/BEdita/API/src/View/JsonApiView.php
+++ b/plugins/BEdita/API/src/View/JsonApiView.php
@@ -39,7 +39,7 @@ class JsonApiView extends JsonView
     protected function _dataToSerialize($serialize = true)
     {
         if (empty($this->viewVars['_error'])) {
-            $fields = empty($this->viewVars['_fields']) ? [] : explode(',', $this->viewVars['_fields']);
+            $fields = $this->parseFieldsQuery();
             $data = parent::_dataToSerialize($serialize) ?: [];
             $options = !empty($this->viewVars['_jsonApiOptions']) ? $this->viewVars['_jsonApiOptions'] : 0;
             if ($data) {
@@ -72,5 +72,28 @@ class JsonApiView extends JsonView
         }
 
         return compact('error', 'data', 'links', 'meta', 'included');
+    }
+
+    /**
+     * Returns a formatted array from `fields` query string, as sparse fieldset or comma separated list
+     * see http://jsonapi.org/format/#fetching-sparse-fieldsets
+     * It's an associative array with type names as keys or `_common` key for type independent fields filter
+     *
+     * @return array Formatted `fields` associative array
+     */
+    protected function parseFieldsQuery()
+    {
+        if (empty($this->viewVars['_fields'])) {
+            return [];
+        }
+        if (!empty($this->viewVars['_fields']) && is_string($this->viewVars['_fields'])) {
+            return ['_common' => explode(',', $this->viewVars['_fields'])];
+        }
+        $res = [];
+        foreach ($this->viewVars['_fields'] as $type => $val) {
+            $res[$type] = explode(',', $val);
+        }
+
+        return $res;
     }
 }

--- a/plugins/BEdita/API/src/View/JsonApiView.php
+++ b/plugins/BEdita/API/src/View/JsonApiView.php
@@ -75,9 +75,9 @@ class JsonApiView extends JsonView
     }
 
     /**
-     * Returns a formatted array from `fields` query string, as sparse fieldset or comma separated list
-     * see http://jsonapi.org/format/#fetching-sparse-fieldsets
-     * It's an associative array with type names as keys or `_common` key for type independent fields filter
+     * Return a formatted array from `fields` query string to apply common or sparse fields filters.
+     * It's an associative array with type names as keys or `_common` key for type independent filters.
+     * See http://jsonapi.org/format/#fetching-sparse-fieldsets
      *
      * @return array Formatted `fields` associative array
      */

--- a/plugins/BEdita/API/src/View/JsonApiView.php
+++ b/plugins/BEdita/API/src/View/JsonApiView.php
@@ -86,7 +86,7 @@ class JsonApiView extends JsonView
         if (empty($this->viewVars['_fields'])) {
             return [];
         }
-        if (!empty($this->viewVars['_fields']) && is_string($this->viewVars['_fields'])) {
+        if (is_string($this->viewVars['_fields'])) {
             return ['_common' => explode(',', $this->viewVars['_fields'])];
         }
         $res = [];

--- a/plugins/BEdita/API/tests/IntegrationTest/FieldsQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FieldsQueryStringTest.php
@@ -39,7 +39,7 @@ class FieldsQueryStringTest extends IntegrationTestCase
                 ['created']
             ],
             'none' => [
-                '/users?fields=gustavo',
+                '/users?fields[users]=gustavo',
                 [],
                 []
             ],
@@ -52,6 +52,11 @@ class FieldsQueryStringTest extends IntegrationTestCase
                 '/roles/1?fields=unchangeable',
                 [],
                 ['unchangeable'],
+            ],
+            'sparse' => [
+                '/roles?fields[roles]=name',
+                ['name'],
+                []
             ],
         ];
     }

--- a/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
+++ b/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
@@ -207,6 +207,36 @@ class JsonApiViewTest extends TestCase
                     '_serialize' => [],
                 ],
             ],
+            'commonFields' => [
+                json_encode([
+                    'links' => [
+                        'self' => 'http://example.com/objects',
+                    ],
+                ]),
+                [
+                    '_links' => [
+                        'self' => 'http://example.com/objects',
+                    ],
+                    '_fields' => 'title,descritpion',
+                    '_serialize' => [],
+                ],
+            ],
+            'sparseFields' => [
+                json_encode([
+                    'links' => [
+                        'self' => 'http://example.com/roles',
+                    ],
+                ]),
+                [
+                    '_links' => [
+                        'self' => 'http://example.com/roles',
+                    ],
+                    '_fields' => [
+                        'roles' => 'name,descritpion',
+                    ],
+                    '_serialize' => [],
+                ],
+            ],
         ];
     }
 

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
@@ -368,7 +368,11 @@ trait JsonApiTrait
     {
         $id = $this->getId();
         $type = $this->getType();
-        $this->setFields($fields);
+        if (!empty($fields[$type])) {
+            $this->setFields($fields[$type]);
+        } elseif (!empty($fields['_common'])) {
+            $this->setFields($fields['_common']);
+        }
 
         if (($options & JsonApiSerializable::JSONAPIOPT_EXCLUDE_ATTRIBUTES) === 0) {
             $attributes = $this->getAttributes();

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -479,6 +479,7 @@ class JsonApiTraitTest extends TestCase
      *
      * @param string[] $excludedKeys Keys to be excluded.
      * @param int $options JSON API serializer options.
+     * @param array $fields Fields filter data.
      * @return void
      *
      * @covers ::jsonApiSerialize()

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -40,6 +40,7 @@ class JsonApiTraitTest extends TestCase
         'plugin.BEdita/Core.object_types',
         'plugin.BEdita/Core.relations',
         'plugin.BEdita/Core.relation_types',
+        'plugin.BEdita/Core.property_types',
         'plugin.BEdita/Core.properties',
         'plugin.BEdita/Core.objects',
         'plugin.BEdita/Core.profiles',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -40,6 +40,7 @@ class JsonApiTraitTest extends TestCase
         'plugin.BEdita/Core.object_types',
         'plugin.BEdita/Core.relations',
         'plugin.BEdita/Core.relation_types',
+        'plugin.BEdita/Core.properties',
         'plugin.BEdita/Core.objects',
         'plugin.BEdita/Core.profiles',
         'plugin.BEdita/Core.users',
@@ -134,7 +135,7 @@ class JsonApiTraitTest extends TestCase
         static::assertEquals($expected, $attributes);
 
         // test with `fields`
-        $role = $this->Roles->get(1)->jsonApiSerialize(0, ['name', 'description']);
+        $role = $this->Roles->get(1)->jsonApiSerialize(0, ['roles' => ['name', 'description']]);
         $attributes = array_keys($role['attributes']);
         static::assertEquals($expected, $attributes);
     }
@@ -145,6 +146,7 @@ class JsonApiTraitTest extends TestCase
      * @return void
      *
      * @covers ::getLinks()
+     * @covers ::routeNamePrefix()
      */
     public function testGetLinks()
     {
@@ -455,6 +457,20 @@ class JsonApiTraitTest extends TestCase
                 ['attributes', 'meta', 'links', 'relationships', 'included'],
                 JsonApiSerializable::JSONAPIOPT_EXCLUDE_ATTRIBUTES | JsonApiSerializable::JSONAPIOPT_EXCLUDE_META | JsonApiSerializable::JSONAPIOPT_EXCLUDE_LINKS | JsonApiSerializable::JSONAPIOPT_EXCLUDE_RELATIONSHIPS,
             ],
+            'commonFields' => [
+                ['meta'],
+                JsonApiSerializable::JSONAPIOPT_EXCLUDE_META,
+                [
+                    '_common' => ['name', 'description'],
+                ],
+            ],
+            'sparseFields' => [
+                ['meta'],
+                JsonApiSerializable::JSONAPIOPT_EXCLUDE_META,
+                [
+                    'roles' => ['name', 'description'],
+                ],
+            ],
         ];
     }
 
@@ -469,7 +485,7 @@ class JsonApiTraitTest extends TestCase
      * @covers ::setFields()
      * @dataProvider jsonApiSerializeProvider()
      */
-    public function testJsonApiSerialize($excludedKeys, $options)
+    public function testJsonApiSerialize($excludedKeys, $options, $fields = null)
     {
         $expected = [
             'id' => '1',
@@ -497,7 +513,7 @@ class JsonApiTraitTest extends TestCase
         ];
         $expected = array_diff_key($expected, array_flip($excludedKeys));
 
-        $role = $this->Roles->get(1)->jsonApiSerialize($options);
+        $role = $this->Roles->get(1)->jsonApiSerialize($options, $fields);
         $role = json_decode(json_encode($role), true);
 
         static::assertEquals($expected, $role);


### PR DESCRIPTION
This PR fixes #1393 

`filter` query string has been updated to support queries like:
 `/objects?fields[documents]=title&fields[locations]=description`

current common `filter` queries are still valid:
 `/documents?fields=title,description`
