### PR TITLE
Included deleted objects #1466

### DIFF
--- a/plugins/BEdita/API/src/TestSuite/IntegrationTestCase.php
+++ b/plugins/BEdita/API/src/TestSuite/IntegrationTestCase.php
@@ -63,6 +63,7 @@ abstract class IntegrationTestCase extends CakeIntegrationTestCase
         'plugin.BEdita/Core.properties',
         'plugin.BEdita/Core.property_types',
         'plugin.BEdita/Core.trees',
+        'plugin.BEdita/Core.object_relations',
     ];
 
     /**

--- a/plugins/BEdita/API/tests/IntegrationTest/AssociatedEntitiesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/AssociatedEntitiesTest.php
@@ -152,4 +152,26 @@ class AssociatedEntitiesTest extends IntegrationTestCase
         $this->assertResponseCode(204);
         $this->assertContentType('application/vnd.api+json');
     }
+
+    /**
+     * Test that deleted entities are never returned as related objects.
+     *
+     * @return void
+     */
+    public function testIncludedDeleted()
+    {
+        $this->configRequestHeaders('DELETE', $this->getUserAuthHeader());
+        $this->delete('/documents/3');
+        $this->assertResponseCode(204);
+
+        $this->configRequestHeaders();
+        $this->get('/documents/2/test');
+        $result = json_decode((string)$this->_response->getBody(), true);
+        static::assertEquals(1, count($result['data']));
+
+        $this->configRequestHeaders();
+        $this->get('/documents/2?include=test');
+        $result = json_decode((string)$this->_response->getBody(), true);
+        static::assertEquals(1, count($result['included']));
+    }
 }

--- a/plugins/BEdita/API/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/plugins/BEdita/API/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -54,6 +54,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
                     'plugin.BEdita/Core.properties',
                     'plugin.BEdita/Core.property_types',
                     'plugin.BEdita/Core.trees',
+                    'plugin.BEdita/Core.object_relations',
                 ],
                 []
             ],
@@ -78,6 +79,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
                     'plugin.BEdita/Core.properties',
                     'plugin.BEdita/Core.property_types',
                     'plugin.BEdita/Core.trees',
+                    'plugin.BEdita/Core.object_relations',
                 ],
                 [
                     'plugin.BEdita/Core.users',

--- a/plugins/BEdita/Core/src/Model/Action/UpdateAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/UpdateAssociatedAction.php
@@ -95,9 +95,10 @@ abstract class UpdateAssociatedAction extends BaseAction
         $prefix = sprintf('%s.', $junction->getAlias());
         $extraFields = [];
         foreach ($conditions as $field => $value) {
-            if (substr($field, 0, strlen($prefix)) === $prefix) {
-                $field = substr($field, strlen($prefix));
+            if (substr($field, 0, strlen($prefix)) !== $prefix) {
+                continue;
             }
+            $field = substr($field, strlen($prefix));
 
             $extraFields[$field] = $value;
         }

--- a/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
@@ -37,8 +37,18 @@ abstract class UpdateRelatedObjectsAction extends UpdateAssociatedAction
         $sourcePrimaryKey = $entity->extract((array)$this->Association->getSource()->getPrimaryKey());
         $foreignKey = array_map([$jointTable, 'aliasField'], (array)$this->Association->getForeignKey());
 
+        $conditionsPrefix = sprintf('%s.', $jointTable->getAlias());
+        $conditions = array_filter(
+            $this->Association->getConditions(),
+            function ($key) use ($conditionsPrefix) {
+                // Filter only conditions that apply to junction table.
+                return substr($key, 0, strlen($conditionsPrefix)) === $conditionsPrefix;
+            },
+            ARRAY_FILTER_USE_KEY
+        );
+
         $existing = $jointTable->find()
-            ->where($this->Association->getConditions())
+            ->where($conditions)
             ->andWhere(array_combine($foreignKey, $sourcePrimaryKey));
 
         return $existing;

--- a/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
@@ -131,6 +131,7 @@ class RelationsBehavior extends Behavior
                 'targetForeignKey' => 'right_id',
                 'conditions' => [
                     $through->aliasField('relation_id') => $relation->id,
+                    sprintf('%s.deleted', $relation->alias) => false,
                 ],
                 'sort' => [
                     $through->aliasField('priority') => 'asc',
@@ -165,6 +166,7 @@ class RelationsBehavior extends Behavior
                 'targetForeignKey' => 'left_id',
                 'conditions' => [
                     $through->aliasField('relation_id') => $relation->id,
+                    sprintf('%s.deleted', $relation->inverse_alias) => false,
                 ],
                 'sort' => [
                     $through->aliasField('inv_priority') => 'asc',

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -23,7 +23,6 @@ use Cake\Event\Event;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
-use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 
 /**
@@ -33,10 +32,9 @@ use Cake\Utility\Hash;
  * @property \Cake\ORM\Association\BelongsTo $CreatedByUser
  * @property \Cake\ORM\Association\BelongsTo $ModifiedByUser
  * @property \Cake\ORM\Association\HasMany $DateRanges
- * @property \Cake\ORM\Association\BelongsTo $CreatedByUser
- * @property \Cake\ORM\Association\BelongsTo $ModifiedByUser
  * @property \Cake\ORM\Association\BelongsToMany $Parents
  * @property \Cake\ORM\Association\HasMany $Trees
+ * @property \Cake\ORM\Association\HasMany $TreeNodes
  *
  * @method \BEdita\Core\Model\Entity\ObjectEntity get($primaryKey, $options = [])
  * @method \BEdita\Core\Model\Entity\ObjectEntity newEntity($data = null, array $options = [])


### PR DESCRIPTION
This PR fixes #1466.

Extra conditions are applied when associations are built in `RelationsBehavior` to exclude deleted objects from results. Some actions needed small fixes to filter conditions when building queries or creating junction entities.