### PR TITLE
fix: card always reachable

### DIFF
--- a/bedita-app/controllers/components/api_validator.php
+++ b/bedita-app/controllers/components/api_validator.php
@@ -376,17 +376,8 @@ class ApiValidatorComponent extends Object {
         }
         // User card always reachable
         $user = $this->controller->ApiAuth->getUser();
-        if (!empty($user['id'])) {
-            $card = ClassRegistry::init('ObjectUsers')->find('first', array(
-                'fields' => array('object_id'),
-                'conditions' => array(
-                    'user_id' => $user['id'],
-                    'switch' => 'card',
-                ),
-            ));
-            if (!empty($card) && !empty($card['ObjectUsers']['object_id']) && $card['ObjectUsers']['object_id'] === $objectId) {
-                return true;
-            }
+        if (!empty($user['card_id']) && $user['card_id'] === $objectId) {
+            return true;
         }
         $tree = ClassRegistry::init('Tree');
         $publication = $this->controller->getPublication();

--- a/bedita-app/controllers/components/api_validator.php
+++ b/bedita-app/controllers/components/api_validator.php
@@ -374,6 +374,15 @@ class ApiValidatorComponent extends Object {
         if (!$this->enableObjectReachableCheck) {
             return true;
         }
+        // Cards always reachable
+        $obj = ClassRegistry::init('BEObject')->find('first', array(
+            'fields' => array('object_type_id'),
+            'conditions' => array('BEObject.id' => $objectId),
+            'contain' => array(),
+        ));
+        if (!empty($obj['BEObject']['object_type_id']) && $obj['BEObject']['object_type_id'] === Configure::read('objectTypes.card.id')) {
+            return true;
+        }
         $tree = ClassRegistry::init('Tree');
         $publication = $this->controller->getPublication();
         $isOnTree = $tree->isOnTree($objectId, $publication['id'], $this->controller->getStatus());

--- a/bedita-app/controllers/components/api_validator.php
+++ b/bedita-app/controllers/components/api_validator.php
@@ -374,14 +374,19 @@ class ApiValidatorComponent extends Object {
         if (!$this->enableObjectReachableCheck) {
             return true;
         }
-        // Cards always reachable
-        $obj = ClassRegistry::init('BEObject')->find('first', array(
-            'fields' => array('object_type_id'),
-            'conditions' => array('BEObject.id' => $objectId),
-            'contain' => array(),
-        ));
-        if (!empty($obj['BEObject']['object_type_id']) && $obj['BEObject']['object_type_id'] === Configure::read('objectTypes.card.id')) {
-            return true;
+        // User card always reachable
+        $user = $this->controller->ApiAuth->getUser();
+        if (!empty($user['id'])) {
+            $card = ClassRegistry::init('ObjectUsers')->find('first', array(
+                'fields' => array('object_id'),
+                'conditions' => array(
+                    'user_id' => $user['id'],
+                    'switch' => 'card',
+                ),
+            ));
+            if (!empty($card) && !empty($card['ObjectUsers']['object_id']) && $card['ObjectUsers']['object_id'] === $objectId) {
+                return true;
+            }
         }
         $tree = ClassRegistry::init('Tree');
         $publication = $this->controller->getPublication();

--- a/bedita-app/models/account/user.php
+++ b/bedita-app/models/account/user.php
@@ -121,7 +121,15 @@ class User extends BEAppModel
 	 */
 	function compact(&$user, $keepGroupsIds = true) {
 		unset($user['Permission']);
-		
+
+		if (!empty($user['ObjectUser'])) {
+			foreach ($user['ObjectUser'] as $objectUser) {
+				if ($objectUser['switch'] === 'card') {
+					$user['User']['card_id'] = $objectUser['object_id'];
+				}
+			}
+		}
+
 		$user['User']['groups'] = array();
 		if (!empty($user['Group'])) {
 			foreach ($user['Group'] as $group) {


### PR DESCRIPTION
This forces api validator `isReachable` to true when object type is a card.
Object validation in api apply to relations too.
When a card is used in a relation, api validator check card id too.
Card is not an object in tree, so it's not reachable itself.
Card can (or cannot) have related data on tree.
However, IMHO, `isReachable` should be ignored for cards.