### PR TITLE
Relations inheritance #1349

### DIFF
--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -28,8 +28,6 @@ use Cake\Network\Exception\ConflictException;
 use Cake\Network\Exception\ForbiddenException;
 use Cake\Network\Exception\InternalErrorException;
 use Cake\ORM\Association;
-use Cake\ORM\Association\BelongsTo;
-use Cake\ORM\Association\HasOne;
 use Cake\ORM\Query;
 use Cake\ORM\TableRegistry;
 use Cake\Routing\Exception\MissingRouteException;
@@ -74,7 +72,7 @@ class ObjectsController extends ResourcesController
             $name = $this->request->getParam('relationship');
             $allowedTypes = TableRegistry::get('ObjectTypes')
                 ->find('list')
-                ->find('byRelation', compact('name'))
+                ->find('byRelation', compact('name') + ['descendants' => true])
                 ->toArray();
 
             $this->setConfig(sprintf('allowedAssociations.%s', $name), $allowedTypes);
@@ -92,9 +90,10 @@ class ObjectsController extends ResourcesController
         }
 
         $behaviorRegistry = $this->Table->behaviors();
-        if ($behaviorRegistry->hasMethod('getRelations')) {
-            $relations = array_keys($behaviorRegistry->call('getRelations'));
-            $this->setConfig('allowedAssociations', array_fill_keys($relations, []));
+        if ($behaviorRegistry->hasMethod('objectType')) {
+            /** @var \BEdita\Core\Model\Entity\ObjectType $objectType */
+            $objectType = $behaviorRegistry->call('objectType');
+            $this->setConfig('allowedAssociations', array_fill_keys($objectType->relations, []));
         }
 
         // Requested object type endpoint MUST be `enabled`

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -366,7 +366,8 @@ class ObjectsController extends ResourcesController
             '_name' => 'api:objects:index',
             'object_type' => 'objects'
         ];
-        if (!empty(array_diff($types, ['objects']))) {
+        if (count(array_diff($types, ['objects'])) > 0) {
+            natsort($types);
             $url['filter'] = ['type' => $types];
         }
 
@@ -381,14 +382,14 @@ class ObjectsController extends ResourcesController
      */
     protected function getAvailableTypes($relationship)
     {
-        foreach ($this->objectType->right_relations as $relation) {
+        foreach ($this->objectType->getRelations('right') as $relation) {
             if ($relation->inverse_name !== $relationship) {
                 continue;
             }
 
             return array_values(Hash::extract($relation->left_object_types, '{n}.name'));
         }
-        foreach ($this->objectType->left_relations as $relation) {
+        foreach ($this->objectType->getRelations('left') as $relation) {
             if ($relation->name !== $relationship) {
                 continue;
             }

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -368,7 +368,7 @@ class ObjectsController extends ResourcesController
         ];
         if (count(array_diff($types, ['objects'])) > 0) {
             natsort($types);
-            $url['filter'] = ['type' => $types];
+            $url['filter'] = ['type' => array_values($types)];
         }
 
         return Router::url($url, true);

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
@@ -400,7 +400,9 @@ class ObjectTypesControllerTest extends IntegrationTestCase
                     ],
                     'meta' => [
                         'alias' => 'Media',
-                        'relations' => [],
+                        'relations' => [
+                            'inverse_test_abstract',
+                        ],
                         'created' => '2017-11-10T09:27:23+00:00',
                         'modified' => '2017-11-10T09:27:23+00:00',
                         'core_type' => true,
@@ -445,7 +447,10 @@ class ObjectTypesControllerTest extends IntegrationTestCase
                     ],
                     'meta' => [
                         'alias' => 'Files',
-                        'relations' => [],
+                        'relations' => [
+                            'test_abstract',
+                            'inverse_test_abstract',
+                        ],
                         'created' => '2017-11-10T09:27:23+00:00',
                         'modified' => '2017-11-10T09:27:23+00:00',
                         'core_type' => true,
@@ -537,7 +542,7 @@ class ObjectTypesControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertEquals($expected, $result);
+        static::assertEquals($expected, $result);
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
@@ -43,10 +43,10 @@ class RelationsControllerTest extends IntegrationTestCase
             ],
             'meta' => [
                 'pagination' => [
-                    'count' => 2,
+                    'count' => 3,
                     'page' => 1,
                     'page_count' => 1,
-                    'page_items' => 2,
+                    'page_items' => 3,
                     'page_size' => 20,
                 ],
             ],
@@ -121,6 +121,35 @@ class RelationsControllerTest extends IntegrationTestCase
                         ],
                     ],
                 ],
+                [
+                    'id' => '3',
+                    'type' => 'relations',
+                    'attributes' => [
+                        'name' => 'test_abstract',
+                        'label' => 'Test relation between abstract types',
+                        'inverse_name' => 'inverse_test_abstract',
+                        'inverse_label' => 'Inverse test relation between abstract types',
+                        'description' => 'Sample description.',
+                        'params' => null,
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/model/relations/3',
+                    ],
+                    'relationships' => [
+                        'left_object_types' => [
+                            'links' => [
+                                'self' => 'http://api.example.com/model/relations/3/relationships/left_object_types',
+                                'related' => 'http://api.example.com/model/relations/3/left_object_types',
+                            ],
+                        ],
+                        'right_object_types' => [
+                            'links' => [
+                                'self' => 'http://api.example.com/model/relations/3/relationships/right_object_types',
+                                'related' => 'http://api.example.com/model/relations/3/right_object_types',
+                            ],
+                        ],
+                    ],
+                ],
             ],
         ];
 
@@ -130,7 +159,7 @@ class RelationsControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertEquals($expected, $result);
+        static::assertEquals($expected, $result);
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -13,8 +13,8 @@
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\Controller\ObjectsController;
-use BEdita\API\TestSuite\IntegrationTestCase;
 use BEdita\API\Test\TestConstants;
+use BEdita\API\TestSuite\IntegrationTestCase;
 use Cake\Http\ServerRequest;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
@@ -431,6 +431,18 @@ class ObjectsControllerTest extends IntegrationTestCase
                                 'self' => 'http://api.example.com/files/10/relationships/parents',
                             ],
                         ],
+                        'test_abstract' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/files/10/test_abstract',
+                                'self' => 'http://api.example.com/files/10/relationships/test_abstract',
+                            ],
+                        ],
+                        'inverse_test_abstract' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/files/10/inverse_test_abstract',
+                                'self' => 'http://api.example.com/files/10/relationships/inverse_test_abstract',
+                            ],
+                        ],
                     ],
                 ],
                 [
@@ -589,6 +601,18 @@ class ObjectsControllerTest extends IntegrationTestCase
                             'links' => [
                                 'related' => 'http://api.example.com/files/14/parents',
                                 'self' => 'http://api.example.com/files/14/relationships/parents',
+                            ],
+                        ],
+                        'test_abstract' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/files/14/test_abstract',
+                                'self' => 'http://api.example.com/files/14/relationships/test_abstract',
+                            ],
+                        ],
+                        'inverse_test_abstract' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/files/14/inverse_test_abstract',
+                                'self' => 'http://api.example.com/files/14/relationships/inverse_test_abstract',
                             ],
                         ],
                     ],

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -13,8 +13,8 @@
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\Controller\ObjectsController;
-use BEdita\API\Test\TestConstants;
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\API\Test\TestConstants;
 use Cake\Http\ServerRequest;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -1396,7 +1396,7 @@ class ObjectsControllerTest extends IntegrationTestCase
     /**
      * Data provider for `testLinksAvailable`
      *
-     * @return void
+     * @return array
      */
     public function linksAvailableProvider()
     {

--- a/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
@@ -105,7 +105,7 @@ class RelationsBehavior extends Behavior
         }
 
         // Add relations to the left side.
-        foreach ($objectType->left_relations as $relation) {
+        foreach ($objectType->getRelations('left') as $relation) {
             if ($this->getTable()->association($relation->alias) !== null) {
                 continue;
             }
@@ -140,7 +140,7 @@ class RelationsBehavior extends Behavior
         }
 
         // Add relations to the right side.
-        foreach ($objectType->right_relations as $relation) {
+        foreach ($objectType->getRelations('right') as $relation) {
             if ($this->getTable()->association($relation->inverse_alias) !== null) {
                 continue;
             }
@@ -179,16 +179,10 @@ class RelationsBehavior extends Behavior
      * Get a list of all available relations indexed by their name with regards of side.
      *
      * @return \BEdita\Core\Model\Entity\Relation[]
+     * @deprecated Use `ObjectType::getRelations()` instead.
      */
     public function getRelations()
     {
-        $relations = collection($this->objectType()->left_relations)
-            ->indexBy('name')
-            ->append(
-                collection($this->objectType()->right_relations)
-                    ->indexBy('inverse_name')
-            );
-
-        return $relations->toArray();
+        return $this->objectType()->getRelations();
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
@@ -427,13 +427,13 @@ class ObjectTypesTable extends Table
             $nsmCounters = $this->find()
                 ->select(['tree_left', 'tree_right'])
                 ->where($conditionsBuilder)
-                ->enableHydration(false);
+                ->enableHydration(false)
+                ->all();
 
             // Replace `$conditionsBuilder` with a more complex one that returns not only the matching object types,
             // but also their descendants.
             $conditionsBuilder = function (QueryExpression $exp) use ($nsmCounters) {
-                $rows = $nsmCounters->all();
-                if ($rows->count() === 0) {
+                if ($nsmCounters->count() === 0) {
                     // No nodes found: relationship apparently does not exist, or has no linked types.
                     // Add contradiction to force empty results.
                     return $exp->add(new Comparison(1, 1, 'integer', '<>'));

--- a/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Model\Table;
 
+use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Model\Validation\Validation;
 use BEdita\Core\ORM\Rule\IsUniqueAmongst;
 use Cake\Cache\Cache;
@@ -186,7 +187,7 @@ class RelationsTable extends Table
     protected function findByName(Query $query, array $options = [])
     {
         if (empty($options['name'])) {
-            throw new \LogicException(__d('bedita', 'Missing required parameter "{0}"', 'name'));
+            throw new BadFilterException(__d('bedita', 'Missing required parameter "{0}"', 'name'));
         }
         $name = Inflector::underscore($options['name']);
 

--- a/plugins/BEdita/Core/tests/Fixture/RelationTypesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/RelationTypesFixture.php
@@ -53,6 +53,16 @@ class RelationTypesFixture extends TestFixture
             'object_type_id' => 6,
             'side' => 'right',
         ],
+        [
+            'relation_id' => 3,
+            'object_type_id' => 9,
+            'side' => 'left',
+        ],
+        [
+            'relation_id' => 3,
+            'object_type_id' => 8,
+            'side' => 'right',
+        ],
     ];
 
     /**

--- a/plugins/BEdita/Core/tests/Fixture/RelationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/RelationsFixture.php
@@ -44,5 +44,13 @@ class RelationsFixture extends TestFixture
             'description' => 'Sample description /2.',
             'params' => '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer","minimum":0}},"required":["name"]}',
         ],
+        [
+            'name' => 'test_abstract',
+            'label' => 'Test relation between abstract types',
+            'inverse_name' => 'inverse_test_abstract',
+            'inverse_label' => 'Inverse test relation between abstract types',
+            'description' => 'Sample description.',
+            'params' => null,
+        ],
     ];
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -215,6 +215,59 @@ class ObjectTypeTest extends TestCase
     }
 
     /**
+     * Data provider for `testGetRelationsByName` test case.
+     *
+     * @return array
+     */
+    public function getRelationsByNameProvider()
+    {
+        return [
+            'empty' => [
+                [],
+                'objects',
+            ],
+            'both' => [
+                ['test', 'inverse_test'],
+                'documents',
+                'both',
+            ],
+            'left' => [
+                ['test'],
+                'documents',
+                'left',
+            ],
+            'right' => [
+                ['inverse_test'],
+                'documents',
+                'right',
+            ],
+            'inherited' => [
+                ['test_abstract', 'inverse_test_abstract'],
+                'files',
+            ],
+        ];
+    }
+
+    /**
+     * Test `getRelations()` method.
+     *
+     * @param string[] $expected List of expected relations.
+     * @param string $name Object type name to get relations for.
+     * @param string $side Side to get relations for.
+     * @return void
+     *
+     * @dataProvider getRelationsByNameProvider()
+     * @covers ::getRelations()
+     */
+    public function testGetRelationsByName($expected, $name, $side = 'both')
+    {
+        $objectType = $this->ObjectTypes->get($name);
+        $relations = array_keys($objectType->getRelations($side));
+
+        static::assertEquals($expected, $relations, '', 0, 10, true);
+    }
+
+    /**
      * Test getter for relations.
      *
      * @return void

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
@@ -496,7 +496,7 @@ class ObjectTypesTableTest extends TestCase
     /**
      * Test finder by relation name.
      *
-     * @param array\\Exception $expected Expected results.
+     * @param array|\Exception $expected Expected results.
      * @param array $options Finder options.
      * @return void
      *
@@ -563,12 +563,13 @@ class ObjectTypesTableTest extends TestCase
     /**
      * Test default parent, plugin and model.
      *
+     * @param array $data Entity data.
      * @return void
      *
      * @dataProvider modelRulesProvider
      * @covers ::beforeRules()
      */
-    public function testDefaultModelRules($data)
+    public function testDefaultModelRules(array $data)
     {
         $objectType = $this->ObjectTypes->newEntity();
         $this->ObjectTypes->patchEntity($objectType, $data);
@@ -663,20 +664,19 @@ class ObjectTypesTableTest extends TestCase
     }
 
     /**
-     * Test `parent_name`change with existing objects
+     * Test `parent_name` change with existing objects
      *
      * @return void
      * @covers ::beforeRules()
+     *
+     * @expectedException \Cake\Network\Exception\ForbiddenException
+     * @expectedExceptionMessage Parent type change forbidden: objects of this type exist
      */
     public function testChangeParent()
     {
-        $expected = new ForbiddenException('Parent type change forbidden: objects of this type exist');
-        $this->expectException(get_class($expected));
-        $this->expectExceptionMessage($expected->getMessage());
-
         $objectType = $this->ObjectTypes->get('users');
         $objectType->set('parent_name', 'media');
-        $success = $this->ObjectTypes->save($objectType);
+        $this->ObjectTypes->save($objectType);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
@@ -490,6 +490,18 @@ class ObjectTypesTableTest extends TestCase
                 ['documents', 'profiles'],
                 ['name' => 'inverse_test', 'side' => 'left'],
             ],
+            'with descendants' => [
+                ['media', 'files'],
+                ['name' => 'test_abstract', 'descendants' => true],
+            ],
+            'relation not found' => [
+                [],
+                ['name' => 'this_relation_does_not_exist'],
+            ],
+            'relation not found, with descendants' => [
+                [],
+                ['name' => 'this_relation_does_not_exist', 'descendants' => true],
+            ],
         ];
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
@@ -14,6 +14,7 @@
 
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
+use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Model\Table\ObjectTypesTable;
 use Cake\Cache\Cache;
 use Cake\Datasource\Exception\RecordNotFoundException;
@@ -144,7 +145,7 @@ class RelationsTableTest extends TestCase
     {
         return [
             'error' => [
-                new \LogicException('Missing required parameter "name"'),
+                new BadFilterException('Missing required parameter "name"'),
                 [],
             ],
             'name' => [
@@ -165,7 +166,7 @@ class RelationsTableTest extends TestCase
     /**
      * Test finder by relation name.
      *
-     * @param array\\Exception $expected Expected results.
+     * @param array|\Exception $expected Expected results.
      * @param array $options Finder options.
      * @return void
      *


### PR DESCRIPTION
This PR resolves #1349, and supersedes #1467.

When a relation is valid for an abstract object type (e.g.: **Objects** or **Media**), it becomes available also for all its sub-types (e.g.: for **Objects**, all object types; for **Media** only **Images**, **Files**, …).
