### PR TITLE
Create/modify not allowed on abstract endpoints

### DIFF
--- a/plugins/BEdita/API/src/Controller/HomeController.php
+++ b/plugins/BEdita/API/src/Controller/HomeController.php
@@ -39,7 +39,6 @@ class HomeController extends AppController
         '/auth' => ['GET', 'POST'],
         '/admin' => 'ALL',
         '/model' => 'ALL',
-        '/objects' => 'ALL',
         '/roles' => 'ALL',
         '/signup' => ['POST'],
         '/status' => ['GET'],
@@ -108,10 +107,10 @@ class HomeController extends AppController
      */
     protected function objectTypesEndpoints()
     {
-        $allTypes = TableRegistry::get('ObjectTypes')->find('list', ['valueField' => 'name'])->toArray();
+        $allTypes = TableRegistry::get('ObjectTypes')->find('list', ['keyField' => 'name', 'valueField' => 'is_abstract'])->toArray();
         $endPoints = [];
-        foreach ($allTypes as $t) {
-            $endPoints['/' . $t] = 'ALL';
+        foreach ($allTypes as $t => $abstract) {
+            $endPoints['/' . $t] = $abstract ? ['GET', 'DELETE'] : 'ALL';
         }
 
         return $endPoints;

--- a/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
@@ -95,7 +95,7 @@ class HomeControllerTest extends IntegrationTestCase
                         'href' => 'http://api.example.com/objects',
                         'hints' => [
                             'allow' => [
-                                'GET', 'POST', 'PATCH', 'DELETE'
+                                'GET', 'DELETE'
                             ],
                             'formats' => [
                                 'application/json',
@@ -271,7 +271,7 @@ class HomeControllerTest extends IntegrationTestCase
                         'href' => 'http://api.example.com/media',
                         'hints' => [
                             'allow' => [
-                                'GET', 'POST', 'PATCH', 'DELETE',
+                                'GET', 'DELETE',
                             ],
                             'formats' => [
                                 'application/json',


### PR DESCRIPTION
This PR fixes object types endpoints **allowed methods**: abstract types may not be created (POST) or modified (PATCH)
