### PR TITLE
Add multiple types flag to `/home` 

### DIFF
--- a/plugins/BEdita/API/src/Controller/HomeController.php
+++ b/plugins/BEdita/API/src/Controller/HomeController.php
@@ -30,19 +30,41 @@ class HomeController extends AppController
 {
 
     /**
-     * Default endpoints with supported methods
-     * 'ALL' means 'GET', 'POST', 'PATCH' and 'DELETE' are supported
+     * Default endpoints with:
+     *  - supported methods, where 'ALL' means 'GET', 'POST', 'PATCH' and 'DELETE' are supported
+     *  - multiple types flag, if true multiple types are handled (like abstract object types or `/trash`)
      *
      * @var array
      */
     protected $defaultEndpoints = [
-        '/auth' => ['GET', 'POST'],
-        '/admin' => 'ALL',
-        '/model' => 'ALL',
-        '/roles' => 'ALL',
-        '/signup' => ['POST'],
-        '/status' => ['GET'],
-        '/trash' => 'ALL',
+        '/auth' => [
+           'methods' => ['GET', 'POST'],
+           'multiple_types' => false,
+        ],
+        '/admin' =>  [
+            'methods' => 'ALL',
+            'multiple_types' => true,
+         ],
+         '/model' =>  [
+            'methods' => 'ALL',
+            'multiple_types' => true,
+         ],
+         '/roles' =>  [
+            'methods' => 'ALL',
+            'multiple_types' => false,
+         ],
+         '/signup' =>  [
+            'methods' => ['POST'],
+            'multiple_types' => false,
+         ],
+         '/status' =>  [
+            'methods' => ['GET'],
+            'multiple_types' => false,
+         ],
+         '/trash' =>  [
+            'methods' => 'ALL',
+            'multiple_types' => true,
+         ],
     ];
 
     /**
@@ -66,32 +88,10 @@ class HomeController extends AppController
     {
         $this->request->allowMethod(['get', 'head']);
 
-        $objectTypesEndpoints = $this->objectTypesEndpoints();
-        $endPoints = array_merge($objectTypesEndpoints, $this->defaultEndpoints);
-        foreach ($endPoints as $e => $methods) {
-            if ($methods === 'ALL') {
-                $methods = ['GET', 'POST', 'PATCH', 'DELETE'];
-            }
-            $allow = [];
-            foreach ($methods as $method) {
-                if ($this->checkAuthorization($e, $method)) {
-                    $allow[] = $method;
-                }
-            }
-            $resources[$e] = [
-                'href' => Router::url($e, true),
-                'hints' => [
-                    'allow' => $allow,
-                    'formats' => [
-                        'application/json',
-                        'application/vnd.api+json',
-                    ],
-                    'display' => [
-                        'label' => Inflector::camelize(substr($e, 1)),
-                    ],
-                    'object_type' => !empty($objectTypesEndpoints[$e]),
-                ],
-            ];
+        $default = Hash::insert($this->defaultEndpoints, '{*}.object_type', false);
+        $endPoints = array_merge($this->objectTypesEndpoints(), $default);
+        foreach ($endPoints as $e => $data) {
+            $resources[$e] = $this->endpointFeatures($e, $data);
         }
         $project = Configure::read('Project');
         $version = Configure::read('BEdita.version');
@@ -99,6 +99,43 @@ class HomeController extends AppController
         $this->set('_meta', compact('resources', 'project', 'version'));
         $this->set('_serialize', []);
     }
+
+    /**
+     * Return endpoint features to display in `/home` response
+     *
+     * @param string $endpoint Endpoint name
+     * @param array $options Endpoint options - methods and multiple types flag
+     * @return array Array of features
+     */
+    protected function endpointFeatures($endpoint, $options)
+    {
+        $methods = $options['methods'];
+        if ($methods === 'ALL') {
+            $methods = ['GET', 'POST', 'PATCH', 'DELETE'];
+        }
+        $allow = [];
+        foreach ($methods as $method) {
+            if ($this->checkAuthorization($endpoint, $method)) {
+                $allow[] = $method;
+            }
+        }
+        return [
+            'href' => Router::url($endpoint, true),
+            'hints' => [
+                'allow' => $allow,
+                'formats' => [
+                    'application/json',
+                    'application/vnd.api+json',
+                ],
+                'display' => [
+                    'label' => Inflector::camelize(substr($endpoint, 1)),
+                ],
+                'object_type' => $options['object_type'],
+                'multiple_types' => $options['multiple_types'],
+            ],
+        ];
+    }
+
 
     /**
      * Returns available object types to list as endpoints
@@ -110,7 +147,11 @@ class HomeController extends AppController
         $allTypes = TableRegistry::get('ObjectTypes')->find('list', ['keyField' => 'name', 'valueField' => 'is_abstract'])->toArray();
         $endPoints = [];
         foreach ($allTypes as $t => $abstract) {
-            $endPoints['/' . $t] = $abstract ? ['GET', 'DELETE'] : 'ALL';
+            $endPoints['/' . $t] = [
+                'methods' => $abstract ? ['GET', 'DELETE'] : 'ALL',
+                'object_type' => true,
+                'multiple_types' => $abstract,
+            ];
         }
 
         return $endPoints;

--- a/plugins/BEdita/API/src/Controller/HomeController.php
+++ b/plugins/BEdita/API/src/Controller/HomeController.php
@@ -41,27 +41,27 @@ class HomeController extends AppController
            'methods' => ['GET', 'POST'],
            'multiple_types' => false,
         ],
-        '/admin' =>  [
+        '/admin' => [
             'methods' => 'ALL',
             'multiple_types' => true,
          ],
-         '/model' =>  [
+         '/model' => [
             'methods' => 'ALL',
             'multiple_types' => true,
          ],
-         '/roles' =>  [
+         '/roles' => [
             'methods' => 'ALL',
             'multiple_types' => false,
          ],
-         '/signup' =>  [
+         '/signup' => [
             'methods' => ['POST'],
             'multiple_types' => false,
          ],
-         '/status' =>  [
+         '/status' => [
             'methods' => ['GET'],
             'multiple_types' => false,
          ],
-         '/trash' =>  [
+         '/trash' => [
             'methods' => 'ALL',
             'multiple_types' => true,
          ],
@@ -119,6 +119,7 @@ class HomeController extends AppController
                 $allow[] = $method;
             }
         }
+
         return [
             'href' => Router::url($endpoint, true),
             'hints' => [
@@ -135,7 +136,6 @@ class HomeController extends AppController
             ],
         ];
     }
-
 
     /**
      * Returns available object types to list as endpoints

--- a/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
@@ -28,6 +28,7 @@ class HomeControllerTest extends IntegrationTestCase
      * @return void
      *
      * @covers ::index()
+     * @covers ::endpointFeatures()
      * @covers ::objectTypesEndpoints()
      * @covers ::checkAuthorization()
      * @covers ::unloggedAuthorized()
@@ -57,6 +58,7 @@ class HomeControllerTest extends IntegrationTestCase
                                 'label' => 'Auth',
                             ],
                             'object_type' => false,
+                            'multiple_types' => false,
                         ],
                     ],
                     '/documents' => [
@@ -73,6 +75,7 @@ class HomeControllerTest extends IntegrationTestCase
                                 'label' => 'Documents',
                             ],
                             'object_type' => true,
+                            'multiple_types' => false,
                         ],
                     ],
                     '/profiles' => [
@@ -89,6 +92,7 @@ class HomeControllerTest extends IntegrationTestCase
                                 'label' => 'Profiles',
                             ],
                             'object_type' => true,
+                            'multiple_types' => false,
                         ],
                     ],
                     '/objects' => [
@@ -105,6 +109,7 @@ class HomeControllerTest extends IntegrationTestCase
                                 'label' => 'Objects',
                             ],
                             'object_type' => true,
+                            'multiple_types' => true,
                         ],
                     ],
                     '/users' => [
@@ -121,6 +126,7 @@ class HomeControllerTest extends IntegrationTestCase
                                 'label' => 'Users',
                             ],
                             'object_type' => true,
+                            'multiple_types' => false,
                         ],
                     ],
                     '/news' => [
@@ -137,6 +143,7 @@ class HomeControllerTest extends IntegrationTestCase
                                 'label' => 'News',
                             ],
                             'object_type' => true,
+                            'multiple_types' => false,
                         ],
                     ],
                     '/locations' => [
@@ -153,6 +160,7 @@ class HomeControllerTest extends IntegrationTestCase
                                 'label' => 'Locations',
                             ],
                             'object_type' => true,
+                            'multiple_types' => false,
                         ],
                     ],
                     '/events' => [
@@ -169,6 +177,7 @@ class HomeControllerTest extends IntegrationTestCase
                                 'label' => 'Events',
                             ],
                             'object_type' => true,
+                            'multiple_types' => false,
                         ],
                     ],
                     '/roles' => [
@@ -185,6 +194,7 @@ class HomeControllerTest extends IntegrationTestCase
                                 'label' => 'Roles',
                             ],
                             'object_type' => false,
+                            'multiple_types' => false,
                         ],
                     ],
                     '/model' => [
@@ -201,6 +211,7 @@ class HomeControllerTest extends IntegrationTestCase
                                 'label' => 'Model',
                             ],
                             'object_type' => false,
+                            'multiple_types' => true,
                         ],
                     ],
                     '/admin' => [
@@ -217,6 +228,7 @@ class HomeControllerTest extends IntegrationTestCase
                                 'label' => 'Admin',
                             ],
                             'object_type' => false,
+                            'multiple_types' => true,
                         ],
                     ],
                     '/status' => [
@@ -233,6 +245,7 @@ class HomeControllerTest extends IntegrationTestCase
                                 'label' => 'Status',
                             ],
                             'object_type' => false,
+                            'multiple_types' => false,
                         ],
                     ],
                     '/signup' => [
@@ -249,6 +262,7 @@ class HomeControllerTest extends IntegrationTestCase
                                 'label' => 'Signup',
                             ],
                             'object_type' => false,
+                            'multiple_types' => false,
                         ],
                     ],
                     '/trash' => [
@@ -265,6 +279,7 @@ class HomeControllerTest extends IntegrationTestCase
                                 'label' => 'Trash',
                             ],
                             'object_type' => false,
+                            'multiple_types' => true,
                         ],
                     ],
                     '/media' => [
@@ -281,6 +296,7 @@ class HomeControllerTest extends IntegrationTestCase
                                 'label' => 'Media',
                             ],
                             'object_type' => true,
+                            'multiple_types' => true,
                         ],
                     ],
                     '/files' => [
@@ -297,6 +313,7 @@ class HomeControllerTest extends IntegrationTestCase
                                 'label' => 'Files',
                             ],
                             'object_type' => true,
+                            'multiple_types' => false,
                         ],
                     ],
                 ],


### PR DESCRIPTION
This PR adds `multiple_types` flag to `/home` endpoint response.

This flag is:
 * `true` if multiple types are handled in this endpoint, like `/objects` or other `abstract` types or endpoints like `/trash`
 * `false` if only a single type is handled, like `/roles` or `/users`

