### PR TITLE
Fix SQL injection vulnerability with relations parameters

### DIFF
--- a/bedita-app/models/object_relation.php
+++ b/bedita-app/models/object_relation.php
@@ -28,6 +28,26 @@ App::import('Sanitize');
 class ObjectRelation extends BEAppModel
 {
 
+    /**
+     * Check if a relation exists.
+     *
+     * @return bool
+     */
+    public function exists() {
+        $name = $this->name;
+        if (!isset($this->data[$name]['id']) || !isset($this->data[$name]['object_id']) || !isset($this->data[$name]['switch'])) {
+            return false;
+        }
+
+        $conditions = array(
+            $this->alias . '.id' => $this->data[$name]['id'],
+            $this->alias . '.object_id' => $this->data[$name]['object_id'],
+            $this->alias . '.switch' => $this->data[$name]['switch'],
+        );
+        $query = array('conditions' => $conditions, 'recursive' => -1, 'callbacks' => false);
+        return ($this->find('count', $query) > 0);
+    }
+
     public function afterFind($results) {
         if (!empty($results[0][$this->alias])) {
             foreach ($results as &$r) {


### PR DESCRIPTION
This PR fixes a (potentially serious) vulnerability. When saving a relation with parameters, since the encoded JSON was not being properly escaped, it was possible to inject custom SQL by simply adding an apostrophe (`'`) to one relation parameter.

For instance, when linking a Document and an Image together, it would have been possible to give a maliciously-crafted "label" to expose arbitrary data from any table.

With this PR the logic has been heavily refactored to make use of CakePHP's ORM, so that we're sure that any user-provided data is escaped as it should.