### PR TITLE
#1431 GET /folders/:id/parent is here

### DIFF
--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -27,6 +27,7 @@ Router::plugin(
             'streams',
             'users',
             'media',
+            'folders',
         ];
         $adminControllers = [
             'applications',

--- a/plugins/BEdita/API/src/Controller/FoldersController.php
+++ b/plugins/BEdita/API/src/Controller/FoldersController.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Controller;
+
+use BEdita\Core\Model\Action\ListRelatedFoldersAction;
+use Cake\Network\Exception\NotFoundException;
+use Cake\ORM\Association;
+
+/**
+ * Controller for `/folders` endpoint.
+ *
+ * The main aim is to bridge `parent` API relationship to `parents` BTM association.
+ *
+ * @since 4.0.0
+ */
+class FoldersController extends ObjectsController
+{
+    /**
+     * {@inheritDoc}
+     */
+    public $modelClass = 'Folders';
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_defaultConfig = [
+        'allowedAssociations' => [
+            'parent' => ['folders'],
+        ],
+    ];
+
+    /**
+     * {@inheritDoc}
+     *
+     * `parent` relationship is valid and will return `parents` association.
+     * `parents` relationship is not allowed.
+     */
+    protected function findAssociation($relationship)
+    {
+        if ($relationship === 'parents') {
+            throw new NotFoundException(__d('bedita', 'Relationship "{0}" does not exist', $relationship));
+        }
+
+        if ($relationship === 'parent') {
+            return $this->Table->association('Parents');
+        }
+
+        return parent::findAssociation($relationship);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getAvailableUrl($relationship)
+    {
+        if ($relationship === 'parent') {
+            $relationship = 'parents';
+        }
+
+        return parent::getAvailableUrl($relationship);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return \BEdita\Core\Model\Action\ListRelatedFoldersAction
+     */
+    protected function getAssociatedAction(Association $association)
+    {
+        return new ListRelatedFoldersAction(compact('association'));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Folder with Parents association allows GET and PATCH
+     */
+    protected function setRelationshipsAllowedMethods(Association $association)
+    {
+        parent::setRelationshipsAllowedMethods($association);
+
+        if ($association->getName() === 'Parents') {
+            $allowedMethods = ['get', 'patch'];
+            $this->request->allowMethod($allowedMethods);
+        }
+    }
+}

--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -1,0 +1,530 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Test\TestCase\Controller;
+
+use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\API\Test\TestConstants;
+use Cake\ORM\TableRegistry;
+use Cake\Utility\Hash;
+
+/**
+ * @coversDefaultClass \BEdita\API\Controller\FoldersController
+ */
+class FoldersControllerTest extends IntegrationTestCase
+{
+    /**
+     * Test index method.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testIndex()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/folders',
+                'first' => 'http://api.example.com/folders',
+                'last' => 'http://api.example.com/folders',
+                'prev' => null,
+                'next' => null,
+                'home' => 'http://api.example.com/home',
+            ],
+            'meta' => [
+                'pagination' => [
+                    'count' => 3,
+                    'page' => 1,
+                    'page_count' => 1,
+                    'page_items' => 3,
+                    'page_size' => 20,
+                ],
+                'schema' => [
+                    'folders' => [
+                        '$id' => 'http://api.example.com/model/schema/folders',
+                        'revision' => TestConstants::SCHEMA_REVISIONS['folders'],
+                    ],
+                ],
+            ],
+            'data' => [
+                [
+                    'id' => '11',
+                    'type' => 'folders',
+                    'attributes' => [
+                        'status' => 'on',
+                        'uname' => 'root-folder',
+                        'title' => 'Root Folder',
+                        'description' => 'first root folder',
+                        'body' => null,
+                        'extra' => null,
+                        'lang' => 'eng',
+                        'publish_start' => null,
+                        'publish_end' => null,
+                    ],
+                    'meta' => [
+                        'locked' => false,
+                        'created' => '2018-01-31T07:09:23+00:00',
+                        'modified' => '2018-01-31T08:30:00+00:00',
+                        'published' => null,
+                        'created_by' => 1,
+                        'modified_by' => 1,
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/folders/11',
+                    ],
+                    'relationships' => [
+                        'children' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/folders/11/children',
+                                'self' => 'http://api.example.com/folders/11/relationships/children',
+                            ],
+                        ],
+                        'parent' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/folders/11/parent',
+                                'self' => 'http://api.example.com/folders/11/relationships/parent',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'id' => '12',
+                    'type' => 'folders',
+                    'attributes' => [
+                        'status' => 'on',
+                        'uname' => 'sub-folder',
+                        'title' => 'Sub Folder',
+                        'description' => 'sub folder of root folder',
+                        'body' => null,
+                        'extra' => null,
+                        'lang' => 'eng',
+                        'publish_start' => null,
+                        'publish_end' => null,
+                    ],
+                    'meta' => [
+                        'locked' => false,
+                        'created' => '2018-01-31T07:09:23+00:00',
+                        'modified' => '2018-01-31T08:30:00+00:00',
+                        'published' => null,
+                        'created_by' => 1,
+                        'modified_by' => 1,
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/folders/12',
+                    ],
+                    'relationships' => [
+                        'children' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/folders/12/children',
+                                'self' => 'http://api.example.com/folders/12/relationships/children',
+                            ],
+                        ],
+                        'parent' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/folders/12/parent',
+                                'self' => 'http://api.example.com/folders/12/relationships/parent',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'id' => '13',
+                    'type' => 'folders',
+                    'attributes' => [
+                        'status' => 'on',
+                        'uname' => 'another-root-folder',
+                        'title' => 'Another Root Folder',
+                        'description' => 'second root folder',
+                        'body' => null,
+                        'extra' => null,
+                        'lang' => 'eng',
+                        'publish_start' => null,
+                        'publish_end' => null,
+                    ],
+                    'meta' => [
+                        'locked' => false,
+                        'created' => '2018-03-08T12:20:00+00:00',
+                        'modified' => '2018-03-08T12:20:00+00:00',
+                        'published' => null,
+                        'created_by' => 1,
+                        'modified_by' => 1,
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/folders/13',
+                    ],
+                    'relationships' => [
+                        'children' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/folders/13/children',
+                                'self' => 'http://api.example.com/folders/13/relationships/children',
+                            ],
+                        ],
+                        'parent' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/folders/13/parent',
+                                'self' => 'http://api.example.com/folders/13/relationships/parent',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->configRequestHeaders();
+        $this->get('/folders');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test index method.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testEmpty()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/folders',
+                'first' => 'http://api.example.com/folders',
+                'last' => 'http://api.example.com/folders',
+                'prev' => null,
+                'next' => null,
+                'home' => 'http://api.example.com/home',
+            ],
+            'meta' => [
+                'pagination' => [
+                    'count' => 0,
+                    'page' => 1,
+                    'page_count' => 1,
+                    'page_items' => 0,
+                    'page_size' => 20,
+                ],
+            ],
+            'data' => [],
+        ];
+
+        TableRegistry::get('folders')->deleteAll([]);
+
+        $this->configRequestHeaders();
+        $this->get('/folders');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test view method.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testSingle()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/folders/11',
+                'home' => 'http://api.example.com/home',
+            ],
+            'data' => [
+                'id' => '11',
+                'type' => 'folders',
+                'attributes' => [
+                    'status' => 'on',
+                    'uname' => 'root-folder',
+                    'title' => 'Root Folder',
+                    'description' => 'first root folder',
+                    'body' => null,
+                    'extra' => null,
+                    'lang' => 'eng',
+                    'publish_start' => null,
+                    'publish_end' => null,
+                ],
+                'meta' => [
+                    'locked' => false,
+                    'created' => '2018-01-31T07:09:23+00:00',
+                    'modified' => '2018-01-31T08:30:00+00:00',
+                    'published' => null,
+                    'created_by' => 1,
+                    'modified_by' => 1,
+                ],
+                'relationships' => [
+                    'children' => [
+                        'links' => [
+                            'related' => 'http://api.example.com/folders/11/children',
+                            'self' => 'http://api.example.com/folders/11/relationships/children',
+                        ],
+                    ],
+                    'parent' => [
+                        'links' => [
+                            'related' => 'http://api.example.com/folders/11/parent',
+                            'self' => 'http://api.example.com/folders/11/relationships/parent',
+                        ],
+                    ],
+                ],
+            ],
+            'meta' => [
+                'schema' => [
+                    'folders' => [
+                        '$id' => 'http://api.example.com/model/schema/folders',
+                        'revision' => TestConstants::SCHEMA_REVISIONS['folders'],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->configRequestHeaders();
+        $this->get('/folders/11');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test view method.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testMissing()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/folders/99',
+                'home' => 'http://api.example.com/home',
+            ],
+            'error' => [
+                'status' => '404',
+            ],
+        ];
+
+        $this->configRequestHeaders();
+        $this->get('/folders/99');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(404);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertArrayNotHasKey('data', $result);
+        $this->assertArrayHasKey('links', $result);
+        $this->assertArrayHasKey('error', $result);
+        $this->assertEquals($expected['links'], $result['links']);
+        $this->assertArraySubset($expected['error'], $result['error']);
+        $this->assertArrayHasKey('title', $result['error']);
+        $this->assertNotEmpty($result['error']['title']);
+    }
+
+    /**
+     * Test add method.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testAdd()
+    {
+        $data = [
+            'type' => 'folders',
+            'attributes' => [
+                'title' => 'A new folder',
+                'description' => 'Here I am',
+            ],
+        ];
+
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $this->post('/folders', json_encode(compact('data')));
+        $folderId = $this->lastObjectId();
+
+        $this->assertResponseCode(201);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertHeader('Location', 'http://api.example.com/folders/' . $folderId);
+        static::assertTrue(TableRegistry::get('Folders')->exists(['id' => $folderId]));
+    }
+
+    /**
+     * Test edit method.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testEdit()
+    {
+        $data = [
+            'id' => '11',
+            'type' => 'folders',
+            'attributes' => [
+                'title' => 'Radice',
+            ],
+        ];
+
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $this->patch('/folders/11', json_encode(compact('data')));
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals('Radice', TableRegistry::get('Folders')->get(11)->get('title'));
+        static::assertEquals('folders', TableRegistry::get('Folders')->get(11)->get('type'));
+
+        $result = json_decode((string)$this->_response->getBody(), true);
+        static::assertEquals($data['id'], $result['data']['id']);
+        static::assertEquals($data['type'], $result['data']['type']);
+        static::assertEquals($data['attributes']['title'], $result['data']['attributes']['title']);
+    }
+
+    /**
+     * Test delete method.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testDelete()
+    {
+        // TODO: how should we behave on folders delete?
+        // a. delete only folders that doesn't have another folder as child
+        // b. delete folder anyway
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * Test related method to get `parent` folder.
+     *
+     * @return void
+     *
+     * @covers ::findAssociation()
+     * @covers ::getAvailableUrl()
+     * @covers ::getAssociatedAction()
+     */
+    public function testRelatedParent()
+    {
+        $this->configRequestHeaders();
+        $this->get('/folders/12/parent');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertSame('11', $result['data']['id']);
+        static::assertSame('folders', $result['data']['type']);
+    }
+
+    /**
+     * Test that an error is returned getting `parents` folder.
+     *
+     * @return void
+     *
+     * @covers ::findAssociation()
+     * @covers ::getAvailableUrl()
+     * @covers ::getAssociatedAction()
+     */
+    public function testErrorRelatedParents()
+    {
+        $this->configRequestHeaders();
+        $this->get('/folders/12/parents');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $expected = [
+            'status' => '404',
+            'title' => 'Relationship "parents" does not exist',
+        ];
+        $this->assertResponseCode(404);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertArrayHasKey('error', $result);
+        static::assertArraySubset($expected, $result['error']);
+    }
+
+    /**
+     * Test related method to get `children` objects.
+     *
+     * @return void
+     *
+     * @covers ::findAssociation()
+     * @covers ::getAvailableUrl()
+     * @covers ::getAssociatedAction()
+     */
+    public function testRelatedChildren()
+    {
+        $this->configRequestHeaders();
+        $this->get('/folders/11/children');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $treesTable = TableRegistry::get('Trees');
+        $node = $treesTable->find()->where(['object_id' => 11])->first();
+        $children = $treesTable
+            ->find('children', ['for' => $node->id, 'direct' => true])
+            ->toArray();
+
+        // build array of ids casted to string
+        $expected = Hash::map($children, '{n}.object_id', function ($id) {
+            return (string)$id;
+        });
+        sort($expected);
+
+        $actual = Hash::extract($result, 'data.{n}.id');
+        sort($actual);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertSame($expected, $actual);
+    }
+
+    /**
+     * Data provider for `testSetRelationshipsAllowedMethods()`
+     *
+     * @return array
+     */
+    public function setRelationshipsAllowedMethodsProvider()
+    {
+        return [
+            'get' => [200, 'get'],
+            'patch' => [
+                204,
+                'patch',
+                [
+                    'type' => 'folders',
+                    'id' => 11,
+                ]
+            ],
+            'post' => [405, 'post'],
+            'delete' => [405, 'delete'],
+        ];
+    }
+
+    /**
+     * Test for setRelationshipsAllowedMethods() method.
+     *
+     * @param int $expected The expected HTTP status code.
+     * @param string $method The http method.
+     * @param array|null $data Payload to use for the request.
+     * @return void
+     *
+     * @dataProvider setRelationshipsAllowedMethodsProvider
+     * @covers ::setRelationshipsAllowedMethods()
+     */
+    public function testSetRelationshipsAllowedMethods($expected, $method, $data = null)
+    {
+        $authHeader = $this->getUserAuthHeader();
+        $this->configRequestHeaders($method, $authHeader);
+        $this->{$method}('/folders/12/relationships/parent', $data);
+        $this->assertResponseCode($expected);
+    }
+}

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -1157,6 +1157,7 @@ class ObjectsControllerTest extends IntegrationTestCase
      * @covers ::related()
      * @covers ::findAssociation()
      * @covers ::getAvailableUrl()
+     * @covers ::getAssociatedAction()
      */
     public function testRelated()
     {
@@ -1310,6 +1311,7 @@ class ObjectsControllerTest extends IntegrationTestCase
      * @covers ::relationships()
      * @covers ::findAssociation()
      * @covers ::getAvailableUrl()
+     * @covers ::getAssociatedAction()
      */
     public function testListAssociations()
     {
@@ -1418,6 +1420,7 @@ class ObjectsControllerTest extends IntegrationTestCase
      * @covers ::initialize()
      * @covers ::relationships()
      * @covers ::findAssociation()
+     * @covers ::getAssociatedAction()
      */
     public function testListAssociationsNotFound()
     {

--- a/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
@@ -30,6 +30,8 @@ class ResourcesControllerTest extends IntegrationTestCase
      * @covers ::relationships()
      * @covers ::findAssociation()
      * @covers ::getAvailableUrl()
+     * @covers ::setRelationshipsAllowedMethods()
+     * @covers ::getAssociatedAction()
      */
     public function testListAssociations()
     {
@@ -94,6 +96,8 @@ class ResourcesControllerTest extends IntegrationTestCase
      * @covers ::initialize()
      * @covers ::relationships()
      * @covers ::findAssociation()
+     * @covers ::setRelationshipsAllowedMethods()
+     * @covers ::getAssociatedAction()
      */
     public function testListAssociationsNotFound()
     {
@@ -112,6 +116,7 @@ class ResourcesControllerTest extends IntegrationTestCase
      * @covers ::initialize()
      * @covers ::relationships()
      * @covers ::findAssociation()
+     * @covers ::setRelationshipsAllowedMethods()
      */
     public function testAddAssociations()
     {
@@ -146,6 +151,7 @@ class ResourcesControllerTest extends IntegrationTestCase
      * @covers ::initialize()
      * @covers ::relationships()
      * @covers ::findAssociation()
+     * @covers ::setRelationshipsAllowedMethods()
      */
     public function testAddAssociationsDuplicateEntry()
     {
@@ -184,6 +190,7 @@ class ResourcesControllerTest extends IntegrationTestCase
      * @covers ::initialize()
      * @covers ::relationships()
      * @covers ::findAssociation()
+     * @covers ::setRelationshipsAllowedMethods()
      */
     public function testAddAssociationsNoContent()
     {
@@ -210,6 +217,7 @@ class ResourcesControllerTest extends IntegrationTestCase
      * @covers ::initialize()
      * @covers ::relationships()
      * @covers ::findAssociation()
+     * @covers ::setRelationshipsAllowedMethods()
      */
     public function testDeleteAssociations()
     {
@@ -285,6 +293,7 @@ class ResourcesControllerTest extends IntegrationTestCase
      * @covers ::initialize()
      * @covers ::relationships()
      * @covers ::findAssociation()
+     * @covers ::setRelationshipsAllowedMethods()
      */
     public function testDeleteAssociationsNoContent()
     {
@@ -312,6 +321,7 @@ class ResourcesControllerTest extends IntegrationTestCase
      * @covers ::initialize()
      * @covers ::relationships()
      * @covers ::findAssociation()
+     * @covers ::setRelationshipsAllowedMethods()
      */
     public function testSetAssociations()
     {
@@ -355,6 +365,7 @@ class ResourcesControllerTest extends IntegrationTestCase
      * @covers ::initialize()
      * @covers ::relationships()
      * @covers ::findAssociation()
+     * @covers ::setRelationshipsAllowedMethods()
      */
     public function testSetAssociationsEmpty()
     {
@@ -379,6 +390,7 @@ class ResourcesControllerTest extends IntegrationTestCase
      * @covers ::initialize()
      * @covers ::relationships()
      * @covers ::findAssociation()
+     * @covers ::setRelationshipsAllowedMethods()
      */
     public function testSetAssociationsNoContent()
     {
@@ -405,6 +417,7 @@ class ResourcesControllerTest extends IntegrationTestCase
      * @covers ::initialize()
      * @covers ::relationships()
      * @covers ::findAssociation()
+     * @covers ::setRelationshipsAllowedMethods()
      */
     public function testUpdateAssociationsMissingId()
     {
@@ -438,6 +451,7 @@ class ResourcesControllerTest extends IntegrationTestCase
      * @covers ::initialize()
      * @covers ::relationships()
      * @covers ::findAssociation()
+     * @covers ::setRelationshipsAllowedMethods()
      */
     public function testWrongAssociation()
     {
@@ -464,6 +478,7 @@ class ResourcesControllerTest extends IntegrationTestCase
      * @covers ::initialize()
      * @covers ::relationships()
      * @covers ::findAssociation()
+     * @covers ::setRelationshipsAllowedMethods()
      */
     public function testUpdateAssociationsUnsupportedType()
     {

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedFoldersAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedFoldersAction.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Model\Action;
+
+/**
+ * Command to list associated objects for folders.
+ *
+ * It behaves exactly as `ListRelatedObjectsAction` except for `Parents` association.
+ * In that case only the first result is returned.
+ *
+ * @since 4.0.0
+ */
+class ListRelatedFoldersAction extends ListRelatedObjectsAction
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function execute(array $data = [])
+    {
+        $result = parent::execute($data);
+
+        if ($this->Association->getName() === 'Parents') {
+            return $result->first();
+        }
+
+        return $result;
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedFoldersActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedFoldersActionTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Action;
+
+use BEdita\Core\Model\Action\ListRelatedFoldersAction;
+use BEdita\Core\Model\Entity\Folder;
+use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\ORM\Query;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
+use Cake\Utility\Inflector;
+
+/**
+ * @coversDefaultClass \BEdita\Core\Model\Action\ListRelatedFoldersAction
+ */
+class ListRelatedFoldersActionTest extends TestCase
+{
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
+        'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.object_relations',
+        'plugin.BEdita/Core.trees',
+    ];
+
+    /**
+     * Test execute for `Parents` association.
+     *
+     * @return void
+     *
+     * @covers ::execute()
+     */
+    public function testExecuteParents()
+    {
+        $association = TableRegistry::get('Folders')->association('Parents');
+        $action = new ListRelatedFoldersAction(compact('association'));
+        $result = $action(['primaryKey' => 12]);
+        static::assertInstanceOf(Folder::class, $result);
+        static::assertEquals(11, $result->get('id'));
+    }
+
+    /**
+     * Test execute for `Children` association.
+     *
+     * @return void
+     *
+     * @covers ::execute()
+     */
+    public function testExecuteChildren()
+    {
+        $association = TableRegistry::get('Folders')->association('Children');
+        $action = new ListRelatedFoldersAction(compact('association'));
+        $result = $action(['primaryKey' => 11]);
+
+        static::assertInstanceOf(Query::class, $result);
+
+        $children = $result->toArray();
+
+        $actual = Hash::extract($children, '{n}.id');
+        sort($actual);
+
+        $treesTable = TableRegistry::get('Trees');
+        $node = $treesTable->find()->where(['object_id' => 11])->first();
+        $expected = $treesTable
+            ->find('children', ['for' => $node->id, 'direct' => true])
+            ->toArray();
+        $expected = Hash::extract($expected, '{n}.object_id');
+        sort($expected);
+
+        static::assertSame($expected, $actual);
+    }
+}


### PR DESCRIPTION
This PR partially cover  #1431 implementing `GET /folders/:id/parent` 

The write operation is almost done but missing a key point.

### DONE

1. allow method for `/folders/:id/relationship/parent` is limited to `GET` and `PATCH` (you can only modify an existent parent)
2. The `PATCH` works... but

### TODO

The `PATCH` should be update the current row on `trees` table but it first remove the current row and then insert a new row. Deleting the row all children are lost :disappointed: 

-----

#### Side note

I expressly marked as **incomplete** `FoldersControllerTest::testDelete()` because I don't know what policy we want to apply deleting a folder. There are different possibilities to treat in different PR if you agree.

1. a folder can be deleted only if it doesn't have folders as children.
2. a folder can be always deleted and the children of type `folders` become orphans.
3. other...

Another thing is about JSON API specs. For root folder `GET /folders/:id/parent` return (response simplified)

```json
{
    "data": []
}
```

From specs I read
> Consider, for example, a request to fetch a to-one related resource link. This request would respond with null when the relationship is empty (such that the link is corresponding to no resources) but with the single related resource’s resource object otherwise.

In our case `parent` is `to-one` related resource so the correct response should be

```json
{
    "data": null
}
```

Maybe we need to consider to fix it (I think in ` BEdita\API\Utility\JsonApi::formatData()`).