### PR TITLE
Allow the use of uname instead of id for objects API

### DIFF
--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -185,6 +185,7 @@ class ObjectsController extends ResourcesController
     {
         $this->request->allowMethod(['get', 'patch', 'delete']);
 
+        $id = TableRegistry::get('Objects')->getId($id);
         $include = $this->request->getQuery('include');
         $contain = $include ? $this->prepareInclude($include) : [];
 
@@ -230,7 +231,7 @@ class ObjectsController extends ResourcesController
         $this->request->allowMethod(['get']);
 
         $relationship = $this->request->getParam('relationship');
-        $relatedId = $this->request->getParam('related_id');
+        $relatedId = TableRegistry::get('Objects')->getId($this->request->getParam('related_id'));
 
         $association = $this->findAssociation($relationship);
         $filter = (array)$this->request->getQuery('filter') + array_filter(['query' => $this->request->getQuery('q')]);
@@ -255,7 +256,7 @@ class ObjectsController extends ResourcesController
      */
     public function relationships()
     {
-        $id = $this->request->getParam('id');
+        $id = TableRegistry::get('Objects')->getId($this->request->getParam('id'));
         $relationship = $this->request->getParam('relationship');
 
         $association = $this->findAssociation($relationship);

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -206,7 +206,7 @@ class ObjectsController extends ResourcesController
 
         if ($this->request->is('patch')) {
             // Patch an existing entity.
-            if ($this->request->getData('id') !== $id) {
+            if ($this->request->getData('id') !== (string)$id) {
                 throw new ConflictException(__d('bedita', 'IDs don\'t match'));
             }
 

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -251,4 +251,28 @@ class ObjectsTable extends Table
             return $exp->eq($this->aliasField($this->CreatedByUser->getForeignKey()), LoggedUser::id());
         });
     }
+
+    /**
+     * Try to get the object `id` from `uname`.
+     *
+     * If `$uname` is numeric it returns immediately.
+     * else try to find it from `uname` field.
+     *
+     * @param int|string $uname Unique identifier for the object.
+     * @return int
+     */
+    public function getId($uname)
+    {
+        if (is_numeric($uname)) {
+            return (int)$uname;
+        }
+
+        $result = $this->find()
+            ->select($this->aliasField('id'))
+            ->where([$this->aliasField('uname') => $uname])
+            ->enableHydration(false)
+            ->firstOrFail();
+
+        return $result['id'];
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -399,4 +399,52 @@ class ObjectsTableTest extends TestCase
 
         static::assertInstanceOf(ObjectEntity::class, $result);
     }
+
+    /**
+     * Data provider for `testGetId()`
+     *
+     * @return array
+     */
+    public function getIdProvider()
+    {
+        return [
+            'id' => [1, 1],
+            'idString' => [1, '1'],
+            'uname' => [1, 'first-user'],
+            'notFound' => [
+                new RecordNotFoundException('Record not found in table "objects"'),
+                'this-uname-doesnt-exist',
+            ],
+            'null' => [
+                new RecordNotFoundException('Record not found in table "objects"'),
+                null,
+            ],
+            'emptyString' => [
+                new RecordNotFoundException('Record not found in table "objects"'),
+                '',
+            ],
+        ];
+    }
+
+    /**
+     * Test `getId()`
+     *
+     * @param mixed $expected The expected result.
+     * @param int|string $uname The unique object identifier.
+     * @return void
+     *
+     * @dataProvider getIdProvider
+     * @covers ::getId()
+     */
+    public function testGetId($expected, $uname)
+    {
+        if ($expected instanceof \Exception) {
+            $this->expectException(get_class($expected));
+            $this->expectExceptionCode($expected->getCode());
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+
+        $id = $this->Objects->getId($uname);
+        static::assertEquals($expected, $id);
+    }
 }


### PR DESCRIPTION
This PR allows the use of `uname` instead of `id` for API requests on objects endpoints.

```http
GET /documents/doc-uname
GET /documents/doc-uname/:relationship
GET /documents/doc-uname/relationships/:relationship
```
