### PR TITLE
Decode JSON Schemas as objects instead of associative arrays

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
@@ -331,7 +331,7 @@ class RelationsControllerTest extends IntegrationTestCase
         $this->assertHeader('Location', 'http://api.example.com/model/relations/' . $relation->id);
 
         $expected = array_merge(['id' => $relation->id], $data['attributes']);
-        static::assertEquals($expected, $relation->toArray());
+        static::assertJsonStringEqualsJsonString(json_encode($expected), json_encode($relation->toArray()));
     }
 
     /**

--- a/plugins/BEdita/Core/config/bootstrap.php
+++ b/plugins/BEdita/Core/config/bootstrap.php
@@ -73,7 +73,7 @@ Type::set('boolean', new BoolType());
 /**
  * Register custom JSON Object type.
  */
-Type::set('jsonobject', new JsonObjectType());
+Type::map('jsonobject', JsonObjectType::class);
 
 /**
  * Set loader for translation domain "bedita".

--- a/plugins/BEdita/Core/config/bootstrap.php
+++ b/plugins/BEdita/Core/config/bootstrap.php
@@ -4,6 +4,7 @@ use BEdita\Core\Configure\Engine\DatabaseConfig;
 use BEdita\Core\Database\Type\BoolType;
 use BEdita\Core\Database\Type\DateTimeType;
 use BEdita\Core\Database\Type\DateType;
+use BEdita\Core\Database\Type\JsonObjectType;
 use BEdita\Core\Filesystem\Thumbnail;
 use BEdita\Core\I18n\MessagesFileLoader;
 use BEdita\Core\ORM\Locator\TableLocator;
@@ -68,6 +69,11 @@ Type::set('timestamp', new DateTimeType());
  * Use custom BoolType
  */
 Type::set('boolean', new BoolType());
+
+/**
+ * Register custom JSON Object type.
+ */
+Type::set('jsonobject', new JsonObjectType());
 
 /**
  * Set loader for translation domain "bedita".

--- a/plugins/BEdita/Core/src/Database/Type/JsonObjectType.php
+++ b/plugins/BEdita/Core/src/Database/Type/JsonObjectType.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Database\Type;
+
+use Cake\Database\Driver;
+use Cake\Database\Type\JsonType;
+
+/**
+ * Custom JSON type that marshals JSONs into objects.
+ *
+ * @since 4.0.0
+ */
+class JsonObjectType extends JsonType
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toPHP($value, Driver $driver)
+    {
+        return json_decode($value, false);
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
@@ -121,7 +121,7 @@ class RelationsBehavior extends Behavior
             );
             $through->getValidator()->setProvider(
                 'jsonSchema',
-                Schema::import(json_decode(json_encode($relation->has('params') ? $relation->params : true)))
+                Schema::import($relation->has('params') ? $relation->params : true)
             );
 
             $this->relatedTo($relation->alias, [
@@ -156,7 +156,7 @@ class RelationsBehavior extends Behavior
             );
             $through->getValidator()->setProvider(
                 'jsonSchema',
-                Schema::import(json_decode(json_encode($relation->has('params') ? $relation->params : true)))
+                Schema::import($relation->has('params') ? $relation->params : true)
             );
 
             $this->relatedTo($relation->inverse_alias, [

--- a/plugins/BEdita/Core/src/Model/Table/PropertyTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/PropertyTypesTable.php
@@ -85,7 +85,7 @@ class PropertyTypesTable extends Table
      */
     protected function _initializeSchema(TableSchema $schema)
     {
-        $schema->setColumnType('params', 'jsonobject');
+        $schema->setColumnType('params', 'json');
 
         return $schema;
     }

--- a/plugins/BEdita/Core/src/Model/Table/PropertyTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/PropertyTypesTable.php
@@ -85,7 +85,7 @@ class PropertyTypesTable extends Table
      */
     protected function _initializeSchema(TableSchema $schema)
     {
-        $schema->setColumnType('params', 'json');
+        $schema->setColumnType('params', 'jsonobject');
 
         return $schema;
     }

--- a/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
@@ -154,7 +154,7 @@ class RelationsTable extends Table
      */
     protected function _initializeSchema(TableSchema $schema)
     {
-        $schema->setColumnType('params', 'json');
+        $schema->setColumnType('params', 'jsonobject');
 
         return $schema;
     }

--- a/plugins/BEdita/Core/tests/TestCase/Database/Type/JsonObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Database/Type/JsonObjectTypeTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Database\Type;
+
+use BEdita\Core\Database\Type\JsonObjectType;
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\TestCase;
+
+/**
+ * @coversDefaultClass \BEdita\Core\Database\Type\JsonObjectType
+ */
+class JsonObjectTypeTest extends TestCase
+{
+
+    /**
+     * Data provider for `testToPHP` test case.
+     *
+     * @return array
+     */
+    public function toPHPProvider()
+    {
+        $obj = new \stdClass();
+        $obj->firstName = 'Gustavo';
+        $obj->lastName = 'Supporto';
+        $obj->age = 42;
+        $obj->skills = [];
+        $obj->randomEmptyObject = new \stdClass();
+
+        return [
+            'string' => [
+                'gustavo',
+                '"gustavo"',
+            ],
+            'number' => [
+                42,
+                '42',
+            ],
+            'boolean' => [
+                true,
+                'true',
+            ],
+            'null' => [
+                null,
+                'null',
+            ],
+            'array' => [
+                ['Gustavo', 'Supporto', 42, true],
+                '["Gustavo","Supporto",42,true]',
+            ],
+            'empty array' => [
+                [],
+                '[]',
+            ],
+            'empty object' => [
+                new \stdClass(),
+                '{}',
+            ],
+            'complex' => [
+                $obj,
+                '{"firstName":"Gustavo","lastName":"Supporto","age":42,"skills":[],"randomEmptyObject":{}}',
+            ],
+        ];
+    }
+
+    /**
+     * Test `toPHP()` method.
+     *
+     * @param mixed $expected Expected result.
+     * @param string $value Value to be decoded.
+     * @return void
+     *
+     * @dataProvider toPHPProvider()
+     * @covers ::toPHP()
+     */
+    public function testToPHP($expected, $value)
+    {
+        /** @var \Cake\Database\Connection $connection */
+        $connection = ConnectionManager::get('default');
+
+        $type = new JsonObjectType();
+        $actual = $type->toPHP($value, $connection->getDriver());
+
+        if (is_scalar($expected)) {
+            static::assertSame($expected, $actual);
+        } else {
+            static::assertEquals($expected, $actual);
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes an issue that was caused by empty objects (`{}`) in JSON Schemas incorrectly being decoded as empty arrays (`[]`).