### PR TITLE
ETag header on json schema

### DIFF
--- a/plugins/BEdita/API/src/Controller/Model/SchemaController.php
+++ b/plugins/BEdita/API/src/Controller/Model/SchemaController.php
@@ -66,6 +66,12 @@ class SchemaController extends AppController
     {
         $this->request->allowMethod(['get']);
 
+        $response = $this->response->withEtag(JsonSchema::schemaRevision($typeName));
+        if ($response->checkNotModified($this->request)) {
+            return $response;
+        }
+        $this->response = $response;
+
         $url = (string)$this->request->getUri();
         $schema = JsonSchema::generate($typeName, $url);
 

--- a/plugins/BEdita/API/src/Controller/Model/SchemaController.php
+++ b/plugins/BEdita/API/src/Controller/Model/SchemaController.php
@@ -66,7 +66,7 @@ class SchemaController extends AppController
     {
         $this->request->allowMethod(['get']);
 
-        $response = $this->response->withEtag(JsonSchema::schemaRevision($typeName));
+        $response = $this->response->withEtag((string)JsonSchema::schemaRevision($typeName));
         if ($response->checkNotModified($this->request)) {
             return $response;
         }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/SchemaControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/SchemaControllerTest.php
@@ -14,6 +14,7 @@
 namespace BEdita\API\Test\TestCase\Controller\Model;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\API\Test\TestConstants;
 
 /**
  * {@see \BEdita\API\Controller\Model\SchemaController} Test Case
@@ -102,5 +103,27 @@ class SchemaControllerTest extends IntegrationTestCase
         $this->assertResponseCode(200);
         $this->assertContentType('application/schema+json');
         static::assertFalse($result);
+    }
+
+    /**
+     * Test ETag response header and Not Modified response.
+     *
+     * @return void
+     *
+     * @covers ::jsonSchema()
+     */
+    public function testETag()
+    {
+        $this->configRequestHeaders('GET');
+        $this->get('/model/schema/roles');
+
+        $etagHeader = $this->_response->getHeaderLine('ETag');
+        static::assertEquals(TestConstants::SCHEMA_REVISIONS['roles'], trim($etagHeader, '"'));
+
+        $this->configRequestHeaders('GET', ['If-None-Match' => $etagHeader]);
+        $this->get('/model/schema/roles');
+
+        $this->assertResponseCode(304);
+        static::assertEmpty((string)$this->_response->getBody());
     }
 }


### PR DESCRIPTION
This PR adds ETag header to `/model/schema/{type}` response, using `revision` as its value.

A 304 Not Modified empty response is provided on  a `'If-None-Match'` matching request.
