### PR TITLE
#1484 Sort contents in folder

### DIFF
--- a/plugins/BEdita/API/src/Error/ExceptionRenderer.php
+++ b/plugins/BEdita/API/src/Error/ExceptionRenderer.php
@@ -116,9 +116,16 @@ class ExceptionRenderer extends CakeExceptionRenderer
         $res = '';
         if (is_array($d)) {
             $d = Hash::flatten($d);
-            foreach ($d as $item => $errDetail) {
-                $res .= "[$item]: $errDetail ";
-            }
+            $res = implode(
+                ' ',
+                array_map(
+                    function ($key, $val) {
+                        return sprintf('[%s]: %s', $key, $val);
+                    },
+                    array_keys($d),
+                    array_values($d)
+                )
+            );
         }
 
         return $res;

--- a/plugins/BEdita/API/tests/IntegrationTest/I18nTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/I18nTest.php
@@ -58,7 +58,7 @@ class I18nTest extends IntegrationTestCase
             'error' => [
                 'status' => '400',
                 'title' => 'Invalid data',
-                'detail' => '[lang.languageTag]: Invalid language tag "fi" ',
+                'detail' => '[lang.languageTag]: Invalid language tag "fi"',
             ],
         ];
 

--- a/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
@@ -10,7 +10,7 @@
  *
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
-namespace BEdita\Api\Test\IntegrationTest;
+namespace BEdita\API\Test\IntegrationTest;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
 use Cake\ORM\TableRegistry;
@@ -52,7 +52,7 @@ class ParentsRelationshipTest extends IntegrationTestCase
     }
 
     /**
-     * Undocumented function
+     * Test setting a parent to an object.
      *
      * @return void
      */
@@ -132,7 +132,7 @@ class ParentsRelationshipTest extends IntegrationTestCase
         sort($parentIds);
         static::assertEquals(Hash::extract($data, '{n}.id'), $parentIds);
 
-        // DELETE: delete all remining parents relationships
+        // DELETE: delete all remaining parents relationships
         $this->configRequestHeaders('DELETE', $authHeader);
         // Cannot use `IntegrationTestCase::delete()`, as it does not allow sending payload with the request.
         $this->_sendRequest($relationshipsEndpoint, 'DELETE', json_encode(compact('data')));

--- a/plugins/BEdita/API/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Error/ExceptionRendererTest.php
@@ -83,7 +83,7 @@ class ExceptionRendererTest extends TestCase
             'detailArray' => [
                 ['title' => 'new title', 'detail' => [['field' => ['cause' => 'err detail']]]],
                 'new title',
-                '[0.field.cause]: err detail '
+                '[0.field.cause]: err detail'
             ],
             'detailArray2' => [
                 [
@@ -97,7 +97,7 @@ class ExceptionRendererTest extends TestCase
                     ]
                 ],
                 'new title',
-                '[field.cause]: err detail [nestedFields.field2.cause2]: err detail2 [nestedFields.field3.cause3]: err detail3 '
+                '[field.cause]: err detail [nestedFields.field2.cause2]: err detail2 [nestedFields.field3.cause3]: err detail3'
             ],
             'code' => [
                 ['title' => 'err title', 'code' => 'err-code'],

--- a/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Model\Behavior;
+
+use Cake\Database\Expression\QueryExpression;
+use Cake\Datasource\EntityInterface;
+use Cake\ORM\Behavior\TreeBehavior as CakeTreeBehavior;
+use Cake\ORM\Table;
+
+/**
+ * This behavior adds absolute positioning of nodes on top of CakePHP {@see \Cake\ORM\Behavior\TreeBehavior}.
+ *
+ * {@inheritDoc}
+ */
+class TreeBehavior extends CakeTreeBehavior
+{
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function __construct(Table $table, array $config = [])
+    {
+        $this->_defaultConfig['implementedMethods'] += [
+            'getCurrentPosition' => 'getCurrentPosition',
+            'moveAt' => 'moveAt',
+        ];
+
+        parent::__construct($table, $config);
+    }
+
+    /**
+     * Get current position of a node within its parent.
+     *
+     * @param \Cake\Datasource\EntityInterface $node Node to get position for.
+     * @return int
+     */
+    public function getCurrentPosition(EntityInterface $node)
+    {
+        return $this->_scope($this->getTable()->find())
+            ->where(function (QueryExpression $exp) use ($node) {
+                $parentField = $this->getConfig('parent');
+                $leftField = $this->getConfig('left');
+
+                if (!$node->has($parentField)) {
+                    $exp = $exp->isNull($this->getTable()->aliasField($parentField));
+                } else {
+                    $exp = $exp->eq($this->getTable()->aliasField($parentField), $node->get($parentField));
+                }
+
+                return $exp
+                    ->lte($this->getTable()->aliasField($leftField), $node->get($leftField));
+            })
+            ->count();
+    }
+
+    /**
+     * Move a node at a specific position without changing the parent.
+     *
+     * @param \Cake\Datasource\EntityInterface $node Node to be moved.
+     * @param int|string $position New position. Can be either an integer, or a string (`'first'` or `'last'`).
+     *      Negative integers are interpreted as number of positions from the end of the list. 0 (zero) is not allowed.
+     * @return \Cake\Datasource\EntityInterface|false
+     */
+    public function moveAt(EntityInterface $node, $position)
+    {
+        return $this->getTable()->getConnection()->transactional(function () use ($node, $position) {
+            $position = static::validatePosition($position);
+            if ($position === false) {
+                return false;
+            }
+
+            $currentPosition = $this->getCurrentPosition($node);
+            if ($position === $currentPosition) {
+                // Do not perform extra queries. Position must still be normalized, so we'll need to re-check later.
+                return $node;
+            }
+
+            $childrenCount = $this->_scope($this->getTable()->find())
+                ->where(function (QueryExpression $exp) use ($node) {
+                    $parentField = $this->getConfig('parent');
+
+                    if (!$node->has($parentField)) {
+                        return $exp->isNull($this->getTable()->aliasField($parentField));
+                    }
+
+                    return $exp->eq($this->getTable()->aliasField($parentField), $node->get($parentField));
+                })
+                ->count();
+
+            // Normalize position. Transform negative indexes, and apply bounds.
+            if ($position < 0) {
+                $position = $childrenCount + $position + 1;
+            }
+            $position = max(1, min($position, $childrenCount));
+
+            if ($position === $currentPosition) {
+                // Already OK.
+                return $node;
+            }
+
+            if ($position > $currentPosition) {
+                return $this->moveDown($node, $position - $currentPosition);
+            }
+
+            return $this->moveUp($node, $currentPosition - $position);
+        });
+    }
+
+    /**
+     * Validate a position.
+     *
+     * @param int|string $position Position to be validated.
+     * @return int|false
+     */
+    protected static function validatePosition($position)
+    {
+        if ($position === 'first') {
+            return 1;
+        }
+        if ($position === 'last') {
+            return -1;
+        }
+
+        $position = filter_var($position, FILTER_VALIDATE_INT);
+        if ($position === false || $position === 0) {
+            return false;
+        }
+
+        return $position;
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Entity/Folder.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Folder.php
@@ -22,8 +22,10 @@ use Cake\Utility\Hash;
  * Folder Entity
  *
  * @property int $parent_id
- * @property \BEdita\Core\Model\Entity\Folder|null $parent
  * @property string $path
+ *
+ * @property \BEdita\Core\Model\Entity\Folder|null $parent
+ * @property \BEdita\Core\Model\Entity\ObjectEntity[] $children
  *
  * @since 4.0.0
  */

--- a/plugins/BEdita/Core/src/Model/Entity/Tree.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Tree.php
@@ -13,10 +13,8 @@
 
 namespace BEdita\Core\Model\Entity;
 
-use BEdita\Core\Model\Entity\Folder;
 use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
-use Cake\Utility\Hash;
 
 /**
  * Tree Entity
@@ -87,7 +85,7 @@ class Tree extends Entity
             ->where(['object_id' => $parentId])
             ->firstOrFail();
 
-        $this->root_id = $parentNode->root_id;
+        $this->root_id = $parentNode->get('root_id');
         $this->parent_node_id = $parentNode->id;
 
         return $parentId;

--- a/plugins/BEdita/Core/src/Model/Entity/Tree.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Tree.php
@@ -28,6 +28,7 @@ use Cake\ORM\TableRegistry;
  * @property int $tree_right
  * @property int $depth_level
  * @property bool $menu
+ * @property int|string $position
  *
  * @property \BEdita\Core\Model\Entity\ObjectEntity $object
  * @property \BEdita\Core\Model\Entity\ObjectEntity $parent_object
@@ -48,6 +49,7 @@ class Tree extends Entity
         'object_id' => true,
         'parent_id' => true,
         'menu' => true,
+        'position' => true,
     ];
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/TreesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TreesTable.php
@@ -4,6 +4,7 @@ namespace BEdita\Core\Model\Table;
 use BEdita\Core\Exception\ImmutableResourceException;
 use BEdita\Core\Model\Entity\Tree;
 use Cake\Event\Event;
+use Cake\Network\Exception\BadRequestException;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Rule\IsUnique;
 use Cake\ORM\Table;
@@ -220,6 +221,8 @@ class TreesTable extends Table
     }
 
     /**
+     * Check if a given ID is the ID of a Folder.
+     *
      * @param int $id ID of object being checked.
      * @return bool
      */

--- a/plugins/BEdita/Core/tests/Fixture/FakeCategoriesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeCategoriesFixture.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Fixture for `fake_categories` table.
+ */
+class FakeCategoriesFixture extends TestFixture
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public $fields = [
+        'id' => ['type' => 'integer', 'length' => 10, 'unsigned' => true, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => true],
+        'name' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'precision' => null],
+        'parent_id' => ['type' => 'integer', 'length' => 10, 'unsigned' => true, 'null' => true, 'default' => null, 'precision' => null],
+        'left_idx' => ['type' => 'integer', 'length' => 10, 'unsigned' => true, 'null' => false, 'default' => null, 'precision' => null],
+        'right_idx' => ['type' => 'integer', 'length' => 10, 'unsigned' => true, 'null' => false, 'default' => null, 'precision' => null],
+        '_indexes' => [
+            'fakecategories_parentid_idx' => [
+                'type' => 'index',
+                'columns' => [
+                    'parent_id',
+                ],
+            ],
+            'fakecategories_leftright_idx' => [
+                'type' => 'index',
+                'columns' => [
+                    'left_idx',
+                    'right_idx',
+                ],
+            ],
+        ],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+            'fakecategories_parentid_fk' => [
+                'type' => 'foreign',
+                'columns' => ['parent_id'],
+                'references' => ['fake_categories', 'id'],
+                'update' => 'noAction',
+                'delete' => 'noAction',
+            ],
+        ],
+        '_options' => [
+            'engine' => 'InnoDB',
+            'collation' => 'utf8_general_ci'
+        ],
+    ];
+
+    /**
+     * {@inheritDoc}
+     *
+     * @example ```
+     * - Science
+     *   - Mathematics
+     *     - Geometry
+     *     - Algebra
+     *     - Mathematical Logic
+     *   - Physics
+     *     - Fluid mechanics
+     *     - Rational mechanics
+     * - History of Art
+     * ```
+     */
+    public $records = [
+        [ // ID: 1
+            'name' => 'Science',
+            'parent_id' => null,
+            'left_idx' => 1,
+            'right_idx' => 16,
+        ],
+        [ // ID: 2
+            'name' => 'Mathematics',
+            'parent_id' => 1,
+            'left_idx' => 2,
+            'right_idx' => 9,
+        ],
+        [ // ID: 3
+            'name' => 'Geometry',
+            'parent_id' => 2,
+            'left_idx' => 3,
+            'right_idx' => 4,
+        ],
+        [ // ID: 4
+            'name' => 'Algebra',
+            'parent_id' => 2,
+            'left_idx' => 5,
+            'right_idx' => 6,
+        ],
+        [ // ID: 5
+            'name' => 'Mathematical Logic',
+            'parent_id' => 2,
+            'left_idx' => 7,
+            'right_idx' => 8,
+        ],
+        [ // ID: 6
+            'name' => 'Physics',
+            'parent_id' => 1,
+            'left_idx' => 10,
+            'right_idx' => 15,
+        ],
+        [ // ID: 7
+            'name' => 'Fluid Mechanics',
+            'parent_id' => 6,
+            'left_idx' => 11,
+            'right_idx' => 12,
+        ],
+        [ // ID: 8
+            'name' => 'Rational Mechanics',
+            'parent_id' => 6,
+            'left_idx' => 13,
+            'right_idx' => 14,
+        ],
+        [ // ID: 9
+            'name' => 'History of Art',
+            'parent_id' => null,
+            'left_idx' => 17,
+            'right_idx' => 18
+        ],
+    ];
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -1,0 +1,209 @@
+<?php
+namespace BEdita\Core\Test\TestCase\Model\Behavior;
+
+use Cake\ORM\Entity;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * @coversDefaultClass \BEdita\Core\Model\Behavior\TreeBehavior
+ */
+class TreeBehaviorTest extends TestCase
+{
+
+    /**
+     * Fixtures.
+     *
+     * @var string[]
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.fake_categories',
+    ];
+
+    /**
+     * Test table.
+     *
+     * @var \Cake\ORM\Table|\BEdita\Core\Model\Behavior\TreeBehavior
+     */
+    public $Table;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->Table = TableRegistry::get('FakeCategories');
+        $this->Table->addBehavior('BEdita/Core.Tree', [
+            'left' => 'left_idx',
+            'right' => 'right_idx',
+        ]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        unset($this->Table);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Data provider for `testGetCurrentPosition` test case.
+     *
+     * @return array
+     */
+    public function getCurrentPositionProvider()
+    {
+        return [
+            '1st node, root' => [
+                1,
+                'Science',
+            ],
+            '2nd node, root' => [
+                2,
+                'History of Art',
+            ],
+            '1st node, depth 1' => [
+                1,
+                'Mathematics',
+            ],
+            '2nd node, depth 1' => [
+                2,
+                'Physics',
+            ],
+            '3rd node, depth 2' => [
+                3,
+                'Mathematical Logic',
+            ],
+        ];
+    }
+
+    /**
+     * Test `getCurrentPosition()` method.
+     *
+     * @param int $expected Expected position.
+     * @param string $name Name of node.
+     * @return void
+     *
+     * @dataProvider getCurrentPositionProvider()
+     * @covers ::getCurrentPosition()
+     */
+    public function testGetCurrentPosition($expected, $name)
+    {
+        $node = $this->Table->find()
+            ->where(compact('name'))
+            ->firstOrFail();
+
+        $position = $this->Table->getCurrentPosition($node);
+
+        static::assertSame($expected, $position);
+    }
+
+    /**
+     * Data provider for `testMoveAt` test case.
+     *
+     * @return array
+     */
+    public function moveAtProvider()
+    {
+        return [
+            'first' => [
+                1,
+                'Mathematical Logic',
+                'first',
+            ],
+            'last' => [
+                3,
+                'Geometry',
+                'last',
+            ],
+            'positive' => [
+                2,
+                'Mathematics',
+                2,
+            ],
+            'positive, out of bounds' => [
+                3,
+                'Geometry',
+                999,
+            ],
+            'positive, unchanged' => [
+                2,
+                'Algebra',
+                2,
+            ],
+            'negative' => [
+                2,
+                'Geometry',
+                -2,
+            ],
+            'negative, out of bounds' => [
+                1,
+                'Algebra',
+                -999,
+            ],
+            'negative, unchanged' => [
+                2,
+                'History of Art',
+                -1,
+            ],
+            'invalid position' => [
+                false,
+                'Science',
+                'gustavo',
+            ],
+            'zero' => [
+                false,
+                'Science',
+                '0',
+            ],
+        ];
+    }
+
+    /**
+     * Test `moveAt()` method.
+     *
+     * @param int|false $expected Expected result.
+     * @param string $name Name of node.
+     * @param int|string $position Position to move node at.
+     * @return void
+     *
+     * @dataProvider moveAtProvider()
+     * @covers ::moveAt()
+     * @covers ::validatePosition()
+     */
+    public function testMoveAt($expected, $name, $position)
+    {
+        $node = $this->Table->find()
+            ->where(compact('name'))
+            ->firstOrFail();
+
+        $previousPosition = $this->Table->getCurrentPosition($node);
+        $previousIndexes = [$node->get('left_idx'), $node->get('right_idx')];
+
+        $result = $this->Table->moveAt($node, $position);
+        $finalPosition = $this->Table->getCurrentPosition($node);
+
+        if ($expected === false) {
+            static::assertFalse($result);
+            static::assertSame($previousPosition, $finalPosition);
+
+            $finalIndexes = [$node->get('left_idx'), $node->get('right_idx')];
+            self::assertSame($previousIndexes, $finalIndexes);
+        } else {
+            static::assertInstanceOf(Entity::class, $result);
+            static::assertSame($expected, $finalPosition);
+
+            $finalIndexes = [$result->get('left_idx'), $result->get('right_idx')];
+            if ($finalPosition === $previousPosition) {
+                self::assertSame($previousIndexes, $finalIndexes);
+            } else {
+                self::assertNotSame($previousIndexes, $finalIndexes);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR resolves #1484 by implementing a way to sort children within a Folder.

## API Interface

The following examples assume that a Folder with ID 42 and a Document with ID 13 exist.

#### `POST|PATCH /folders/42/relationships/children`

```http
POST /folders/42/relationships/children
Accept: application/vnd.api+json
Content-Type: application/vnd.api+json

{
  "data": [
    {
      "id": "13",
      "type": "documents",
      "meta": {
        "relation": {
          "position": 3
        }
      }
    }
  ]
}
```

#### `POST|PATCH /documents/13/relationships/parents`

```http
POST /documents/13/relationships/parents
Accept: application/vnd.api+json
Content-Type: application/vnd.api+json

{
  "data": [
    {
      "id": "42",
      "type": "folders",
      "meta": {
        "relation": {
          "position": -2
        }
      }
    }
  ]
}
```

## Code changes

A new `TreeBehavior` has been added, that extends CakePHP `TreeBehavior` and adds two public methods: `getCurrentPosition(EntityInterface $node)` and `moveAt(EntityInterface $node, $position)`.

Some other minor changes have been applied to other pieces of code, mainly to clean up a few things.

### Valid values for `position`

Valid values for position are any integer value except `0` (zero), and the two strings `'first'` and `'last'`:

- `'first'` is an alias for `1`
- `'last'` is an alias for `-1`
- positive values represent the position from the beginning of the list, with `1` being the first element.
- negative values represent the position from the end of the list, with `-1` being the last element.

Values "out of bounds" are silently limited. For instance:
- `10` if the parent has only 5 children is equivalent to `last`.
- `-10` if the parent has only 5 children is equivalent to `first`.

## Known issues

It is not possible to sort a folder position within its parent, as it is not possible to set `position` via the `POST /folders/42/relationships/parent`. This problem can be circumvented for sub-folders (e.g. if Folder 42 is within Folder 101, we can use `POST /folders/101/relationships/children` instead), but at the present stage makes root Folders not-sortable.

A possible solution would be to pass `position` using a payload similar to this:
```http
POST /folders/42/relationships/parent
Accept: application/vnd.api+json
Content-Type: application/vnd.api+json

{
  "data": {
    "id": "101",
    "type": "folders"
  },
  "meta": {
    "relation": {
      "position": "first"
    }
  }
}
```

It is required to place `meta` outside of `data`, since `data` in this case may be `null`. However, such a solution hasn't been implemented in this PR.