### PR TITLE
Disabled types updates

### DIFF
--- a/plugins/BEdita/API/src/Controller/HomeController.php
+++ b/plugins/BEdita/API/src/Controller/HomeController.php
@@ -107,7 +107,10 @@ class HomeController extends AppController
      */
     protected function objectTypesEndpoints()
     {
-        $allTypes = TableRegistry::get('ObjectTypes')->find('list', ['keyField' => 'name', 'valueField' => 'is_abstract'])->toArray();
+        $allTypes = TableRegistry::get('ObjectTypes')
+                        ->find('list', ['keyField' => 'name', 'valueField' => 'is_abstract'])
+                        ->where(['enabled' => true])
+                        ->toArray();
         $endPoints = [];
         foreach ($allTypes as $t => $abstract) {
             $endPoints['/' . $t] = $abstract ? ['GET', 'DELETE'] : 'ALL';

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -88,6 +88,11 @@ class ObjectsController extends ResourcesController
             $this->setConfig('allowedAssociations', array_fill_keys($relations, []));
         }
 
+        // Requested object type endpoint MUST be `enabled`
+        if (!$this->objectType->get('enabled')) {
+            throw new MissingRouteException(['url' => $this->request->getRequestTarget()]);
+        }
+
         if (isset($this->JsonApi)) {
             $this->JsonApi->setConfig('resourceTypes', [$this->objectType->name]);
         }
@@ -123,10 +128,6 @@ class ObjectsController extends ResourcesController
             if ($this->objectType->is_abstract) {
                 // Refuse to save an abstract object type.
                 throw new ForbiddenException(__d('bedita', 'Abstract object types cannot be instantiated'));
-            }
-            if (!$this->objectType->enabled) {
-                // Refuse to save a disabled object type.
-                throw new ForbiddenException(__d('bedita', 'Disabled object types cannot be instantiated'));
             }
 
             $entity = $this->Table->newEntity();

--- a/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
@@ -123,22 +123,6 @@ class HomeControllerTest extends IntegrationTestCase
                             'object_type' => true,
                         ],
                     ],
-                    '/news' => [
-                        'href' => 'http://api.example.com/news',
-                        'hints' => [
-                            'allow' => [
-                                'GET', 'POST', 'PATCH', 'DELETE'
-                            ],
-                            'formats' => [
-                                'application/json',
-                                'application/vnd.api+json'
-                            ],
-                            'display' => [
-                                'label' => 'News',
-                            ],
-                            'object_type' => true,
-                        ],
-                    ],
                     '/locations' => [
                         'href' => 'http://api.example.com/locations',
                         'hints' => [

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -729,7 +729,7 @@ class ObjectsControllerTest extends IntegrationTestCase
      *
      * @return void
      *
-     * @covers ::index()
+     * @covers ::initialize()
      */
     public function testAddNotEnabled()
     {
@@ -740,15 +740,15 @@ class ObjectsControllerTest extends IntegrationTestCase
             ],
         ];
         $expected = [
-            'status' => '403',
-            'title' => 'Disabled object types cannot be instantiated',
+            'status' => '404',
+            'title' => 'A route matching "/news" could not be found.',
         ];
 
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
         $this->post('/news', json_encode(compact('data')));
         $result = json_decode((string)$this->_response->getBody(), true);
 
-        $this->assertResponseCode(403);
+        $this->assertResponseCode(404);
         $this->assertContentType('application/vnd.api+json');
         static::assertArrayHasKey('error', $result);
         static::assertArraySubset($expected, $result['error']);
@@ -773,7 +773,7 @@ class ObjectsControllerTest extends IntegrationTestCase
         ];
 
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
-        $this->post('/news', json_encode(compact('data')));
+        $this->post('/profiles', json_encode(compact('data')));
 
         $this->assertResponseCode(409);
         $this->assertContentType('application/vnd.api+json');
@@ -842,7 +842,7 @@ class ObjectsControllerTest extends IntegrationTestCase
         $this->assertEquals('title one', TableRegistry::get('Documents')->get(2)->get('title'));
 
         $this->configRequestHeaders('PATCH', $authHeader);
-        $this->patch('/news/3', json_encode(compact('data')));
+        $this->patch('/profiles/3', json_encode(compact('data')));
 
         $this->assertResponseCode(409);
         $this->assertContentType('application/vnd.api+json');


### PR DESCRIPTION
This PR fixes 2 problems on `disabled` object types:

1. in `/home` endpoint disabled object types must not appear
2. trying to access a disabled endpoint should cause a `404` response 
