### PR TITLE
Existing user signup

### DIFF
--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -159,10 +159,6 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
             $validator
                 ->requirePresence('username')
                 ->notEmpty('username');
-
-            $validator
-                ->requirePresence('password')
-                ->notEmpty('password');
         } else {
             $validator
                 ->requirePresence('provider_username')

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -42,6 +42,13 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
     use MailerAwareTrait;
 
     /**
+     * 400 Username already registered
+     *
+     * @var string
+     */
+    const BE_USER_EXISTS = 'be_user_exists';
+
+    /**
      * The UsersTable table
      *
      * @var \BEdita\Core\Model\Table\UsersTable
@@ -148,6 +155,14 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
 
         if (empty($data['auth_provider'])) {
             $validator->requirePresence('activation_url');
+
+            $validator
+                ->requirePresence('username')
+                ->notEmpty('username');
+
+            $validator
+                ->requirePresence('password')
+                ->notEmpty('password');
         } else {
             $validator
                 ->requirePresence('provider_username')
@@ -221,6 +236,13 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
      */
     protected function createUserEntity(array $data, $status, $validate)
     {
+        if ($this->Users->exists(['username' => $data['username']])) {
+            $this->dispatchEvent('Auth.signupUserExists', [$data], $this->Users);
+            throw new BadRequestException([
+                'title' => __d('bedita', 'User "{0}" already registered', $data['username']),
+                'code' => self::BE_USER_EXISTS,
+            ]);
+        }
         $action = new SaveEntityAction(['table' => $this->Users]);
 
         return $action([

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -201,7 +201,6 @@ class SignupUserActionTest extends TestCase
             static::assertTrue(is_string($arguments[3]));
         });
 
-        // Restore this part:
         if ($expected instanceof \Exception) {
             static::expectException(get_class($expected));
         }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -182,7 +182,7 @@ class SignupUserActionTest extends TestCase
     /**
      * Test command execution.
      *
-     * @param array|\Exception $expected Expected result.
+     * @param bool|\Exception $expected Expected result.
      * @param array $data Action data.
      * @return void
      *
@@ -201,22 +201,26 @@ class SignupUserActionTest extends TestCase
             static::assertTrue(is_string($arguments[3]));
         });
 
+        // Restore this part:
+        if ($expected instanceof \Exception) {
+            static::expectException(get_class($expected));
+        }
+
         try {
             $action = new SignupUserAction();
             $result = $action($data);
-            $success = true;
         } catch (CakeException $e) {
-            $success = $e;
+            static::assertInstanceOf(CakeException::class, $expected); // Ensure we're expecting an exception of the same kind.
             static::assertEquals($expected->getAttributes(), $e->getAttributes());
             static::assertEquals($expected->getCode(), $e->getCode());
+
+            throw $e; // Re-throw exception.
         }
 
-        static::assertEquals($expected, $success);
-        if ($success === true) {
-            static::assertInstanceOf(User::class, $result);
-            static::assertSame('draft', $result->status);
-            static::assertSame(1, $eventDispatched, 'Event not dispatched');
-        }
+        static::assertTrue((bool)$result);
+        static::assertInstanceOf(User::class, $result);
+        static::assertSame('draft', $result->status);
+        static::assertSame(1, $eventDispatched, 'Event not dispatched');
     }
 
     /**


### PR DESCRIPTION
This PR adds a custom exception `code` and event in case of existing user signup.

Useful for clients and be4 plugins to better handle this use case.
