### PR TITLE
Add default `title` for profiles and users

### DIFF
--- a/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
@@ -110,7 +110,7 @@ class ProfilesTable extends Table
         if (empty($entity->get('email'))) {
             $entity->set('email', null);
         }
-        if (empty($entity->get('title')) && (!empty($entity->get('name')) || !empty($entity->get('surname')))) {
+        if (!$entity->has('title') && ($entity->has('name') || $entity->has('surname'))) {
             $title = sprintf('%s %s', (string)Hash::get($entity, 'name', ''), (string)Hash::get($entity, 'surname', ''));
             $entity->set('title', $title);
         }

--- a/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
@@ -18,6 +18,7 @@ use BEdita\Core\ORM\Inheritance\Table;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\ORM\RulesChecker;
+use Cake\Utility\Hash;
 
 /**
  * Profiles Model
@@ -57,6 +58,8 @@ class ProfilesTable extends Table
 
         $this->addBehavior('BEdita/Core.CustomProperties');
 
+        $this->addBehavior('BEdita/Core.DataCleanup');
+
         $this->extensionOf('Objects');
 
         $this->addBehavior('BEdita/Core.UniqueName', [
@@ -94,7 +97,9 @@ class ProfilesTable extends Table
     }
 
     /**
-     * Before save checks: if `email` is empty set it to NULL to avoid unique constraint errors
+     * Before save actions:
+     *  - if `email` is empty set it to NULL to avoid unique constraint errors
+     *  - on empty `title` use `name` `surname` as default
      *
      * @param \Cake\Event\Event $event The beforeSave event that was fired
      * @param \Cake\Datasource\EntityInterface $entity the entity that is going to be saved
@@ -104,6 +109,10 @@ class ProfilesTable extends Table
     {
         if (empty($entity->get('email'))) {
             $entity->set('email', null);
+        }
+        if (empty($entity->get('title')) && (!empty($entity->get('name')) || !empty($entity->get('surname')))) {
+            $title = sprintf('%s %s', (string)Hash::get($entity, 'name', ''), (string)Hash::get($entity, 'surname', ''));
+            $entity->set('title', $title);
         }
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
@@ -250,5 +250,18 @@ class ProfilesTableTest extends TestCase
         static::assertTrue((bool)$success);
         static::assertNull($success->get('email'));
         static::assertEquals('Gustavo Supporto', $success->get('title'));
+
+        $data = [
+            'title' => 'Dr. Supporto Matteo',
+            'name' => 'Matteo',
+            'surname' => 'Supporto',
+        ];
+
+        $profile = $this->Profiles->newEntity($data);
+        $profile->type = 'profiles';
+
+        $success = $this->Profiles->save($profile);
+        static::assertTrue((bool)$success);
+        static::assertEquals('Dr. Supporto Matteo', $success->get('title'));
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
@@ -249,5 +249,6 @@ class ProfilesTableTest extends TestCase
         $success = $this->Profiles->save($profile);
         static::assertTrue((bool)$success);
         static::assertNull($success->get('email'));
+        static::assertEquals('Gustavo Supporto', $success->get('title'));
     }
 }


### PR DESCRIPTION
This PR adds a default `title` like a `display name` or `fullname` field for `Profiles` and `Users` if no `title` is set.


