### PR TITLE
Fix `?include=children,parent` query string

### DIFF
--- a/plugins/BEdita/API/src/Controller/FoldersController.php
+++ b/plugins/BEdita/API/src/Controller/FoldersController.php
@@ -36,6 +36,7 @@ class FoldersController extends ObjectsController
     protected $_defaultConfig = [
         'allowedAssociations' => [
             'parent' => ['folders'],
+            'children' => ['objects'],
         ],
     ];
 

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -132,8 +132,9 @@ abstract class ResourcesController extends AppController
                 throw new BadRequestException(__d('bedita', 'Inclusion of nested resources is not yet supported'));
             }
 
-            $association = $this->Table->associations()->getByProperty($relationship);
-            if (!array_key_exists($relationship, $this->getConfig('allowedAssociations')) || $association === null) {
+            try {
+                $association = $this->findAssociation($relationship);
+            } catch (NotFoundException $e) {
                 throw new BadRequestException(
                     __d('bedita', 'Invalid "{0}" query parameter ({1})', 'include', __d('bedita', 'Relationship "{0}" does not exist', $relationship))
                 );

--- a/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
@@ -179,4 +179,20 @@ class ParentsRelationshipTest extends IntegrationTestCase
             ->where(['object_id' => $objectId])
             ->count();
     }
+
+    /**
+     * Test `?include=parents` query string
+     *
+     * @return void
+     */
+    public function testIncludeParents()
+    {
+        $this->configRequestHeaders('GET');
+        $this->get('/documents/2?include=parents');
+        $this->assertResponseCode(200);
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $includedIds = Hash::extract($result, 'included.{n}.id');
+        static::assertEquals(['11'], $includedIds);
+    }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -527,4 +527,39 @@ class FoldersControllerTest extends IntegrationTestCase
         $this->{$method}('/folders/12/relationships/parent', $data);
         $this->assertResponseCode($expected);
     }
+
+    /**
+     * Test `?include=children` query
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testIncludeChildren()
+    {
+        $this->configRequestHeaders();
+        $this->get('/folders/11?include=children');
+        $this->assertResponseCode(200);
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $includedIds = Hash::extract($result, 'included.{n}.id');
+        static::assertEquals(['12', '2'], $includedIds);
+    }
+
+    /**
+     * Test `?include=parent` query
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testIncludeParent()
+    {
+        $this->configRequestHeaders();
+        $this->get('/folders/12?include=parent');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $includedIds = Hash::extract($result, 'included.{n}.id');
+        static::assertEquals(['11'], $includedIds);
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
@@ -192,6 +192,9 @@ class ObjectEntity extends Entity implements JsonApiSerializable
             if ($this->has($relationship)) {
                 $entities = $this->get($relationship);
                 $data = $this->getIncluded($entities);
+                if (!is_array($entities)) {
+                    $entities = [$entities];
+                }
                 $included = array_merge($included, $entities);
             }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectEntityTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectEntityTest.php
@@ -507,6 +507,26 @@ class ObjectEntityTest extends TestCase
      */
     public function testGetRelationshipsIncluded()
     {
+        $entity = TableRegistry::get('Documents')->get(2, ['contain' => ['Test']]);
+        $entity = $entity->jsonApiSerialize();
+
+        static::assertArrayHasKey('relationships', $entity);
+        static::assertArrayHasKey('test', $entity['relationships']);
+        static::assertArrayHasKey('data', $entity['relationships']['test']);
+
+        static::assertArrayHasKey('included', $entity);
+        static::assertSameSize($entity['relationships']['test']['data'], $entity['included']);
+    }
+
+    /**
+     * Test magic getter for JSON API relations with single entity `included`
+     *
+     * @return void
+     *
+     * @covers ::getRelationships()
+     */
+    public function testGetRelationshipsSingleIncluded()
+    {
         $entity = TableRegistry::get('Folders')->get(12, ['contain' => ['Parents']]);
         $entity = $entity->jsonApiSerialize();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectEntityTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectEntityTest.php
@@ -49,6 +49,7 @@ class ObjectEntityTest extends TestCase
         'plugin.BEdita/Core.users',
         'plugin.BEdita/Core.roles',
         'plugin.BEdita/Core.roles_users',
+        'plugin.BEdita/Core.trees',
         'plugin.BEdita/Core.object_relations',
     ];
 
@@ -506,14 +507,14 @@ class ObjectEntityTest extends TestCase
      */
     public function testGetRelationshipsIncluded()
     {
-        $entity = TableRegistry::get('Documents')->get(2, ['contain' => ['Test']]);
+        $entity = TableRegistry::get('Folders')->get(12, ['contain' => ['Parents']]);
         $entity = $entity->jsonApiSerialize();
 
         static::assertArrayHasKey('relationships', $entity);
-        static::assertArrayHasKey('test', $entity['relationships']);
-        static::assertArrayHasKey('data', $entity['relationships']['test']);
+        static::assertArrayHasKey('parent', $entity['relationships']);
+        static::assertArrayHasKey('data', $entity['relationships']['parent']);
 
         static::assertArrayHasKey('included', $entity);
-        static::assertSameSize($entity['relationships']['test']['data'], $entity['included']);
+        static::assertEquals(1, count($entity['included']));
     }
 }


### PR DESCRIPTION
This PR fixes errors on `?include=children`, `?include=parent` query string on `/folders` and `?include=parents` on other object endpoints.

