### PR TITLE
#1495 permanent remove folder

### DIFF
--- a/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
@@ -245,7 +245,7 @@ class FoldersTable extends ObjectsTable
         }
 
         foreach ((array)$options['descendants'] as $subfolder) {
-            $this->delete($subfolder, ['_isDescendant' => true]);
+            $this->deleteOrFail($subfolder, ['_isDescendant' => true]);
         }
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
@@ -401,10 +401,10 @@ class FoldersTableTest extends TestCase
             static::assertTrue($Objects->exists(['id' => $id]));
         }
 
-        $currenTree = $Trees->find()->toArray();
+        $currenTree = $Trees->find()->order(['tree_left' => 'ASC'])->toArray();
         // check that after recover the tree is the same.
         $Trees->recover();
-        static::assertEquals($currenTree, $Trees->find()->toArray());
+        static::assertEquals($currenTree, $Trees->find()->order(['tree_left' => 'ASC'])->toArray());
     }
 
     /**


### PR DESCRIPTION
This PR fixes #1495 

Briefly:

1. Before deleting a folder all **descendants** are found and stored in `descendants` key of `\ArrayObject $options`. The `$options` is chained to `afterDelete()` by CakePHP.
2. After deleting the main folder and consequently its tree node, the **descendants** are deleted passing `$options['_isDescendant'] = true` to avoid useless query on `trees` that is already correct.

