### PR TITLE
Add `id` property to json schema

### DIFF
--- a/plugins/BEdita/API/tests/TestConstants.php
+++ b/plugins/BEdita/API/tests/TestConstants.php
@@ -24,12 +24,12 @@ class TestConstants
      * @var array
      */
     const SCHEMA_REVISIONS = [
-        'documents' => '1389311771',
-        'events' => '3616621047',
-        'files' => '336351369',
-        'locations' => '1962607368',
-        'profiles' => '4263816212',
-        'roles' => '2455170079',
-        'users' => '3778063754',
+        'documents' => '3090683659',
+        'events' => '1906204265',
+        'files' => '894208275',
+        'locations' => '1369205356',
+        'profiles' => '3766083092',
+        'roles' => '2845943672',
+        'users' => '4176671339',
     ];
 }

--- a/plugins/BEdita/Core/src/Model/Table/StaticPropertiesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/StaticPropertiesTable.php
@@ -246,7 +246,8 @@ class StaticPropertiesTable extends Table
 
         $properties = [];
         foreach ($schema->columns() as $name) {
-            if (in_array($name, (array)$table->getPrimaryKey()) || in_array($name, $hiddenProperties)) {
+            // primary keys saved only for root `objects' table
+            if ((in_array($name, (array)$table->getPrimaryKey()) && !empty($objectType->parent)) || in_array($name, $hiddenProperties)) {
                 continue;
             }
 

--- a/plugins/BEdita/Core/src/Utility/JsonSchema.php
+++ b/plugins/BEdita/Core/src/Utility/JsonSchema.php
@@ -156,8 +156,8 @@ class JsonSchema
         $properties = [];
         $required = [];
         foreach ($schema->columns() as $name) {
-            if (in_array($name, (array)$table->getPrimaryKey()) || in_array($name, $hiddenProperties)) {
-                continue;
+            if (in_array($name, $hiddenProperties)) {
+                    continue;
             }
 
             $accessMode = null;

--- a/plugins/BEdita/Core/src/Utility/JsonSchema.php
+++ b/plugins/BEdita/Core/src/Utility/JsonSchema.php
@@ -156,7 +156,7 @@ class JsonSchema
         $required = [];
         foreach ($schema->columns() as $name) {
             if (in_array($name, $hiddenProperties)) {
-                    continue;
+                continue;
             }
 
             $accessMode = null;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -363,6 +363,12 @@ class ObjectTypeTest extends TestCase
             'documents' => [
                 [
                     'properties' => [
+                        'id' => [
+                            '$id' => '/properties/id',
+                            'title' => 'Id',
+                            'type' => 'integer',
+                            'readOnly' => true,
+                        ],
                         'title' => [
                             '$id' => '/properties/title',
                             'title' => 'Title',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertiesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertiesTableTest.php
@@ -222,6 +222,7 @@ class PropertiesTableTest extends TestCase
     public function findTypeProvider()
     {
         $objects = [
+            'id',
             'uname',
             'status',
             'published',
@@ -362,6 +363,7 @@ class PropertiesTableTest extends TestCase
     {
         $expected = [
             // Objects static properties.
+            'id',
             'uname',
             'status',
             'published',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/StaticPropertiesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/StaticPropertiesTableTest.php
@@ -173,7 +173,10 @@ class StaticPropertiesTableTest extends TestCase
                 ],
             ],
             '*.id' => [
-                null, // ID should never be present.
+                [
+                    'name' => 'id',
+                    'object_type_id' => 1,
+                ],
                 [
                     'name' => 'id',
                 ],

--- a/plugins/BEdita/Core/tests/TestCase/Utility/JsonSchemaTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/JsonSchemaTest.php
@@ -76,6 +76,7 @@ class JsonSchemaTest extends TestCase
             'users' => [
                 [
                     'properties' => [
+                        'id',
                         'another_email',
                         'another_username',
                         'birthdate',
@@ -130,6 +131,7 @@ class JsonSchemaTest extends TestCase
             'roles' => [
                 [
                     'properties' => [
+                        'id',
                         'created',
                         'description',
                         'modified',
@@ -146,6 +148,7 @@ class JsonSchemaTest extends TestCase
             'documents' => [
                 [
                     'properties' => [
+                        'id',
                         'another_description',
                         'another_title',
                         'body',
@@ -173,6 +176,7 @@ class JsonSchemaTest extends TestCase
             'streams' => [
                 [
                     'properties' => [
+                        'uuid',
                         'created',
                         'duration',
                         'file_name',
@@ -297,7 +301,7 @@ class JsonSchemaTest extends TestCase
             ],
             'documents' => [
                 'documents',
-                '1389311771',
+                '3090683659',
             ],
         ];
     }
@@ -306,7 +310,7 @@ class JsonSchemaTest extends TestCase
      * Test schemaRevision method
 
      * @param string $type Type name
-     * @param string|bool $expected Expected revision
+     * @param string|bool $expected Expected revision1389311771
      * @return void
      * @covers ::schemaRevision()
      * @dataProvider schemaRevisionProvider

--- a/plugins/BEdita/Core/tests/TestCase/Utility/JsonSchemaTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/JsonSchemaTest.php
@@ -310,7 +310,7 @@ class JsonSchemaTest extends TestCase
      * Test schemaRevision method
 
      * @param string $type Type name
-     * @param string|bool $expected Expected revision1389311771
+     * @param string|bool $expected Expected revision
      * @return void
      * @covers ::schemaRevision()
      * @dataProvider schemaRevisionProvider


### PR DESCRIPTION
This PR adds `id` read-only property to JSON Schema representations for resources and objects.
