### PR TITLE
Routing rules change

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -27,7 +27,7 @@ use Cake\Core\Plugin;
 $plugins = Plugin::loaded();
 foreach ($plugins as $plugin) {
     if (!in_array($plugin, ['BEdita/API', 'BEdita/Core'])) {
-        static::routes($plugin);
+        Plugin::routes($plugin);
     }
 }
 

--- a/config/routes.php
+++ b/config/routes.php
@@ -21,7 +21,17 @@
 use Cake\Core\Plugin;
 
 /**
- * Load all plugin routes.  See the Plugin documentation on
- * how to customize the loading of plugin routes.
+ * Load plugin routes.
+ * First loaded plugins then 'BEdita/API'
  */
-Plugin::routes();
+$plugins = Plugin::loaded();
+foreach ($plugins as $plugin) {
+    if (!in_array($plugin, ['BEdita/API', 'BEdita/Core'])) {
+        static::routes($plugin);
+    }
+}
+
+// Load 'BEdita/API' as last route
+if (Plugin::loaded('BEdita/API')) {
+    Plugin::routes('BEdita/API');
+}

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -21,6 +21,7 @@ use BEdita\Core\Model\Action\ListRelatedObjectsAction;
 use BEdita\Core\Model\Action\RemoveAssociatedAction;
 use BEdita\Core\Model\Action\SaveEntityAction;
 use BEdita\Core\Model\Action\SetRelatedObjectsAction;
+use Cake\Datasource\EntityInterface;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Event\Event;
 use Cake\Network\Exception\ConflictException;
@@ -153,7 +154,7 @@ class ObjectsController extends ResourcesController
                 ->withStatus(201)
                 ->withHeader(
                     'Location',
-                    $this->resourceUrl($data->id)
+                    $this->resourceUrl($data, 'id')
                 );
         } else {
             // List existing entities.
@@ -175,13 +176,13 @@ class ObjectsController extends ResourcesController
     /**
      * {@inheritDoc}
      */
-    protected function resourceUrl($id)
+    protected function resourceUrl(EntityInterface $entity, $primaryKey)
     {
         return Router::url(
             [
                 '_name' => 'api:objects:resource',
                 'object_type' => $this->objectType->name,
-                'id' => $id,
+                'id' => $entity->get($primaryKey),
             ],
             true
         );

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -67,13 +67,6 @@ abstract class ResourcesController extends AppController
     protected $Table;
 
     /**
-     * Prefix used in `_name` creating route urls
-     *
-     * @var string
-     */
-    protected $routeNamePrefix = 'api:resources';
-
-    /**
      * {@inheritDoc}
      */
     public function initialize()

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -403,7 +403,7 @@ abstract class ResourcesController extends AppController
         return Router::url(
             [
                 '_name' => $destinationEntity->routeNamePrefix() . ':index',
-                'controller' => \Cake\Utility\Inflector::camelize($jsonApiData['type']),
+                'controller' => Inflector::camelize($jsonApiData['type']),
             ],
             true
         );

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiAdminTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiAdminTrait.php
@@ -30,7 +30,7 @@ trait JsonApiAdminTrait
      *
      * @codeCoverageIgnore
      */
-    protected function routeNamePrefix()
+    public function routeNamePrefix()
     {
         return 'api:admin:resources';
     }

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiModelTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiModelTrait.php
@@ -27,7 +27,7 @@ trait JsonApiModelTrait
      *
      * @codeCoverageIgnore
      */
-    protected function routeNamePrefix()
+    public function routeNamePrefix()
     {
         return 'api:model:resources';
     }

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
@@ -20,6 +20,7 @@ use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Routing\Router;
 use Cake\Utility\Hash;
+use Cake\Utility\Inflector;
 
 /**
  * Trait for exposing useful properties required for JSON API response formatting at the entity level.
@@ -221,7 +222,7 @@ trait JsonApiTrait
      *
      * @return string
      */
-    protected function routeNamePrefix()
+    public function routeNamePrefix()
     {
         return 'api:resources';
     }
@@ -236,7 +237,7 @@ trait JsonApiTrait
         $self = Router::url(
             [
                 '_name' => $this->routeNamePrefix() . ':resource',
-                'controller' => $this->getType(),
+                'controller' => Inflector::camelize($this->getType()),
                 'id' => $this->getId(),
             ],
             true
@@ -292,7 +293,7 @@ trait JsonApiTrait
             $self = Router::url(
                 [
                     '_name' => $this->routeNamePrefix() . ':relationships',
-                    'controller' => $this->getType(),
+                    'controller' => Inflector::camelize($this->getType()),
                     'relationship' => $relationship,
                     'id' => $this->getId(),
                 ],
@@ -301,7 +302,7 @@ trait JsonApiTrait
             $related = Router::url(
                 [
                     '_name' => $this->routeNamePrefix() . ':related',
-                    'controller' => $this->getType(),
+                    'controller' => Inflector::camelize($this->getType()),
                     'relationship' => $relationship,
                     'related_id' => $this->getId(),
                 ],

--- a/plugins/BEdita/Core/src/Plugin.php
+++ b/plugins/BEdita/Core/src/Plugin.php
@@ -32,9 +32,9 @@ class Plugin extends CakePlugin
     protected static $_defaults = [
         'debugOnly' => false,
         'autoload' => false,
-        'bootstrap' => false,
-        'routes' => false,
-        'ignoreMissing' => false
+        'bootstrap' => true,
+        'routes' => true,
+        'ignoreMissing' => true
     ];
 
     /**
@@ -44,13 +44,11 @@ class Plugin extends CakePlugin
      */
     public static function loadFromConfig()
     {
-        $plugins = Configure::read('Plugins');
-        if ($plugins) {
-            foreach ($plugins as $plugin => $options) {
-                $options = array_merge(static::$_defaults, $options);
-                if (!$options['debugOnly'] || ($options['debugOnly'] && Configure::read('debug'))) {
-                    static::load($plugin, $options);
-                }
+        $plugins = (array)Configure::read('Plugins', []);
+        foreach ($plugins as $plugin => $options) {
+            $options = array_merge(static::$_defaults, $options);
+            if (!$options['debugOnly'] || ($options['debugOnly'] && Configure::read('debug'))) {
+                static::load($plugin, $options);
             }
         }
     }

--- a/plugins/BEdita/Core/src/Utility/JsonApiSerializable.php
+++ b/plugins/BEdita/Core/src/Utility/JsonApiSerializable.php
@@ -66,4 +66,11 @@ interface JsonApiSerializable
      * @return array
      */
     public function jsonApiSerialize($options = 0, $fields = []);
+
+    /**
+     * Get prefix used for `_name` in routing urls creation.
+     *
+     * @return string
+     */
+    public function routeNamePrefix();
 }


### PR DESCRIPTION
This PR changes routing rules this way:

 * route load order was changed in order to allow other plugins to use resources (not objects)  properly in JSON API 
 * rule names are now set in models to have better control
 *  fix: `controller` names in rules are now `camelized` 
