### PR TITLE
Update child position with `POST` action as well

### DIFF
--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -27,7 +27,6 @@ use Cake\Event\Event;
 use Cake\Network\Exception\ConflictException;
 use Cake\Network\Exception\ForbiddenException;
 use Cake\Network\Exception\InternalErrorException;
-use Cake\Network\Exception\NotFoundException;
 use Cake\ORM\Association;
 use Cake\ORM\Query;
 use Cake\ORM\TableRegistry;

--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -26,7 +26,7 @@ class FoldersControllerTest extends IntegrationTestCase
     /**
      * Folders table.
      *
-     * @var \BEdita\Core\Model\Table\FoldersTable+
+     * @var \BEdita\Core\Model\Table\FoldersTable
      */
     public $Folders;
 
@@ -995,5 +995,35 @@ class FoldersControllerTest extends IntegrationTestCase
 
         $childrenIds = Hash::extract($folder->children, '{n}.id');
         static::assertEquals(['4'], $childrenIds);
+    }
+
+    /**
+     * Test updating an object's position within its parent using `POST`.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testUpdateChildPosition()
+    {
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $data = [
+            [
+                'id' => '2',
+                'type' => 'documents',
+                'meta' => [
+                    'relation' => [
+                        'position' => 'first',
+                    ],
+                ],
+            ],
+        ];
+        $this->post('/folders/11/relationships/children', json_encode(compact('data')));
+        $this->assertResponseCode(200);
+
+        $folder = $this->Folders->get(11, ['contain' => ['Children']]);
+        $childrenIds = Hash::extract($folder->children, '{n}.id');
+
+        static::assertEquals([2, 12], $childrenIds);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Action/AddAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/AddAssociatedAction.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Model\Action;
 
+use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
 use Cake\Network\Exception\BadRequestException;
 use Cake\ORM\Association\BelongsToMany;
@@ -29,6 +30,107 @@ class AddAssociatedAction extends UpdateAssociatedAction
 {
 
     /**
+     * Find existing join data relative to an entity.
+     *
+     * @param \Cake\Datasource\EntityInterface $relatedEntity Related entity to find join data for.
+     * @param \Cake\Datasource\EntityInterface[] $joinData Loaded join data.
+     * @return \Cake\Datasource\EntityInterface|null
+     */
+    protected function findJoinData(EntityInterface $relatedEntity, array $joinData)
+    {
+        $primaryKey = array_values($relatedEntity->extract((array)$this->Association->getBindingKey()));
+        foreach ($joinData as $joinDatum) {
+            $foreignKey = array_values($joinDatum->extract((array)$this->Association->getTargetForeignKey()));
+            if ($primaryKey === $foreignKey) {
+                return $joinDatum;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Filter entities to be actually updated.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity Source entity.
+     * @param \Cake\Datasource\EntityInterface[] $diff Related entities.
+     * @return \Cake\Datasource\EntityInterface[]
+     */
+    protected function patchJoinData(EntityInterface $entity, array $diff)
+    {
+        if (!($this->Association instanceof BelongsToMany) || empty($diff)) {
+            return $diff;
+        }
+
+        // Load existing join data.
+        $junctionTablePrefix = sprintf('%s.', $this->Association->junction()->getAlias());
+        $sourcePrimaryKey = (array)$this->Association->getSource()->getPrimaryKey();
+        $bindingKey = (array)$this->Association->getBindingKey();
+        $joinData = $this->Association->junction()->find()
+
+            // Apply association-defined conditions.
+            ->where(array_filter(
+                $this->Association->getConditions(),
+                function ($key) use ($junctionTablePrefix) {
+                    // Filter only conditions that apply to junction table.
+                    return substr($key, 0, strlen($junctionTablePrefix)) === $junctionTablePrefix;
+                },
+                ARRAY_FILTER_USE_KEY
+            ))
+
+            // Build conditions on source entity primary key (can be composite).
+            ->where(array_combine(
+                (array)$this->Association->getForeignKey(),
+                $entity->extract($sourcePrimaryKey)
+            ))
+
+            // Build conditions on target entities primary key (can be composite).
+            ->where(function (QueryExpression $exp) use ($bindingKey, $diff) {
+                $conditions = array_map(
+                    function (EntityInterface $relatedEntity) use ($bindingKey) {
+                        return function (QueryExpression $exp) use ($bindingKey, $relatedEntity) {
+                            $conditions = array_combine(
+                                (array)$this->Association->getTargetForeignKey(),
+                                $relatedEntity->extract($bindingKey)
+                            );
+                            foreach ($conditions as $field => $value) {
+                                $exp = $exp->eq($field, $value);
+                            }
+
+                            return $exp;
+                        };
+                    },
+                    $diff
+                );
+
+                return $exp->or_($conditions);
+            })
+
+            ->toArray();
+
+        // Patch existing join data with new values.
+        foreach ($diff as $relatedEntity) {
+            if (!$relatedEntity->has('_joinData')) {
+                continue;
+            }
+
+            $existing = $this->findJoinData($relatedEntity, $joinData);
+            if ($existing === null) {
+                continue;
+            }
+
+            $new = $relatedEntity->get('_joinData');
+            if ($new instanceof EntityInterface) {
+                $new = $new->toArray();
+            }
+
+            $relatedEntity->set('_joinData', $this->Association->junction()->patchEntity($existing, $new));
+        }
+
+        return $diff;
+    }
+
+    /**
      * Filter entities to be actually updated.
      *
      * @param \Cake\Datasource\EntityInterface $entity Source entity.
@@ -40,28 +142,18 @@ class AddAssociatedAction extends UpdateAssociatedAction
         $bindingKey = (array)$this->Association->getBindingKey();
         $existing = $this->existing($entity);
 
+        /** @var \Cake\Datasource\EntityInterface[] $diff */
         $diff = [];
         foreach ($relatedEntities as $relatedEntity) {
             $primaryKey = $relatedEntity->extract($bindingKey);
-            if (in_array($primaryKey, $existing)) {
-                if (!($this->Association instanceof BelongsToMany) || !$relatedEntity->has('_joinData')) {
-                    continue;
-                }
-
-                $relatedEntity->_joinData = $this->Association->junction()->patchEntity(
-                    $this->Association->junction()->find()
-                        ->where([
-                            $this->Association->getForeignKey() => $entity->get($this->Association->getSource()->getPrimaryKey()),
-                            $this->Association->getTargetForeignKey() => $relatedEntity->get($this->Association->getBindingKey()),
-                        ])
-                        ->firstOrFail(),
-                    $relatedEntity->_joinData->toArray()
-                );
-                $relatedEntity->setDirty('_joinData', true);
+            if (in_array($primaryKey, $existing) && (!($this->Association instanceof BelongsToMany) || !$relatedEntity->has('_joinData'))) {
+                continue;
             }
 
             $diff[] = $relatedEntity;
         }
+
+        $diff = $this->patchJoinData($entity, $diff);
 
         return $diff;
     }
@@ -92,10 +184,10 @@ class AddAssociatedAction extends UpdateAssociatedAction
                     return false;
                 }
                 foreach ($relatedEntities as $relatedEntity) {
-                    if ($relatedEntity->_joinData && $relatedEntity->_joinData->getErrors()) {
+                    if ($relatedEntity->has('_joinData') && $relatedEntity->get('_joinData')->getErrors()) {
                         throw new BadRequestException([
                             'title' => __d('bedita', 'Error linking entities'),
-                            'detail' => $relatedEntity->_joinData->getErrors(),
+                            'detail' => $relatedEntity->get('_joinData')->getErrors(),
                         ]);
                     }
                 }

--- a/plugins/BEdita/Core/src/Model/Action/AddAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/AddAssociatedAction.php
@@ -50,7 +50,7 @@ class AddAssociatedAction extends UpdateAssociatedAction
     }
 
     /**
-     * Filter entities to be actually updated.
+     * Patch join data on existing associations.
      *
      * @param \Cake\Datasource\EntityInterface $entity Source entity.
      * @param \Cake\Datasource\EntityInterface[] $diff Related entities.
@@ -142,7 +142,6 @@ class AddAssociatedAction extends UpdateAssociatedAction
         $bindingKey = (array)$this->Association->getBindingKey();
         $existing = $this->existing($entity);
 
-        /** @var \Cake\Datasource\EntityInterface[] $diff */
         $diff = [];
         foreach ($relatedEntities as $relatedEntity) {
             $primaryKey = $relatedEntity->extract($bindingKey);

--- a/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
@@ -160,7 +160,7 @@ class FoldersTable extends ObjectsTable
      */
     public function beforeSave(Event $event, EntityInterface $entity)
     {
-        $entity->dirty('parents', false);
+        $entity->setDirty('parents', false);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
@@ -20,13 +20,12 @@ use Cake\Event\Event;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Rule\ValidCount;
-use Cake\ORM\TableRegistry;
 
 /**
  * Folders Model
  *
- * @property \Cake\ORM\Association\HasOne $Trees
- * @property \Cake\ORM\Association\BelongsToMany $Children
+ * @property \BEdita\Core\Model\Table\TreesTable|\Cake\ORM\Association\HasOne $TreeParentNodes
+ * @property \BEdita\Core\Model\Table\ObjectsTable|\Cake\ORM\Association\BelongsToMany $Children
  *
  * @method \BEdita\Core\Model\Entity\Folder get($primaryKey, $options = [])
  * @method \BEdita\Core\Model\Entity\Folder newEntity($data = null, array $options = [])
@@ -102,7 +101,7 @@ class FoldersTable extends ObjectsTable
      * Custom rule for checking that entity has at most one parent.
      * The check is done on `parents` property
      *
-     * @param Folder $entity The folder entity to check
+     * @param \BEdita\Core\Model\Entity\Folder $entity The folder entity to check
      * @return bool
      */
     public function hasAtMostOneParent(Folder $entity)
@@ -122,7 +121,7 @@ class FoldersTable extends ObjectsTable
      *
      * If entity is new or `deleted` is not dirty (no change) or it is equal to true (delete action) then return true.
      *
-     * @param Folder $entity The entity to check
+     * @param \BEdita\Core\Model\Entity\Folder $entity The entity to check
      * @return bool
      */
     public function isFolderRestorable(Folder $entity)
@@ -154,8 +153,8 @@ class FoldersTable extends ObjectsTable
      * Set `parents` as not dirty to prevent automatic save that could breaks the tree.
      * The tree is saved later in `afterSave()`
      *
-     * @param Event $event The event
-     * @param EntityInterface $entity The entity to save
+     * @param \Cake\Event\Event $event The event
+     * @param \Cake\Datasource\EntityInterface $entity The entity to save
      * @return void
      */
     public function beforeSave(Event $event, EntityInterface $entity)
@@ -166,11 +165,11 @@ class FoldersTable extends ObjectsTable
     /**
      * Update the tree setting the right parent.
      *
-     * @param Event $event The event
-     * @param EntityInterface $entity The folder entity persisted
+     * @param \Cake\Event\Event $event The event
+     * @param \BEdita\Core\Model\Entity\Folder $entity The folder entity persisted
      * @return void
      */
-    public function afterSave(Event $event, EntityInterface $entity)
+    public function afterSave(Event $event, Folder $entity)
     {
         $this->updateChildrenDeletedField($entity);
 
@@ -179,19 +178,18 @@ class FoldersTable extends ObjectsTable
             return;
         }
 
-        $trees = TableRegistry::get('Trees');
-
         if ($entity->isNew()) {
-            $node = $trees->newEntity([
+            $node = $this->TreeNodes->newEntity([
                 'object_id' => $entity->id,
                 'parent_id' => $entity->parent_id,
             ]);
-            $trees->saveOrFail($node);
+            $this->TreeNodes->saveOrFail($node);
 
             return;
         }
 
-        $node = $trees->find()
+        /** @var \BEdita\Core\Model\Entity\Tree $node */
+        $node = $this->TreeNodes->find()
             ->where(['object_id' => $entity->id])
             ->firstOrFail();
 
@@ -201,7 +199,7 @@ class FoldersTable extends ObjectsTable
         }
 
         $node->parent_id = $entity->parent_id;
-        $trees->saveOrFail($node);
+        $this->TreeNodes->saveOrFail($node);
     }
 
     /**
@@ -252,7 +250,7 @@ class FoldersTable extends ObjectsTable
     /**
      * Finder for root folders.
      *
-     * @param Query $query Query object instance.
+     * @param \Cake\ORM\Query $query Query object instance.
      * @return \Cake\ORM\Query
      */
     protected function findRoots(Query $query)
@@ -270,8 +268,8 @@ class FoldersTable extends ObjectsTable
      * Update the `deleted` field of children folders to parent value.
      * The update is executed only if parent folder `deleted` is dirty.
      *
-     * @param Folder $folder The parent folder.
-     * @return int
+     * @param \BEdita\Core\Model\Entity\Folder $folder The parent folder.
+     * @return void
      */
     protected function updateChildrenDeletedField(Folder $folder)
     {
@@ -297,7 +295,7 @@ class FoldersTable extends ObjectsTable
             });
 
         // Update deleted field of descendants
-        return $this->updateAll(
+        $this->updateAll(
             [
                 'deleted' => $folder->deleted,
                 'modified' => $this->timestamp(null, true),

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -22,7 +22,6 @@ use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
-use Cake\Network\Exception\BadRequestException;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
@@ -49,6 +48,7 @@ use Cake\Utility\Hash;
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @mixin \BEdita\Core\Model\Behavior\UserModifiedBehavior
+ * @mixin \BEdita\Core\Model\Behavior\ObjectTypeBehavior
  * @mixin \BEdita\Core\Model\Behavior\RelationsBehavior
  *
  * @since 4.0.0


### PR DESCRIPTION
This PR fixes #1523.

The `AddAssociatedAction` has been slightly refactored so that it always saves an association if it detects that join data are present in the request. This is suboptimal because we should check if something actually changed before saving, but it works fine and it shouldn't cause big troubles.

A regression test and a unit test are included in this PR.