### PR TITLE
Enable filter on multiple associated items by id

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -228,6 +228,18 @@ class FilterQueryStringTest extends IntegrationTestCase
                     '5',
                 ],
             ],
+            'usersFilterRole' => [
+                '/users?filter[roles]=1',
+                [
+                    '1',
+                ],
+            ],
+            'usersFilterRoles' => [
+                '/users?filter[roles][]=1&filter[roles][]=2',
+                [
+                    '1',
+                ],
+            ],
             'here2' => [
                 '/objects?q=here',
                 [

--- a/plugins/BEdita/Core/src/Model/Action/ListEntitiesAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListEntitiesAction.php
@@ -104,11 +104,11 @@ class ListEntitiesAction extends BaseAction
             if ($this->Table->associations()->has($camelizedKey)) {
                 // Associated match (primary key only).
                 $target = $this->Table->association($camelizedKey)->getTarget();
-                $targetPrimaryKey = array_map(
-                    [$target, 'aliasField'],
-                    (array)$target->getPrimaryKey()
-                );
-                $conditions = array_combine($targetPrimaryKey, (array)$value);
+                $targetPrimaryKey = $target->aliasField($target->getPrimaryKey());
+                if (is_array($value)) {
+                    $targetPrimaryKey .= ' IN';
+                }
+                $conditions = [$targetPrimaryKey => $value];
 
                 $query = $query
                     ->distinct(array_map(

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListEntitiesActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListEntitiesActionTest.php
@@ -137,6 +137,12 @@ class ListEntitiesActionTest extends TestCase
                 ],
                 'fake_articles=1',
             ],
+            'associationList' => [
+                [
+                    ['id' => 1, 'name' => 'cat', 'legs' => 4],
+                ],
+                ['fake_articles' => [1, 2] ],
+            ],
             'inheritedField' => [
                 [
                     ['id' => 1, 'name' => 'cat', 'legs' => 4, 'subclass' => 'Eutheria'],

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListEntitiesActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListEntitiesActionTest.php
@@ -170,7 +170,12 @@ class ListEntitiesActionTest extends TestCase
             ],
             'associationList' => [
                 [
-                    ['id' => 1, 'name' => 'cat', 'legs' => 4],
+                    [
+                        'id' => 1,
+                        'name' => 'cat',
+                        'legs' => 4,
+                        'updated_at' => new Time('2018-02-20 09:50:00'),
+                    ],
                 ],
                 ['fake_articles' => [1, 2] ],
             ],


### PR DESCRIPTION
This PR enables filters on associated items using lists.

`GET /users?filter[roles]=1` lists users having associated role with id=1, already works.

With this PR it will also be possible:
* `GET /users?filter[roles][]=1&filter[roles][]=2` lists users having associated role with id=1 or id=2

This will work for every relation, suppose we have `locations` **described_by** `documents`

 * `GET /locations?filter[described_by][]=11&filter[described_by][]=12` will list locations having a `documents` with id=11 or id=12 related with `described_by`
