### PR TITLE
Fix warning when including to-one resources

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "cakephp/cakephp": "~3.5.2",
+        "cakephp/cakephp": "~3.5.3",
         "wikimedia/composer-merge-plugin": "^1.4"
     },
     "require-dev": {

--- a/plugins/BEdita/API/composer.json
+++ b/plugins/BEdita/API/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "cakephp/cakephp": "~3.5.2",
+        "cakephp/cakephp": "~3.5.3",
         "symfony/yaml": "~3.3",
         "firebase/php-jwt": "~5.0"
     },

--- a/plugins/BEdita/Core/composer.json
+++ b/plugins/BEdita/Core/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "cakephp/cakephp": "~3.5.2",
+        "cakephp/cakephp": "~3.5.3",
         "cakephp/migrations": "~1.7",
         "league/flysystem": "^1.0.40",
         "league/json-guard": "~1.0",

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
@@ -311,6 +311,9 @@ trait JsonApiTrait
             if ($this->has($relationship)) {
                 $entities = $this->get($relationship);
                 $data = $this->getIncluded($entities);
+                if (!is_array($entities)) {
+                    $entities = [$entities];
+                }
                 $included = array_merge($included, $entities);
             }
 
@@ -337,7 +340,7 @@ trait JsonApiTrait
             function (BelongsToMany $val) {
                 return $val->junction()->getAlias();
             },
-            $associations->type('BelongsToMany')
+            $associations->getByType('BelongsToMany')
         );
 
         $relationships = [];

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -32,6 +32,13 @@ class JsonApiTraitTest extends TestCase
     public $Roles;
 
     /**
+     * Helper table.
+     *
+     * @var \BEdita\Core\Model\Table\ObjectTypesTable
+     */
+    public $ObjectTypes;
+
+    /**
      * Fixtures
      *
      * @var array
@@ -57,6 +64,7 @@ class JsonApiTraitTest extends TestCase
         parent::setUp();
 
         $this->Roles = TableRegistry::get('Roles');
+        $this->ObjectTypes = TableRegistry::get('ObjectTypes');
     }
 
     /**
@@ -65,6 +73,7 @@ class JsonApiTraitTest extends TestCase
     public function tearDown()
     {
         unset($this->Roles);
+        unset($this->ObjectTypes);
 
         parent::tearDown();
     }
@@ -240,6 +249,63 @@ class JsonApiTraitTest extends TestCase
 
         static::assertSame($expected, $relationships);
         static::assertCount(1, $included);
+    }
+
+    /**
+     * Test getter for relationships with included resources.
+     *
+     * @return void
+     *
+     * @covers ::getRelationships()
+     * @covers ::getIncluded()
+     * @covers ::listAssociations()
+     */
+    public function testGetRelationshipsIncludedSingle()
+    {
+        $expected = [
+            'left_relations' => [
+                'data' => [
+                    [
+                        'id' => '1',
+                        'type' => 'relations',
+                    ],
+                ],
+                'links' => [
+                    'related' => '/model/object_types/2/left_relations',
+                    'self' => '/model/object_types/2/relationships/left_relations',
+                ],
+            ],
+            'right_relations' => [
+                'data' => [
+                    [
+                        'id' => '1',
+                        'type' => 'relations',
+                    ],
+                ],
+                'links' => [
+                    'related' => '/model/object_types/2/right_relations',
+                    'self' => '/model/object_types/2/relationships/right_relations',
+                ],
+            ],
+            'parent' => [
+                'data' => [
+                    'id' => '1',
+                    'type' => 'object_types',
+                ],
+                'links' => [
+                    'related' => '/model/object_types/2/parent',
+                    'self' => '/model/object_types/2/relationships/parent',
+                ],
+            ],
+        ];
+
+        $objectType = $this->ObjectTypes->get(2, ['contain' => ['Parent', 'RightRelations', 'LeftRelations']])->jsonApiSerialize();
+
+        $relationships = $objectType['relationships'];
+        $included = $objectType['included'];
+
+        static::assertSame($expected, $relationships);
+        static::assertCount(3, $included);
     }
 
     /**


### PR DESCRIPTION
This PR fixes a PHP warning issue when including a to-one relationship, such as `GET /model/object_types?include=parent`.