### PR TITLE
Don't list deleted objects in `children` and `parents

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
@@ -179,4 +179,28 @@ class ParentsRelationshipTest extends IntegrationTestCase
             ->where(['object_id' => $objectId])
             ->count();
     }
+
+    /**
+     * Test deleted objects as `parent`
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testDeletedParent()
+    {
+        // a deleted folder must not be listed in `parents`
+        $foldersTable = TableRegistry::get('Folders');
+        $folder = $foldersTable->get(12);
+        $folder->deleted = true;
+        $foldersTable->saveOrFail($folder);
+
+        $this->configRequestHeaders();
+        $this->get('/profiles/4/parents');
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        $result = json_decode((string)$this->_response->getBody(), true);
+        $ids = Hash::extract($result, 'data.{n}.id');
+        static::assertEmpty($ids);
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedFoldersAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedFoldersAction.php
@@ -27,6 +27,18 @@ class ListRelatedFoldersAction extends ListRelatedObjectsAction
     /**
      * {@inheritDoc}
      */
+    protected function initialize(array $config)
+    {
+        parent::initialize($config);
+        if ($this->Association->getName() === 'Children') {
+            $table = $this->Association->getTarget();
+            $this->ListAction = new ListObjectsAction(compact('table'));
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function execute(array $data = [])
     {
         $result = parent::execute($data);

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedFoldersAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedFoldersAction.php
@@ -23,19 +23,6 @@ namespace BEdita\Core\Model\Action;
  */
 class ListRelatedFoldersAction extends ListRelatedObjectsAction
 {
-
-    /**
-     * {@inheritDoc}
-     */
-    protected function initialize(array $config)
-    {
-        parent::initialize($config);
-        if ($this->Association->getName() === 'Children') {
-            $table = $this->Association->getTarget();
-            $this->ListAction = new ListObjectsAction(compact('table'));
-        }
-    }
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
@@ -13,7 +13,9 @@
 
 namespace BEdita\Core\Model\Action;
 
+use BEdita\Core\Model\Table\ObjectsTable;
 use BEdita\Core\ORM\Association\RelatedTo;
+use BEdita\Core\ORM\Inheritance\Table;
 use Cake\ORM\Association;
 use Cake\ORM\TableRegistry;
 
@@ -44,7 +46,8 @@ class ListRelatedObjectsAction extends ListAssociatedAction
                 $objectType = current($objectTypes);
             }
             $this->ListAction = new ListObjectsAction(compact('table', 'objectType'));
-        } elseif ($this->Association->getName() === 'Parents') {
+        } elseif ($this->Association->getTarget() instanceof ObjectsTable
+                || $this->Association->getTarget() instanceof Table) {
             $table = $this->Association->getTarget();
             $this->ListAction = new ListObjectsAction(compact('table'));
         }

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
@@ -44,6 +44,9 @@ class ListRelatedObjectsAction extends ListAssociatedAction
                 $objectType = current($objectTypes);
             }
             $this->ListAction = new ListObjectsAction(compact('table', 'objectType'));
+        } elseif ($this->Association->getName() === 'Parents') {
+            $table = $this->Association->getTarget();
+            $this->ListAction = new ListObjectsAction(compact('table'));
         }
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedFoldersActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedFoldersActionTest.php
@@ -48,6 +48,7 @@ class ListRelatedFoldersActionTest extends TestCase
      * @return void
      *
      * @covers ::execute()
+     * @covers \BEdita\Core\Model\Action\ListRelatedObjectsAction::initialize()
      */
     public function testExecuteParents()
     {
@@ -64,6 +65,7 @@ class ListRelatedFoldersActionTest extends TestCase
      * @return void
      *
      * @covers ::execute()
+     * @covers ::initialize()
      */
     public function testExecuteChildren()
     {


### PR DESCRIPTION
This PR fixes a bug in `children`, `parents` and `parent` relations: deleted objects MUST not be listed.

Problem: `ListEntitiesAction` was used instead of `ListObjectsAction` as list association.

Deleted `children` and `parents` test cases have been added.
