### PR TITLE
Update profiles title also if blank

### DIFF
--- a/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
@@ -99,7 +99,7 @@ class ProfilesTable extends Table
     /**
      * Before save actions:
      *  - if `email` is empty set it to NULL to avoid unique constraint errors
-     *  - on empty `title` use `name` `surname` as default
+     *  - if `title` is blank use `name` `surname` as default
      *
      * @param \Cake\Event\Event $event The beforeSave event that was fired
      * @param \Cake\Datasource\EntityInterface $entity the entity that is going to be saved
@@ -110,7 +110,7 @@ class ProfilesTable extends Table
         if (empty($entity->get('email'))) {
             $entity->set('email', null);
         }
-        if (empty($entity->get('title')) && (!empty($entity->get('name')) || !empty($entity->get('surname')))) {
+        if ($entity->get('title') === '' && (!empty($entity->get('name')) || !empty($entity->get('surname')))) {
             $title = sprintf('%s %s', (string)Hash::get($entity, 'name', ''), (string)Hash::get($entity, 'surname', ''));
             $entity->set('title', trim($title));
         }

--- a/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
@@ -110,9 +110,9 @@ class ProfilesTable extends Table
         if (empty($entity->get('email'))) {
             $entity->set('email', null);
         }
-        if (!$entity->has('title') && ($entity->has('name') || $entity->has('surname'))) {
+        if (empty($entity->get('title')) && (!empty($entity->get('name')) || !empty($entity->get('surname')))) {
             $title = sprintf('%s %s', (string)Hash::get($entity, 'name', ''), (string)Hash::get($entity, 'surname', ''));
-            $entity->set('title', $title);
+            $entity->set('title', trim($title));
         }
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
@@ -240,7 +240,7 @@ class ProfilesTableTest extends TestCase
             'missing' => [
                 [
                     'email' => null,
-                    'title' => 'Gustavo Supporto',
+                    'title' => null,
                 ],
                 [
                     'name' => 'Gustavo',
@@ -256,6 +256,23 @@ class ProfilesTableTest extends TestCase
                     'name' => 'Gustavo',
                     'surname' => 'Supporto',
                     'title' => '',
+                ],
+            ],
+            'null title' => [
+                [
+                    'title' => null,
+                ],
+                [
+                    'name' => 'Gustavo',
+                    'title' => null,
+                ],
+            ],
+            'no title' => [
+                [
+                    'title' => null,
+                ],
+                [
+                    'name' => 'Gustavo',
                 ],
             ],
             'title set' => [

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
@@ -230,38 +230,74 @@ class ProfilesTableTest extends TestCase
     }
 
     /**
+     * Data provider for `testBeforeSave` test case.
+     *
+     * @return array
+     */
+    public function beforeSaveProvider()
+    {
+        return [
+            'missing' => [
+                [
+                    'email' => null,
+                    'title' => 'Gustavo Supporto',
+                ],
+                [
+                    'name' => 'Gustavo',
+                    'surname' => 'Supporto',
+                    'email' => '',
+                ],
+            ],
+            'empty title' => [
+                [
+                    'title' => 'Gustavo Supporto',
+                ],
+                [
+                    'name' => 'Gustavo',
+                    'surname' => 'Supporto',
+                    'title' => '',
+                ],
+            ],
+            'title set' => [
+                [
+                    'title' => 'Dr. Supporto Matteo',
+                ],
+                [
+                    'title' => 'Dr. Supporto Matteo',
+                    'name' => 'Matteo',
+                    'surname' => 'Supporto',
+                ],
+            ],
+            'surname only' => [
+                [
+                    'title' => 'Supporto',
+                ],
+                [
+                    'title' => '',
+                    'surname' => 'Supporto',
+                ],
+            ],
+        ];
+    }
+
+    /**
      * Test `beforeSave` method.
      *
+     * @param array $expected Expected result.
+     * @param array $data Save input data.
      * @return void
+     * @dataProvider beforeSaveProvider
      * @covers ::beforeSave()
      */
-    public function testBeforeSave()
+    public function testBeforeSave(array $expected, array $data)
     {
-        $data = [
-            'name' => 'Gustavo',
-            'surname' => 'Supporto',
-            'email' => '',
-        ];
-
         $profile = $this->Profiles->newEntity($data);
         $profile->type = 'profiles';
-
         $success = $this->Profiles->save($profile);
         static::assertTrue((bool)$success);
-        static::assertNull($success->get('email'));
-        static::assertEquals('Gustavo Supporto', $success->get('title'));
 
-        $data = [
-            'title' => 'Dr. Supporto Matteo',
-            'name' => 'Matteo',
-            'surname' => 'Supporto',
-        ];
-
-        $profile = $this->Profiles->newEntity($data);
-        $profile->type = 'profiles';
-
-        $success = $this->Profiles->save($profile);
-        static::assertTrue((bool)$success);
-        static::assertEquals('Dr. Supporto Matteo', $success->get('title'));
+        foreach ($expected as $key => $value) {
+            static::assertEquals($value, $success->get($key));
+        }
     }
 }


### PR DESCRIPTION
This PR changes slightly the `Profiles` before save rule: 
in some applications (like BE4Web) `profiles`/`users` form data are passed like blank if not set or null.

With the previous rule in those cases `title` was never set as expected - for profiles and users title means `display name`   

