### PR TITLE
fix: 500 error getting path of orphan folder

### DIFF
--- a/plugins/BEdita/Core/src/Model/Entity/Folder.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Folder.php
@@ -110,6 +110,7 @@ class Folder extends ObjectEntity
      * Getter for `path` virtual property
      *
      * @return string|null
+     * @throws \RuntimeException If Folder is not found on tree.
      */
     protected function _getPath()
     {
@@ -120,7 +121,11 @@ class Folder extends ObjectEntity
         $trees = TableRegistry::get('Trees');
         $node = $trees->find()
             ->where(['object_id' => $this->id])
-            ->firstOrFail();
+            ->first();
+
+        if (!$node) {
+            throw new \RuntimeException(__d('bedita', 'Folder "{0}" is not on the tree.', $this->id));
+        }
 
         $path = $trees->find('list', [
                 'keyField' => 'id',

--- a/plugins/BEdita/Core/src/Model/Entity/Folder.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Folder.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Model\Entity;
 
+use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
@@ -119,12 +120,12 @@ class Folder extends ObjectEntity
         }
 
         $trees = TableRegistry::get('Trees');
-        $node = $trees->find()
-            ->where(['object_id' => $this->id])
-            ->first();
-
-        if (!$node) {
-            throw new \RuntimeException(__d('bedita', 'Folder "{0}" is not on the tree.', $this->id));
+        try {
+            $node = $trees->find()
+                ->where(['object_id' => $this->id])
+                ->firstOrFail();
+        } catch (RecordNotFoundException $previous) {
+            throw new \RuntimeException(__d('bedita', 'Folder "{0}" is not on the tree.', $this->id), 0, $previous);
         }
 
         $path = $trees->find('list', [

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
@@ -233,6 +233,6 @@ class FolderTest extends TestCase
         $entity = $treesTable->find()->where(['object_id' => 12])->firstOrFail();
         $treesTable->delete($entity);
 
-        $folder = $this->Folders->get(12);
+        $this->Folders->get(12);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
@@ -217,4 +217,22 @@ class FolderTest extends TestCase
         $folder = $this->Folders->newEntity();
         static::assertNull($folder->path);
     }
+
+    /**
+     * Test getter for `path` throws RuntimeException if folder is orphan.
+     *
+     * @return void
+     *
+     * @covers ::_getPath()
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Folder "12" is not on the tree.
+     */
+    public function testGetPathOrphanFolder()
+    {
+        $treesTable = TableRegistry::get('Trees');
+        $entity = $treesTable->find()->where(['object_id' => 12])->firstOrFail();
+        $treesTable->delete($entity);
+
+        $folder = $this->Folders->get(12);
+    }
 }


### PR DESCRIPTION
This PR replaces the previous **404** error with a **500** error getting `Folder::$path` virtual property since an orphan folder (folder without entry on `trees` table) should not exists.
