### PR TITLE
Chore: LocalAdapter path + test

### DIFF
--- a/plugins/BEdita/Core/src/Filesystem/Adapter/LocalAdapter.php
+++ b/plugins/BEdita/Core/src/Filesystem/Adapter/LocalAdapter.php
@@ -30,7 +30,7 @@ class LocalAdapter extends FilesystemAdapter
      */
     protected $_defaultConfig = [
         'baseUrl' => null,
-        'path' => WWW_ROOT . DS . 'files',
+        'path' => WWW_ROOT . '_files',
         'writeFlags' => LOCK_EX,
         'linkHandling' => Local::DISALLOW_LINKS,
         'permissions' => [],
@@ -44,7 +44,7 @@ class LocalAdapter extends FilesystemAdapter
     {
         $success = parent::initialize($config);
 
-        if (empty($this->_config['baseUrl']) && strpos($this->getConfig('path'), WWW_ROOT . DS) === 0) {
+        if (empty($this->_config['baseUrl']) && strpos($this->getConfig('path'), WWW_ROOT) === 0) {
             // Files are stored within the document root, so base URL can be automatically detected if not already set.
             $path = str_replace(DS, '/', substr($this->getConfig('path'), strlen(WWW_ROOT)));
             $this->setConfig('baseUrl', Router::url($path, true));

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/Adapter/LocalAdapterTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/Adapter/LocalAdapterTest.php
@@ -23,6 +23,24 @@ use League\Flysystem\Adapter\Local;
  */
 class LocalAdapterTest extends TestCase
 {
+    /**
+     * Temporary test files path, removed after test
+     * @var string
+     */
+    const FILES_PATH = WWW_ROOT . 'static-files' . DS . 'subdir';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        if (file_exists(self::FILES_PATH)) {
+            rmdir(self::FILES_PATH);
+            rmdir(WWW_ROOT . 'static-files');
+        }
+
+        parent::tearDown();
+    }
 
     /**
      * Test adapter initialization.
@@ -35,7 +53,7 @@ class LocalAdapterTest extends TestCase
     {
         $fullBaseUrl = 'http://example.org/base';
         $expectedBaseUrl = 'http://example.org/base/static-files/subdir';
-        $path = WWW_ROOT . DS . 'static-files/subdir';
+        $path = self::FILES_PATH;
         $expectedPublicUrl = 'http://example.org/base/static-files/subdir/myObject/image.png';
         $objectPath = '/myObject/image.png';
 
@@ -58,7 +76,7 @@ class LocalAdapterTest extends TestCase
     public function testBuildAdapter()
     {
         $config = [
-            'path' => WWW_ROOT . DS . 'static-files/subdir',
+            'path' => self::FILES_PATH,
         ];
 
         $adapter = new LocalAdapter();


### PR DESCRIPTION
This PR fixes default local adapter path configuration using `webroot/_files` as default and avoiding double slashes `//`

Bonus track: temporary folders created in testcase are removed after test execution.
