### PR TITLE
Fix date & datetime input

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/DateTimeTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/DateTimeTest.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Test\IntegrationTest;
+
+use BEdita\API\TestSuite\IntegrationTestCase;
+use Cake\Utility\Hash;
+
+/**
+ * Test date & datetime input/output
+ */
+class DateTimeTest extends IntegrationTestCase
+{
+    public function dateTimeInputProvider()
+    {
+        return [
+            'simple date' => [
+                [
+                    'birthdate' => '2018-02-02',
+                ],
+                [
+                    'birthdate' => '2018-02-02',
+                ],
+            ],
+            'date with time' => [
+                [
+                    'birthdate' => '2018-02-02',
+                ],
+                [
+                    'birthdate' => '2018-02-02 12:30',
+                ],
+            ],
+            'date with iso time' => [
+                [
+                    'birthdate' => '2018-01-02',
+                ],
+                [
+                    'birthdate' => '2018-01-02T14:23:23+00:00',
+                ],
+            ],
+            'simple date time' => [
+                [
+                    'publish_start' => '2018-08-02T14:23:23+00:00',
+                ],
+                [
+                    'publish_start' => '2018-08-02 14:23:23',
+                ],
+            ],
+            'datetime without time' => [
+                [
+                    'publish_start' => '2018-08-02T00:00:00+00:00',
+                ],
+                [
+                    'publish_start' => '2018-08-02',
+                ],
+            ],
+            'timezone' => [
+                [
+                    'publish_start' => '2018-08-02T16:23:23+00:00',
+                ],
+                [
+                    'publish_start' => '2018-08-02T16:23:23+00:00',
+                ],
+            ],
+            'date timestamp' => [
+                [
+                    'birthdate' => '2018-08-01',
+                ],
+                [
+                    'birthdate' => '1533117600',
+                ],
+            ],
+            'datetime timestamp' => [
+                [
+                    'publish_start' => '2018-08-01T10:00:00+00:00',
+                ],
+                [
+                    'publish_start' => '1533117600',
+                ],
+            ],
+            'date fail' => [
+                [
+                    'error' => [
+                        'status' => '400',
+                        'title' => 'Invalid data',
+                        'detail' => '[birthdate.date]: Invalid date or datetime "July, 1"',
+                    ],
+                ],
+                [
+                    'birthdate' => 'July, 1',
+                ],
+            ],
+            'datetime fail' => [
+                [
+                    'error' => [
+                        'status' => '400',
+                        'title' => 'Invalid data',
+                        'detail' => '[birthdate.date]: Invalid date or datetime "gustavo"',
+                    ],
+                ],
+                [
+                    'birthdate' => 'gustavo',
+                ],
+            ],
+            'bad datetime' => [
+                [
+                    'error' => [
+                        'status' => '400',
+                        'title' => 'Invalid data',
+                        'detail' => '[birthdate.date]: Invalid date or datetime "2008 June, 1"',
+                    ],
+                ],
+                [
+                    'birthdate' => '2008 June, 1',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test date & date time save using `profiles`
+     *
+     * @param array $expected Extected result
+     * @param array $input Input data
+     * @dataProvider dateTimeInputProvider
+     * @return void
+     * @coversNothing
+     */
+    public function testDateTimeInput($expected, $input)
+    {
+        $data = [
+            'type' => 'profiles',
+            'id' => '4',
+            'attributes' => $input,
+        ];
+
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $this->patch('/profiles/4', json_encode(compact('data')));
+        $this->assertResponseCode((int)Hash::get($expected, 'error.status', 200));
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        if (empty($expected['error'])) {
+            $attributes = Hash::get($result, 'data.attributes', []);
+        } else {
+            $attributes = Hash::get($result, 'error', []);
+            unset($attributes['meta']);
+            $expected = $expected['error'];
+        }
+        static::assertNotEmpty($attributes);
+        $fields = array_intersect_key($attributes, $expected);
+        static::assertEquals($expected, $fields);
+    }
+}

--- a/plugins/BEdita/Core/config/bootstrap.php
+++ b/plugins/BEdita/Core/config/bootstrap.php
@@ -3,6 +3,7 @@
 use BEdita\Core\Configure\Engine\DatabaseConfig;
 use BEdita\Core\Database\Type\BoolType;
 use BEdita\Core\Database\Type\DateTimeType;
+use BEdita\Core\Database\Type\DateType;
 use BEdita\Core\Filesystem\Thumbnail;
 use BEdita\Core\I18n\MessagesFileLoader;
 use BEdita\Core\ORM\Locator\TableLocator;
@@ -57,8 +58,9 @@ FrozenDate::setJsonEncodeFormat('yyyy-MM-dd');
 Date::setJsonEncodeFormat('yyyy-MM-dd');
 
 /**
- * Use custom DateTimeType
+ * Use custom DateType & DateTimeType
  */
+Type::set('date', new DateType());
 Type::set('datetime', new DateTimeType());
 Type::set('timestamp', new DateTimeType());
 

--- a/plugins/BEdita/Core/src/Database/Type/DateTimeType.php
+++ b/plugins/BEdita/Core/src/Database/Type/DateTimeType.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Database\Type;
 
+use BEdita\Core\Model\Validation\Validation;
 use Cake\Database\Type\DateTimeType as CakeDateTimeType;
 
 /**
@@ -22,7 +23,13 @@ class DateTimeType extends CakeDateTimeType
 {
     /**
      * {@inheritDoc}
-     *
+     */
+    public function marshal($value)
+    {
+        return static::marshalDateTime($value, $this->getDateTimeClassName());
+    }
+
+    /**
      * Accepted date time formats are
      *  - 2017-01-01                    YYYY-MM-DD
      *  - 2017-01-01 11:22              YYYY-MM-DD hh:mm
@@ -33,16 +40,21 @@ class DateTimeType extends CakeDateTimeType
      *  - 2017-01-01T19:20:30.45+01:00  YYYY-MM-DDThh:mm:ss.sTZD
      *
      * See ISO 8601 subset as defined here https://www.w3.org/TR/NOTE-datetime:
+     *
+     * @param mixed $value DateTime input
+     * @param string $dateTimeClassName DateTime class name to use to parse string
+     *
+     * @return \DateTimeInterface|null|mixed
      */
-    public function marshal($value)
+    public static function marshalDateTime($value, $dateTimeClassName)
     {
         if ($value instanceof \DateTimeInterface) {
             return $value;
         }
 
-        if (is_string($value) && preg_match('/^\d{4}(-\d\d(-\d\d([T ]\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?)?$/i', $value)) {
+        if (Validation::dateTime($value) === true) {
             /* @var \Cake\I18n\Time|\Cake\I18n\FrozenTime $value */
-            $value = call_user_func([$this->getDateTimeClassName(), 'parse'], $value);
+            $value = call_user_func([$dateTimeClassName, 'parse'], $value);
             if ($value->getTimezone()->getName() === 'Z') {
                 $value = $value->setTimezone('UTC');
             }

--- a/plugins/BEdita/Core/src/Database/Type/DateType.php
+++ b/plugins/BEdita/Core/src/Database/Type/DateType.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Database\Type;
+
+use Cake\Database\Type\DateType as CakeDateType;
+use DateTime;
+
+/**
+ * Custom DateType class with simplified marshal
+ */
+class DateType extends CakeDateType
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function marshal($value)
+    {
+        $date = DateTimeType::marshalDateTime($value, $this->getDateTimeClassName());
+        if ($date instanceof DateTime) {
+            $date->setTime(0, 0, 0);
+        }
+
+        return $date;
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Table/AsyncJobsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/AsyncJobsTable.php
@@ -1,6 +1,7 @@
 <?php
 namespace BEdita\Core\Model\Table;
 
+use BEdita\Core\Model\Validation\Validation;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
@@ -89,11 +90,11 @@ class AsyncJobsTable extends Table
             ->allowEmpty('payload');
 
         $validator
-            ->dateTime('scheduled_from')
+            ->add('scheduled_from', 'dateTime', ['rule' => [Validation::class, 'dateTime']])
             ->allowEmpty('scheduled_from');
 
         $validator
-            ->dateTime('expires')
+            ->add('expires', 'dateTime', ['rule' => [Validation::class, 'dateTime']])
             ->allowEmpty('expires');
 
         $validator
@@ -101,11 +102,11 @@ class AsyncJobsTable extends Table
             ->notEmpty('max_attempts');
 
         $validator
-            ->dateTime('locked_until')
+            ->add('locked_until', 'dateTime', ['rule' => [Validation::class, 'dateTime']])
             ->allowEmpty('locked_until');
 
         $validator
-            ->dateTime('completed')
+            ->add('completed', 'dateTime', ['rule' => [Validation::class, 'dateTime']])
             ->allowEmpty('completed');
 
         return $validator;

--- a/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Exception\BadFilterException;
+use BEdita\Core\Model\Validation\Validation;
 use BEdita\Core\ORM\QueryFilterTrait;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
@@ -73,9 +74,11 @@ class DateRangesTable extends Table
             ->allowEmpty('id', 'create');
 
         $validator
+            ->add('start_date', 'dateTime', ['rule' => [Validation::class, 'dateTime']])
             ->allowEmpty('start_date');
 
         $validator
+            ->add('end_date', 'dateTime', ['rule' => [Validation::class, 'dateTime']])
             ->allowEmpty('end_date');
 
         $validator

--- a/plugins/BEdita/Core/src/Model/Validation/ObjectsValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/ObjectsValidator.php
@@ -68,10 +68,10 @@ class ObjectsValidator extends Validator
             ->add('lang', 'languageTag', ['rule' => [Validation::class, 'languageTag']])
             ->allowEmpty('lang')
 
-            ->dateTime('publish_start')
+            ->add('publish_start', 'dateTime', ['rule' => [Validation::class, 'dateTime']])
             ->allowEmpty('publish_start')
 
-            ->dateTime('publish_end')
+            ->add('publish_end', 'dateTime', ['rule' => [Validation::class, 'dateTime']])
             ->allowEmpty('publish_end');
     }
 }

--- a/plugins/BEdita/Core/src/Model/Validation/ProfilesValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/ProfilesValidator.php
@@ -47,10 +47,10 @@ class ProfilesValidator extends ObjectsValidator
 
             ->allowEmpty('gender')
 
-            ->date('birthdate')
+            ->add('birthdate', 'date', ['rule' => [Validation::class, 'dateTime']])
             ->allowEmpty('birthdate')
 
-            ->date('deathdate')
+            ->add('deathdate', 'date', ['rule' => [Validation::class, 'dateTime']])
             ->allowEmpty('deathdate')
 
             ->boolean('company')

--- a/plugins/BEdita/Core/src/Model/Validation/Validation.php
+++ b/plugins/BEdita/Core/src/Model/Validation/Validation.php
@@ -199,6 +199,6 @@ class Validation
             return true;
         }
 
-        return __d('bedita', 'Invalid date or datetime "{0}"', $value);
+        return __d('bedita', 'Invalid date or datetime "{0}"', print_r($value, true));
     }
 }

--- a/plugins/BEdita/Core/src/Model/Validation/Validation.php
+++ b/plugins/BEdita/Core/src/Model/Validation/Validation.php
@@ -17,13 +17,14 @@ use Cake\Core\Configure;
 use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Utility\Hash;
 use Cake\Validation\Validation as CakeValidation;
+use DateTimeInterface;
 use League\JsonGuard\Validator as JsonSchemaValidator;
 use League\JsonReference\Dereferencer as JsonSchemaDereferencer;
 use League\JsonReference\Loader\ArrayLoader;
 use League\JsonReference\Loader\ChainedLoader;
 
 /**
- * Reusable class to check for reserved names.
+ * Class to provide reusable validation rules.
  * Used for object types and properties.
  *
  * @since 4.0.0
@@ -159,5 +160,45 @@ class Validation
         }
 
         return true;
+    }
+
+    /**
+     * Validate input date and datetime.
+     * Accepetd input formats:
+     *  - string date format
+     *  - integer timestamps
+     *  - DateTime objects
+     *
+     * Accepted date time string formats are
+     *  - 2017-01-01                    YYYY-MM-DD
+     *  - 2017-01-01 11:22              YYYY-MM-DD hh:mm
+     *  - 2017-01-01T11:22:33           YYYY-MM-DDThh:mm:ss
+     *  - 2017-01-01T11:22:33Z          YYYY-MM-DDThh:mm:ssZ
+     *  - 2017-01-01T19:20+01:00        YYYY-MM-DDThh:mmTZD
+     *  - 2017-01-01T11:22:33+01:00     YYYY-MM-DDThh:mm:ssTZD
+     *  - 2017-01-01T19:20:30.45+01:00  YYYY-MM-DDThh:mm:ss.sTZD
+     *
+     * See ISO 8601 subset as defined here https://www.w3.org/TR/NOTE-datetime:
+     *
+     * Also timestamp as integer are accepted.
+     *
+     * @param mixed $value Date or datetime value
+     * @return true|string
+     */
+    public static function dateTime($value)
+    {
+        if ($value instanceof DateTimeInterface) {
+            return true;
+        }
+
+        if (is_string($value) && preg_match('/^\d{4}(-\d\d(-\d\d([T ]\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?)?$/i', $value)) {
+            return true;
+        }
+
+        if (filter_var($value, FILTER_VALIDATE_INT)) {
+            return true;
+        }
+
+        return __d('bedita', 'Invalid date or datetime "{0}"', $value);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -73,6 +73,10 @@ class DateTimeTypeTest extends TestCase
                 '2017-01-01T19:20:30.45+01:00',
                 '2017-01-01T19:20:30.45+01:00',
             ],
+            [
+                '2018-08-01 10:00:00+00:00',
+                1533117600,
+            ],
             'datetime' => [
                 new DateTime('2000-01-01 00:00:00'),
                 new DateTime('2000-01-01 00:00:00'),
@@ -94,7 +98,7 @@ class DateTimeTypeTest extends TestCase
      * @return void
      *
      * @dataProvider marshalSuccessProvider
-     * @covers ::marshal
+     * @covers ::marshalDateTime
      */
     public function testMarshalSuccess($expected, $input, $useImmutable = false)
     {
@@ -120,9 +124,6 @@ class DateTimeTypeTest extends TestCase
     {
         return [
             [
-                '20170301121212',
-            ],
-            [
                 '2017 1 1',
             ],
             [
@@ -144,7 +145,7 @@ class DateTimeTypeTest extends TestCase
      * @return void
      *
      * @dataProvider marshalFailureProvider
-     * @covers ::marshal
+     * @covers ::marshalDateTime
      */
     public function testMarshalFailure($input)
     {
@@ -160,6 +161,7 @@ class DateTimeTypeTest extends TestCase
      * @return void
      *
      * @covers ::marshal
+     * @covers ::marshalDateTime
      */
     public function testMarshalEmpty()
     {

--- a/plugins/BEdita/Core/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Database/Type/DateTypeTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Core\Test\TestCase\Database\Type;
+
+use BEdita\Core\Database\Type\DateType;
+use Cake\I18n\Time;
+use Cake\TestSuite\TestCase;
+use DateTime;
+
+/**
+ * {@see \BEdita\Core\Database\Type\DateType} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Database\Type\DateType
+ */
+class DateTypeTest extends TestCase
+{
+
+    /**
+     * Data provider for `testMarshal`.
+     *
+     * @return array
+     */
+    public function marshalProvider()
+    {
+        return [
+            [
+                '2018-03-01',
+                '2018-03-01 12:12:12',
+            ],
+            [
+                '2017-12-31',
+                '2017-12-31T23:59:59Z',
+            ],
+            [
+                '2018-01-01',
+                '2018-01-01',
+            ],
+            [
+                '2018-01-01',
+                '2018-01-01 11:22',
+            ],
+            [
+                '2017-01-01',
+                '2017-01-01T11:22:33',
+            ],
+            [
+                '2018-08-01',
+                1533117600,
+            ],
+            'datetime' => [
+                new DateTime('2008-02-01 00:00:00'),
+                new DateTime('2008-02-01 11:12:00'),
+            ],
+        ];
+    }
+
+    /**
+     * Test `marshal` method
+     *
+     * @param \DateTimeInterface|string $expected Expected result
+     * @param mixed $input Input data to be marshaled.
+     * @param bool $useImmutable Should immutable datetime objects be used?
+     * @return void
+     *
+     * @dataProvider marshalProvider
+     * @covers ::marshal
+     */
+    public function testMarshal($expected, $input, $useImmutable = false)
+    {
+        $dateTimeType = new DateType();
+        $result = $dateTimeType->marshal($input);
+        if (is_string($expected)) {
+            static::assertInstanceOf($dateTimeType->getDateTimeClassName(), $result);
+            $expected = Time::parse($expected);
+        }
+        static::assertSame($expected->getTimestamp(), $result->getTimestamp());
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/ValidationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/ValidationTest.php
@@ -17,6 +17,7 @@ use BEdita\Core\Model\Validation\Validation;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
+use DateTime;
 
 /**
  * {@see \BEdita\Core\Model\Validation\Validation} Test Case
@@ -276,6 +277,58 @@ class ValidationTest extends TestCase
         Configure::write('I18n', $config);
 
         $result = Validation::languageTag($lang);
+
+        static::assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider for `testDateTime` test case.
+     *
+     * @return array
+     */
+    public function dateTimeProvider()
+    {
+        return [
+            'bad date' => [
+                'Invalid date or datetime "July, 1"',
+                'July, 1',
+            ],
+            'ok date' => [
+                true,
+                '2018-08-02',
+            ],
+            'date time object' => [
+                true,
+                new DateTime('2018-08-02'),
+            ],
+            'ok date time' => [
+                true,
+                '2018-08-02 14:23',
+            ],
+            'ok iso date time' => [
+                true,
+                '2018-08-02T09:00:00+20:00',
+            ],
+            'ok timestamp' => [
+                true,
+                '1533117600',
+            ],
+        ];
+    }
+
+    /**
+     * Test `dateTime` validation.
+     *
+     * @param bool|string $expected Expected result.
+     * @param string|int $value Datetime validated.
+     * @return void
+     *
+     * @dataProvider dateTimeProvider()
+     * @covers ::dateTime()
+     */
+    public function testDateTime($expected, $value)
+    {
+        $result = Validation::dateTime($value);
 
         static::assertSame($expected, $result);
     }


### PR DESCRIPTION
This PR fixes some issues on date - datetime input: some input format are not currently accepted and give a validation error, even when using the default ISO 8601 output format like `2018-02-17T17:33:20+00:00` (!!!).

* a new `Validation::dateTime` rule was added for date and date times input validation.
* this new rule has been applied to existing editable properties
* `BEdita\Core\Database\Type\DatetimeType` has been reafactored in order to use the same validation rule
* a new `BEdita\Core\Database\Type\DateType` has been introduced, same input is accepted but hour/minute/second information is dropped
* a new `IntegrationTest/DateTimeTest.php` has been added to test many API input formats cases


Look here https://github.com/orgs/bedita/teams/core/discussions/8 for an exaplanation on acceptable date and datetime input.
Timezone handling has not yet been addressed.
 
