### PR TITLE
fix: users validation, empty password now allowed, if present

### DIFF
--- a/plugins/BEdita/Core/src/Model/Validation/UsersValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/UsersValidator.php
@@ -39,7 +39,7 @@ class UsersValidator extends ProfilesValidator
             ->requirePresence('username', 'create')
             ->notEmpty('username')
 
-            ->allowEmpty('password_hash')
+            ->notEmpty('password')
 
             ->boolean('blocked')
             ->allowEmpty('blocked');


### PR DESCRIPTION
This PR fixes an expected behaviour on users `patch`: if `password` is an empty string, system should stop saving; if `password` is a non empty string or it's missing, system should perform `patch`.