### PR TITLE
Feat: avoid to save ubiquitous sections

### DIFF
--- a/bedita-app/controllers/api_base_controller.php
+++ b/bedita-app/controllers/api_base_controller.php
@@ -1315,7 +1315,10 @@ abstract class ApiBaseController extends FrontendController {
             if (empty($row)) {
                 $priority = !empty($child['priority']) ? $child['priority'] : null;
                 if (!$tree->appendChild($child['child_id'], $objectId, $priority)) {
-                    throw new BeditaInternalErrorException('Error appending ' . $child['child_id'] . ' to ' . $objectId);
+                    throw new BeditaInternalErrorException(
+                        'Error appending ' . $child['child_id'] . ' to ' . $objectId,
+                        $tree->validationErrors
+                    );
                 }
                 $created = true;
             // update priority if any and different from current value

--- a/bedita-app/models/objects/collection/section.php
+++ b/bedita-app/models/objects/collection/section.php
@@ -179,8 +179,10 @@ class Section extends BeditaCollectionModel
 				$row["Tree"]["area_id"] = $sectionId;
 				$row["Tree"]["object_path"] = preg_replace($objectPathPattern, $replacement, $row["Tree"]["object_path"]);
 				$row["Tree"]["parent_path"] = preg_replace($parentPathPattern, $replacement, $row["Tree"]["parent_path"]);
-				$this->Tree->create();
-				if (!$this->Tree->save($row)) {
+                $this->Tree->create();
+                // skip validation because updating object_path (that is the trees primary key) of a
+                // section already present in the tree would fail
+				if (!$this->Tree->save($row, array('validate' => false))) {
 					throw new BeditaException(__("Error updating tree", true), $row["Tree"]);
 				}
 			}

--- a/bedita-app/models/tree.php
+++ b/bedita-app/models/tree.php
@@ -38,7 +38,7 @@ class Tree extends BEAppModel
      */
     public $validate = array(
         'id' => array(
-            'rule' => 'validateBranchNode',
+            'rule' => 'isUniqueSection',
             'message' => 'Ubiquitous sections/publications are not allowed',
         ),
     );
@@ -51,16 +51,16 @@ class Tree extends BEAppModel
     }
 
     /**
-     * Custom validation rule to verify that a node (section)
+     * Custom validation rule to verify that a branch node (section, publication)
      * is not already on the tree.
      * A section must stay only in one tree node.
      *
      * @param array $check The array to validate
      * @return bool
      */
-    public function validateBranchNode($check) {
+    public function isUniqueSection($check) {
         if (empty($check) || empty($check['id'])) {
-            return true;
+            return false;
         }
 
         $objectTypeId = ClassRegistry::init('BEObject')->findObjectTypeId($check['id']);
@@ -69,7 +69,7 @@ class Tree extends BEAppModel
             return true;
         }
 
-        return !$this->isOnTree($check['id']);
+        return $this->isUnique($check);
     }
 
 	/**

--- a/bedita-app/models/tree.php
+++ b/bedita-app/models/tree.php
@@ -26,17 +26,50 @@ class Tree extends BEAppModel
 {
 
 	public $primaryKey = "object_path";
-    /**
+	
+	/**
      * Object cache 
      * 
      */
-    protected $BeObjectCache = null;
+	protected $BeObjectCache = null;
+
+    /**
+     * {@inheritDoc}
+     */
+    public $validate = array(
+        'id' => array(
+            'rule' => 'validateBranchNode',
+            'message' => 'Ubiquitous sections/publications are not allowed',
+        ),
+    );
 
     public function  __construct() {
         parent::__construct();
         if (!BACKEND_APP && Configure::read('objectCakeCache') && !Configure::read('staging')) {
             $this->BeObjectCache = BeLib::getObject('BeObjectCache');
         }
+    }
+
+    /**
+     * Custom validation rule to verify that a node (section)
+     * is not already on the tree.
+     * A section must stay only in one tree node.
+     *
+     * @param array $check The array to validate
+     * @return bool
+     */
+    public function validateBranchNode($check) {
+        if (empty($check) || empty($check['id'])) {
+            return true;
+        }
+
+        $objectTypeId = ClassRegistry::init('BEObject')->findObjectTypeId($check['id']);
+        $objectType = Configure::read('objectTypes.' . $objectTypeId . '.name');
+        if (!in_array($objectType, array('section', 'area'))) {
+            return true;
+        }
+
+        return !$this->isOnTree($check['id']);
     }
 
 	/**

--- a/bedita-app/tests/bedita_base.test.php
+++ b/bedita-app/tests/bedita_base.test.php
@@ -19,24 +19,22 @@
  *------------------------------------------------------------------->8-----
  */
 
+App::import('Controller', 'App'); // base controller, beditaexcepion...
+App::import('Lib', 'BeLib');
+
 /**
- *
- *
- * @version			$Revision$
- * @modifiedby 		$LastChangedBy$
- * @lastmodified	$LastChangedDate$
- *
- * $Id$
+ * BeditaTestData base class
  */
 class BeditaTestData extends Object {
 	var $data =  array() ;
 	function &getData() { return $this->data ;  }
 }
 
-App::import('Controller', 'App'); // base controller, beditaexcepion...
-
 class BeditaTestController extends AppController{}
 
+/**
+ * BeditaTestCase base class
+ */
 class BeditaTestCase extends CakeTestCase {
 
 	var $dataSource	= 'test' ;
@@ -90,7 +88,9 @@ class BeditaTestCase extends CakeTestCase {
 	 * Default constructor, loads models, components, data....
 	 */
 	public   function __construct ($t=NULL, $phpDataDir=NULL) {
-		parent::__construct() ;
+		parent::__construct();
+
+		BeLib::getObject("BeConfigure")->initConfig();
 
 		// setup unit test user id
 		$conf = Configure::getInstance() ;

--- a/bedita-app/tests/cases/models/tree.test.php
+++ b/bedita-app/tests/cases/models/tree.test.php
@@ -199,6 +199,13 @@ class TreeTestCase extends BeditaTestCase {
 		pr($tree);
 	}
 
+	public function testFailSaveSectionAlreadyOnTree() {
+		$idParent = $this->savedIds["Section 1"];
+		$idSection = $this->savedIds["Section 12"];
+		$res = $this->Tree->appendChild($idSection, $idParent);
+		$this->assertFalse($res);
+	}
+
 	public function testDeleteAppendedChild() {
 		$idDoc = $this->savedIds["Document 1"];
 		$res = ClassRegistry::init("Document")->delete($idDoc);


### PR DESCRIPTION
This PR add a custom validation in `Tree` model to avoid that a section was placed in two nodes on tree.
