### PR TITLE
Ignore empty `password` on /auth/user update

### DIFF
--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -230,7 +230,7 @@ class LoginController extends AppController
      */
     protected function checkPassword(User $entity, array $data)
     {
-        if (!isset($data['password'])) {
+        if (empty($data['password'])) {
             return;
         }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
@@ -555,6 +555,15 @@ class LoginControllerTest extends IntegrationTestCase
                 ],
                 'Wrong password',
             ],
+            'empty pass' => [
+                200,
+                [
+                    'password' => '',
+                    'old_password' => '',
+                    'name' => 'Gustavo',
+                ],
+                'Wrong password',
+            ],
             'ok' => [
                 200,
                 [


### PR DESCRIPTION
This PR avoid password renewal and current password check in `PATCH /auth/user` when an empty password is passed.

