### PR TITLE
Empty date inputs marshalled as `null`

### DIFF
--- a/plugins/BEdita/Core/src/Database/Type/DateTimeType.php
+++ b/plugins/BEdita/Core/src/Database/Type/DateTimeType.php
@@ -48,6 +48,6 @@ class DateTimeType extends CakeDateTimeType
             }
         }
 
-        return $value;
+        return !empty($value) ? $value : null;
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -153,4 +153,21 @@ class DateTimeTypeTest extends TestCase
 
         static::assertSame($input, $result);
     }
+
+    /**
+     * Test empty string `marshal`
+     *
+     * @return void
+     *
+     * @covers ::marshal
+     */
+    public function testMarshalEmpty()
+    {
+        $dateTimeType = new DateTimeType();
+        $result = $dateTimeType->marshal('');
+        static::assertNull($result);
+
+        $result = $dateTimeType->marshal(false);
+        static::assertNull($result);
+    }
 }


### PR DESCRIPTION
If an empty string is provided in a POST/PATCH request for a date property field -> it should be treated as `null` to avoid SQL errors.
Patch example:
```json
{
  "data":  {
     "type":"documents",
     "id":"123",
     "attributes":{
        "publish_start":"",
        "publish_end":""
     }
   }
}
```





