### PR TITLE
Query string filter fields with `null`

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -407,6 +407,19 @@ class FilterQueryStringTest extends IntegrationTestCase
                 [
                 ],
             ],
+            'profileNameNull' => [
+                '/profiles',
+                'filter[name]=null',
+                [
+                ],
+            ],
+            'profileNameNotNull' => [
+                '/profiles',
+                'filter[name][ne]=null',
+                [
+                    '4',
+                 ],
+            ],
         ];
     }
 

--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -409,13 +409,13 @@ class FilterQueryStringTest extends IntegrationTestCase
             ],
             'profileNameNull' => [
                 '/profiles',
-                'filter[name]=null',
+                'filter[name][null]=1',
                 [
                 ],
             ],
             'profileNameNotNull' => [
                 '/profiles',
-                'filter[name][ne]=null',
+                'filter[name][null]=0',
                 [
                     '4',
                  ],

--- a/plugins/BEdita/Core/config/reserved.php
+++ b/plugins/BEdita/Core/config/reserved.php
@@ -28,6 +28,7 @@ return [
     'folders',
     'model',
     'models',
+    'null',
     'object_type',
     'object_types',
     'parent',

--- a/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
+++ b/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -51,8 +51,8 @@ trait QueryFilterTrait
      * // field1 greater or equal 5, field2 less or equal 4
      * ['field1' => ['>=' => 10], 'field2' => ['<=' => 4]];
      *
-     * // field1 is null, field2 is not null
-     * ['field1' => ['null' => 1], 'field2' => ['null' => 0]];
+     * // field1 is null, field2 is not null, field3 is null
+     * ['field1' => ['null' => 1], 'field2' => ['null' => 0], 'field3' => null];
      * ```
      *
      * //
@@ -65,7 +65,7 @@ trait QueryFilterTrait
     {
         return $query->where(function (QueryExpression $exp) use ($options) {
             foreach ($options as $field => $conditions) {
-                if ($conditions === null || $conditions === 'null') {
+                if ($conditions === null) {
                     $exp = $exp->isNull($field);
 
                     continue;

--- a/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
+++ b/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
@@ -101,7 +101,7 @@ trait QueryFilterTrait
      * @param string $operator Filter operator
      * @param string $field Filter field
      * @param string $value Filter value
-     * @return QueryExpression|null
+     * @return QueryExpression Operator query expression
      */
     protected function operatorExpression(QueryExpression $exp, $operator, $field, $value)
     {

--- a/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
+++ b/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
@@ -97,7 +97,7 @@ trait QueryFilterTrait
 
             // return the current expression if not empty
             // otherwise a trivial comparison to avoid SQL errors
-            return $exp->count() > 0 ? $exp: new Comparison('1', '1', 'integer', '=');
+            return $exp->count() > 0 ? $exp : new Comparison('1', '1', 'integer', '=');
         });
     }
 

--- a/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
+++ b/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
@@ -50,7 +50,12 @@ trait QueryFilterTrait
      *
      * // field1 greater or equal 5, field2 less or equal 4
      * ['field1' => ['>=' => 10], 'field2' => ['<=' => 4]];
+     *
+     * // field1 is null, field2 is not null
+     * ['field1' => ['null' => 1], 'field2' => ['null' => 0]];
      * ```
+     *
+     * //
 
      * @param \Cake\ORM\Query $query Query object instance.
      * @param array $options Array of acceptable fields and conditions.
@@ -108,39 +113,45 @@ trait QueryFilterTrait
         switch ($operator) {
             case 'eq':
             case '=':
-                if ($value === null || $value === 'null') {
-                    return $exp->isNull($field);
-                }
-
-                return $exp->eq($field, $value);
+                $exp = $exp->eq($field, $value);
+                break;
 
             case 'neq':
             case 'ne':
             case '!=':
             case '<>':
-                if ($value === null || $value === 'null') {
-                    return $exp->isNotNull($field);
-                }
-
-                return $exp->notEq($field, $value);
+                $exp = $exp->notEq($field, $value);
+                break;
 
             case 'lt':
             case '<':
-                return $exp->lt($field, $value);
+                $exp = $exp->lt($field, $value);
+                break;
 
             case 'lte':
             case 'le':
             case '<=':
-                return $exp->lte($field, $value);
+                $exp = $exp->lte($field, $value);
+                break;
 
             case 'gt':
             case '>':
-                return $exp->gt($field, $value);
+                $exp = $exp->gt($field, $value);
+                break;
 
             case 'gte':
             case 'ge':
             case '>=':
-                return $exp->gte($field, $value);
+                $exp = $exp->gte($field, $value);
+                break;
+
+            case 'null':
+                if (empty($value) || $value === '0') {
+                    $exp = $exp->isNotNull($field);
+                } else {
+                    $exp = $exp->isNull($field);
+                }
+                break;
         }
 
         return $exp;

--- a/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
+++ b/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\ORM;
 
+use Cake\Database\Expression\Comparison;
 use Cake\Database\Expression\QueryExpression;
 use Cake\ORM\Query;
 
@@ -94,7 +95,9 @@ trait QueryFilterTrait
                 }
             }
 
-            return $exp;
+            // return the current expression if not empty
+            // otherwise a trivial comparison to avoid SQL errors
+            return $exp->count() > 0 ? $exp: new Comparison('1', '1', 'integer', '=');
         });
     }
 
@@ -146,9 +149,10 @@ trait QueryFilterTrait
                 break;
 
             case 'null':
-                if (empty($value) || $value === '0') {
+                $op = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+                if ($op === false) {
                     $exp = $exp->isNotNull($field);
-                } else {
+                } elseif ($op === true) {
                     $exp = $exp->isNull($field);
                 }
                 break;

--- a/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
@@ -79,6 +79,24 @@ class QueryFilterTraitTest extends TestCase
                 ],
                 0,
             ],
+            'nameNullStr' => [
+                [
+                    'name' => 'null',
+                ],
+                0,
+            ],
+            'nameNotNull' => [
+                [
+                    'name' => ['ne' => null],
+                ],
+                3,
+            ],
+            'nameNotNullStr' => [
+                [
+                    'name' => ['ne' => 'null'],
+                ],
+                3,
+            ],
             'nameEagle' => [
                 [
                     'name' => 'eagle',
@@ -154,6 +172,7 @@ class QueryFilterTraitTest extends TestCase
      *
      * @dataProvider fieldsFilterProvider
      * @covers ::fieldsFilter()
+     * @covers ::operatorExpression()
      */
     public function testFieldsFilter($options, $numExpected)
     {

--- a/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
@@ -97,6 +97,18 @@ class QueryFilterTraitTest extends TestCase
                 ],
                 3,
             ],
+            'nameEqNull' => [
+                [
+                    'name' => ['eq' => null],
+                ],
+                0,
+            ],
+            'nameBadOp' => [
+                [
+                    'name' => ['!=' => null, '<<<<' => 'zz'],
+                ],
+                3,
+            ],
             'nameEagle' => [
                 [
                     'name' => 'eagle',

--- a/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
@@ -97,6 +97,12 @@ class QueryFilterTraitTest extends TestCase
                 ],
                 3,
             ],
+            'nameNullIgnore' => [
+                [
+                    'name' => ['null' => 'gustavo'],
+                ],
+                3,
+            ],
             'nameEagle' => [
                 [
                     'name' => 'eagle',

--- a/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
@@ -75,11 +75,17 @@ class QueryFilterTraitTest extends TestCase
             ],
             'nameNull' => [
                 [
+                    'name' => null,
+                ],
+                0,
+            ],
+            'nameNullOp' => [
+                [
                     'name' => ['null' => true],
                 ],
                 0,
             ],
-            'nameNotNull' => [
+            'nameNotNullOp' => [
                 [
                     'name' => ['null' => false],
                 ],

--- a/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
@@ -75,37 +75,19 @@ class QueryFilterTraitTest extends TestCase
             ],
             'nameNull' => [
                 [
-                    'name' => null,
-                ],
-                0,
-            ],
-            'nameNullStr' => [
-                [
-                    'name' => 'null',
+                    'name' => ['null' => true],
                 ],
                 0,
             ],
             'nameNotNull' => [
                 [
-                    'name' => ['ne' => null],
+                    'name' => ['null' => false],
                 ],
                 3,
             ],
             'nameNotNullStr' => [
                 [
-                    'name' => ['ne' => 'null'],
-                ],
-                3,
-            ],
-            'nameEqNull' => [
-                [
-                    'name' => ['eq' => null],
-                ],
-                0,
-            ],
-            'nameBadOp' => [
-                [
-                    'name' => ['!=' => null, '<<<<' => 'zz'],
+                    'name' => ['null' => '0'],
                 ],
                 3,
             ],


### PR DESCRIPTION
This PR adds missing `null` support on query string fields filter.

~As a result using filters like `filter[lang]=null` or `filter[lang][ne]=null` will provide the expected result: objects with NULL or NOT NULL field are returned.~

**UPDATE**

New filter expressions are available:

* `filter[lang][null]=1` - return objects where `lang` field is `NULL`
* `filter[lang][null]=0` - return objects where `lang` field is `NOT NULL` 

