### PR TITLE
`parent`, `ancestor` and `roots` filter

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -505,17 +505,17 @@ class FilterQueryStringTest extends IntegrationTestCase
                 '/objects',
                 'filter[parent]=root-folder',
                 [
-                    '2',
                     '12',
+                    '2',
                 ],
             ],
             'root ancestor' => [
                 '/objects',
                 'filter[ancestor]=root-folder',
                 [
-                    '2',
-                    '4',
                     '12',
+                    '4',
+                    '2',
                 ],
             ],
             'documents' => [

--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -492,4 +492,88 @@ class FilterQueryStringTest extends IntegrationTestCase
         static::assertArrayHasKey('data', $result);
         static::assertEquals($expected, Hash::extract($result['data'], '{n}.id'), '', 0, 10, true);
     }
+
+    /**
+     * Data provider for `testParentAncestorFilter` test case.
+     *
+     * @return array
+     */
+    public function parentAncestorFilterProvider()
+    {
+        return [
+            'root parent' => [
+                '/objects',
+                'filter[parent]=root-folder',
+                [
+                    '2',
+                    '12',
+                ],
+            ],
+            'root ancestor' => [
+                '/objects',
+                'filter[ancestor]=root-folder',
+                [
+                    '2',
+                    '4',
+                    '12',
+                ],
+            ],
+            'documents' => [
+                '/documents',
+                'filter[ancestor]=11',
+                [
+                    '2',
+                ],
+            ],
+            'folders' => [
+                '/folders',
+                'filter[parent]=11',
+                [
+                    '12',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test filters on /trash endpoint.
+     *
+     * @param string $endpoint Endpoint.
+     * @param string $query Query string.
+     * @param array $expected Expected result.
+     * @return void
+     *
+     * @dataProvider parentAncestorFilterProvider
+     * @coversNothing
+     */
+    public function testParentAncestorFilter($endpoint, $query, $expected)
+    {
+        $this->configRequestHeaders();
+        $this->get("$endpoint?$query");
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        static::assertArrayHasKey('data', $result);
+        static::assertEquals($expected, Hash::extract($result['data'], '{n}.id'));
+    }
+
+    /**
+     * Test `/folders?filter[roots]`.
+     *
+     * @coversNothing
+     */
+    public function testRootsFilter()
+    {
+        $this->configRequestHeaders();
+        $this->get('/folders?filter[roots]');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        static::assertArrayHasKey('data', $result);
+        static::assertEquals([11, 13], Hash::extract($result['data'], '{n}.id'));
+    }
 }

--- a/plugins/BEdita/Core/config/reserved.php
+++ b/plugins/BEdita/Core/config/reserved.php
@@ -12,7 +12,7 @@
  */
 
 /**
- * Reserved names for types and properties.
+ * Reserved names for types, properties and relations.
  */
 return [
     'ancestor',
@@ -40,4 +40,8 @@ return [
     'schema',
     'stream',
     'streams',
+    'tree',
+    'trees',
+    'tree_nodes',
+    'tree_parent_nodes',
 ];

--- a/plugins/BEdita/Core/config/reserved.php
+++ b/plugins/BEdita/Core/config/reserved.php
@@ -15,6 +15,7 @@
  * Reserved names for types and properties.
  */
 return [
+    'ancestor',
     'application',
     'applications',
     'async_job',
@@ -27,6 +28,7 @@ return [
     'models',
     'object_type',
     'object_types',
+    'parent',
     'properties',
     'property',
     'property_type',

--- a/plugins/BEdita/Core/src/Model/Entity/Folder.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Folder.php
@@ -35,7 +35,7 @@ class Folder extends ObjectEntity
         parent::__construct($properties, $options);
 
         $this->setAccess('parents', false);
-        $this->setHidden(['parents'], true);
+        $this->setHidden(['parents', 'tree_parent_nodes'], true);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
@@ -93,6 +93,7 @@ class ObjectEntity extends Entity implements JsonApiSerializable
         'object_type',
         'deleted',
         'custom_props',
+        'tree_nodes',
     ];
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
@@ -161,17 +161,16 @@ class FoldersTable extends ObjectsTable
      */
     protected function findRoots(Query $query)
     {
-        $subquery = TableRegistry::get('Trees')->find('list')->where(['parent_id IS NULL']);
-
         $query->join([
             'table' => 'trees',
             'alias' => 'Trees',
             'type' => 'INNER',
             'conditions' => 'Trees.object_id = ' . $this->aliasField('id'),
         ])
-        ->where(function (QueryExpression $exp) use ($subquery) {
-            return $exp->in('Trees.id', $subquery);
-        });
+        ->where(function (QueryExpression $exp) {
+            return $exp->isNull('Trees.parent_id');
+        })
+        ->order('Trees.tree_left');
 
         return $query;
     }

--- a/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
@@ -62,6 +62,11 @@ class FoldersTable extends ObjectsTable
                 'Trees.tree_left' => 'asc',
             ],
         ]);
+
+        $this->hasMany('TreeParentNodes', [
+            'className' => 'Trees',
+            'foreignKey' => 'parent_id',
+        ]);
     }
 
     /**
@@ -161,17 +166,12 @@ class FoldersTable extends ObjectsTable
      */
     protected function findRoots(Query $query)
     {
-        $query->join([
-            'table' => 'trees',
-            'alias' => 'Trees',
-            'type' => 'INNER',
-            'conditions' => 'Trees.object_id = ' . $this->aliasField('id'),
-        ])
-        ->where(function (QueryExpression $exp) {
-            return $exp->isNull('Trees.parent_id');
-        })
-        ->order('Trees.tree_left');
-
-        return $query;
+        return $query
+            ->innerJoinWith('TreeNodes', function (Query $query) {
+                return $query->where(function (QueryExpression $exp) {
+                    return $exp->isNull($this->TreeNodes->aliasField('parent_id'));
+                });
+            })
+            ->order('TreeNodes.tree_left');
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -312,21 +312,16 @@ class ObjectsTable extends Table
      */
     protected function treeDescendants(Query $query, $id, $direct = true)
     {
-        $id = $this->getId($id);
-        $condition = ['object_id' => $id];
-        if ($id === 0) {
-            $condition = ['parent_id' => null];
-        }
-
         $node = TableRegistry::get('Trees')->find()
-            ->where(['object_id' => $id])
+            ->where(['object_id' => $this->getId($id)])
             ->first();
 
-        $subquery = TableRegistry::get('Trees')->find('children', [
-            'for' => $node->id,
-            'direct' => $direct,
-        ]);
-        $subquery->find('list');
+        $subquery = TableRegistry::get('Trees')
+            ->find('children', [
+                'for' => $node->id,
+                'direct' => $direct,
+            ])
+            ->find('list');
 
         $query->join([
             'table' => 'trees',
@@ -334,7 +329,7 @@ class ObjectsTable extends Table
             'type' => 'INNER',
             'conditions' => 'Trees.object_id = ' . $this->aliasField('id'),
         ])
-        ->where(function (QueryExpression $exp) use ($node, $subquery) {
+        ->where(function (QueryExpression $exp) use ($subquery) {
             return $exp->in('Trees.id', $subquery);
         });
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
@@ -17,6 +17,7 @@ use BEdita\Core\Utility\LoggedUser;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 
 /**
  * BEdita\Core\Model\Table\FoldersTable Test Case
@@ -268,5 +269,18 @@ class FoldersTableTest extends TestCase
             $actual = $trees->childCount($node);
             static::assertEquals($descendants, $actual);
         }
+    }
+
+    /**
+     * Test `findRoots()`
+     *
+     * @covers ::findRoots()
+     */
+    public function testFindRoots()
+    {
+        $folders = $this->Folders->find('roots')->toArray();
+        static::assertNotEmpty($folders);
+        $ids = Hash::extract($folders, '{n}.id');
+        static::assertEquals([11, 13], $ids);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -8,6 +8,7 @@ use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\ORM\Exception\PersistenceFailedException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 
 /**
  * {@see \BEdita\Core\Model\Table\ObjectsTable} Test Case
@@ -34,6 +35,7 @@ class ObjectsTableTest extends TestCase
         'plugin.BEdita/Core.object_types',
         'plugin.BEdita/Core.properties',
         'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.trees',
         'plugin.BEdita/Core.relations',
         'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.object_relations',
@@ -446,5 +448,33 @@ class ObjectsTableTest extends TestCase
 
         $id = $this->Objects->getId($uname);
         static::assertEquals($expected, $id);
+    }
+
+    /**
+     * Test `findAncestor()`
+     *
+     * @covers ::findAncestor()
+     * @covers ::treeDescendants()
+     */
+    public function testFindAncestor()
+    {
+        $objects = $this->Objects->find('ancestor', [11])->toArray();
+        static::assertNotEmpty($objects);
+        $ids = Hash::extract($objects, '{n}.id');
+        static::assertEquals([12, 2, 4], $ids);
+    }
+
+    /**
+     * Test `findParent()`
+     *
+     * @covers ::findParent()
+     * @covers ::treeDescendants()
+     */
+    public function testFindParent()
+    {
+        $objects = $this->Objects->find('parent', [12])->toArray();
+        static::assertNotEmpty($objects);
+        $ids = Hash::extract($objects, '{n}.id');
+        static::assertEquals([4], $ids);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -454,7 +454,6 @@ class ObjectsTableTest extends TestCase
      * Test `findAncestor()`
      *
      * @covers ::findAncestor()
-     * @covers ::treeDescendants()
      */
     public function testFindAncestor()
     {
@@ -468,7 +467,6 @@ class ObjectsTableTest extends TestCase
      * Test `findParent()`
      *
      * @covers ::findParent()
-     * @covers ::treeDescendants()
      */
     public function testFindParent()
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -461,7 +461,7 @@ class ObjectsTableTest extends TestCase
         $objects = $this->Objects->find('ancestor', [11])->toArray();
         static::assertNotEmpty($objects);
         $ids = Hash::extract($objects, '{n}.id');
-        static::assertEquals([12, 2, 4], $ids);
+        static::assertEquals([12, 4, 2], $ids);
     }
 
     /**


### PR DESCRIPTION
This PR fixes #1460 

Three new filters have been introduced:

* `filter[parent]={id|uname}` to get children of a certain `folder`
* `filter[ancestor]={id|uname}` to get all descendants of a certain folder
* `/folders?filter[roots]` to get root folders

