### PR TITLE
Avoid `setDirty` false on CTI

### DIFF
--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -194,8 +194,9 @@ class CustomPropertiesBehavior extends Behavior
             $value[$propertyName] = $entity->get($propertyName);
         }
 
-        $entity->set($field, $value);
-        $entity->setDirty($field, $dirty);
+        if ($dirty) {
+            $entity->set($field, $value);
+        }
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -457,4 +457,56 @@ class UsersTableTest extends TestCase
 
         $this->assertEquals($expected, (bool)$success);
     }
+
+    /**
+     * Data provider for `testCustomPropsCreate`
+     *
+     * @return array
+     */
+    public function customPropsCreateProvider()
+    {
+        return [
+            'users custom prop' => [
+                [
+                    'username' => 'gustavo_supporto',
+                    'another_username' => 'supporto_gustavo',
+                ],
+            ],
+            'profiles custom prop' => [
+                [
+                    'username' => 'gustavo_supporto',
+                    'another_surname' => 'aiuto',
+                ],
+            ],
+            'both custom prop' => [
+                [
+                    'username' => 'gustavo_supporto',
+                    'another_email' => 'supporto@gusta.vo',
+                    'another_surname' => 'helpus',
+                ],
+            ]
+        ];
+    }
+
+    /**
+     * Test create new user with custom properties
+     *
+     * @param array $data User data
+     *
+     * @return void
+     * @dataProvider customPropsCreateProvider
+     * @coversNothing
+     */
+    public function testCustomPropsCreate(array $data)
+    {
+        $user = $this->Users->newEntity();
+        $user = $this->Users->patchEntity($user, $data);
+        $user->type = 'users';
+        $success = $this->Users->save($user);
+
+        $user = $this->Users->get($success['id']);
+        foreach ($data as $key => $value) {
+            static::assertEquals($value, $user[$key]);
+        }
+    }
 }


### PR DESCRIPTION
This PR fixes a bug on custom properties on object creation.

Creating a new object with a custom property on `Users` but no custom properties on `Profiles` failed because an `$entity->setDirty('custom_props', false);` was called in CTI after having been set previously to `true`.

