### PR TITLE
Avoid errors on blank `email`

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
@@ -601,4 +601,32 @@ class UsersControllerTest extends IntegrationTestCase
         $this->assertContentType('application/vnd.api+json');
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * Test empty `email` case.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testEmptyEmail()
+    {
+        $data = [
+            'type' => 'users',
+            'attributes' => [
+                'username' => 'gustavo_supporto',
+                'password_hash' => 'help me!',
+                'email' => '',
+            ],
+        ];
+
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $this->post('/users', json_encode(compact('data')));
+
+        $this->assertResponseCode(201);
+
+        $user = TableRegistry::get('Users')->get(11);
+        static::assertEquals('gustavo_supporto', $user['username']);
+        static::assertNull($user['email']);
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
@@ -15,6 +15,8 @@ namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Model\Validation\ProfilesValidator;
 use BEdita\Core\ORM\Inheritance\Table;
+use Cake\Datasource\EntityInterface;
+use Cake\Event\Event;
 use Cake\ORM\RulesChecker;
 
 /**
@@ -89,5 +91,19 @@ class ProfilesTable extends Table
         $rules->add($rules->isUnique(['email']));
 
         return $rules;
+    }
+
+    /**
+     * Before save checks: if `email` is empty set it to NULL to avoid unique constraint errors
+     *
+     * @param \Cake\Event\Event $event The beforeSave event that was fired
+     * @param \Cake\Datasource\EntityInterface $entity the entity that is going to be saved
+     * @return void
+     */
+    public function beforeSave(Event $event, EntityInterface $entity)
+    {
+        if (empty($entity->get('email'))) {
+            $entity->set('email', null);
+        }
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
@@ -39,6 +39,8 @@ class ProfilesTableTest extends TestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.property_types',
+        'plugin.BEdita/Core.properties',
         'plugin.BEdita/Core.objects',
         'plugin.BEdita/Core.profiles',
         'plugin.BEdita/Core.users',
@@ -184,6 +186,8 @@ class ProfilesTableTest extends TestCase
             'publish_start',
             'publish_end',
             'type',
+            'another_birthdate',
+            'another_surname',
         ];
 
         sort($expectedProperties);
@@ -219,5 +223,27 @@ class ProfilesTableTest extends TestCase
                 continue;
             }
         }
+    }
+
+    /**
+     * Test `beforeSave` method.
+     *
+     * @return void
+     * @covers ::beforeSave()
+     */
+    public function testBeforeSave()
+    {
+        $data = [
+            'name' => 'Gustavo',
+            'surname' => 'Supporto',
+            'email' => '',
+        ];
+
+        $profile = $this->Profiles->newEntity($data);
+        $profile->type = 'profiles';
+
+        $success = $this->Profiles->save($profile);
+        static::assertTrue((bool)$success);
+        static::assertNull($success->get('email'));
     }
 }


### PR DESCRIPTION
This PR fixes #1423 

A simple `beforeSave` on `ProfilesTable` has been introduced in order to avoid *blank* `email` field data causing unique constraint errors.
