### PR TITLE
Allow resource subtypes in relationships

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
@@ -163,7 +163,7 @@ class ParentsRelationshipTest extends IntegrationTestCase
         $this->post('/documents/2/relationships/parents', json_encode(compact('data')));
         $this->assertResponseCode(409);
         $body = json_decode((string)$this->_response->getBody(), true);
-        static::assertEquals('Unsupported resource type', $body['error']['title']);
+        static::assertEquals('Unsupported resource type profiles', $body['error']['title']);
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
@@ -406,6 +406,22 @@ class JsonApiComponentTest extends TestCase
                     'key' => 'value',
                 ],
             ],
+            'allowedSubType' => [
+                true,
+                ['media'],
+                [
+                    'type' => 'files',
+                    'key' => 'value',
+                ],
+            ],
+            'notAllowedSubType' => [
+                false,
+                ['media'],
+                [
+                    'type' => 'profiles',
+                    'key' => 'value',
+                ],
+            ],
         ];
     }
 
@@ -419,6 +435,7 @@ class JsonApiComponentTest extends TestCase
      *
      * @dataProvider allowedResourceTypesProvider
      * @covers ::allowedResourceTypes()
+     * @covers ::checkAllowedType()
      * @covers ::startup()
      */
     public function testAllowedResourceTypes($expected, $types, array $data)

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -1950,7 +1950,7 @@ class ObjectsControllerTest extends IntegrationTestCase
     {
         $expected = [
             'status' => '409',
-            'title' => 'Unsupported resource type',
+            'title' => 'Unsupported resource type myCustomType',
         ];
 
         $data = [

--- a/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
@@ -484,7 +484,7 @@ class ResourcesControllerTest extends IntegrationTestCase
     {
         $expected = [
             'status' => '409',
-            'title' => 'Unsupported resource type',
+            'title' => 'Unsupported resource type myCustomType',
         ];
 
         $data = [


### PR DESCRIPTION
This PR allows use of a subtype in a relationship when its parent abstract type is allowed.

`JsonApiComponent::checkAllowedType()` method was added in order to check on allowed parent abstract types -> it can be **heavily** improved....


