### PR TITLE
Annotations endpoint

### DIFF
--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -29,6 +29,7 @@ Router::plugin(
             'media',
             'folders',
             'translations',
+            'annotations',
         ];
         $adminControllers = [
             'applications',

--- a/plugins/BEdita/API/src/Controller/AnnotationsController.php
+++ b/plugins/BEdita/API/src/Controller/AnnotationsController.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Controller;
+
+use BEdita\Core\Model\Action\ListRelatedObjectsAction;
+use Cake\ORM\Association;
+use Cake\Routing\Router;
+
+/**
+ * Controller for `/annotations` endpoint.
+ *
+ * @since 4.0.0
+ *
+ * @property \BEdita\Core\Model\Table\AnnotationsTable $Annotations
+ */
+class AnnotationsController extends ResourcesController
+{
+    /**
+     * {@inheritDoc}
+     */
+    public $modelClass = 'Annotations';
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_defaultConfig = [
+        'allowedAssociations' => [
+            'object' => [],
+        ],
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getAvailableUrl($relationship)
+    {
+        return Router::url(
+            [
+                '_name' => 'api:objects:index',
+                'object_type' => 'objects'
+            ],
+            true
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return \BEdita\Core\Model\Action\ListRelatedObjectsAction
+     */
+    protected function getAssociatedAction(Association $association)
+    {
+        return new ListRelatedObjectsAction(compact('association'));
+    }
+}

--- a/plugins/BEdita/API/tests/TestCase/Controller/AnnotationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AnnotationsControllerTest.php
@@ -1,0 +1,379 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Test\TestCase\Controller;
+
+use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\API\Test\TestConstants;
+use Cake\ORM\TableRegistry;
+
+/**
+ * @coversDefaultClass \BEdita\API\Controller\AnnotationsController
+ */
+class AnnotationsControllerTest extends IntegrationTestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.annotations'
+    ];
+
+    /**
+     * Test index method.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testIndex()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/annotations',
+                'first' => 'http://api.example.com/annotations',
+                'last' => 'http://api.example.com/annotations',
+                'prev' => null,
+                'next' => null,
+                'home' => 'http://api.example.com/home',
+            ],
+            'meta' => [
+                'pagination' => [
+                    'count' => 2,
+                    'page' => 1,
+                    'page_count' => 1,
+                    'page_items' => 2,
+                    'page_size' => 20,
+                ],
+            ],
+            'data' => [
+                [
+                    'id' => '1',
+                    'type' => 'annotations',
+                    'attributes' => [
+                        'object_id' => 2,
+                        'description' => 'Lorem ipsum dolor sit amet, aliquet feugiat. Best regards.',
+                        'params' => 'something',
+                    ],
+                    'meta' => [
+                        'created' => '2018-02-17T10:23:15+00:00',
+                        'modified' => '2018-02-17T10:23:15+00:00',
+                        'user_id' => 1,
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/annotations/1',
+                    ],
+                    'relationships' => [
+                        'object' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/annotations/1/object',
+                                'self' => 'http://api.example.com/annotations/1/relationships/object',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'id' => '2',
+                    'type' => 'annotations',
+                    'attributes' => [
+                        'object_id' => 3,
+                        'description' => 'Gustavo for President!',
+                        'params' => 1,
+                    ],
+                    'meta' => [
+                        'created' => '2018-06-17T13:34:25+00:00',
+                        'modified' => '2018-06-17T13:34:25+00:00',
+                        'user_id' => 5,
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/annotations/2',
+                    ],
+                    'relationships' => [
+                        'object' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/annotations/2/object',
+                                'self' => 'http://api.example.com/annotations/2/relationships/object',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->configRequestHeaders();
+        $this->get('/annotations');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test view method.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testSingle()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/annotations/1',
+                'home' => 'http://api.example.com/home',
+            ],
+            'data' => [
+                'id' => '1',
+                'type' => 'annotations',
+                'attributes' => [
+                    'object_id' => 2,
+                    'description' => 'Lorem ipsum dolor sit amet, aliquet feugiat. Best regards.',
+                    'params' => 'something',
+                ],
+                'meta' => [
+                    'created' => '2018-02-17T10:23:15+00:00',
+                    'modified' => '2018-02-17T10:23:15+00:00',
+                    'user_id' => 1,
+                ],
+                'relationships' => [
+                    'object' => [
+                        'links' => [
+                            'related' => 'http://api.example.com/annotations/1/object',
+                            'self' => 'http://api.example.com/annotations/1/relationships/object',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->configRequestHeaders();
+        $this->get('/annotations/1');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test add method.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testAdd()
+    {
+        $data = [
+            'type' => 'annotations',
+            'attributes' => [
+                'object_id' => 3,
+                'description' => 'a note',
+            ],
+        ];
+
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $this->post('/annotations', json_encode(compact('data')));
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(201);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertArrayHasKey('data', $result);
+        $this->assertHeader('Location', 'http://api.example.com/annotations/3');
+    }
+
+    /**
+     * Test edit method.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testEdit()
+    {
+        $data = [
+            'id' => '1',
+            'type' => 'annotations',
+            'attributes' => [
+                'description' => 'Lorem ipsum NO MORE!',
+            ],
+        ];
+
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $this->patch('/annotations/1', json_encode(compact('data')));
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+    }
+
+    /**
+     * Test delete method.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testDelete()
+    {
+        // delete annotation 1
+        $this->configRequestHeaders('DELETE', $this->getUserAuthHeader());
+        $this->delete('/annotations/1');
+        $this->assertResponseCode(204);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertFalse(TableRegistry::get('Annotations')->exists(['id' => 1]));
+    }
+
+    /**
+     * Test related objects.
+     *
+     * @return void
+     *
+     * @covers ::getAvailableUrl()
+     */
+    public function testRelated()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/annotations/1/object',
+                'home' => 'http://api.example.com/home',
+                'available' => 'http://api.example.com/objects',
+            ],
+            'data' => [
+                'id' => '2',
+                'type' => 'documents',
+                'attributes' => [
+                    'status' => 'on',
+                    'uname' => 'title-one',
+                    'title' => 'title one',
+                    'description' => 'description here',
+                    'body' => 'body here',
+                    'extra' => [
+                        'abstract' => 'abstract here',
+                        'list' => ['one', 'two', 'three'],
+                    ],
+                    'lang' => 'en',
+                    'publish_start' => '2016-05-13T07:09:23+00:00',
+                    'publish_end' => '2016-05-13T07:09:23+00:00',
+                ],
+                'meta' => [
+                    'locked' => true,
+                    'created_by' => 1,
+                    'modified_by' => 1,
+                    'created' => '2016-05-13T07:09:23+00:00',
+                    'modified' => '2016-05-13T07:09:23+00:00',
+                    'published' => '2016-05-13T07:09:23+00:00',
+                ],
+                'relationships' => [
+                    'test' => [
+                        'links' => [
+                            'self' => 'http://api.example.com/documents/2/relationships/test',
+                            'related' => 'http://api.example.com/documents/2/test',
+                        ],
+                    ],
+                    'inverse_test' => [
+                        'links' => [
+                            'self' => 'http://api.example.com/documents/2/relationships/inverse_test',
+                            'related' => 'http://api.example.com/documents/2/inverse_test',
+                        ],
+                    ],
+                    'parents' => [
+                        'links' => [
+                            'self' => 'http://api.example.com/documents/2/relationships/parents',
+                            'related' => 'http://api.example.com/documents/2/parents',
+                        ],
+                    ],
+                    'translations' => [
+                        'links' => [
+                            'self' => 'http://api.example.com/documents/2/relationships/translations',
+                            'related' => 'http://api.example.com/documents/2/translations',
+                        ],
+                    ],
+                ],
+            ],
+            'meta' => [
+                'schema' => [
+                    'documents' => [
+                        '$id' => 'http://api.example.com/model/schema/documents',
+                        'revision' => TestConstants::SCHEMA_REVISIONS['documents'],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->configRequestHeaders();
+        $this->get('/annotations/1/object');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test relationships method to list existing relationships.
+     *
+     * @return void
+     *
+     * @covers ::getAssociatedAction()
+     */
+    public function testRelationships()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/annotations/1/relationships/object',
+                'home' => 'http://api.example.com/home',
+                'available' => 'http://api.example.com/objects',
+            ],
+            'data' => [
+                'id' => '2',
+                'type' => 'documents',
+                'relationships' => [
+                    'test' => [
+                        'links' => [
+                            'related' => 'http://api.example.com/documents/2/test',
+                            'self' => 'http://api.example.com/documents/2/relationships/test',
+                        ],
+                    ],
+                    'inverse_test' => [
+                        'links' => [
+                            'related' => 'http://api.example.com/documents/2/inverse_test',
+                            'self' => 'http://api.example.com/documents/2/relationships/inverse_test',
+                        ],
+                    ],
+                    'parents' => [
+                        'links' => [
+                            'related' => 'http://api.example.com/documents/2/parents',
+                            'self' => 'http://api.example.com/documents/2/relationships/parents',
+                        ],
+                    ],
+                    'translations' => [
+                        'links' => [
+                            'related' => 'http://api.example.com/documents/2/translations',
+                            'self' => 'http://api.example.com/documents/2/relationships/translations',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->configRequestHeaders();
+        $this->get('/annotations/1/relationships/object');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals($expected, $result);
+    }
+}

--- a/plugins/BEdita/Core/config/reserved.php
+++ b/plugins/BEdita/Core/config/reserved.php
@@ -16,6 +16,8 @@
  */
 return [
     'ancestor',
+    'annotation',
+    'annotations',
     'application',
     'applications',
     'async_job',
@@ -40,6 +42,8 @@ return [
     'schema',
     'stream',
     'streams',
+    'translation',
+    'translations',
     'tree',
     'trees',
     'tree_nodes',

--- a/plugins/BEdita/Core/src/Model/Entity/Annotation.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Annotation.php
@@ -39,6 +39,7 @@ class Annotation extends Entity implements JsonApiSerializable
      * {@inheritDoc}
      */
     protected $_accessible = [
+        '*' => false,
         'object_id' => true,
         'description' => true,
         'params' => true,

--- a/plugins/BEdita/Core/src/Model/Entity/Annotation.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Annotation.php
@@ -1,6 +1,20 @@
 <?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
 namespace BEdita\Core\Model\Entity;
 
+use BEdita\Core\Model\Entity\JsonApiTrait;
+use BEdita\Core\Utility\JsonApiSerializable;
 use Cake\ORM\Entity;
 
 /**
@@ -17,20 +31,23 @@ use Cake\ORM\Entity;
  * @property \BEdita\Core\Model\Entity\ObjectEntity $object
  * @property \BEdita\Core\Model\Entity\User $user
  */
-class Annotation extends Entity
+class Annotation extends Entity implements JsonApiSerializable
 {
+    use JsonApiTrait;
 
     /**
-     * Fields that can be mass assigned using newEntity() or patchEntity().
-     *
-     * Note that when '*' is set to true, this allows all unspecified fields to
-     * be mass assigned. For security purposes, it is advised to set '*' to false
-     * (or remove it), and explicitly make individual fields accessible as needed.
-     *
-     * @var array
+     * {@inheritDoc}
      */
     protected $_accessible = [
-        '*' => true,
-        'id' => false
+        'object_id' => true,
+        'description' => true,
+        'params' => true,
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_hidden = [
+        'user',
     ];
 }

--- a/plugins/BEdita/Core/src/Model/Table/AnnotationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/AnnotationsTable.php
@@ -37,6 +37,7 @@ use Cake\Validation\Validator;
  * @method \BEdita\Core\Model\Entity\Annotation findOrCreate($search, callable $callback = null, $options = [])
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \BEdita\Core\Model\Behavior\UserModifiedBehavior
  */
 class AnnotationsTable extends Table
 {

--- a/plugins/BEdita/Core/src/Model/Table/AnnotationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/AnnotationsTable.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Model\Table;
 
+use Cake\Database\Schema\TableSchema;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
@@ -94,5 +95,17 @@ class AnnotationsTable extends Table
         $rules->add($rules->existsIn(['user_id'], 'Users'));
 
         return $rules;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    protected function _initializeSchema(TableSchema $schema)
+    {
+        $schema->setColumnType('params', 'json');
+
+        return $schema;
     }
 }

--- a/plugins/BEdita/Core/tests/Fixture/AnnotationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/AnnotationsFixture.php
@@ -16,7 +16,6 @@ class AnnotationsFixture extends TestFixture
      */
     public $records = [
         [
-            'id' => 1,
             'object_id' => 2,
             'description' => 'Lorem ipsum dolor sit amet, aliquet feugiat. Best regards.',
             'user_id' => 1,
@@ -25,7 +24,6 @@ class AnnotationsFixture extends TestFixture
             'params' => '"something"'
         ],
         [
-            'id' => 2,
             'object_id' => 3,
             'description' => 'Gustavo for President!',
             'user_id' => 5,

--- a/plugins/BEdita/Core/tests/Fixture/AnnotationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/AnnotationsFixture.php
@@ -17,12 +17,21 @@ class AnnotationsFixture extends TestFixture
     public $records = [
         [
             'id' => 1,
-            'object_id' => 1,
-            'description' => 'Lorem ipsum dolor sit amet, aliquet feugiat. Convallis morbi fringilla gravida, phasellus feugiat dapibus velit nunc, pulvinar eget sollicitudin venenatis cum nullam, vivamus ut a sed, mollitia lectus. Nulla vestibulum massa neque ut et, id hendrerit sit, feugiat in taciti enim proin nibh, tempor dignissim, rhoncus duis vestibulum nunc mattis convallis.',
+            'object_id' => 2,
+            'description' => 'Lorem ipsum dolor sit amet, aliquet feugiat. Best regards.',
             'user_id' => 1,
-            'created' => '2017-02-17 10:23:15',
-            'modified' => '2017-02-17 10:23:15',
-            'params' => 'Lorem ipsum dolor sit amet, aliquet feugiat. Convallis morbi fringilla gravida, phasellus feugiat dapibus velit nunc, pulvinar eget sollicitudin venenatis cum nullam, vivamus ut a sed, mollitia lectus. Nulla vestibulum massa neque ut et, id hendrerit sit, feugiat in taciti enim proin nibh, tempor dignissim, rhoncus duis vestibulum nunc mattis convallis.'
+            'created' => '2018-02-17 10:23:15',
+            'modified' => '2018-02-17 10:23:15',
+            'params' => '"something"'
+        ],
+        [
+            'id' => 2,
+            'object_id' => 3,
+            'description' => 'Gustavo for President!',
+            'user_id' => 5,
+            'created' => '2018-06-17 13:34:25',
+            'modified' => '2018-06-17 13:34:25',
+            'params' => '1'
         ],
     ];
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/AnnotationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/AnnotationsTableTest.php
@@ -1,8 +1,12 @@
 <?php
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
+use BEdita\Core\Utility\LoggedUser;
+use Cake\Network\Exception\ForbiddenException;
+use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 
 /**
  * BEdita\Core\Model\Table\AnnotationsTable Test Case
@@ -24,27 +28,26 @@ class AnnotationsTableTest extends TestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
         'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.profiles',
         'plugin.BEdita/Core.users',
         'plugin.BEdita/Core.annotations',
     ];
 
     /**
-     * setUp method
-     *
-     * @return void
+     * {@inheritDoc}
      */
     public function setUp()
     {
         parent::setUp();
-        $config = TableRegistry::exists('Annotations') ? [] : ['className' => 'BEdita\Core\Model\Table\AnnotationsTable'];
-        $this->Annotations = TableRegistry::get('Annotations', $config);
+
+        $this->Annotations = TableRegistry::get('Annotations');
     }
 
     /**
-     * tearDown method
-     *
-     * @return void
+     * {@inheritDoc}
      */
     public function tearDown()
     {
@@ -54,32 +57,157 @@ class AnnotationsTableTest extends TestCase
     }
 
     /**
-     * Test initialize method
+     * Test initialization.
      *
      * @return void
+     *
+     * @coversNothing
      */
     public function testInitialize()
     {
-        $this->markTestIncomplete('Not implemented yet.');
+        static::assertInstanceOf(BelongsTo::class, $this->Annotations->Objects);
+        static::assertInstanceOf(BelongsTo::class, $this->Annotations->Users);
     }
 
     /**
-     * Test validationDefault method
+     * Data provider for `testValidation` test case.
      *
-     * @return void
+     * @return array
      */
-    public function testValidationDefault()
+    public function validationProvider()
     {
-        $this->markTestIncomplete('Not implemented yet.');
+        return [
+            'ok' => [
+                [],
+                [
+                    'object_id' => 2,
+                    'description' => 'some text',
+                ],
+            ],
+            'invalid 1' => [
+                [
+                    'object_id.integer',
+                ],
+                [
+                    'object_id' => 'definitely not a number',
+                ],
+            ],
+            'invalid 2' => [
+                [
+                    'object_id._required',
+                ],
+                [
+                    'description' => 'some description',
+                ],
+            ],
+        ];
     }
 
     /**
-     * Test buildRules method
+     * Test validation.
      *
+     * @param string[] $expected Expected errors.
+     * @param array $data Data.
      * @return void
+     *
+     * @dataProvider validationProvider()
+     * @coversNothing
      */
-    public function testBuildRules()
+    public function testValidation(array $expected, array $data)
     {
-        $this->markTestIncomplete('Not implemented yet.');
+        $entity = $this->Annotations->newEntity();
+        $entity = $this->Annotations->patchEntity($entity, $data);
+        $errors = array_keys(Hash::flatten($entity->getErrors()));
+
+        static::assertEquals($expected, $errors);
+    }
+
+    /**
+     * Data provider for `testBeforeSave` test case.
+     *
+     * @return array
+     */
+    public function beforeSaveProvider()
+    {
+        return [
+            // 'help' => [
+            //     true,
+            //     [
+            //         'description' => 'Gustavo Supporto Help!',
+            //         'object_id' => 3,
+            //     ],
+            // ],
+            'user error' => [
+                new ForbiddenException('Could not change annotation "1" of user "1"'),
+                [
+                    'description' => '',
+                ],
+                1,
+            ],
+            'object error' => [
+                new ForbiddenException('Could not change object id on annotation "2"'),
+                [
+                    'object_id' => 9,
+                ],
+                2,
+            ],
+        ];
+    }
+
+    /**
+     * Test `beforeSave` method.
+     *
+     * @param array|\Exception $expected Expected result.
+     * @param array $data Save input data.
+     * @param int $id Annotation id.
+     * @return void
+     * @dataProvider beforeSaveProvider
+     * @covers ::beforeSave()
+     */
+    public function testBeforeSave($expected, array $data, $id = null)
+    {
+        LoggedUser::setUser(['id' => 5]);
+        if ($expected instanceof \Exception) {
+            $this->expectException(get_class($expected));
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+
+        if ($id) {
+            $entity = $this->Annotations->get($id);
+        } else {
+            $entity = $this->Annotations->newEntity();
+        }
+        $entity = $this->Annotations->patchEntity($entity, $data);
+
+        $success = $this->Annotations->save($entity);
+        static::assertTrue((bool)$success);
+    }
+
+    /**
+     * Test `beforeDelete` method.
+     *
+     * @covers ::beforeDelete()
+     */
+    public function testBeforeDelete()
+    {
+        LoggedUser::setUser(['id' => 1]);
+        $annotation = $this->Annotations->get(1);
+        $success = $this->Annotations->delete($annotation);
+        static::assertTrue((bool)$success);
+    }
+
+    /**
+     * Test `beforeDelete` failure.
+     *
+     * @covers ::beforeDelete()
+     *
+     * @expectedException \Cake\Network\Exception\ForbiddenException
+     * @expectedExceptionMessage Could not delete annotation "1" of user "1"
+     */
+    public function testBeforeDeleteFailure()
+    {
+        LoggedUser::setUser(['id' => 5]);
+        $annotation = $this->Annotations->get(1);
+        $success = $this->Annotations->delete($annotation);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/AnnotationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/AnnotationsTableTest.php
@@ -9,7 +9,9 @@ use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
 
 /**
- * BEdita\Core\Model\Table\AnnotationsTable Test Case
+ * {@see \BEdita\Core\Model\Table\AnnotationsTable} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Model\Table\AnnotationsTable
  */
 class AnnotationsTableTest extends TestCase
 {
@@ -61,7 +63,7 @@ class AnnotationsTableTest extends TestCase
      *
      * @return void
      *
-     * @coversNothing
+     * @covers ::initialize()
      */
     public function testInitialize()
     {
@@ -130,13 +132,13 @@ class AnnotationsTableTest extends TestCase
     public function beforeSaveProvider()
     {
         return [
-            // 'help' => [
-            //     true,
-            //     [
-            //         'description' => 'Gustavo Supporto Help!',
-            //         'object_id' => 3,
-            //     ],
-            // ],
+            'help' => [
+                true,
+                [
+                    'description' => 'Gustavo Supporto Help!',
+                    'object_id' => 3,
+                ],
+            ],
             'user error' => [
                 new ForbiddenException('Could not change annotation "1" of user "1"'),
                 [


### PR DESCRIPTION
This PR introduces a basic `/annotations` endpoint

 * `AnnotationsController` + routing rules added
 * `Annotation` entity updated for JSON API and API representation
 * `AnnotationsTable` updated with `beforeSave` and `beforeDelete` checks: only author user can modify or delete an annotation, annotation related object id cannot be changed
