### PR TITLE
Roles on signup

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -425,9 +425,12 @@ return [
      *
      * - `requireActivation` - boolean (default: true) - Are new users required to verify their contact method
      *      before being "activated"?
+     * - 'roles' - allowed role names on user signup (this config should be set normally at application level),
+     *      requested user roles MUST be included in this array
      */
     'Signup' => [
         // 'requireActivation' => true,
+        'roles' => [],
     ],
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -91,9 +91,10 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
 
         // operations are not in transaction because AsyncJobs could use a different connection
         $user = $this->createUser($data['data']);
-        // add roles to user, with validity check
-        $this->addRoles($user, $data['data']);
         try {
+            // add roles to user, with validity check
+            $this->addRoles($user, $data['data']);
+
             $job = $this->createSignupJob($user);
             $activationUrl = $this->getActivationUrl($job, $data['data']);
 

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -196,15 +196,15 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
         if (empty($data['roles'])) {
             return;
         }
-        $relatedEntities = $this->loadRoles($data['roles']);
+        $roles = $this->loadRoles($data['roles']);
         $association = $this->Users->associations()->getByProperty('roles');
-        $association->link($entity, $relatedEntities);
+        $association->link($entity, $roles);
     }
 
     /**
      * Load requested roles entities with validation
      *
-     * @param array $roles Requested role names or ids
+     * @param array $roles Requested role names
      * @return \BEdita\Core\Model\Entity\Role[] requested role entities
      * @throws \Cake\Network\Exception\BadRequestException When role validation fails
      */
@@ -212,15 +212,10 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
     {
         $entities = [];
         $allowed = (array)Configure::read('Signup.roles');
-        foreach ($roles as $value) {
-            $role = null;
-            if (is_numeric($value)) {
-                $role = $this->Roles->get($value);
-            } else {
-                $role = $this->Roles->find()->where(['name' => $value])->first();
-            }
-            if (RolesTable::ADMIN_ROLE === $role->get('id') || !in_array($role->get('name'), $allowed)) {
-                throw new BadRequestException(__d('bedita', 'Role "{0}" not allowed on signup', [$role->get('name')]));
+        foreach ($roles as $name) {
+            $role = $this->Roles->find()->where(compact('name'))->first();
+            if (RolesTable::ADMIN_ROLE === $role->get('id') || !in_array($name, $allowed)) {
+                throw new BadRequestException(__d('bedita', 'Role "{0}" not allowed on signup', [$name]));
             }
             $entities[] = $role;
         }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -45,6 +45,7 @@ class SignupUserActionTest extends TestCase
         'plugin.BEdita/Core.users',
         'plugin.BEdita/Core.async_jobs',
         'plugin.BEdita/Core.roles',
+        'plugin.BEdita/Core.trees',
         'plugin.BEdita/Core.roles_users',
         'plugin.BEdita/Core.external_auth',
         'plugin.BEdita/Core.auth_providers',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -24,6 +24,7 @@ use Cake\Network\Exception\BadRequestException;
 use Cake\Network\Exception\InternalErrorException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 
 /**
  * @covers \BEdita\Core\Model\Action\SignupUserAction
@@ -36,10 +37,12 @@ class SignupUserActionTest extends TestCase
      * @var array
      */
     public $fixtures = [
+        'plugin.BEdita/Core.property_types',
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.properties',
         'plugin.BEdita/Core.objects',
         'plugin.BEdita/Core.profiles',
         'plugin.BEdita/Core.users',
-        'plugin.BEdita/Core.object_types',
         'plugin.BEdita/Core.async_jobs',
         'plugin.BEdita/Core.roles',
         'plugin.BEdita/Core.roles_users',
@@ -256,5 +259,83 @@ class SignupUserActionTest extends TestCase
             static::assertSame(1, $eventDispatched, 'Event not dispatched');
             static::assertFalse(TableRegistry::get('Users')->exists(['username' => 'testsignup']));
         }
+    }
+
+    /**
+     * Data provider for `testRoles()`
+     *
+     * @return array
+     */
+    public function rolesProvider()
+    {
+        return [
+            'admin' => [
+                true,
+                [
+                    'data' => [
+                        'username' => 'testsignup',
+                        'password' => 'testsignup',
+                        'email' => 'test.signup@example.com',
+                        'roles' => ['second role'],
+                        'activation_url' => 'http://sample.com?confirm=true',
+                        'redirect_url' => 'http://sample.com/ok',
+                    ],
+                ],
+                ['second role'],
+            ],
+            'failNoRoles' => [
+                new BadRequestException('Role "second role" not allowed on signup'),
+                [
+                    'data' => [
+                        'username' => 'testsignup',
+                        'password' => 'testsignup',
+                        'email' => 'test.signup@example.com',
+                        'roles' => ['second role'],
+                        'activation_url' => 'http://sample.com?confirm=true',
+                        'redirect_url' => 'http://sample.com/ok',
+                    ],
+                ],
+                [],
+            ],
+            'failAdminRole' => [
+                new BadRequestException('Role "first role" not allowed on signup'),
+                [
+                    'data' => [
+                        'username' => 'testsignup',
+                        'password' => 'testsignup',
+                        'email' => 'test.signup@example.com',
+                        'roles' => ['first role'],
+                        'activation_url' => 'http://sample.com?confirm=true',
+                        'redirect_url' => 'http://sample.com/ok',
+                    ],
+                ],
+                ['first role'],
+            ],
+        ];
+    }
+
+    /**
+     * Test `addRoles` and `loadRoles` methods
+     *
+     * @param bool|\Exception $expected Expected result.
+     * @param array $data Action data.
+     * @param array $allowed Allowe roles to set in configuration.
+     *
+     * @dataProvider rolesProvider
+     * @return void
+     */
+    public function testRoles($expected, array $data, array $allowed)
+    {
+        Configure::write('Signup.roles', $allowed);
+        if ($expected instanceof \Exception) {
+            static::expectException(get_class($expected));
+            static::expectExceptionMessage($expected->getMessage());
+        }
+
+        $action = new SignupUserAction();
+        $result = $action($data);
+
+        static::assertTrue((bool)$result);
+        static::assertSame($data['data']['roles'], Hash::extract($result->get('roles'), '{n}.name'));
     }
 }


### PR DESCRIPTION
This PR fixes #1438 

* on `/signup` request using a `roles` array it is now possible to set roles on a newly created user
* requested roles MUST be in `Signup.roles` config and cannot contain `admin` role

Note: `SignupUserActionTest` class needs a refactor since there are many methods and only global  `@covers` at class level  => we should cover as much as possible single methods...
