### PR TITLE
#1431 feat: write operations on parents relationships for objects

### DIFF
--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -57,6 +57,15 @@ class ObjectsController extends ResourcesController
     /**
      * {@inheritDoc}
      */
+    protected $_defaultConfig = [
+        'allowedAssociations' => [
+            'parents' => ['folders'],
+        ],
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
     public function initialize()
     {
         if (in_array($this->request->getParam('action'), ['related', 'relationships'])) {
@@ -68,8 +77,6 @@ class ObjectsController extends ResourcesController
 
             $this->setConfig(sprintf('allowedAssociations.%s', $name), $allowedTypes);
         }
-
-        parent::initialize();
 
         $type = $this->request->getParam('object_type', $this->request->getParam('controller'));
         try {
@@ -93,8 +100,10 @@ class ObjectsController extends ResourcesController
             throw new MissingRouteException(['url' => $this->request->getRequestTarget()]);
         }
 
-        if (isset($this->JsonApi)) {
-            $this->JsonApi->setConfig('resourceTypes', [$this->objectType->name]);
+        parent::initialize();
+
+        if (isset($this->JsonApi) && $this->request->getParam('action') !== 'relationships') {
+            $this->JsonApi->setConfig('resourceTypes', [$this->objectType->name], false);
         }
     }
 

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -85,7 +85,8 @@ abstract class ResourcesController extends AppController
             if ($this->request->getParam('action') === 'relationships') {
                 $this->JsonApi->setConfig(
                     'resourceTypes',
-                    $this->getConfig(sprintf('allowedAssociations.%s', $this->request->getParam('relationship')))
+                    $this->getConfig(sprintf('allowedAssociations.%s', $this->request->getParam('relationship'))),
+                    false
                 );
                 $this->JsonApi->setConfig('clientGeneratedIds', true);
             }

--- a/plugins/BEdita/API/src/Controller/UsersController.php
+++ b/plugins/BEdita/API/src/Controller/UsersController.php
@@ -30,6 +30,7 @@ class UsersController extends ObjectsController
     protected $_defaultConfig = [
         'allowedAssociations' => [
             'roles' => ['roles'],
+            'parents' => ['folders'],
         ],
     ];
 }

--- a/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Api\Test\IntegrationTest;
+
+use BEdita\API\TestSuite\IntegrationTestCase;
+use Cake\ORM\TableRegistry;
+use Cake\Utility\Hash;
+
+/**
+ * Test operations on `parents` relationships.
+ *
+ * @coversNothing
+ */
+class ParentsRelationshipTest extends IntegrationTestCase
+{
+
+    /**
+     * Keep the TreesTable instance
+     *
+     * @var \BEdita\Core\Model\Table\TreesTable
+     */
+    protected $Trees = null;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->Trees = TableRegistry::get('Trees');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        $this->Trees = null;
+    }
+
+    /**
+     * Undocumented function
+     *
+     * @return void
+     */
+    public function testParents()
+    {
+        $authHeader = $this->getUserAuthHeader();
+
+        // create documents
+        $data = [
+            'type' => 'documents',
+            'attributes' => [
+                'title' => 'Doc here',
+                'description' => 'Please put me on tree',
+            ],
+        ];
+        $this->configRequestHeaders('POST', $authHeader);
+        $this->post('/documents', json_encode(compact('data')));
+        $this->assertResponseCode(201);
+        $this->assertContentType('application/vnd.api+json');
+
+        $docId = $this->lastObjectId();
+        static::assertEquals(0, $this->countTrees($docId));
+
+        // POST: add 3 folders as parents relationships
+        $foldersTable = TableRegistry::get('Folders');
+        $folders = $foldersTable
+            ->find('list', [
+                'keyField' => 'uname',
+                'valueField' => 'id'
+            ])
+            ->where(['object_type_id' => $foldersTable->objectType()->id])
+            ->order(['id' => 'ASC'])
+            ->limit(3)
+            ->toArray();
+
+        $data = [];
+        foreach ($folders as $folderId) {
+            $data[] = [
+                'type' => 'folders',
+                'id' => "$folderId",
+            ];
+        }
+
+        $relationshipsEndpoint = sprintf('/documents/%s/relationships/parents', $docId);
+        $relatedEndpoint = sprintf('/documents/%s/parents', $docId);
+
+        $this->configRequestHeaders('POST', $authHeader);
+        $this->post($relationshipsEndpoint, json_encode(compact('data')));
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals(3, $this->countTrees($docId));
+
+        // GET: get parents of doc created
+        $this->configRequestHeaders();
+        $this->get($relatedEndpoint);
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        $body = json_decode((string)$this->_response->getBody(), true);
+        static::assertCount(3, $body['data']);
+        $parentIds = Hash::extract($body['data'], '{n}.id');
+        sort($parentIds);
+        static::assertEquals(array_values($folders), $parentIds);
+
+        // PATCH: patch parents relationships removing one item
+        $this->configRequestHeaders('PATCH', $authHeader);
+        array_pop($data);
+        $this->patch($relationshipsEndpoint, json_encode(compact('data')));
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals(2, $this->countTrees($docId));
+
+        $this->configRequestHeaders();
+        $this->get($relatedEndpoint);
+        $body = json_decode((string)$this->_response->getBody(), true);
+        static::assertCount(2, $body['data']);
+        $parentIds = Hash::extract($body['data'], '{n}.id');
+        sort($parentIds);
+        static::assertEquals(Hash::extract($data, '{n}.id'), $parentIds);
+
+        // DELETE: delete all remining parents relationships
+        $this->configRequestHeaders('DELETE', $authHeader);
+        // Cannot use `IntegrationTestCase::delete()`, as it does not allow sending payload with the request.
+        $this->_sendRequest($relationshipsEndpoint, 'DELETE', json_encode(compact('data')));
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals(0, $this->countTrees($docId));
+
+        $this->configRequestHeaders();
+        $this->get($relatedEndpoint);
+        $body = json_decode((string)$this->_response->getBody(), true);
+        static::assertCount(0, $body['data']);
+    }
+
+    /**
+     * Return the count of an object on tree
+     *
+     * @param int $objectId The object id to count
+     * @return int
+     */
+    private function countTrees($objectId)
+    {
+        return $this->Trees
+            ->find()
+            ->where(['object_id' => $objectId])
+            ->count();
+    }
+}

--- a/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
@@ -147,6 +147,26 @@ class ParentsRelationshipTest extends IntegrationTestCase
     }
 
     /**
+     * Test not valid type for parents relationship
+     *
+     * @return void
+     */
+    public function testNotAllowedResourceType()
+    {
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $data = [
+            [
+                'type' => 'profiles',
+                'id' => '4', // <= he is Gustavo!
+            ],
+        ];
+        $this->post('/documents/2/relationships/parents', json_encode(compact('data')));
+        $this->assertResponseCode(409);
+        $body = json_decode((string)$this->_response->getBody(), true);
+        static::assertEquals('Unsupported resource type', $body['error']['title']);
+    }
+
+    /**
      * Return the count of an object on tree
      *
      * @param int $objectId The object id to count

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -2320,12 +2320,14 @@ class ObjectsControllerTest extends IntegrationTestCase
     /**
      * Test `resourceTypes` config of `jsonApiComponent` set in `initialize()`
      *
+     * @param array $expected The expected result
+     * @param array $requestData The data needed to create the request
      * @return void
      *
      * @dataProvider resourceTypeProvider
      * @covers ::initialize()
      */
-    public function testInitializeResourceTypes($expected, $requestData)
+    public function testInitializeResourceTypes(array $expected, array $requestData)
     {
         $request = new ServerRequest($requestData + [
             'environment' => [

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -2335,6 +2335,8 @@ class ObjectsControllerTest extends IntegrationTestCase
         $controller = new ObjectsController($request);
         $resourceTypes = $controller->JsonApi->getConfig('resourceTypes');
 
+        sort($expected);
+        sort($resourceTypes);
         static::assertEquals($expected, array_values($resourceTypes));
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -12,8 +12,10 @@
  */
 namespace BEdita\API\Test\TestCase\Controller;
 
+use BEdita\API\Controller\ObjectsController;
 use BEdita\API\TestSuite\IntegrationTestCase;
 use BEdita\API\Test\TestConstants;
+use Cake\Http\ServerRequest;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -2273,5 +2275,66 @@ class ObjectsControllerTest extends IntegrationTestCase
             'bedita',
             'You are not authorized to manage an object relationship to streams, please update stream relationship to objects instead'
         ));
+    }
+
+    /**
+     * Data provider fo `testInitializeResourceTypes()`
+     *
+     * @return array
+     */
+    public function resourceTypeProvider()
+    {
+        return [
+            'mainResource' => [
+                ['documents'],
+                [
+                    'params' => [
+                        'controller' => 'Documents',
+                        'action' => 'index',
+                    ],
+                ],
+            ],
+            'beditaRelation' => [
+                ['documents', 'profiles'],
+                [
+                    'params' => [
+                        'controller' => 'Documents',
+                        'action' => 'relationships',
+                        'relationship' => 'test',
+                    ],
+                ],
+            ],
+            'parentRelationships' => [
+                ['folders'],
+                [
+                    'params' => [
+                        'controller' => 'Documents',
+                        'action' => 'relationships',
+                        'relationship' => 'parents',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `resourceTypes` config of `jsonApiComponent` set in `initialize()`
+     *
+     * @return void
+     *
+     * @dataProvider resourceTypeProvider
+     * @covers ::initialize()
+     */
+    public function testInitializeResourceTypes($expected, $requestData)
+    {
+        $request = new ServerRequest($requestData + [
+            'environment' => [
+                'HTTP_ACCEPT' => 'application/vnd.api+json',
+            ],
+        ]);
+        $controller = new ObjectsController($request);
+        $resourceTypes = $controller->JsonApi->getConfig('resourceTypes');
+
+        static::assertEquals($expected, array_values($resourceTypes));
     }
 }


### PR DESCRIPTION
This PR introduces API write operations for `parents` relationship as described in #1431

`POST/PATCH/DELETE /:object_type/:id/relationships/parents`

The `parent` relationship of `folders` object type will be treated in another PR.

A little refactor of `ObjectsController::initialize()` and `ResourceController::initialize()` methods was done to limit the `resourceType` config set for `JsonApiComponent` at the right types.




