### PR TITLE
Avoid `NotFoundException` on SQlite 

### DIFF
--- a/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
+++ b/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
@@ -218,7 +218,7 @@ class EndpointAuthorize extends BaseAuthorize
             $this->endpoint = $Endpoints->newEntity(
                 [
                     'name' => $endpointName,
-                    'enabled' => true,
+                    'enabled' => 1,
                 ],
                 ['validate' => false]
             );

--- a/plugins/BEdita/API/tests/TestCase/Auth/EndpointAuthorizeTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/EndpointAuthorizeTest.php
@@ -148,6 +148,18 @@ class EndpointAuthorizeTest extends TestCase
                 1,
                 new Uri('/auth'),
             ],
+            '/documents' => [
+                new Endpoint(
+                    [
+                        'name' => 'documents',
+                        'enabled' => true
+                    ],
+                    [
+                        'source' => 'Endpoints'
+                    ]
+                ),
+                new Uri('/documents'),
+            ],
             '/home/sweet/home' => [
                 2,
                 new Uri('/home/sweet/home'),
@@ -179,7 +191,7 @@ class EndpointAuthorizeTest extends TestCase
             '/disabled/endpoint' => [
                 new NotFoundException('Resource not found.'),
                 new Uri('/disabled/endpoint'),
-            ]
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR fixes an error on SQlite

If an *endpoint* is not in `endpoints` table a `NotFoundException` is thrown on every call

A test case has been added in `EndpointAuthorizeTest.php`
