### PR TITLE
Add schema revision and cache

### DIFF
--- a/plugins/BEdita/Core/src/Utility/JsonSchema.php
+++ b/plugins/BEdita/Core/src/Utility/JsonSchema.php
@@ -15,6 +15,8 @@ namespace BEdita\Core\Utility;
 
 use BEdita\Core\Model\Entity\ObjectType;
 use BEdita\Core\Model\Entity\StaticProperty;
+use BEdita\Core\Model\Table\ObjectTypesTable;
+use Cake\Cache\Cache;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Network\Exception\NotFoundException;
 use Cake\ORM\TableRegistry;
@@ -47,12 +49,17 @@ class JsonSchema
      */
     public static function generate($typeName, $url)
     {
-        $schema = static::typeSchema($typeName);
-        if (!is_array($schema)) {
+        $schema = Cache::remember(
+            'schema_' . $typeName,
+            function () use ($typeName) {
+                return static::addRevision(static::typeSchema($typeName));
+            },
+            ObjectTypesTable::CACHE_CONFIG
+        );
+
+        if (!$schema) {
             return $schema;
         }
-
-        $schema['revision'] = sprintf("%u", crc32(json_encode($schema)));
 
         $baseSchema = [
             'definitions' => new \stdClass(),
@@ -86,6 +93,22 @@ class JsonSchema
         } catch (RecordNotFoundException $e) {
             throw new NotFoundException(__d('bedita', 'Type "{0}" not found', $typeName));
         }
+    }
+
+    /**
+     * Add revision information to schema
+     *
+     * @param array|bool $schema Schema array or `false`
+     * @return array|bool Schema with `revision` or `false`
+     */
+    protected static function addRevision($schema)
+    {
+        if (!$schema) {
+            return $schema;
+        }
+        $schema['revision'] = sprintf("%u", crc32(json_encode($schema)));
+
+        return $schema;
     }
 
     /**

--- a/plugins/BEdita/Core/src/Utility/JsonSchema.php
+++ b/plugins/BEdita/Core/src/Utility/JsonSchema.php
@@ -52,6 +52,8 @@ class JsonSchema
             return $schema;
         }
 
+        $schema['revision'] = sprintf("%u", crc32(json_encode($schema)));
+
         $baseSchema = [
             'definitions' => new \stdClass(),
             '$id' => $url,

--- a/plugins/BEdita/Core/src/Utility/JsonSchema.php
+++ b/plugins/BEdita/Core/src/Utility/JsonSchema.php
@@ -57,7 +57,7 @@ class JsonSchema
             ObjectTypesTable::CACHE_CONFIG
         );
 
-        if (!$schema) {
+        if (!is_array($schema)) {
             return $schema;
         }
 
@@ -103,7 +103,7 @@ class JsonSchema
      */
     protected static function addRevision($schema)
     {
-        if (!$schema) {
+        if (!is_array($schema)) {
             return $schema;
         }
         $schema['revision'] = sprintf("%u", crc32(json_encode($schema)));


### PR DESCRIPTION
This PR fixes #1404 and #1405 

* custom property `revision` added to schema with a `crc32` hash of schema data
* type cache added using `_bedita_object_types_` config with same invalidation rules
