### PR TITLE
`meta.schema` info on JSON API responses (#1406)

### DIFF
--- a/plugins/BEdita/API/src/TestSuite/IntegrationTestCase.php
+++ b/plugins/BEdita/API/src/TestSuite/IntegrationTestCase.php
@@ -99,7 +99,6 @@ abstract class IntegrationTestCase extends CakeIntegrationTestCase
             'className' => 'Debug'
         ]);
 
-        JsonApi::resetSchemaInfo();
         EventManager::instance()->on(new CommonEventHandler());
     }
 

--- a/plugins/BEdita/API/src/TestSuite/IntegrationTestCase.php
+++ b/plugins/BEdita/API/src/TestSuite/IntegrationTestCase.php
@@ -14,7 +14,6 @@
 namespace BEdita\API\TestSuite;
 
 use BEdita\API\Event\CommonEventHandler;
-use BEdita\API\Utility\JsonApi;
 use BEdita\Core\State\CurrentApplication;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Event\EventManager;

--- a/plugins/BEdita/API/src/TestSuite/IntegrationTestCase.php
+++ b/plugins/BEdita/API/src/TestSuite/IntegrationTestCase.php
@@ -14,6 +14,7 @@
 namespace BEdita\API\TestSuite;
 
 use BEdita\API\Event\CommonEventHandler;
+use BEdita\API\Utility\JsonApi;
 use BEdita\Core\State\CurrentApplication;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Event\EventManager;
@@ -49,6 +50,8 @@ abstract class IntegrationTestCase extends CakeIntegrationTestCase
         'plugin.BEdita/Core.external_auth',
         'plugin.BEdita/Core.object_types',
         'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.locations',
+        'plugin.BEdita/Core.media',
         'plugin.BEdita/Core.profiles',
         'plugin.BEdita/Core.users',
         'plugin.BEdita/Core.roles',
@@ -96,6 +99,7 @@ abstract class IntegrationTestCase extends CakeIntegrationTestCase
             'className' => 'Debug'
         ]);
 
+        JsonApi::resetSchemaInfo();
         EventManager::instance()->on(new CommonEventHandler());
     }
 

--- a/plugins/BEdita/API/src/Utility/JsonApi.php
+++ b/plugins/BEdita/API/src/Utility/JsonApi.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -32,14 +32,14 @@ class JsonApi
      *
      * @var array
      */
-    protected static $_schema = [];
+    protected static $schema = [];
 
     /**
      * Resource types not having a JSON Schema.
      *
      * @var array
      */
-    protected static $_noSchema = [
+    protected static $noSchema = [
         'applications',
         'async_jobs',
         'config',
@@ -124,7 +124,7 @@ class JsonApi
     {
         $schema = [];
         foreach ($types as $type) {
-            if (empty($schema[$type]) && !in_array($type, static::$_noSchema)) {
+            if (empty($schema[$type]) && !in_array($type, static::$noSchema)) {
                 $schema[$type] = static::schemaInfo($type);
             }
         }
@@ -140,11 +140,11 @@ class JsonApi
      */
     public static function schemaInfo($type)
     {
-        if (!empty(static::$_schema[$type])) {
-            return static::$_schema[$type];
+        if (!empty(static::$schema[$type])) {
+            return static::$schema[$type];
         }
 
-        static::$_schema[$type] = [
+        static::$schema[$type] = [
             '$id' => Router::url(
                 [
                     '_name' => 'api:model:schema',
@@ -155,7 +155,7 @@ class JsonApi
             'revision' => JsonSchema::schemaRevision($type),
         ];
 
-        return static::$_schema[$type];
+        return static::$schema[$type];
     }
 
     /**
@@ -165,7 +165,7 @@ class JsonApi
      */
     public static function resetSchemaInfo()
     {
-        static::$_schema = [];
+        static::$schema = [];
     }
 
     /**

--- a/plugins/BEdita/API/src/Utility/JsonApi.php
+++ b/plugins/BEdita/API/src/Utility/JsonApi.php
@@ -27,14 +27,6 @@ use Cake\Utility\Hash;
 class JsonApi
 {
     /**
-     * JSON Schema type information.
-     * Array containing URL and revision for each type included in response.
-     *
-     * @var array
-     */
-    protected static $schema = [];
-
-    /**
      * Resource types not having a JSON Schema.
      *
      * @var array
@@ -140,11 +132,7 @@ class JsonApi
      */
     public static function schemaInfo($type)
     {
-        if (!empty(static::$schema[$type])) {
-            return static::$schema[$type];
-        }
-
-        static::$schema[$type] = [
+        return [
             '$id' => Router::url(
                 [
                     '_name' => 'api:model:schema',
@@ -154,18 +142,6 @@ class JsonApi
             ),
             'revision' => JsonSchema::schemaRevision($type),
         ];
-
-        return static::$schema[$type];
-    }
-
-    /**
-     * Reset internal schema info array.
-     *
-     * @return void
-     */
-    public static function resetSchemaInfo()
-    {
-        static::$schema = [];
     }
 
     /**

--- a/plugins/BEdita/API/src/View/JsonApiView.php
+++ b/plugins/BEdita/API/src/View/JsonApiView.php
@@ -50,6 +50,7 @@ class JsonApiView extends JsonView
                 unset($included);
             } else {
                 $included = JsonApi::formatData($included, $options, $fields);
+                unset($included['_schema']);
             }
         } else {
             $error = $this->viewVars['_error'];
@@ -65,6 +66,11 @@ class JsonApiView extends JsonView
 
         if (!empty($this->viewVars['_meta'])) {
             $meta = $this->viewVars['_meta'];
+        }
+
+        if (!empty($data['_schema'])) {
+            $meta['schema'] = $data['_schema'];
+            unset($data['_schema']);
         }
 
         if (empty($serialize)) {

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/ApplicationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/ApplicationsControllerTest.php
@@ -14,6 +14,7 @@
 namespace BEdita\API\Test\TestCase\Controller\Admin;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\API\Test\TestConstants;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -48,6 +49,12 @@ class ApplicationsControllerTest extends IntegrationTestCase
                     'page_count' => 1,
                     'page_items' => 2,
                     'page_size' => 20,
+                ],
+                'schema' => [
+                    'applications' => [
+                        '$id' => 'http://api.example.com/model/schema/applications',
+                        'revision' => TestConstants::SCHEMA_REVISIONS['applications'],
+                    ],
                 ],
             ],
             'data' => [
@@ -167,6 +174,15 @@ class ApplicationsControllerTest extends IntegrationTestCase
                     'api_key' => API_KEY,
                     'created' => '2016-10-28T07:10:57+00:00',
                     'modified' => '2016-10-28T07:10:57+00:00',
+                ],
+            ],
+            'meta' => [
+
+                'schema' => [
+                    'applications' => [
+                        '$id' => 'http://api.example.com/model/schema/applications',
+                        'revision' => TestConstants::SCHEMA_REVISIONS['applications'],
+                    ],
                 ],
             ],
         ];

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -13,7 +13,7 @@
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
-use BEdita\API\Test\TestData;
+use BEdita\API\Test\TestConstants;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -63,27 +63,27 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'schema' => [
                     'users' => [
                         '$id' => 'http://api.example.com/model/schema/users',
-                        'revision' => TestData::SCHEMA_REVISIONS['users'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['users'],
                     ],
                     'documents' => [
                         '$id' => 'http://api.example.com/model/schema/documents',
-                        'revision' => TestData::SCHEMA_REVISIONS['documents'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['documents'],
                     ],
                     'profiles' => [
                         '$id' => 'http://api.example.com/model/schema/profiles',
-                        'revision' => TestData::SCHEMA_REVISIONS['profiles'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['profiles'],
                     ],
                     'locations' => [
                         '$id' => 'http://api.example.com/model/schema/locations',
-                        'revision' => TestData::SCHEMA_REVISIONS['locations'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['locations'],
                     ],
                     'events' => [
                         '$id' => 'http://api.example.com/model/schema/events',
-                        'revision' => TestData::SCHEMA_REVISIONS['events'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['events'],
                     ],
                     'files' => [
                         '$id' => 'http://api.example.com/model/schema/files',
-                        'revision' => TestData::SCHEMA_REVISIONS['files'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['files'],
                     ],
                 ]
             ],
@@ -489,7 +489,7 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'schema' => [
                     'documents' => [
                         '$id' => 'http://api.example.com/model/schema/documents',
-                        'revision' => TestData::SCHEMA_REVISIONS['documents'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['documents'],
                     ]
                 ]
             ]
@@ -561,7 +561,7 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'schema' => [
                     'documents' => [
                         '$id' => 'http://api.example.com/model/schema/documents',
-                        'revision' => TestData::SCHEMA_REVISIONS['documents'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['documents'],
                     ]
                 ]
             ]
@@ -1042,11 +1042,11 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'schema' => [
                     'documents' => [
                         '$id' => 'http://api.example.com/model/schema/documents',
-                        'revision' => TestData::SCHEMA_REVISIONS['documents'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['documents'],
                     ],
                     'profiles' => [
                         '$id' => 'http://api.example.com/model/schema/profiles',
-                        'revision' => TestData::SCHEMA_REVISIONS['profiles'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['profiles'],
                     ],
                 ],
             ],
@@ -1899,11 +1899,11 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'schema' => [
                     'documents' => [
                         '$id' => 'http://api.example.com/model/schema/documents',
-                        'revision' => TestData::SCHEMA_REVISIONS['documents'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['documents'],
                     ],
                     'profiles' => [
                         '$id' => 'http://api.example.com/model/schema/profiles',
-                        'revision' => TestData::SCHEMA_REVISIONS['profiles'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['profiles'],
                     ],
                 ],
             ],

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -13,6 +13,7 @@
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\API\Test\TestData;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -59,6 +60,32 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'page_items' => 8,
                     'page_size' => 20,
                 ],
+                'schema' => [
+                    'users' => [
+                        '$id' => 'http://api.example.com/model/schema/users',
+                        'revision' => TestData::SCHEMA_REVISIONS['users'],
+                    ],
+                    'documents' => [
+                        '$id' => 'http://api.example.com/model/schema/documents',
+                        'revision' => TestData::SCHEMA_REVISIONS['documents'],
+                    ],
+                    'profiles' => [
+                        '$id' => 'http://api.example.com/model/schema/profiles',
+                        'revision' => TestData::SCHEMA_REVISIONS['profiles'],
+                    ],
+                    'locations' => [
+                        '$id' => 'http://api.example.com/model/schema/locations',
+                        'revision' => TestData::SCHEMA_REVISIONS['locations'],
+                    ],
+                    'events' => [
+                        '$id' => 'http://api.example.com/model/schema/events',
+                        'revision' => TestData::SCHEMA_REVISIONS['events'],
+                    ],
+                    'files' => [
+                        '$id' => 'http://api.example.com/model/schema/files',
+                        'revision' => TestData::SCHEMA_REVISIONS['files'],
+                    ],
+                ]
             ],
             'data' => [
                 [
@@ -458,6 +485,14 @@ class ObjectsControllerTest extends IntegrationTestCase
                     ],
                 ],
             ],
+            'meta' => [
+                'schema' => [
+                    'documents' => [
+                        '$id' => 'http://api.example.com/model/schema/documents',
+                        'revision' => TestData::SCHEMA_REVISIONS['documents'],
+                    ]
+                ]
+            ]
         ];
 
         $this->configRequestHeaders();
@@ -522,6 +557,14 @@ class ObjectsControllerTest extends IntegrationTestCase
                     ],
                 ],
             ],
+            'meta' => [
+                'schema' => [
+                    'documents' => [
+                        '$id' => 'http://api.example.com/model/schema/documents',
+                        'revision' => TestData::SCHEMA_REVISIONS['documents'],
+                    ]
+                ]
+            ]
         ];
 
         $this->configRequestHeaders();
@@ -995,6 +1038,16 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'page_count' => 1,
                     'page_items' => 2,
                     'page_size' => 20,
+                ],
+                'schema' => [
+                    'documents' => [
+                        '$id' => 'http://api.example.com/model/schema/documents',
+                        'revision' => TestData::SCHEMA_REVISIONS['documents'],
+                    ],
+                    'profiles' => [
+                        '$id' => 'http://api.example.com/model/schema/profiles',
+                        'revision' => TestData::SCHEMA_REVISIONS['profiles'],
+                    ],
                 ],
             ],
         ];
@@ -1839,6 +1892,18 @@ class ObjectsControllerTest extends IntegrationTestCase
                                 'self' => 'http://api.example.com/documents/3/relationships/inverse_test',
                             ],
                         ],
+                    ],
+                ],
+            ],
+            'meta' => [
+                'schema' => [
+                    'documents' => [
+                        '$id' => 'http://api.example.com/model/schema/documents',
+                        'revision' => TestData::SCHEMA_REVISIONS['documents'],
+                    ],
+                    'profiles' => [
+                        '$id' => 'http://api.example.com/model/schema/profiles',
+                        'revision' => TestData::SCHEMA_REVISIONS['profiles'],
                     ],
                 ],
             ],

--- a/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
@@ -14,7 +14,7 @@
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
-use BEdita\API\Test\TestData;
+use BEdita\API\Test\TestConstants;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\ResourcesController
@@ -591,11 +591,11 @@ class ResourcesControllerTest extends IntegrationTestCase
                 'schema' => [
                     'roles' => [
                         '$id' => 'http://api.example.com/model/schema/roles',
-                        'revision' => TestData::SCHEMA_REVISIONS['roles'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['roles'],
                     ],
                     'users' => [
                         '$id' => 'http://api.example.com/model/schema/users',
-                        'revision' => TestData::SCHEMA_REVISIONS['users'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['users'],
                     ],
                 ],
             ],

--- a/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
@@ -14,6 +14,7 @@
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\API\Test\TestData;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\ResourcesController
@@ -583,6 +584,18 @@ class ResourcesControllerTest extends IntegrationTestCase
                                 'self' => 'http://api.example.com/users/1/relationships/roles',
                             ],
                         ],
+                    ],
+                ],
+            ],
+            'meta' => [
+                'schema' => [
+                    'roles' => [
+                        '$id' => 'http://api.example.com/model/schema/roles',
+                        'revision' => TestData::SCHEMA_REVISIONS['roles'],
+                    ],
+                    'users' => [
+                        '$id' => 'http://api.example.com/model/schema/users',
+                        'revision' => TestData::SCHEMA_REVISIONS['users'],
                     ],
                 ],
             ],

--- a/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
@@ -13,6 +13,7 @@
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\API\Test\TestData;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -46,6 +47,12 @@ class RolesControllerTest extends IntegrationTestCase
                     'page_count' => 1,
                     'page_items' => 2,
                     'page_size' => 20,
+                ],
+                'schema' => [
+                    'roles' => [
+                        '$id' => 'http://api.example.com/model/schema/roles',
+                        'revision' => TestData::SCHEMA_REVISIONS['roles'],
+                    ],
                 ],
             ],
             'data' => [
@@ -185,6 +192,14 @@ class RolesControllerTest extends IntegrationTestCase
                             'self' => 'http://api.example.com/roles/1/relationships/users',
                             'related' => 'http://api.example.com/roles/1/users',
                         ],
+                    ],
+                ],
+            ],
+            'meta' => [
+                'schema' => [
+                    'roles' => [
+                        '$id' => 'http://api.example.com/model/schema/roles',
+                        'revision' => TestData::SCHEMA_REVISIONS['roles'],
                     ],
                 ],
             ],
@@ -423,6 +438,12 @@ class RolesControllerTest extends IntegrationTestCase
                     'page_count' => 1,
                     'page_items' => 1,
                     'page_size' => 20,
+                ],
+                'schema' => [
+                    'users' => [
+                        '$id' => 'http://api.example.com/model/schema/users',
+                        'revision' => TestData::SCHEMA_REVISIONS['users'],
+                    ],
                 ],
             ],
             'data' => [

--- a/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
@@ -13,7 +13,7 @@
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
-use BEdita\API\Test\TestData;
+use BEdita\API\Test\TestConstants;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -51,7 +51,7 @@ class RolesControllerTest extends IntegrationTestCase
                 'schema' => [
                     'roles' => [
                         '$id' => 'http://api.example.com/model/schema/roles',
-                        'revision' => TestData::SCHEMA_REVISIONS['roles'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['roles'],
                     ],
                 ],
             ],
@@ -199,7 +199,7 @@ class RolesControllerTest extends IntegrationTestCase
                 'schema' => [
                     'roles' => [
                         '$id' => 'http://api.example.com/model/schema/roles',
-                        'revision' => TestData::SCHEMA_REVISIONS['roles'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['roles'],
                     ],
                 ],
             ],
@@ -442,7 +442,7 @@ class RolesControllerTest extends IntegrationTestCase
                 'schema' => [
                     'users' => [
                         '$id' => 'http://api.example.com/model/schema/users',
-                        'revision' => TestData::SCHEMA_REVISIONS['users'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['users'],
                     ],
                 ],
             ],

--- a/plugins/BEdita/API/tests/TestCase/Controller/TrashControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TrashControllerTest.php
@@ -13,7 +13,7 @@
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
-use BEdita\API\Test\TestData;
+use BEdita\API\Test\TestConstants;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\ORM\TableRegistry;
 
@@ -69,7 +69,7 @@ class TrashControllerTest extends IntegrationTestCase
                 'schema' => [
                     'documents' => [
                         '$id' => 'http://api.example.com/model/schema/documents',
-                        'revision' => TestData::SCHEMA_REVISIONS['documents'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['documents'],
                     ],
                 ],
             ],
@@ -228,7 +228,7 @@ class TrashControllerTest extends IntegrationTestCase
                 'schema' => [
                     'documents' => [
                         '$id' => 'http://api.example.com/model/schema/documents',
-                        'revision' => TestData::SCHEMA_REVISIONS['documents'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['documents'],
                     ],
                 ],
             ],

--- a/plugins/BEdita/API/tests/TestCase/Controller/TrashControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TrashControllerTest.php
@@ -13,6 +13,7 @@
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\API\Test\TestData;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\ORM\TableRegistry;
 
@@ -64,6 +65,12 @@ class TrashControllerTest extends IntegrationTestCase
                     'page_count' => 1,
                     'page_items' => 2,
                     'page_size' => 20,
+                ],
+                'schema' => [
+                    'documents' => [
+                        '$id' => 'http://api.example.com/model/schema/documents',
+                        'revision' => TestData::SCHEMA_REVISIONS['documents'],
+                    ],
                 ],
             ],
             'data' => [
@@ -215,6 +222,14 @@ class TrashControllerTest extends IntegrationTestCase
                     'published' => '2016-10-13T07:09:23+00:00',
                     'created_by' => 1,
                     'modified_by' => 1,
+                ],
+            ],
+            'meta' => [
+                'schema' => [
+                    'documents' => [
+                        '$id' => 'http://api.example.com/model/schema/documents',
+                        'revision' => TestData::SCHEMA_REVISIONS['documents'],
+                    ],
                 ],
             ],
         ];

--- a/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
@@ -13,6 +13,7 @@
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\API\Test\TestData;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -46,6 +47,12 @@ class UsersControllerTest extends IntegrationTestCase
                     'page_count' => 1,
                     'page_items' => 2,
                     'page_size' => 20,
+                ],
+                'schema' => [
+                    'users' => [
+                        '$id' => 'http://api.example.com/model/schema/users',
+                        'revision' => TestData::SCHEMA_REVISIONS['users'],
+                    ],
                 ],
             ],
             'data' => [
@@ -298,6 +305,14 @@ class UsersControllerTest extends IntegrationTestCase
                     ],
                 ],
             ],
+            'meta' => [
+                'schema' => [
+                    'users' => [
+                        '$id' => 'http://api.example.com/model/schema/users',
+                        'revision' => TestData::SCHEMA_REVISIONS['users'],
+                    ],
+                ],
+            ],
         ];
 
         $this->configRequestHeaders();
@@ -542,6 +557,12 @@ class UsersControllerTest extends IntegrationTestCase
                     'page_count' => 1,
                     'page_items' => 1,
                     'page_size' => 20,
+                ],
+                'schema' => [
+                    'roles' => [
+                        '$id' => 'http://api.example.com/model/schema/roles',
+                        'revision' => TestData::SCHEMA_REVISIONS['roles'],
+                    ],
                 ],
             ],
             'data' => [

--- a/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
@@ -13,7 +13,7 @@
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
-use BEdita\API\Test\TestData;
+use BEdita\API\Test\TestConstants;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -51,7 +51,7 @@ class UsersControllerTest extends IntegrationTestCase
                 'schema' => [
                     'users' => [
                         '$id' => 'http://api.example.com/model/schema/users',
-                        'revision' => TestData::SCHEMA_REVISIONS['users'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['users'],
                     ],
                 ],
             ],
@@ -309,7 +309,7 @@ class UsersControllerTest extends IntegrationTestCase
                 'schema' => [
                     'users' => [
                         '$id' => 'http://api.example.com/model/schema/users',
-                        'revision' => TestData::SCHEMA_REVISIONS['users'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['users'],
                     ],
                 ],
             ],
@@ -561,7 +561,7 @@ class UsersControllerTest extends IntegrationTestCase
                 'schema' => [
                     'roles' => [
                         '$id' => 'http://api.example.com/model/schema/roles',
-                        'revision' => TestData::SCHEMA_REVISIONS['roles'],
+                        'revision' => TestConstants::SCHEMA_REVISIONS['roles'],
                     ],
                 ],
             ],

--- a/plugins/BEdita/API/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/plugins/BEdita/API/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -40,6 +40,8 @@ class IntegrationTestCaseTest extends IntegrationTestCase
                     'plugin.BEdita/Core.external_auth',
                     'plugin.BEdita/Core.object_types',
                     'plugin.BEdita/Core.objects',
+                    'plugin.BEdita/Core.locations',
+                    'plugin.BEdita/Core.media',
                     'plugin.BEdita/Core.profiles',
                     'plugin.BEdita/Core.users',
                     'plugin.BEdita/Core.roles',
@@ -61,6 +63,8 @@ class IntegrationTestCaseTest extends IntegrationTestCase
                     'plugin.BEdita/Core.external_auth',
                     'plugin.BEdita/Core.object_types',
                     'plugin.BEdita/Core.objects',
+                    'plugin.BEdita/Core.locations',
+                    'plugin.BEdita/Core.media',
                     'plugin.BEdita/Core.profiles',
                     'plugin.BEdita/Core.users',
                     'plugin.BEdita/Core.roles',
@@ -72,10 +76,8 @@ class IntegrationTestCaseTest extends IntegrationTestCase
                     'plugin.BEdita/Core.relation_types',
                     'plugin.BEdita/Core.properties',
                     'plugin.BEdita/Core.property_types',
-                    'plugin.BEdita/Core.locations',
                 ],
                 [
-                    'plugin.BEdita/Core.locations',
                     'plugin.BEdita/Core.users',
                 ]
             ]

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -661,7 +661,6 @@ class JsonApiTest extends TestCase
      *
      * @return void
      * @covers ::schemaInfo
-     * @covers ::resetSchemaInfo
      */
     public function testSchemaInfo()
     {
@@ -670,7 +669,6 @@ class JsonApiTest extends TestCase
             'revision' => TestConstants::SCHEMA_REVISIONS['roles'],
         ];
 
-        JsonApi::resetSchemaInfo();
         $result = JsonApi::schemaInfo('roles');
         static::assertEquals($expected, $result);
 

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\API\Test\TestCase\Utility;
 
+use BEdita\API\Test\TestData;
 use BEdita\API\Utility\JsonApi;
 use BEdita\Core\Utility\JsonApiSerializable;
 use Cake\ORM\Table;
@@ -38,9 +39,13 @@ class JsonApiTest extends TestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.property_types',
         'plugin.BEdita/Core.relations',
         'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.properties',
+        'plugin.BEdita/Core.locations',
+        'plugin.BEdita/Core.media',
         'plugin.BEdita/Core.profiles',
         'plugin.BEdita/Core.users',
         'plugin.BEdita/Core.roles',
@@ -125,6 +130,12 @@ class JsonApiTest extends TestCase
                             'self' => '/roles/2',
                         ],
                     ],
+                    '_schema' => [
+                        'roles' => [
+                            '$id' => '/model/schema/roles',
+                            'revision' => TestData::SCHEMA_REVISIONS['roles'],
+                        ]
+                    ]
                 ],
                 function (Table $Table) {
                     return $Table->find('all');
@@ -180,6 +191,12 @@ class JsonApiTest extends TestCase
                             'self' => '/roles/2',
                         ],
                     ],
+                    '_schema' => [
+                        'roles' => [
+                            '$id' => '/model/schema/roles',
+                            'revision' => TestData::SCHEMA_REVISIONS['roles'],
+                        ]
+                    ]
                 ],
                 function (Table $Table) {
                     return $Table->find('all')->all();
@@ -235,6 +252,12 @@ class JsonApiTest extends TestCase
                             'self' => '/roles/2',
                         ],
                     ],
+                    '_schema' => [
+                        'roles' => [
+                            '$id' => '/model/schema/roles',
+                            'revision' => TestData::SCHEMA_REVISIONS['roles'],
+                        ]
+                    ]
                 ],
                 function (Table $Table) {
                     return $Table->find('all')->toArray();
@@ -261,6 +284,12 @@ class JsonApiTest extends TestCase
                             ],
                         ],
                     ],
+                    '_schema' => [
+                        'roles' => [
+                            '$id' => '/model/schema/roles',
+                            'revision' => TestData::SCHEMA_REVISIONS['roles'],
+                        ]
+                    ]
                 ],
                 function (Table $Table) {
                     return $Table->get(1);
@@ -287,6 +316,12 @@ class JsonApiTest extends TestCase
                             ],
                         ],
                     ],
+                    '_schema' => [
+                        'roles' => [
+                            '$id' => '/model/schema/roles',
+                            'revision' => TestData::SCHEMA_REVISIONS['roles'],
+                        ]
+                    ]
                 ],
                 function (Table $Table) {
                     return $Table->get(1);
@@ -513,6 +548,8 @@ class JsonApiTest extends TestCase
                 'lang' => 'eng',
                 'publish_start' => '2016-05-13T07:09:23+00:00',
                 'publish_end' => '2016-05-13T07:09:23+00:00',
+                'another_title' => null,
+                'another_description' => null,
             ],
             'meta' => [
                 'locked' => true,
@@ -536,11 +573,40 @@ class JsonApiTest extends TestCase
                     ],
                 ],
             ],
+            '_schema' => [
+                'documents' => [
+                    '$id' => '/model/schema/documents',
+                    'revision' => TestData::SCHEMA_REVISIONS['documents'],
+                ]
+            ]
         ];
 
         $result = JsonApi::formatData(TableRegistry::get('Documents')->get(2));
         $result = json_decode(json_encode($result), true);
 
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test `schemaInfo` method
+     *
+     * @return void
+     * @covers ::schemaInfo
+     * @covers ::resetSchemaInfo
+     */
+    public function testSchemaInfo()
+    {
+        $expected = [
+            '$id' => '/model/schema/roles',
+            'revision' => TestData::SCHEMA_REVISIONS['roles'],
+        ];
+
+        JsonApi::resetSchemaInfo();
+        $result = JsonApi::schemaInfo('roles');
+        static::assertEquals($expected, $result);
+
+        // use internal array
+        $result = JsonApi::schemaInfo('roles');
         static::assertEquals($expected, $result);
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -657,23 +657,41 @@ class JsonApiTest extends TestCase
     }
 
     /**
+     * Data provider for `testSchemaInfo` test case.
+     *
+     * @return array
+     */
+    public function schemaInfoProvider()
+    {
+        return [
+            'roles' => [
+                'roles',
+                [
+                    '$id' => '/model/schema/roles',
+                    'revision' => TestConstants::SCHEMA_REVISIONS['roles'],
+                ],
+            ],
+            'objects' => [
+                'object_types',
+                null,
+            ],
+            'properties' => [
+                'properties',
+                null,
+            ],
+        ];
+    }
+
+    /**
      * Test `schemaInfo` method
      *
      * @return void
      * @covers ::schemaInfo
+     * @dataProvider schemaInfoProvider
      */
-    public function testSchemaInfo()
+    public function testSchemaInfo($type, $expected)
     {
-        $expected = [
-            '$id' => '/model/schema/roles',
-            'revision' => TestConstants::SCHEMA_REVISIONS['roles'],
-        ];
-
-        $result = JsonApi::schemaInfo('roles');
-        static::assertEquals($expected, $result);
-
-        // use internal array
-        $result = JsonApi::schemaInfo('roles');
+        $result = JsonApi::schemaInfo($type);
         static::assertEquals($expected, $result);
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -13,7 +13,7 @@
 
 namespace BEdita\API\Test\TestCase\Utility;
 
-use BEdita\API\Test\TestData;
+use BEdita\API\Test\TestConstants;
 use BEdita\API\Utility\JsonApi;
 use BEdita\Core\Utility\JsonApiSerializable;
 use Cake\ORM\Table;
@@ -133,7 +133,7 @@ class JsonApiTest extends TestCase
                     '_schema' => [
                         'roles' => [
                             '$id' => '/model/schema/roles',
-                            'revision' => TestData::SCHEMA_REVISIONS['roles'],
+                            'revision' => TestConstants::SCHEMA_REVISIONS['roles'],
                         ]
                     ]
                 ],
@@ -194,7 +194,7 @@ class JsonApiTest extends TestCase
                     '_schema' => [
                         'roles' => [
                             '$id' => '/model/schema/roles',
-                            'revision' => TestData::SCHEMA_REVISIONS['roles'],
+                            'revision' => TestConstants::SCHEMA_REVISIONS['roles'],
                         ]
                     ]
                 ],
@@ -255,7 +255,7 @@ class JsonApiTest extends TestCase
                     '_schema' => [
                         'roles' => [
                             '$id' => '/model/schema/roles',
-                            'revision' => TestData::SCHEMA_REVISIONS['roles'],
+                            'revision' => TestConstants::SCHEMA_REVISIONS['roles'],
                         ]
                     ]
                 ],
@@ -287,7 +287,7 @@ class JsonApiTest extends TestCase
                     '_schema' => [
                         'roles' => [
                             '$id' => '/model/schema/roles',
-                            'revision' => TestData::SCHEMA_REVISIONS['roles'],
+                            'revision' => TestConstants::SCHEMA_REVISIONS['roles'],
                         ]
                     ]
                 ],
@@ -319,7 +319,7 @@ class JsonApiTest extends TestCase
                     '_schema' => [
                         'roles' => [
                             '$id' => '/model/schema/roles',
-                            'revision' => TestData::SCHEMA_REVISIONS['roles'],
+                            'revision' => TestConstants::SCHEMA_REVISIONS['roles'],
                         ]
                     ]
                 ],
@@ -576,7 +576,7 @@ class JsonApiTest extends TestCase
             '_schema' => [
                 'documents' => [
                     '$id' => '/model/schema/documents',
-                    'revision' => TestData::SCHEMA_REVISIONS['documents'],
+                    'revision' => TestConstants::SCHEMA_REVISIONS['documents'],
                 ]
             ]
         ];
@@ -598,7 +598,7 @@ class JsonApiTest extends TestCase
     {
         $expected = [
             '$id' => '/model/schema/roles',
-            'revision' => TestData::SCHEMA_REVISIONS['roles'],
+            'revision' => TestConstants::SCHEMA_REVISIONS['roles'],
         ];
 
         JsonApi::resetSchemaInfo();

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -43,6 +43,7 @@ class JsonApiTest extends TestCase
         'plugin.BEdita/Core.relations',
         'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.object_relations',
         'plugin.BEdita/Core.properties',
         'plugin.BEdita/Core.locations',
         'plugin.BEdita/Core.media',
@@ -368,7 +369,74 @@ class JsonApiTest extends TestCase
                     return $Table->get(1);
                 },
                 JsonApiSerializable::JSONAPIOPT_EXCLUDE_ATTRIBUTES | JsonApiSerializable::JSONAPIOPT_EXCLUDE_META,
-            ]
+            ],
+            'included' => [
+                [
+                    'id' => '2',
+                    'type' => 'documents',
+                    'attributes' => [
+                        'status' => 'on',
+                        'uname' => 'title-one',
+                        'title' => 'title one',
+                        'description' => 'description here',
+                        'body' => 'body here',
+                        'extra' => [
+                            'abstract' => 'abstract here',
+                            'list' => ['one', 'two', 'three'],
+                        ],
+                        'lang' => 'eng',
+                        'publish_start' => '2016-05-13T07:09:23+00:00',
+                        'publish_end' => '2016-05-13T07:09:23+00:00',
+                        'another_title' => null,
+                        'another_description' => null,
+                    ],
+                    'meta' => [
+                        'locked' => true,
+                        'created' => '2016-05-13T07:09:23+00:00',
+                        'modified' => '2016-05-13T07:09:23+00:00',
+                        'published' => '2016-05-13T07:09:23+00:00',
+                        'created_by' => 1,
+                        'modified_by' => 1,
+                    ],
+                    'relationships' => [
+                        'test' => [
+                            'links' => [
+                                'related' => '/documents/2/test',
+                                'self' => '/documents/2/relationships/test',
+                            ],
+                            'data' => [
+                                [
+                                    'id' => '4',
+                                    'type' => 'profiles',
+                                ],
+                                [
+                                    'id' => '3',
+                                    'type' => 'documents',
+                                ],
+                            ]
+                        ],
+                        'inverse_test' => [
+                            'links' => [
+                                'related' => '/documents/2/inverse_test',
+                                'self' => '/documents/2/relationships/inverse_test',
+                            ],
+                        ],
+                    ],
+                    '_schema' => [
+                        'profiles' => [
+                            '$id' => '/model/schema/profiles',
+                            'revision' => TestConstants::SCHEMA_REVISIONS['profiles'],
+                        ],
+                        'documents' => [
+                            '$id' => '/model/schema/documents',
+                            'revision' => TestConstants::SCHEMA_REVISIONS['documents'],
+                        ],
+                    ],
+                ],
+                function () {
+                    return TableRegistry::get('Documents')->get(2, ['contain' => ['Test']]);
+                },
+            ],
         ];
     }
 
@@ -383,6 +451,7 @@ class JsonApiTest extends TestCase
      *
      * @dataProvider formatDataProvider
      * @covers ::formatData
+     * @covers ::metaSchema
      */
     public function testFormatData($expected, callable $items, $options = 0)
     {

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published

--- a/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
+++ b/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\API\Test\TestCase\View;
 
+use BEdita\API\Test\TestData;
 use Cake\Controller\Controller;
 use Cake\Network\Request;
 use Cake\Network\Response;
@@ -39,6 +40,7 @@ class JsonApiViewTest extends TestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.property_types',
         'plugin.BEdita/Core.relations',
         'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.objects',
@@ -99,6 +101,14 @@ class JsonApiViewTest extends TestCase
                             ],
                         ],
                     ],
+                    'meta' => [
+                        'schema' => [
+                            'roles' => [
+                                '$id' => '/model/schema/roles',
+                                'revision' => TestData::SCHEMA_REVISIONS['roles'],
+                            ],
+                        ],
+                    ],
                 ]),
                 function (Table $Table) {
                     return [
@@ -130,6 +140,14 @@ class JsonApiViewTest extends TestCase
                                     'self' => '/roles/1/relationships/users',
                                     'related' => '/roles/1/users',
                                 ],
+                            ],
+                        ],
+                    ],
+                    'meta' => [
+                        'schema' => [
+                            'roles' => [
+                                '$id' => '/model/schema/roles',
+                                'revision' => TestData::SCHEMA_REVISIONS['roles'],
                             ],
                         ],
                     ],

--- a/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
+++ b/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
@@ -13,7 +13,7 @@
 
 namespace BEdita\API\Test\TestCase\View;
 
-use BEdita\API\Test\TestData;
+use BEdita\API\Test\TestConstants;
 use Cake\Controller\Controller;
 use Cake\Network\Request;
 use Cake\Network\Response;
@@ -105,7 +105,7 @@ class JsonApiViewTest extends TestCase
                         'schema' => [
                             'roles' => [
                                 '$id' => '/model/schema/roles',
-                                'revision' => TestData::SCHEMA_REVISIONS['roles'],
+                                'revision' => TestConstants::SCHEMA_REVISIONS['roles'],
                             ],
                         ],
                     ],
@@ -147,7 +147,7 @@ class JsonApiViewTest extends TestCase
                         'schema' => [
                             'roles' => [
                                 '$id' => '/model/schema/roles',
-                                'revision' => TestData::SCHEMA_REVISIONS['roles'],
+                                'revision' => TestConstants::SCHEMA_REVISIONS['roles'],
                             ],
                         ],
                     ],

--- a/plugins/BEdita/API/tests/TestConstants.php
+++ b/plugins/BEdita/API/tests/TestConstants.php
@@ -24,12 +24,12 @@ class TestConstants
      * @var array
      */
     const SCHEMA_REVISIONS = [
-        'documents' => '1626723409',
-        'events' => '4232492187',
-        'files' => '2375452932',
-        'locations' => '3704626079',
-        'profiles' => '2293379270',
-        'roles' => '1598151971',
-        'users' => '72522241',
+        'documents' => '1389311771',
+        'events' => '3616621047',
+        'files' => '336351369',
+        'locations' => '1962607368',
+        'profiles' => '4263816212',
+        'roles' => '2455170079',
+        'users' => '3778063754',
     ];
 }

--- a/plugins/BEdita/API/tests/TestConstants.php
+++ b/plugins/BEdita/API/tests/TestConstants.php
@@ -24,6 +24,7 @@ class TestConstants
      * @var array
      */
     const SCHEMA_REVISIONS = [
+        'applications' => '320029666',
         'documents' => '1389311771',
         'events' => '3616621047',
         'files' => '336351369',

--- a/plugins/BEdita/API/tests/TestConstants.php
+++ b/plugins/BEdita/API/tests/TestConstants.php
@@ -16,14 +16,14 @@ namespace BEdita\API\Test;
 /**
  * Test utility class with useful constants
  */
-class TestData
+class TestConstants
 {
     /**
-     * Revision for each resource and object used in tests
+     * Schema revision for each resource and object used in tests
      *
      * @var array
      */
-    public const SCHEMA_REVISIONS = [
+    const SCHEMA_REVISIONS = [
         'documents' => '1626723409',
         'events' => '4232492187',
         'files' => '2375452932',

--- a/plugins/BEdita/API/tests/TestData.php
+++ b/plugins/BEdita/API/tests/TestData.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\API\Test;
+
+/**
+ * Test utility class with useful constants
+ */
+class TestData
+{
+    /**
+     * Revision for each resource and object used in tests
+     *
+     * @var array
+     */
+    public const SCHEMA_REVISIONS = [
+        'documents' => '1626723409',
+        'events' => '4232492187',
+        'files' => '2375452932',
+        'locations' => '3704626079',
+        'profiles' => '2293379270',
+        'roles' => '1598151971',
+        'users' => '72522241',
+    ];
+}

--- a/plugins/BEdita/Core/src/Utility/JsonSchema.php
+++ b/plugins/BEdita/Core/src/Utility/JsonSchema.php
@@ -53,7 +53,7 @@ class JsonSchema
         $schema = Cache::remember(
             'schema_' . $type,
             function () use ($type) {
-                return static::addRevision(static::typeSchema($type), $type);
+                return static::addRevision(static::typeSchema($type));
             },
             ObjectTypesTable::CACHE_CONFIG
         );
@@ -100,10 +100,9 @@ class JsonSchema
      * Add revision information to schema
      *
      * @param array|bool $schema Schema array or `false`
-     * @param string $type Resource or object type name
      * @return array|bool Schema with `revision` or `false`
      */
-    protected static function addRevision($schema, $type)
+    protected static function addRevision($schema)
     {
         if (!is_array($schema)) {
             return $schema;

--- a/plugins/BEdita/Core/tests/TestCase/Utility/JsonSchemaTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/JsonSchemaTest.php
@@ -316,22 +316,4 @@ class JsonSchemaTest extends TestCase
         $result = JsonSchema::schemaRevision($type);
         static::assertEquals($expected, $result);
     }
-
-    /**
-     * Test schemaRevision method with cache
-
-     * @return void
-     * @covers ::schemaRevision()
-     */
-    // public function testSchemaRevisionCache()
-    // {
-    //     $type = 'documents';
-    //     $result = JsonSchema::schemaRevision($type);
-    //     $expected = Cache::read('revision_schema_' . $type, ObjectTypesTable::CACHE_CONFIG);
-    //     static::assertEquals($expected, $result);
-
-    //     // this will read from cache
-    //     $resultCache = JsonSchema::schemaRevision($type);
-    //     static::assertEquals($resultCache, $result);
-    // }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Utility/JsonSchemaTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/JsonSchemaTest.php
@@ -13,7 +13,9 @@
 
 namespace BEdita\Core\Test\TestCase\Utility;
 
+use BEdita\Core\Model\Table\ObjectTypesTable;
 use BEdita\Core\Utility\JsonSchema;
+use Cake\Cache\Cache;
 use Cake\Network\Exception\NotFoundException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -44,6 +46,16 @@ class JsonSchemaTest extends TestCase
         'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.streams',
     ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        Cache::clear(false, ObjectTypesTable::CACHE_CONFIG);
+    }
 
     /**
      * Data provider for `testGenerate` test case.
@@ -270,4 +282,56 @@ class JsonSchemaTest extends TestCase
         $result = JsonSchema::generate($type, $url);
         static::assertFalse($result);
     }
+
+    /**
+     * Data provider for `testGenerate` test case.
+     *
+     * @return array
+     */
+    public function schemaRevisionProvider()
+    {
+        return [
+            'objects' => [
+                'objects',
+                false,
+            ],
+            'documents' => [
+                'documents',
+                '1389311771',
+            ],
+        ];
+    }
+
+    /**
+     * Test schemaRevision method
+
+     * @param string $type Type name
+     * @param string|bool $expected Expected revision
+     * @return void
+     * @covers ::schemaRevision()
+     * @dataProvider schemaRevisionProvider
+     */
+    public function testSchemaRevision($type, $expected)
+    {
+        $result = JsonSchema::schemaRevision($type);
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test schemaRevision method with cache
+
+     * @return void
+     * @covers ::schemaRevision()
+     */
+    // public function testSchemaRevisionCache()
+    // {
+    //     $type = 'documents';
+    //     $result = JsonSchema::schemaRevision($type);
+    //     $expected = Cache::read('revision_schema_' . $type, ObjectTypesTable::CACHE_CONFIG);
+    //     static::assertEquals($expected, $result);
+
+    //     // this will read from cache
+    //     $resultCache = JsonSchema::schemaRevision($type);
+    //     static::assertEquals($resultCache, $result);
+    // }
 }


### PR DESCRIPTION
This PR fixes #1406

On every JSON API response schema information on represented types is added, where URL and revision of schema is displayed.

A section is added to main `meta` reponse like this:
```json
"meta": {
  "schema": {
    "users": {
      "$id": "http://api.example.com/model/schema/users"
      "revision": "2112132969"
    }
  }
}
``` 
Schema info of all types included in a response will be presented, 
 
This information is added only for types having a `JSON Schema` representation, some internal resources like `properties`, `applications` and `object_types` are not supported - see `/model` and `/admin` endpoints.
