### PR TITLE
feat: relations whitelist to skip object reachable check

### DIFF
--- a/bedita-app/controllers/components/api_validator.php
+++ b/bedita-app/controllers/components/api_validator.php
@@ -91,6 +91,9 @@ class ApiValidatorComponent extends Object {
         if (!empty($validateConf['allowedUrlParams'])) {
             $this->registerAllowedUrlParams($validateConf['allowedUrlParams']);
         }
+        if (!empty($validateConf['reachableRelations'])) {
+            $this->reachableRelations = $validateConf['reachableRelations'];
+        }
     }
 
     /**
@@ -587,7 +590,6 @@ class ApiValidatorComponent extends Object {
         if (is_numeric($objectType)) {
             $objectType = Configure::read('objectTypes.' . $objectType . '.name');
         }
-        $this->reachableRelations = Configure::read('api.validation.reachableRelations');
         $objectRelation = ClassRegistry::init('ObjectRelation');
         foreach ($relations as $name => $data) {
             if ($objectType) {

--- a/bedita-app/controllers/components/api_validator.php
+++ b/bedita-app/controllers/components/api_validator.php
@@ -92,7 +92,7 @@ class ApiValidatorComponent extends Object {
             $this->registerAllowedUrlParams($validateConf['allowedUrlParams']);
         }
         if (!empty($validateConf['reachableRelations'])) {
-            $this->reachableRelations = $validateConf['reachableRelations'];
+            $this->reachableRelations = (array)$validateConf['reachableRelations'];
         }
     }
 
@@ -609,10 +609,8 @@ class ApiValidatorComponent extends Object {
                     throw new BeditaBadRequestException('Invalid relation: ' . $name . ' for object type ' . $relatedObjectType);
                 }
 
-                if (empty($this->reachableRelations) || !in_array($name, $this->reachableRelations)) {
-                    if (!$this->isObjectReachable($relData['related_id'])) {
-                        throw new BeditaBadRequestException('Invalid Relation: ' . $relData['related_id'] . ' is unreachable');
-                    }
+                if (!in_array($name, $this->reachableRelations) && !$this->isObjectReachable($relData['related_id'])) {
+                    throw new BeditaBadRequestException('Invalid Relation: ' . $relData['related_id'] . ' is unreachable');
                 }
             }
         }

--- a/bedita-app/controllers/components/api_validator.php
+++ b/bedita-app/controllers/components/api_validator.php
@@ -48,6 +48,14 @@ class ApiValidatorComponent extends Object {
      */
     protected $enableObjectReachableCheck = true;
 
+
+    /**
+     * List of relations considered reachable (used to skip object reachable check)
+     *
+     * @var array
+     */
+    protected $reachableRelations = array();
+
     /**
      * The supported query string parameters names for every endpoint.
      *
@@ -579,6 +587,7 @@ class ApiValidatorComponent extends Object {
         if (is_numeric($objectType)) {
             $objectType = Configure::read('objectTypes.' . $objectType . '.name');
         }
+        $this->reachableRelations = Configure::read('api.validation.reachableRelations');
         $objectRelation = ClassRegistry::init('ObjectRelation');
         foreach ($relations as $name => $data) {
             if ($objectType) {
@@ -597,8 +606,11 @@ class ApiValidatorComponent extends Object {
                 if (!$this->isRelationValid($inverseName, $relatedObjectType)) {
                     throw new BeditaBadRequestException('Invalid relation: ' . $name . ' for object type ' . $relatedObjectType);
                 }
-                if (!$this->isObjectReachable($relData['related_id'])) {
-                    throw new BeditaBadRequestException('Invalid Relation: ' . $relData['related_id'] . ' is unreachable');
+
+                if (empty($this->reachableRelations) || !in_array($name, $this->reachableRelations)) {
+                    if (!$this->isObjectReachable($relData['related_id'])) {
+                        throw new BeditaBadRequestException('Invalid Relation: ' . $relData['related_id'] . ' is unreachable');
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR fixes #1510 

Using a specified config, api validation on `POST` can skip `objectReachable` check.
Usage:
 * specify relations whitelist in api config, i.e. `$config['api']['validation']['reachableRelations'] = array('my_relation');`

Try a post:
```
POST /objects/<id>
{
  "id": <id>,
  "object_type": <object_type>,
  "relations": {
    "my_relation": [
      {
        "related_id": <related_id>
      }
    ]
  }
}
```