### PR TITLE
#1454 Move folders action

### DIFF
--- a/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
@@ -83,7 +83,7 @@ class JsonApiComponent extends Component
         }
         try {
             $json = json_decode($json, true);
-            if (json_last_error() || !is_array($json) || !isset($json['data'])) {
+            if (json_last_error() || !is_array($json) || !array_key_exists('data', $json)) {
                 throw new BadRequestException(__d('bedita', 'Invalid JSON input'));
             }
 

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -18,7 +18,7 @@ use BEdita\Core\Model\Action\DeleteObjectAction;
 use BEdita\Core\Model\Action\GetObjectAction;
 use BEdita\Core\Model\Action\ListObjectsAction;
 use BEdita\Core\Model\Action\ListRelatedObjectsAction;
-use BEdita\Core\Model\Action\RemoveAssociatedAction;
+use BEdita\Core\Model\Action\RemoveRelatedObjectsAction;
 use BEdita\Core\Model\Action\SaveEntityAction;
 use BEdita\Core\Model\Action\SetRelatedObjectsAction;
 use Cake\Datasource\EntityInterface;
@@ -292,7 +292,7 @@ class ObjectsController extends ResourcesController
                 break;
 
             case 'DELETE':
-                $action = new RemoveAssociatedAction(compact('association'));
+                $action = new RemoveRelatedObjectsAction(compact('association'));
                 break;
 
             case 'GET':

--- a/plugins/BEdita/API/src/Utility/JsonApi.php
+++ b/plugins/BEdita/API/src/Utility/JsonApi.php
@@ -30,7 +30,7 @@ class JsonApi
     /**
      * Format single or multiple data items in JSON API format.
      *
-     * @param \BEdita\Core\Utility\JsonApiSerializable|\BEdita\Core\Utility\JsonApiSerializable[] $items Items to be formatted.
+     * @param \BEdita\Core\Utility\JsonApiSerializable|\BEdita\Core\Utility\JsonApiSerializable[]|null $items Items to be formatted.
      * @param int $options Serializer options.
      * @param array $fields Selected fields to view in `attributes` and `meta`, if empty (default) all fields are serialized
      * @param array $included Array to be populated with included resources.

--- a/plugins/BEdita/API/src/Utility/JsonApi.php
+++ b/plugins/BEdita/API/src/Utility/JsonApi.php
@@ -44,6 +44,10 @@ class JsonApi
             $items = $items->toList();
         }
 
+        if ($items === null) {
+            return null;
+        }
+
         if (empty($items)) {
             return [];
         }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
@@ -329,6 +329,10 @@ class JsonApiComponentTest extends TestCase
                 [],
                 '',
             ],
+            'dataNull' => [
+                [],
+                '{"data":null}',
+            ],
         ];
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -813,7 +813,7 @@ class FoldersControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(200);
         if ($parentId === null) {
-            static::assertSame(null, Hash::get($result, 'data'));
+            static::assertSame(null, $result['data']);
         } else {
             static::assertSame((string)$parentId, Hash::get($result, 'data.id'));
         }

--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -695,7 +695,7 @@ class FoldersControllerTest extends IntegrationTestCase
      *
      * @return array
      */
-    public function getOrhanFolderProvider()
+    public function getOrphanFolderProvider()
     {
         return [
             'folders/:id' => ['12'],
@@ -708,7 +708,7 @@ class FoldersControllerTest extends IntegrationTestCase
      *
      * @return void
      *
-     * @dataProvider getOrhanFolderProvider
+     * @dataProvider getOrphanFolderProvider
      * @coversNothing
      */
     public function testGetOrphanFolder($id = null)

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -334,6 +334,12 @@ class JsonApiTest extends TestCase
                     return [];
                 },
             ],
+            'nullItem' => [
+                null,
+                function () {
+                    return null;
+                }
+            ],
             'unsupportedType' => [
                 false,
                 function () {

--- a/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
@@ -250,6 +250,9 @@ class ListAssociatedAction extends BaseAction
         $inverseAssociation = $this->buildInverseAssociation();
         $query = $this->buildQuery($primaryKey, $data, $inverseAssociation);
 
+        // remove temporary alias of inverse association from TableRegistry
+        TableRegistry::remove(static::INVERSE_ASSOCIATION_NAME);
+
         if ($this->Association instanceof HasOne || $this->Association instanceof BelongsTo) {
             return $query->first();
         }

--- a/plugins/BEdita/Core/src/Model/Action/RemoveRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/RemoveRelatedObjectsAction.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -16,7 +16,7 @@ namespace BEdita\Core\Model\Action;
 use Cake\Datasource\EntityInterface;
 
 /**
- * Command to remove links between objects.
+ * Command to remove links between related objects or objects and associated entities.
  *
  * @since 4.0.0
  *
@@ -26,12 +26,11 @@ class RemoveRelatedObjectsAction extends UpdateRelatedObjectsAction
 {
 
     /**
-     * Remove existing relations.
+     * Remove existing relations using `\BEdita\Core\Model\Action\RemoveAssociatedAction`.
      *
      * @param \Cake\Datasource\EntityInterface $entity Source entity.
      * @param \Cake\Datasource\EntityInterface|\Cake\Datasource\EntityInterface[]|null $relatedEntities Related entity(-ies).
      * @return int|false Number of updated relationships, or `false` on failure.
-     * @throws \RuntimeException Throws an exception if an unsupported association is passed.
      */
     protected function update(EntityInterface $entity, $relatedEntities)
     {

--- a/plugins/BEdita/Core/src/Model/Action/RemoveRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/RemoveRelatedObjectsAction.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Model\Action;
+
+use Cake\Datasource\EntityInterface;
+
+/**
+ * Command to remove links between objects.
+ *
+ * @since 4.0.0
+ *
+ * @property \Cake\ORM\Association\BelongsToMany|\Cake\ORM\Association\HasMany $Association
+ */
+class RemoveRelatedObjectsAction extends UpdateRelatedObjectsAction
+{
+
+    /**
+     * Remove existing relations.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity Source entity.
+     * @param \Cake\Datasource\EntityInterface|\Cake\Datasource\EntityInterface[]|null $relatedEntities Related entity(-ies).
+     * @return int|false Number of updated relationships, or `false` on failure.
+     * @throws \RuntimeException Throws an exception if an unsupported association is passed.
+     */
+    protected function update(EntityInterface $entity, $relatedEntities)
+    {
+        $action = new RemoveAssociatedAction($this->getConfig());
+
+        return $action->execute(compact('entity', 'relatedEntities'));
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Action/SetAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SetAssociatedAction.php
@@ -83,6 +83,10 @@ class SetAssociatedAction extends UpdateAssociatedAction
             return $this->toMany($entity, $relatedEntities);
         }
 
+        if ($relatedEntities === []) {
+            $relatedEntities = null;
+        }
+
         if ($relatedEntities !== null && !($relatedEntities instanceof EntityInterface)) {
             throw new \InvalidArgumentException(__d('bedita', 'Unable to link multiple entities'));
         }

--- a/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
@@ -68,8 +68,12 @@ abstract class UpdateRelatedObjectsAction extends UpdateAssociatedAction
     /**
      * Get the right entity for the action.
      *
-     * @param EntityInterface $entity The starting entity.
-     * @return void
+     * For `Folder` entity with `Parents` association changes the point of view
+     * using `Tree` entity with `ParentObjects` association assuring to
+     * always use a "to one" relation.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity The starting entity.
+     * @return \Cake\Datasource\EntityInterface
      */
     protected function getEntity(EntityInterface $entity)
     {

--- a/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
@@ -60,7 +60,9 @@ abstract class UpdateRelatedObjectsAction extends UpdateAssociatedAction
      */
     public function execute(array $data = [])
     {
-        $data['entity'] = $this->getEntity($data['entity']);
+        if (array_key_exists('entity', $data)) {
+            $data['entity'] = $this->getEntity($data['entity']);
+        }
 
         return parent::execute($data);
     }

--- a/plugins/BEdita/Core/tests/Fixture/ObjectTypesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ObjectTypesFixture.php
@@ -27,6 +27,7 @@ class ObjectTypesFixture extends TestFixture
      * @var array
      */
     public $records = [
+        // 1
         [
             'singular' => 'object',
             'name' => 'objects',
@@ -42,6 +43,7 @@ class ObjectTypesFixture extends TestFixture
             'enabled' => true,
             'core_type' => true,
         ],
+        // 2
         [
             'singular' => 'document',
             'name' => 'documents',
@@ -57,6 +59,7 @@ class ObjectTypesFixture extends TestFixture
             'enabled' => true,
             'core_type' => true,
         ],
+        // 3
         [
             'singular' => 'profile',
             'name' => 'profiles',
@@ -72,6 +75,7 @@ class ObjectTypesFixture extends TestFixture
             'enabled' => true,
             'core_type' => true,
         ],
+        // 4
         [
             'singular' => 'user',
             'name' => 'users',
@@ -87,6 +91,7 @@ class ObjectTypesFixture extends TestFixture
             'enabled' => true,
             'core_type' => true,
         ],
+        // 5
         [
             'singular' => 'news_item',
             'name' => 'news',
@@ -103,6 +108,7 @@ class ObjectTypesFixture extends TestFixture
             'enabled' => false,
             'core_type' => false,
         ],
+        // 6
         [
             'singular' => 'location',
             'name' => 'locations',
@@ -118,6 +124,7 @@ class ObjectTypesFixture extends TestFixture
             'enabled' => true,
             'core_type' => true,
         ],
+        // 7
         [
             'singular' => 'event',
             'name' => 'events',
@@ -134,6 +141,7 @@ class ObjectTypesFixture extends TestFixture
             'enabled' => true,
             'core_type' => true,
         ],
+        // 8
         [
             'singular' => 'media_item',
             'name' => 'media',
@@ -150,6 +158,7 @@ class ObjectTypesFixture extends TestFixture
             'enabled' => true,
             'core_type' => true,
         ],
+        // 9
         [
             'singular' => 'file',
             'name' => 'files',
@@ -166,6 +175,7 @@ class ObjectTypesFixture extends TestFixture
             'enabled' => true,
             'core_type' => true,
         ],
+        // 10
         [
             'singular' => 'folder',
             'name' => 'folders',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
@@ -96,7 +96,7 @@ class RemoveRelatedObjectsActionTest extends TestCase
     /**
      * Test invocation of command.
      *
-     * @param bool|\Exception Expected result.
+     * @param bool|\Exception $expected Expected result.
      * @param string $table Table to use.
      * @param string $association Association to use.
      * @param int $entity Entity to update relations for.

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Action;
+
+use BEdita\Core\Model\Action\RemoveRelatedObjectsAction;
+use Cake\ORM\Query;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Inflector;
+
+/**
+ * @coversDefaultClass \BEdita\Core\Model\Action\RemoveRelatedObjectsAction
+ */
+class RemoveRelatedObjectsActionTest extends TestCase
+{
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
+        'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.object_relations',
+        'plugin.BEdita/Core.profiles',
+        'plugin.BEdita/Core.properties',
+        'plugin.BEdita/Core.users',
+        'plugin.BEdita/Core.roles',
+        'plugin.BEdita/Core.roles_users',
+        'plugin.BEdita/Core.trees',
+    ];
+
+    /**
+     * Data provider for `testInvocation` test case.
+     *
+     * @return array
+     */
+    public function invocationProvider()
+    {
+        return [
+            'nothingToDo' => [
+                0,
+                'Documents',
+                'Test',
+                1,
+                null,
+            ],
+            'removingNotExistingRelation' => [
+                0,
+                'Documents',
+                'Test',
+                2,
+                5,
+            ],
+            'removingOneRelation' => [
+                1,
+                'Documents',
+                'Test',
+                2,
+                4,
+            ],
+            'removingAllRelations' => [
+                2,
+                'Documents',
+                'Test',
+                2,
+                [4, 3],
+            ],
+            'removingParent' => [
+                new \RuntimeException(
+                    'Unable to remove existing links with association of type "Cake\ORM\Association\BelongsTo"'
+                ),
+                'Folders',
+                'Parents',
+                12,
+                null,
+            ],
+        ];
+    }
+
+    /**
+     * Test invocation of command.
+     *
+     * @param bool|\Exception Expected result.
+     * @param string $table Table to use.
+     * @param string $association Association to use.
+     * @param int $entity Entity to update relations for.
+     * @param int|int[]|null $related Related entity(-ies).
+     * @return void
+     *
+     * @dataProvider invocationProvider()
+     * @covers ::update()
+     * @covers \BEdita\Core\Model\Action\UpdateRelatedObjectsAction::execute()
+     * @covers \BEdita\Core\Model\Action\UpdateRelatedObjectsAction::getEntity()
+     */
+    public function testInvocation($expected, $table, $association, $entity, $related)
+    {
+        if ($expected instanceof \Exception) {
+            $this->expectException(get_class($expected));
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+
+        $association = TableRegistry::get($table)->association($association);
+        $action = new RemoveRelatedObjectsAction(compact('association'));
+
+        $entity = $association->getSource()->get($entity, ['contain' => [$association->getName()]]);
+        $relatedEntities = null;
+        if (is_int($related)) {
+            $relatedEntities = $association->getTarget()->get($related);
+        } elseif (is_array($related)) {
+            $relatedEntities = $association->getTarget()->find()
+                ->where([
+                    $association->getTarget()->getPrimaryKey() . ' IN' => $related,
+                ])
+                ->toArray();
+        }
+
+        $result = $action(compact('entity', 'relatedEntities'));
+
+        $count = 0;
+        if ($related !== null) {
+            $count = $association->getTarget()->find()
+                ->where([
+                    $association->getTarget()->aliasField($association->getTarget()->getPrimaryKey()) . ' IN' => $related,
+                ])
+                ->matching(
+                    Inflector::camelize($association->getSource()->getAlias()),
+                    function (Query $query) use ($association, $entity) {
+                        return $query->where([
+                            $association->getSource()->aliasField($association->getSource()->getPrimaryKey()) => $entity->id,
+                        ]);
+                    }
+                )
+                ->count();
+        }
+
+        $this->assertEquals($expected, $result);
+        $this->assertEquals(0, $count);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
@@ -38,6 +38,7 @@ class RemoveRelatedObjectsActionTest extends TestCase
         'plugin.BEdita/Core.object_relations',
         'plugin.BEdita/Core.profiles',
         'plugin.BEdita/Core.properties',
+        'plugin.BEdita/Core.property_types',
         'plugin.BEdita/Core.users',
         'plugin.BEdita/Core.roles',
         'plugin.BEdita/Core.roles_users',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SetAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SetAssociatedActionTest.php
@@ -147,6 +147,13 @@ class SetAssociatedActionTest extends TestCase
                 1,
                 null,
             ],
+            'hasOneEmptyArray' => [
+                0,
+                'FakeTags',
+                'FakeLabels',
+                1,
+                [],
+            ],
             'hasOneNothingToDo' => [
                 0,
                 'FakeTags',
@@ -187,15 +194,20 @@ class SetAssociatedActionTest extends TestCase
         $action = new SetAssociatedAction(compact('association'));
 
         $entity = $association->getSource()->get($entity, ['contain' => [$association->getName()]]);
+
         $relatedEntities = null;
         if (is_int($related)) {
             $relatedEntities = $association->getTarget()->get($related);
         } elseif (is_array($related)) {
-            $relatedEntities = $association->getTarget()->find()
-                ->where([
-                    $association->getTarget()->getPrimaryKey() . ' IN' => $related,
-                ])
-                ->toArray();
+            if (empty($related)) {
+                $relatedEntities = [];
+            } else {
+                $relatedEntities = $association->getTarget()->find()
+                    ->where([
+                        $association->getTarget()->getPrimaryKey() . ' IN' => $related,
+                    ])
+                    ->toArray();
+            }
         }
 
         $result = $action(compact('entity', 'relatedEntities'));


### PR DESCRIPTION
This PR fixes #1454 

### Folder move to other position

```http
PATCH /folders/:id/relationships/parent

{
    "data": {
        "type": "folders",
        "id": "12"
    }
}
```

### Folder become root

```http
PATCH /folders/:id/relationships/parent

{
    "data": null
}
```

All descendants are maintained on the move action.

#### Side note
Some minor bugs are been fixed:
* handle JSON with `"data": null`
* avoid error in `TableRegistry::get()` using sequentially `ListAssociatedAction`. That action add to registry a termporary alias for inverse association that was never removed.
