### PR TITLE
Schema on disabled types and hidden properties

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/SchemaControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/SchemaControllerTest.php
@@ -106,6 +106,24 @@ class SchemaControllerTest extends IntegrationTestCase
     }
 
     /**
+     * Test `jsonSchema` method on a disabled object type.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testJsonSchemaDisabled()
+    {
+        $this->configRequestHeaders('GET');
+        $this->get('model/schema/news');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/schema+json');
+        static::assertFalse($result);
+    }
+
+    /**
      * Test ETag response header and Not Modified response.
      *
      * @return void

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
@@ -283,7 +283,7 @@ class ObjectType extends Entity implements JsonApiSerializable
      */
     protected function _getSchema()
     {
-        if ($this->is_abstract || empty($this->id)) {
+        if ($this->is_abstract || empty($this->id) || $this->enabled === false) {
             return false;
         }
 
@@ -293,9 +293,13 @@ class ObjectType extends Entity implements JsonApiSerializable
             ->toArray();
         $entity = TableRegistry::get($this->name)->newEntity();
         $hiddenProperties = $entity->hiddenProperties();
+        $typeHidden = !empty($this->hidden) ? $this->hidden : [];
 
         $properties = $required = [];
         foreach ($allProperties as $property) {
+            if (in_array($property->name, $typeHidden)) {
+                continue;
+            }
             $accessMode = null;
             if (!$entity->isAccessible($property->name)) {
                 $accessMode = 'readOnly';

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -648,4 +648,39 @@ class ObjectTypeTest extends TestCase
 
         static::assertFalse($schema);
     }
+
+    /**
+     * Test getter for disabled `schema`.
+     *
+     * @return void
+     *
+     * @covers ::_getSchema()
+     */
+    public function testGetSchemaDisabled()
+    {
+        $objectType = $this->ObjectTypes->get('news');
+        $schema = $objectType->schema;
+        static::assertFalse($schema);
+    }
+
+    /**
+     * Test getter for `schema` whith hidden properties.
+     *
+     * @return void
+     *
+     * @covers ::_getSchema()
+     */
+    public function testGetSchemaHiddenProperties()
+    {
+        // enable type `news`
+        $objectType = $this->ObjectTypes->get('news');
+        $objectType->enabled = true;
+        $success = $this->ObjectTypes->save($objectType);
+        static::assertTrue((bool)$success);
+
+        // `body` property is hidden
+        $schema = $objectType->schema;
+        $properties = Hash::extract($schema, 'properties');
+        static::assertArrayNotHasKey('body', $properties);
+    }
 }


### PR DESCRIPTION
This PR fixes two bugs in JSON Schema generation

- object types with `enabled` == `false` must produce `false` as schema
- properties listed in `object_types.hidden` must not be present
