### PR TITLE
Include related entities in related endpoint

### DIFF
--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -159,8 +159,7 @@ class ObjectsController extends ResourcesController
         } else {
             // List existing entities.
             $filter = (array)$this->request->getQuery('filter') + array_filter(['query' => $this->request->getQuery('q')]);
-            $include = $this->request->getQuery('include');
-            $contain = $include ? $this->prepareInclude($include) : [];
+            $contain = $this->prepareInclude($this->request->getQuery('include'));
 
             $action = new ListObjectsAction(['table' => $this->Table, 'objectType' => $this->objectType]);
             $query = $action(compact('filter', 'contain'));
@@ -196,8 +195,7 @@ class ObjectsController extends ResourcesController
         $this->request->allowMethod(['get', 'patch', 'delete']);
 
         $id = TableRegistry::get('Objects')->getId($id);
-        $include = $this->request->getQuery('include');
-        $contain = $include ? $this->prepareInclude($include) : [];
+        $contain = $this->prepareInclude($this->request->getQuery('include'));
 
         $action = new GetObjectAction(['table' => $this->Table, 'objectType' => $this->objectType]);
         $entity = $action(['primaryKey' => $id, 'contain' => $contain]);
@@ -255,9 +253,10 @@ class ObjectsController extends ResourcesController
 
         $association = $this->findAssociation($relationship);
         $filter = (array)$this->request->getQuery('filter') + array_filter(['query' => $this->request->getQuery('q')]);
+        $contain = $this->prepareInclude($this->request->getQuery('include'));
 
         $action = $this->getAssociatedAction($association);
-        $objects = $action(['primaryKey' => $relatedId, 'filter' => $filter]);
+        $objects = $action(['primaryKey' => $relatedId] + compact('filter', 'contain'));
 
         if ($objects instanceof Query) {
             $objects = $this->paginate($objects);

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -113,13 +113,13 @@ abstract class ResourcesController extends AppController
     /**
      * Prepare a list of associations to be contained from `?include` query parameter.
      *
-     * @param string|null $include Association(s) to be included.
+     * @param string|array|null $include Association(s) to be included.
      * @return array
      * @throws \Cake\Network\Exception\BadRequestException Throws an exception if a
      */
     protected function prepareInclude($include)
     {
-        if (empty($include)) {
+        if ($include === null) {
             return [];
         }
         if (!is_string($include)) {

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -113,12 +113,15 @@ abstract class ResourcesController extends AppController
     /**
      * Prepare a list of associations to be contained from `?include` query parameter.
      *
-     * @param string $include Association(s) to be included.
+     * @param string|null $include Association(s) to be included.
      * @return array
      * @throws \Cake\Network\Exception\BadRequestException Throws an exception if a
      */
     protected function prepareInclude($include)
     {
+        if (empty($include)) {
+            return [];
+        }
         if (!is_string($include)) {
             throw new BadRequestException(
                 __d('bedita', 'Invalid "{0}" query parameter ({1})', 'include', __d('bedita', 'Must be a comma-separated string'))
@@ -179,8 +182,7 @@ abstract class ResourcesController extends AppController
         } else {
             // List existing entities.
             $filter = (array)$this->request->getQuery('filter') + array_filter(['query' => $this->request->getQuery('q')]);
-            $include = $this->request->getQuery('include');
-            $contain = $include ? $this->prepareInclude($include) : [];
+            $contain = $this->prepareInclude($this->request->getQuery('include'));
 
             $action = new ListEntitiesAction(['table' => $this->Table]);
             $query = $action(compact('filter', 'contain'));
@@ -231,8 +233,7 @@ abstract class ResourcesController extends AppController
     {
         $this->request->allowMethod(['get', 'patch', 'delete']);
 
-        $include = $this->request->getQuery('include');
-        $contain = $include ? $this->prepareInclude($include) : [];
+        $contain = $this->prepareInclude($this->request->getQuery('include'));
 
         $action = new GetEntityAction(['table' => $this->Table]);
         $entity = $action(['primaryKey' => $id, 'contain' => $contain]);
@@ -284,9 +285,10 @@ abstract class ResourcesController extends AppController
 
         $association = $this->findAssociation($relationship);
         $filter = (array)$this->request->getQuery('filter') + array_filter(['query' => $this->request->getQuery('q')]);
+        $contain = $this->prepareInclude($this->request->getQuery('include'));
 
         $action = $this->getAssociatedAction($association);
-        $data = $action->execute(['primaryKey' => $relatedId, 'filter' => $filter]);
+        $data = $action->execute(['primaryKey' => $relatedId] + compact('filter', 'contain'));
 
         if ($data instanceof Query) {
             $data = $this->paginate($data);

--- a/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
@@ -690,4 +690,22 @@ class ResourcesControllerTest extends IntegrationTestCase
         static::assertArrayHasKey('error', $result);
         static::assertArraySubset($expected, $result['error']);
     }
+
+    /**
+     * Test that no resources are included unless asked.
+     *
+     * @return void
+     *
+     * @covers ::prepareInclude()
+     */
+    public function testIncludeEmpty()
+    {
+        $this->configRequestHeaders();
+        $this->get('/roles');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertArrayNotHasKey('included', $result);
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
@@ -41,10 +41,12 @@ class ListRelatedObjectsAction extends ListAssociatedAction
                     'name' => $this->Association->getName(),
                     'side' => 'right',
                 ])
+                ->contain(['LeftRelations.RightObjectTypes', 'RightRelations.LeftObjectTypes'])
                 ->toArray();
             $table = $this->Association->getTarget();
             if (count($objectTypes) === 1) {
                 $objectType = current($objectTypes);
+                $table->setupRelations($objectType);
             }
             $this->ListAction = new ListObjectsAction(compact('table', 'objectType'));
         } elseif ($this->Association->getTarget() instanceof ObjectsTable

--- a/plugins/BEdita/Core/tests/Fixture/RelationTypesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/RelationTypesFixture.php
@@ -29,38 +29,38 @@ class RelationTypesFixture extends TestFixture
      */
     public $records = [
         [
-            'relation_id' => 1,
-            'object_type_id' => 2,
+            'relation_id' => 1, // test / inverse_test
+            'object_type_id' => 2, // documents
             'side' => 'left',
         ],
         [
-            'relation_id' => 1,
-            'object_type_id' => 2,
+            'relation_id' => 1, // test / inverse_test
+            'object_type_id' => 2, // documents
             'side' => 'right',
         ],
         [
-            'relation_id' => 1,
-            'object_type_id' => 3,
+            'relation_id' => 1, // test / inverse_test
+            'object_type_id' => 3, // profiles
             'side' => 'right',
         ],
         [
-            'relation_id' => 2,
-            'object_type_id' => 6,
+            'relation_id' => 2, // another_test / inverse_another_test
+            'object_type_id' => 6, // locations
             'side' => 'left',
         ],
         [
-            'relation_id' => 2,
-            'object_type_id' => 6,
+            'relation_id' => 2, // another_test / inverse_another_test
+            'object_type_id' => 6, // locations
             'side' => 'right',
         ],
         [
-            'relation_id' => 3,
-            'object_type_id' => 9,
+            'relation_id' => 3, // test_abstract / inverse_test_abstract
+            'object_type_id' => 9, // files
             'side' => 'left',
         ],
         [
-            'relation_id' => 3,
-            'object_type_id' => 8,
+            'relation_id' => 3, // test_abstract / inverse_test_abstract
+            'object_type_id' => 8, // media
             'side' => 'right',
         ],
     ];


### PR DESCRIPTION
This PR enables the use of `?include` query parameter for `GET /:objectType/:id/:relationName` endpoints.

For instance, `GET /documents/10/attach?include=my_relation` should now yield the expected result.

Some minor refactors were necessary, but there shouldn't be any major change in this patch.