### PR TITLE
Prevent login from blocked, deleted and off users

### DIFF
--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -65,8 +65,8 @@ class LoginController extends AppController
                             'Weak' => ['hashType' => 'md5'],
                         ],
                     ],
-                    'finder' => 'userLogin',
-                ],
+                    'finder' => 'login',
+                 ],
                 'BEdita/API.Jwt' => [
                     'queryDatasource' => true,
                 ],

--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -65,6 +65,7 @@ class LoginController extends AppController
                             'Weak' => ['hashType' => 'md5'],
                         ],
                     ],
+                    'finder' => 'login',
                 ],
                 'BEdita/API.Jwt' => [
                     'queryDatasource' => true,

--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -65,7 +65,7 @@ class LoginController extends AppController
                             'Weak' => ['hashType' => 'md5'],
                         ],
                     ],
-                    'finder' => 'login',
+                    'finder' => 'userLogin',
                 ],
                 'BEdita/API.Jwt' => [
                     'queryDatasource' => true,

--- a/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
@@ -26,6 +26,22 @@ use Cake\Utility\Hash;
 class LoginControllerTest extends IntegrationTestCase
 {
     /**
+     * Not successful login expected result
+     *
+     * @var array
+     */
+    public const NOT_SUCCESSFUL_EXPECTED_RESULT = [
+        'error' => [
+            'status' => '401',
+            'title' => 'Login not successful',
+        ],
+        'links' => [
+            'self' => 'http://api.example.com/auth',
+            'home' => 'http://api.example.com/home',
+        ],
+    ];
+
+    /**
      * Test login method.
      *
      * @return string A valid JWT.
@@ -418,25 +434,6 @@ class LoginControllerTest extends IntegrationTestCase
     }
 
     /**
-     * Not successful login expected result
-     *
-     * @return array
-     */
-    protected function notSuccessfulExpectedResult()
-    {
-        return [
-            'error' => [
-                'status' => '401',
-                'title' => 'Login not successful',
-            ],
-            'links' => [
-                'self' => 'http://api.example.com/auth',
-                'home' => 'http://api.example.com/home',
-            ],
-        ];
-    }
-
-    /**
      * Login with deleted user method.
      *
      * @return void.
@@ -455,7 +452,7 @@ class LoginControllerTest extends IntegrationTestCase
         $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->assertResponseCode(401);
-        static::assertEquals($this->notSuccessfulExpectedResult(), Hash::remove($result, 'error.meta'));
+        static::assertEquals(self::NOT_SUCCESSFUL_EXPECTED_RESULT, Hash::remove($result, 'error.meta'));
     }
 
     /**
@@ -477,7 +474,7 @@ class LoginControllerTest extends IntegrationTestCase
         $this->assertResponseCode(401);
 
         $result = json_decode((string)$this->_response->getBody(), true);
-        static::assertEquals($this->notSuccessfulExpectedResult(), Hash::remove($result, 'error.meta'));
+        static::assertEquals(self::NOT_SUCCESSFUL_EXPECTED_RESULT, Hash::remove($result, 'error.meta'));
     }
 
     /**
@@ -528,7 +525,7 @@ class LoginControllerTest extends IntegrationTestCase
         } else {
             $this->assertResponseCode(401);
             $result = json_decode((string)$this->_response->getBody(), true);
-            static::assertEquals($this->notSuccessfulExpectedResult(), Hash::remove($result, 'error.meta'));
+            static::assertEquals(self::NOT_SUCCESSFUL_EXPECTED_RESULT, Hash::remove($result, 'error.meta'));
         }
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
@@ -30,7 +30,7 @@ class LoginControllerTest extends IntegrationTestCase
      *
      * @var array
      */
-    public const NOT_SUCCESSFUL_EXPECTED_RESULT = [
+    const NOT_SUCCESSFUL_EXPECTED_RESULT = [
         'error' => [
             'status' => '401',
             'title' => 'Login not successful',

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -269,24 +269,6 @@ class UsersTable extends Table
     }
 
     /**
-     * Check a valid users for login
-     *
-     * @param \Cake\ORM\Query $query Query object instance.
-     * @param array $options Input data with `username`
-     * @return \Cake\ORM\Query
-     * @throws \Cake\Network\Exception\BadRequestException if `username` is missing
-     */
-    protected function findUserLogin(Query $query, array $options)
-    {
-        if (empty($options['username'])) {
-            throw new BadRequestException(__d('bedita', 'Missing username'));
-        }
-
-        return $query->find('login')
-            ->andWhere([$this->aliasField('username') => $options['username']]);
-    }
-
-    /**
      * Before delete checks: if record is not deletable, raise a ImmutableResourceException
      *
      * @param \Cake\Event\Event $event The beforeSave event that was fired

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -160,27 +160,54 @@ class UsersTableTest extends TestCase
         $lastLogin = $this->Users->get(1)->last_login;
         static::assertNotNull($lastLogin);
         static::assertLessThanOrEqual(2, $expected->diffInSeconds($lastLogin));
-        static::assertNull($result->getResult());
     }
 
     /**
-     * Test login blocked.
+     * Test `login` finder.
      *
      * @return void
      *
-     * @covers ::login()
+     * @covers ::findLogin()
+     * @covers ::loginConditions()
      */
-    public function testLoginBlocked()
+    public function testFindLogin()
+    {
+        $user = $this->Users->find('login', ['username' => 'second user'])->first();
+        static::assertNotEmpty($user);
+        static::assertEquals('second user', $user['username']);
+    }
+
+    /**
+     * Test `login` finder fail.
+     *
+     * @return void
+     *
+     * @covers ::findLogin()
+     * @covers ::loginConditions()
+     */
+    public function testFailFindLogin()
     {
         $user = $this->Users->get(5);
         $user->blocked = true;
         $this->Users->saveOrFail($user);
 
-        $result = $this->Users->dispatchEvent('Auth.afterIdentify', [$this->Users->get(5)->toArray()]);
+        $user = $this->Users->find('login', ['username' => 'second user'])->first();
+        static::assertNull($user);
+    }
 
-        $lastLogin = $this->Users->get(5)->last_login;
-        static::assertEquals($user->last_login, $lastLogin);
-        static::assertFalse($result->getResult());
+    /**
+     * Test `login` finder error.
+     *
+     * @return void
+     *
+     * @expectedException \Cake\Network\Exception\BadRequestException
+     * @expectedExceptionMessage Missing username
+     *
+     * @covers ::findLogin()
+     */
+    public function testFindLoginError()
+    {
+        $this->Users->find('login', [])->first();
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -163,54 +163,6 @@ class UsersTableTest extends TestCase
     }
 
     /**
-     * Test `login` finder.
-     *
-     * @return void
-     *
-     * @covers ::findUserLogin()
-     * @covers ::findLogin()
-     */
-    public function testFindLogin()
-    {
-        $user = $this->Users->find('userLogin', ['username' => 'second user'])->first();
-        static::assertNotEmpty($user);
-        static::assertEquals('second user', $user['username']);
-    }
-
-    /**
-     * Test `login` finder fail.
-     *
-     * @return void
-     *
-     * @covers ::findUserLogin()
-     * @covers ::findLogin()
-     */
-    public function testFailFindLogin()
-    {
-        $user = $this->Users->get(5);
-        $user->blocked = true;
-        $this->Users->saveOrFail($user);
-
-        $user = $this->Users->find('userLogin', ['username' => 'second user'])->first();
-        static::assertNull($user);
-    }
-
-    /**
-     * Test `login` finder error.
-     *
-     * @return void
-     *
-     * @expectedException \Cake\Network\Exception\BadRequestException
-     * @expectedExceptionMessage Missing username
-     *
-     * @covers ::findUserLogin()
-     */
-    public function testFindLoginError()
-    {
-        $this->Users->find('userLogin', [])->first();
-    }
-
-    /**
      * Test login with no data.
      *
      * @return void
@@ -222,6 +174,37 @@ class UsersTableTest extends TestCase
         $result = $this->Users->dispatchEvent('Auth.afterIdentify', []);
         static::assertEmpty($result->getData());
         static::assertNull($result->getResult());
+    }
+
+    /**
+     * Test `login` finder.
+     *
+     * @return void
+     *
+     * @covers ::findLogin()
+     */
+    public function testFindLogin()
+    {
+        $user = $this->Users->find('login')->where(['username' => 'second user'])->first();
+        static::assertNotEmpty($user);
+        static::assertEquals('second user', $user['username']);
+    }
+
+    /**
+     * Test `login` finder fail.
+     *
+     * @return void
+     *
+     * @covers ::findLogin()
+     */
+    public function testFailFindLogin()
+    {
+        $user = $this->Users->get(5);
+        $user->blocked = true;
+        $this->Users->saveOrFail($user);
+
+        $user = $this->Users->find('login')->where(['username' => 'second user'])->first();
+        static::assertNull($user);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -167,12 +167,12 @@ class UsersTableTest extends TestCase
      *
      * @return void
      *
+     * @covers ::findUserLogin()
      * @covers ::findLogin()
-     * @covers ::loginConditions()
      */
     public function testFindLogin()
     {
-        $user = $this->Users->find('login', ['username' => 'second user'])->first();
+        $user = $this->Users->find('userLogin', ['username' => 'second user'])->first();
         static::assertNotEmpty($user);
         static::assertEquals('second user', $user['username']);
     }
@@ -182,8 +182,8 @@ class UsersTableTest extends TestCase
      *
      * @return void
      *
+     * @covers ::findUserLogin()
      * @covers ::findLogin()
-     * @covers ::loginConditions()
      */
     public function testFailFindLogin()
     {
@@ -191,7 +191,7 @@ class UsersTableTest extends TestCase
         $user->blocked = true;
         $this->Users->saveOrFail($user);
 
-        $user = $this->Users->find('login', ['username' => 'second user'])->first();
+        $user = $this->Users->find('userLogin', ['username' => 'second user'])->first();
         static::assertNull($user);
     }
 
@@ -203,11 +203,11 @@ class UsersTableTest extends TestCase
      * @expectedException \Cake\Network\Exception\BadRequestException
      * @expectedExceptionMessage Missing username
      *
-     * @covers ::findLogin()
+     * @covers ::findUserLogin()
      */
     public function testFindLoginError()
     {
-        $this->Users->find('login', [])->first();
+        $this->Users->find('userLogin', [])->first();
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -145,17 +145,17 @@ class UsersTableTest extends TestCase
     }
 
     /**
-     * Test login event.
+     * Test handling of login event.
      *
      * @return void
      *
      * @covers ::login()
      */
-    public function testLoginOk()
+    public function testLogin()
     {
         $data = $this->Users->get(1)->toArray();
         $expected = new Time();
-        $result = $this->Users->dispatchEvent('Auth.afterIdentify', [$data]);
+        $this->Users->dispatchEvent('Auth.afterIdentify', [$data]);
 
         $lastLogin = $this->Users->get(1)->last_login;
         static::assertNotNull($lastLogin);


### PR DESCRIPTION
This PR fixes a problem in `POST /auth` login action.

Users having `"blocked": true`, `"status": "off"` or deleted users must not be able to login.

Is `status` draft acceptable? Leaved because is used in `UuidAuthenticateTest` but I'm not sure if it's correct.

In order to achieve this a `login` finder was introduced in `UsersTable` and in `LoginController`.

Same login conditions are applied to `externalAuth` finder.
