### PR TITLE
Login authorization

### DIFF
--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -103,6 +103,10 @@ class LoginController extends AppController
         if (!$user) {
             throw new UnauthorizedException(__('Login not successful'));
         }
+        // Check endpoint permission on `/auth`
+        if (!$this->Auth->isAuthorized($user)) {
+            throw new UnauthorizedException(__('Login not authorized'));
+        }
 
         $user = $this->reducedUserData($user);
         $jwtMeta = $this->jwtTokens($user);

--- a/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
@@ -139,22 +139,21 @@ class LoginControllerTest extends IntegrationTestCase
     }
 
     /**
-     * Test login authorization.
+     * Test login ok but authorization denied.
      *
      * @return void
      *
      * @covers ::login()
      */
-    public function testLoginAuthorization()
+    public function testLoginAuthorizationDenied()
     {
         // Add role id 2 to user id 5
         $table = TableRegistry::get('RolesUsers');
         $entity = $table->newEntity(['user_id' => 5, 'role_id' => 2]);
         $table->saveOrFail($entity);
 
-        // Permissions on endpoint `auth` for application id 2 amd role 2
-        // 0b0001 --> write NO, read MINE
-        // POST /auth on for role 2 on application 2 MUST fail
+        // Permissions on endpoint `/auth` for application id 2 and role 2 is 0b0001 --> write NO, read MINE
+        // POST /auth with role id 2 on application id 2 MUST fail
         CurrentApplication::setApplication(TableRegistry::get('Applications')->get(2));
 
         $this->configRequestHeaders('POST', ['Content-Type' => 'application/json']);

--- a/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
@@ -15,6 +15,7 @@ namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
 use BEdita\Core\Model\Action\SaveEntityAction;
+use BEdita\Core\State\CurrentApplication;
 use Cake\I18n\Time;
 use Cake\ORM\TableRegistry;
 
@@ -135,6 +136,35 @@ class LoginControllerTest extends IntegrationTestCase
         $this->post('/auth', json_encode(['username' => 'first user', 'password' => 'wrongPassword']));
 
         $this->assertResponseCode(400);
+    }
+
+    /**
+     * Test login authorization.
+     *
+     * @return void
+     *
+     * @covers ::login()
+     */
+    public function testLoginAuthorization()
+    {
+        // Add role id 2 to user id 5
+        $table = TableRegistry::get('RolesUsers');
+        $entity = $table->newEntity(['user_id' => 5, 'role_id' => 2]);
+        $table->saveOrFail($entity);
+
+        // Permissions on endpoint `auth` for application id 2 amd role 2
+        // 0b0001 --> write NO, read MINE
+        // POST /auth on for role 2 on application 2 MUST fail
+        CurrentApplication::setApplication(TableRegistry::get('Applications')->get(2));
+
+        $this->configRequestHeaders('POST', ['Content-Type' => 'application/json']);
+
+        $this->post('/auth', json_encode(['username' => 'second user', 'password' => 'password2']));
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(401);
+        static::assertArrayHasKey('error', $result);
+        static::assertEquals('Login not authorized', $result['error']['title']);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/Fixture/EndpointPermissionsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/EndpointPermissionsFixture.php
@@ -56,8 +56,8 @@ class EndpointPermissionsFixture extends TestFixture
         [
             'endpoint_id' => 1,
             'application_id' => 2,
-            'role_id' => null,
-            'permission' => 0b1101,
+            'role_id' => 2,
+            'permission' => 0b0001,
         ],
     ];
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointPermissionsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointPermissionsTableTest.php
@@ -309,7 +309,7 @@ class EndpointPermissionsTableTest extends TestCase
     {
         return [
             'first' => [
-                4,
+                3,
                 1,
             ],
             'second' => [
@@ -317,7 +317,7 @@ class EndpointPermissionsTableTest extends TestCase
                 2,
             ],
             'null' => [
-                3,
+                2,
                 '',
             ],
             'first,second' => [


### PR DESCRIPTION
This PR adds proper authorization check on `POST /auth` aka `login`operations.

Upon `login` no authorization check is done via `AuthComponent` beacause user identification is done directly in LoginController and not via `Authorization` header.
We need to check authorization after identification.
