### PR TITLE
Tree maintenance shell #1476

### DIFF
--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -33,7 +33,6 @@ use Cake\Utility\Hash;
  * @property \Cake\ORM\Association\BelongsTo $ModifiedByUser
  * @property \Cake\ORM\Association\HasMany $DateRanges
  * @property \Cake\ORM\Association\BelongsToMany $Parents
- * @property \Cake\ORM\Association\HasMany $Trees
  * @property \Cake\ORM\Association\HasMany $TreeNodes
  *
  * @method \BEdita\Core\Model\Entity\ObjectEntity get($primaryKey, $options = [])

--- a/plugins/BEdita/Core/src/Model/Table/TreesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TreesTable.php
@@ -24,6 +24,8 @@ use Cake\Validation\Validator;
  * @method \BEdita\Core\Model\Entity\Tree patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \BEdita\Core\Model\Entity\Tree[] patchEntities($entities, array $data, array $options = [])
  * @method \BEdita\Core\Model\Entity\Tree findOrCreate($search, callable $callback = null, $options = [])
+ *
+ * @mixin \Cake\ORM\Behavior\TreeBehavior
  */
 class TreesTable extends Table
 {

--- a/plugins/BEdita/Core/src/Shell/Task/CheckTreeTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/CheckTreeTask.php
@@ -174,14 +174,13 @@ class CheckTreeTask extends Shell
             ->select([
                 $this->Objects->aliasField('id'),
                 $this->Objects->aliasField('uname'),
-                'count' => $query->func()->count('*'),
             ])
             ->matching('TreeNodes')
             ->group([
                 $this->Objects->aliasField($this->Objects->getPrimaryKey()),
             ])
-            ->having(function (QueryExpression $exp) {
-                return $exp->gt('count', 1, 'integer');
+            ->having(function (QueryExpression $exp) use ($query) {
+                return $exp->gt($query->func()->count('*'), 1, 'integer');
             });
     }
 
@@ -217,15 +216,14 @@ class CheckTreeTask extends Shell
                 $this->Objects->aliasField('object_type_id'),
                 $this->Objects->Parents->aliasField('id'),
                 $this->Objects->Parents->aliasField('uname'),
-                'count' => $query->func()->count('*'),
             ])
             ->matching('Parents')
             ->group([
                 $this->Objects->aliasField('id'),
                 $this->Objects->Parents->aliasField('id'),
             ])
-            ->having(function (QueryExpression $exp) {
-                return $exp->gt('count', 1, 'integer');
+            ->having(function (QueryExpression $exp) use ($query) {
+                return $exp->gt($query->func()->count('*'), 1, 'integer');
             });
     }
 }

--- a/plugins/BEdita/Core/src/Shell/Task/CheckTreeTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/CheckTreeTask.php
@@ -154,7 +154,7 @@ class CheckTreeTask extends Shell
             $this->verbose('=====> <success>There are no other objects with children.</success>');
         }
 
-        // Checks on other objects with children.
+        // Checks on other objects twice inside same folder.
         $results = $this->getObjectsTwiceInFolder()
             ->all();
         $count = $results->count();
@@ -169,8 +169,8 @@ class CheckTreeTask extends Shell
                         $this->Objects->ObjectTypes->get($entity['object_type_id'])->get('singular'),
                         $entity['uname'],
                         $entity['id'],
-                        Hash::get($entity, '_matchingData.Parents.uname', '(unknown)'),
-                        Hash::get($entity, '_matchingData.Parents.id', 0)
+                        (string)Hash::get($entity, '_matchingData.Parents.uname', '(unknown)'),
+                        (string)Hash::get($entity, '_matchingData.Parents.id', 0)
                     )
                 );
             });
@@ -212,7 +212,7 @@ class CheckTreeTask extends Shell
             ])
             ->innerJoinWith('TreeNodes')
             ->group([
-                $this->Objects->aliasField($this->Objects->getPrimaryKey()),
+                $this->Objects->aliasField('id'),
             ])
             ->having(function (QueryExpression $exp) use ($query) {
                 return $exp->gt($query->func()->count('*'), 1, 'integer');

--- a/plugins/BEdita/Core/src/Shell/Task/CheckTreeTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/CheckTreeTask.php
@@ -1,0 +1,231 @@
+<?php
+namespace BEdita\Core\Shell\Task;
+
+use Cake\Console\Shell;
+use Cake\Database\Expression\QueryExpression;
+use Cake\Datasource\EntityInterface;
+use Cake\Utility\Hash;
+
+/**
+ * Task to check tree sanity and perform objects-aware tree recovery.
+ *
+ * @since 4.0.0
+ *
+ * @property \BEdita\Core\Model\Table\ObjectsTable $Objects
+ */
+class CheckTreeTask extends Shell
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public $modelClass = 'Objects';
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+
+        return $parser;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        // Add association to help building queries. This association normally would live in the "Folders" table,
+        // but we're checking for anomalies, so let's assume it makes sense here.
+        $this->Objects->hasMany('TreeParentNodes', [
+            'className' => 'Trees',
+            'foreignKey' => 'parent_id',
+        ]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function main()
+    {
+        $ok = true;
+
+        // Checks on folders not in tree.
+        $results = $this->getFoldersNotInTree()
+            ->all();
+        $count = $results->count();
+        if ($count > 0) {
+            $ok = false;
+
+            $this->out(sprintf('=====> <warning>Found %d folders not in tree!</warning>', $count));
+            $results->each(function (EntityInterface $entity) {
+                $this->verbose(
+                    sprintf(
+                        '=====>   - folder <info>%s</info> (#<info>%d</info>) is not in the tree',
+                        $entity['uname'],
+                        $entity['id']
+                    )
+                );
+            });
+        } else {
+            $this->verbose('=====> <success>There are no folders that are not in tree.</success>');
+        }
+
+        // Checks on ubiquitous folders.
+        $results = $this->getUbiquitousFolders()
+            ->all();
+        $count = $results->count();
+        if ($count > 0) {
+            $ok = false;
+
+            $this->out(sprintf('=====> <warning>Found %d ubiquitous folders!</warning>', $count));
+            $results->each(function (EntityInterface $entity) {
+                $this->verbose(
+                    sprintf(
+                        '=====>   - folder <info>%s</info> (#<info>%d</info>) is ubiquitous',
+                        $entity['uname'],
+                        $entity['id']
+                    )
+                );
+            });
+        } else {
+            $this->verbose('=====> <success>There are no ubiquitous folders.</success>');
+        }
+
+        // Checks on other objects with children.
+        $results = $this->getObjectsWithChildren()
+            ->all();
+        $count = $results->count();
+        if ($count > 0) {
+            $ok = false;
+
+            $this->out(sprintf('=====> <warning>Found %d other objects with children!</warning>', $count));
+            $results->each(function (EntityInterface $entity) {
+                $this->verbose(
+                    sprintf(
+                        '=====>   - %s <info>%s</info> (#<info>%d</info>) has children',
+                        $this->Objects->ObjectTypes->get($entity['object_type_id'])->get('singular'),
+                        $entity['uname'],
+                        $entity['id']
+                    )
+                );
+            });
+        } else {
+            $this->verbose('=====> <success>There are no other objects with children.</success>');
+        }
+
+        // Checks on other objects with children.
+        $results = $this->getObjectsTwiceInFolder()
+            ->all();
+        $count = $results->count();
+        if ($count > 0) {
+            $ok = false;
+
+            $this->out(sprintf('=====> <warning>Found %d objects that are present multiple times within same parent!</warning>', $count));
+            $results->each(function (EntityInterface $entity) {
+                $this->verbose(
+                    sprintf(
+                        '=====>   - %s <info>%s</info> (#<info>%d</info>) is present multiple times within parent <info>%s</info> (#<info>%d</info>)',
+                        $this->Objects->ObjectTypes->get($entity['object_type_id'])->get('singular'),
+                        $entity['uname'],
+                        $entity['id'],
+                        Hash::get($entity, '_matchingData.Parents.uname', '(unknown)'),
+                        Hash::get($entity, '_matchingData.Parents.id', 0)
+                    )
+                );
+            });
+        } else {
+            $this->verbose('=====> <success>There are no objects that are present multiple times within same parent.</success>');
+        }
+
+        return $ok;
+    }
+
+    /**
+     * Return query to find all folders that are not in the tree.
+     *
+     * @return \Cake\ORM\Query
+     */
+    protected function getFoldersNotInTree()
+    {
+        return $this->Objects->find('type', ['folders'])
+            ->select([
+                $this->Objects->aliasField('id'),
+                $this->Objects->aliasField('uname'),
+            ])
+            ->notMatching('TreeNodes');
+    }
+
+    /**
+     * Return query to find all folders that are ubiquitous.
+     *
+     * @return \Cake\ORM\Query
+     */
+    protected function getUbiquitousFolders()
+    {
+        $query = $this->Objects->find('type', ['folders']);
+
+        return $query
+            ->select([
+                $this->Objects->aliasField('id'),
+                $this->Objects->aliasField('uname'),
+                'count' => $query->func()->count('*'),
+            ])
+            ->innerJoinWith('TreeNodes')
+            ->group([
+                $this->Objects->aliasField($this->Objects->getPrimaryKey()),
+            ])
+            ->having(function (QueryExpression $exp) {
+                return $exp->gt('count', 1);
+            });
+    }
+
+    /**
+     * Return query to find all objects that have children despite not being folders.
+     *
+     * @return \Cake\ORM\Query
+     */
+    protected function getObjectsWithChildren()
+    {
+        return $this->Objects->find('type', ['!=' => 'folders'])
+            ->select([
+                $this->Objects->aliasField('id'),
+                $this->Objects->aliasField('uname'),
+                $this->Objects->aliasField('object_type_id'),
+            ])
+            ->matching('TreeParentNodes');
+    }
+
+    /**
+     * Return query to find all objects that are placed twice inside same parent.
+     *
+     * @return \Cake\ORM\Query
+     */
+    protected function getObjectsTwiceInFolder()
+    {
+        $query = $this->Objects->find('type', ['!=' => 'folders']);
+
+        return $query
+            ->select([
+                $this->Objects->aliasField('id'),
+                $this->Objects->aliasField('uname'),
+                $this->Objects->aliasField('object_type_id'),
+                $this->Objects->Parents->aliasField('id'),
+                $this->Objects->Parents->aliasField('uname'),
+                'count' => $query->func()->count('*'),
+            ])
+            ->matching('Parents')
+            ->group([
+                $this->Objects->aliasField('id'),
+                $this->Objects->Parents->aliasField('id'),
+            ])
+            ->having(function (QueryExpression $exp) {
+                return $exp->gt('count', 1);
+            });
+    }
+}

--- a/plugins/BEdita/Core/src/Shell/Task/CheckTreeTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/CheckTreeTask.php
@@ -170,7 +170,7 @@ class CheckTreeTask extends Shell
                         $entity['uname'],
                         $entity['id'],
                         (string)Hash::get($entity, '_matchingData.Parents.uname', '(unknown)'),
-                        (string)Hash::get($entity, '_matchingData.Parents.id', 0)
+                        (int)Hash::get($entity, '_matchingData.Parents.id', 0)
                     )
                 );
             });

--- a/plugins/BEdita/Core/src/Shell/Task/CheckTreeTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/CheckTreeTask.php
@@ -176,12 +176,12 @@ class CheckTreeTask extends Shell
                 $this->Objects->aliasField('uname'),
                 'count' => $query->func()->count('*'),
             ])
-            ->innerJoinWith('TreeNodes')
+            ->matching('TreeNodes')
             ->group([
                 $this->Objects->aliasField($this->Objects->getPrimaryKey()),
             ])
             ->having(function (QueryExpression $exp) {
-                return $exp->gt('count', 1);
+                return $exp->gt('count', 1, 'integer');
             });
     }
 
@@ -225,7 +225,7 @@ class CheckTreeTask extends Shell
                 $this->Objects->Parents->aliasField('id'),
             ])
             ->having(function (QueryExpression $exp) {
-                return $exp->gt('count', 1);
+                return $exp->gt('count', 1, 'integer');
             });
     }
 }

--- a/plugins/BEdita/Core/src/Shell/Task/CheckTreeTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/CheckTreeTask.php
@@ -1,4 +1,16 @@
 <?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
 namespace BEdita\Core\Shell\Task;
 
 use Cake\Console\Shell;

--- a/plugins/BEdita/Core/src/Shell/Task/RecoverTreeTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/RecoverTreeTask.php
@@ -1,4 +1,16 @@
 <?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
 namespace BEdita\Core\Shell\Task;
 
 use Cake\Console\Shell;

--- a/plugins/BEdita/Core/src/Shell/Task/RecoverTreeTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/RecoverTreeTask.php
@@ -1,0 +1,48 @@
+<?php
+namespace BEdita\Core\Shell\Task;
+
+use Cake\Console\Shell;
+
+/**
+ * Shell task to recover tree.
+ *
+ * @since 4.0.0
+ *
+ * @property \BEdita\Core\Model\Table\TreesTable $Trees
+ */
+class RecoverTreeTask extends Shell
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public $modelClass = 'Trees';
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+        $parser
+            ->setDescription('Recover tree from corruption.');
+
+        return $parser;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function main()
+    {
+        $this->out('=====> <info>Beginning tree recovery...</info>');
+
+        $start = microtime(true);
+        $this->Trees->recover();
+        $end = microtime(true);
+
+        $this->out(sprintf('=====> <success>Tree recovery completed</success> (took <info>%f</info> seconds)', $end - $start));
+    }
+}

--- a/plugins/BEdita/Core/src/Shell/TreeShell.php
+++ b/plugins/BEdita/Core/src/Shell/TreeShell.php
@@ -1,4 +1,16 @@
 <?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
 namespace BEdita\Core\Shell;
 
 use BEdita\Core\Shell\Task\CheckTreeTask;

--- a/plugins/BEdita/Core/src/Shell/TreeShell.php
+++ b/plugins/BEdita/Core/src/Shell/TreeShell.php
@@ -1,0 +1,47 @@
+<?php
+namespace BEdita\Core\Shell;
+
+use BEdita\Core\Shell\Task\CheckTreeTask;
+use BEdita\Core\Shell\Task\RecoverTreeTask;
+use Cake\Console\Shell;
+
+/**
+ * Trees shell command.
+ *
+ * @since 4.0.0
+ *
+ * @property \BEdita\Core\Shell\Task\RecoverTreeTask $Recover
+ * @property \BEdita\Core\Shell\Task\CheckTreeTask $Check
+ */
+class TreeShell extends Shell
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public $tasks = [
+        'Recover' => ['className' => RecoverTreeTask::class],
+        'Check' => ['className' => CheckTreeTask::class],
+    ];
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+        $parser
+            ->addSubcommand('recover', [
+                'help' => 'Recover objects\' tree from corruption.',
+                'parser' => $this->Recover->getOptionParser(),
+            ])
+            ->addSubcommand('check', [
+                'help' => 'Objects-aware sanity checks on tree.',
+                'parser' => $this->Check->getOptionParser(),
+            ]);
+
+        return $parser;
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckTreeTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckTreeTaskTest.php
@@ -95,6 +95,7 @@ class CheckTreeTaskTest extends ConsoleIntegrationTestCase
         $this->assertOutputContains('Found 1 folders not in tree!');
         $this->assertOutputContains('folder <info>sub-folder</info> (#<info>12</info>) is not in the tree');
         $this->assertOutputContains('There are no ubiquitous folders');
+        $this->assertOutputContains('There are no other objects in root.');
         $this->assertOutputContains('There are no other objects with children');
         $this->assertOutputContains('There are no objects that are present multiple times within same parent');
     }
@@ -120,7 +121,33 @@ class CheckTreeTaskTest extends ConsoleIntegrationTestCase
         $this->assertOutputContains('There are no folders that are not in tree');
         $this->assertOutputContains('Found 1 ubiquitous folders!');
         $this->assertOutputContains('folder <info>sub-folder</info> (#<info>12</info>) is ubiquitous');
+        $this->assertOutputContains('There are no other objects in root.');
         $this->assertOutputContains('There are no other objects with children');
+        $this->assertOutputContains('There are no objects that are present multiple times within same parent');
+    }
+
+    /**
+     * Test execution when there are other objects that are roots.
+     *
+     * @return void
+     */
+    public function testExecutionOtherObjectInRoot()
+    {
+        $this->Trees->save(
+            $this->Trees->newEntity([
+                'object_id' => 2,
+                'parent_id' => null,
+            ]),
+            ['checkRules' => false]
+        );
+
+        $this->exec(sprintf('%s --verbose', CheckTreeTask::class));
+
+        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertOutputContains('There are no folders that are not in tree');
+        $this->assertOutputContains('There are no ubiquitous folders');
+        $this->assertOutputContains('Found 1 other objects in root!');
+        $this->assertOutputContains('document <info>title-one</info> (#<info>2</info>) is a root');
         $this->assertOutputContains('There are no objects that are present multiple times within same parent');
     }
 
@@ -144,6 +171,7 @@ class CheckTreeTaskTest extends ConsoleIntegrationTestCase
         $this->assertExitCode(Shell::CODE_ERROR);
         $this->assertOutputContains('There are no folders that are not in tree');
         $this->assertOutputContains('There are no ubiquitous folders');
+        $this->assertOutputContains('There are no other objects in root.');
         $this->assertOutputContains('Found 1 other objects with children!');
         $this->assertOutputContains('document <info>title-one</info> (#<info>2</info>) has children');
         $this->assertOutputContains('There are no objects that are present multiple times within same parent');
@@ -177,6 +205,7 @@ class CheckTreeTaskTest extends ConsoleIntegrationTestCase
         $this->assertExitCode(Shell::CODE_ERROR);
         $this->assertOutputContains('There are no folders that are not in tree');
         $this->assertOutputContains('There are no ubiquitous folders');
+        $this->assertOutputContains('There are no other objects in root.');
         $this->assertOutputContains('There are no other objects with children');
         $this->assertOutputContains('Found 1 objects that are present multiple times within same parent!');
         $this->assertOutputContains('document <info>title-one</info> (#<info>2</info>) is present multiple times within parent <info>root-folder</info> (#<info>11</info>)');

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckTreeTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckTreeTaskTest.php
@@ -1,4 +1,16 @@
 <?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
 namespace BEdita\Core\Test\TestCase\Shell\Task;
 
 use BEdita\Core\Shell\Task\CheckTreeTask;

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckTreeTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckTreeTaskTest.php
@@ -3,6 +3,7 @@ namespace BEdita\Core\Test\TestCase\Shell\Task;
 
 use BEdita\Core\Shell\Task\CheckTreeTask;
 use Cake\Console\Shell;
+use Cake\Database\Driver\Mysql;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\ConsoleIntegrationTestCase;
 
@@ -156,8 +157,13 @@ class CheckTreeTaskTest extends ConsoleIntegrationTestCase
     public function testExecutionObjectTwiceInFolder()
     {
         // Worse-than-worst case scenario: drop unique index to simulate a case where the constraint was violated somehow.
-        $this->Trees->getConnection()
-            ->execute('DROP INDEX trees_objectparent_uq ON trees');
+        if (!($this->Trees->getConnection()->getDriver() instanceof Mysql)) {
+            static::markTestSkipped('This test requires dropping a constraint and happens only on MySQL');
+        }
+
+        $this->Trees->getConnection()->execute(
+            sprintf('DROP INDEX %s ON %s', 'trees_objectparent_uq', $this->Trees->getTable())
+        );
         $this->Trees->save(
             $this->Trees->newEntity([
                 'object_id' => 2,

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckTreeTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckTreeTaskTest.php
@@ -86,7 +86,7 @@ class CheckTreeTaskTest extends ConsoleIntegrationTestCase
             $this->Trees->find()
                 ->where(['object_id' => 12])
                 ->firstOrFail(),
-            ['checkRules' => false]
+            ['checkRules' => false, '_primary' => false]
         );
 
         $this->exec(sprintf('%s --verbose', CheckTreeTask::class));

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckTreeTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckTreeTaskTest.php
@@ -1,0 +1,178 @@
+<?php
+namespace BEdita\Core\Test\TestCase\Shell\Task;
+
+use BEdita\Core\Shell\Task\CheckTreeTask;
+use Cake\Console\Shell;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\ConsoleIntegrationTestCase;
+
+/**
+ * @covers \BEdita\Core\Shell\Task\CheckTreeTask
+ */
+class CheckTreeTaskTest extends ConsoleIntegrationTestCase
+{
+
+    /**
+     * Trees table.
+     *
+     * @var \BEdita\Core\Model\Table\TreesTable
+     */
+    public $Trees;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relation_types',
+        'plugin.BEdita/Core.property_types',
+        'plugin.BEdita/Core.properties',
+        'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.trees',
+    ];
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->Trees = TableRegistry::get('Trees');
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->Trees);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test execution when tree is already valid.
+     *
+     * @return void
+     */
+    public function testExecutionOk()
+    {
+        $this->exec(sprintf('%s --verbose', CheckTreeTask::class));
+
+        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertOutputContains('There are no folders that are not in tree');
+        $this->assertOutputContains('There are no ubiquitous folders');
+        $this->assertOutputContains('There are no other objects with children');
+        $this->assertOutputContains('There are no objects that are present multiple times within same parent');
+    }
+
+    /**
+     * Test execution when there are folders that are not in the tree.
+     *
+     * @return void
+     */
+    public function testExecutionFolderNotInTree()
+    {
+        $this->Trees->delete(
+            $this->Trees->find()
+                ->where(['object_id' => 12])
+                ->firstOrFail(),
+            ['checkRules' => false]
+        );
+
+        $this->exec(sprintf('%s --verbose', CheckTreeTask::class));
+
+        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertOutputContains('Found 1 folders not in tree!');
+        $this->assertOutputContains('folder <info>sub-folder</info> (#<info>12</info>) is not in the tree');
+        $this->assertOutputContains('There are no ubiquitous folders');
+        $this->assertOutputContains('There are no other objects with children');
+        $this->assertOutputContains('There are no objects that are present multiple times within same parent');
+    }
+
+    /**
+     * Test execution when there are ubiquitous folders.
+     *
+     * @return void
+     */
+    public function testExecutionUbiquitousFolder()
+    {
+        $this->Trees->save(
+            $this->Trees->newEntity([
+                'object_id' => 12,
+                'parent_id' => null,
+            ]),
+            ['checkRules' => false]
+        );
+
+        $this->exec(sprintf('%s --verbose', CheckTreeTask::class));
+
+        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertOutputContains('There are no folders that are not in tree');
+        $this->assertOutputContains('Found 1 ubiquitous folders!');
+        $this->assertOutputContains('folder <info>sub-folder</info> (#<info>12</info>) is ubiquitous');
+        $this->assertOutputContains('There are no other objects with children');
+        $this->assertOutputContains('There are no objects that are present multiple times within same parent');
+    }
+
+    /**
+     * Test execution when there are other objects that have children.
+     *
+     * @return void
+     */
+    public function testExecutionOtherObjectWithChildren()
+    {
+        $this->Trees->save(
+            $this->Trees->newEntity([
+                'object_id' => 4,
+                'parent_id' => 2,
+            ]),
+            ['checkRules' => false]
+        );
+
+        $this->exec(sprintf('%s --verbose', CheckTreeTask::class));
+
+        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertOutputContains('There are no folders that are not in tree');
+        $this->assertOutputContains('There are no ubiquitous folders');
+        $this->assertOutputContains('Found 1 other objects with children!');
+        $this->assertOutputContains('document <info>title-one</info> (#<info>2</info>) has children');
+        $this->assertOutputContains('There are no objects that are present multiple times within same parent');
+    }
+
+    /**
+     * Test execution when there are other objects that have children.
+     *
+     * @return void
+     */
+    public function testExecutionObjectTwiceInFolder()
+    {
+        // Worse-than-worst case scenario: drop unique index to simulate a case where the constraint was violated somehow.
+        $this->Trees->getConnection()
+            ->execute('DROP INDEX trees_objectparent_uq ON trees');
+        $this->Trees->save(
+            $this->Trees->newEntity([
+                'object_id' => 2,
+                'parent_id' => 11,
+            ]),
+            ['checkRules' => false]
+        );
+
+        $this->exec(sprintf('%s --verbose', CheckTreeTask::class));
+
+        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertOutputContains('There are no folders that are not in tree');
+        $this->assertOutputContains('There are no ubiquitous folders');
+        $this->assertOutputContains('There are no other objects with children');
+        $this->assertOutputContains('Found 1 objects that are present multiple times within same parent!');
+        $this->assertOutputContains('document <info>title-one</info> (#<info>2</info>) is present multiple times within parent <info>root-folder</info> (#<info>11</info>)');
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/RecoverTreeTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/RecoverTreeTaskTest.php
@@ -1,0 +1,105 @@
+<?php
+namespace BEdita\Core\Test\TestCase\Shell\Task;
+
+use BEdita\Core\Shell\Task\RecoverTreeTask;
+use Cake\Console\Shell;
+use Cake\Database\Expression\Comparison;
+use Cake\Datasource\EntityInterface;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\ConsoleIntegrationTestCase;
+
+/**
+ * @covers \BEdita\Core\Shell\Task\RecoverTreeTask
+ */
+class RecoverTreeTaskTest extends ConsoleIntegrationTestCase
+{
+
+    /**
+     * Trees table.
+     *
+     * @var \BEdita\Core\Model\Table\TreesTable
+     */
+    public $Trees;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.trees',
+    ];
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->Trees = TableRegistry::get('Trees');
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->Trees);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test main execution.
+     *
+     * @return void
+     */
+    public function testExecute()
+    {
+        /**
+         * Helper function to get a "snapshot" describing tree state.
+         *
+         * @return array
+         */
+        $getTreeState = function () {
+            return $this->Trees->find()
+                ->combine('id', function (EntityInterface $node) {
+                    return sprintf('%d / %d', $node['tree_left'], $node['tree_right']);
+                })
+                ->toArray();
+        };
+
+        // Get current snapshot. This assumes fixtures cause tree to be in a valid state.
+        $expected = $getTreeState();
+
+        // Corrupt tree: `UPDATE * FROM trees SET tree_left = id * 2, tree_right = id * 2 + 1`.
+        $this->Trees->updateAll(
+            [
+                'tree_left' => new Comparison('id', 2, 'integer', '*'),
+                'tree_right' => new Comparison(new Comparison('id', 2, 'integer', '*'), 1, 'integer', '+'),
+            ],
+            []
+        );
+
+        // Check that some corruption actually happened.
+        $corrupt = $getTreeState();
+        static::assertNotEquals($expected, $corrupt, 'Tree hasn\'t been corrupted prior to testing');
+
+        // Recover.
+        $this->exec(RecoverTreeTask::class);
+
+        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertOutputContains('Tree recovery completed');
+
+        // Assert that tree returned to a valid state.
+        $actual = $getTreeState();
+        static::assertEquals($expected, $actual);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/RecoverTreeTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/RecoverTreeTaskTest.php
@@ -1,4 +1,16 @@
 <?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
 namespace BEdita\Core\Test\TestCase\Shell\Task;
 
 use BEdita\Core\Shell\Task\RecoverTreeTask;


### PR DESCRIPTION
This PR implements part of the shell requested in #1476.

A new `tree` shell has been added with two tasks:

* `bin/cake tree recover` performs a basic recovery of a corrupt tree, by simply invoking CakePHP's `TreeBehavior::recover()`
* `bin/cake tree check` performs some object-aware checks such as:
  - detect folders that are not in the tree
  - detect ubiquitous folders
  - detect non-folder objects that are roots
  - detect non-folder objects that have descendants
  - detect objects that are present more than once within same parent

It has not been implemented a shell that helps the user recover the tree from these kinds of semantic errors.