### PR TITLE
Add local cache of JSON Schema Draft-06 meta schema

### DIFF
--- a/plugins/BEdita/Core/src/Model/Validation/Validation.php
+++ b/plugins/BEdita/Core/src/Model/Validation/Validation.php
@@ -17,6 +17,8 @@ use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Validation\Validation as CakeValidation;
 use League\JsonGuard\Validator as JsonSchemaValidator;
 use League\JsonReference\Dereferencer as JsonSchemaDereferencer;
+use League\JsonReference\Loader\ArrayLoader;
+use League\JsonReference\Loader\ChainedLoader;
 
 /**
  * Reusable class to check for reserved names.
@@ -104,7 +106,22 @@ class Validation
     public static function jsonSchema($value, $schema)
     {
         if (is_string($schema)) {
-            $schema = JsonSchemaDereferencer::draft6()->dereference($schema);
+            $cacheLoader = new ArrayLoader([
+                'json-schema.org/draft-06/schema' => json_decode(file_get_contents(__DIR__ . DS . 'schemas' . DS . 'draft-06.json')),
+            ]);
+
+            $dereferencer = JsonSchemaDereferencer::draft6();
+            $loaderManager = $dereferencer->getLoaderManager();
+            $loaderManager->registerLoader('http', new ChainedLoader(
+                $cacheLoader,
+                $loaderManager->getLoader('http')
+            ));
+            $loaderManager->registerLoader('https', new ChainedLoader(
+                $cacheLoader,
+                $loaderManager->getLoader('https')
+            ));
+
+            $schema = $dereferencer->dereference($schema);
         }
         if (empty($schema)) {
             return true;

--- a/plugins/BEdita/Core/src/Model/Validation/schemas/draft-06.json
+++ b/plugins/BEdita/Core/src/Model/Validation/schemas/draft-06.json
@@ -1,0 +1,154 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "http://json-schema.org/draft-06/schema#",
+    "title": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "nonNegativeInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "nonNegativeIntegerDefault0": {
+            "allOf": [
+                { "$ref": "#/definitions/nonNegativeInteger" },
+                { "default": 0 }
+            ]
+        },
+        "simpleTypes": {
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "default": []
+        }
+    },
+    "type": ["object", "boolean"],
+    "properties": {
+        "$id": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$ref": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": {},
+        "examples": {
+            "type": "array",
+            "items": {}
+        },
+        "multipleOf": {
+            "type": "number",
+            "exclusiveMinimum": 0
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "number"
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "number"
+        },
+        "maxLength": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minLength": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": { "$ref": "#" },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": {}
+        },
+        "maxItems": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minItems": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "contains": { "$ref": "#" },
+        "maxProperties": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minProperties": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": { "$ref": "#" },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "propertyNames": { "$ref": "#" },
+        "const": {},
+        "enum": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "format": { "type": "string" },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "default": {}
+}


### PR DESCRIPTION
This PR adds a local cache of JSON Schema Draft-06 meta schema.

This aims to avoid useless outgoing HTTP requests, and especially to avoid errors in case json-schema.org is unreachable for some reason.