### PR TITLE
Introduce `lang` query string #1494 

### DIFF
--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -190,9 +190,10 @@ class ObjectsController extends ResourcesController
             // List existing entities.
             $filter = (array)$this->request->getQuery('filter') + array_filter(['query' => $this->request->getQuery('q')]);
             $contain = $this->prepareInclude($this->request->getQuery('include'));
+            $lang = $this->request->getQuery('lang');
 
             $action = new ListObjectsAction(['table' => $this->Table, 'objectType' => $this->objectType]);
-            $query = $action(compact('filter', 'contain'));
+            $query = $action(compact('filter', 'contain', 'lang'));
 
             $this->set('_fields', $this->request->getQuery('fields', []));
             $data = $this->paginate($query);
@@ -228,7 +229,11 @@ class ObjectsController extends ResourcesController
         $contain = $this->prepareInclude($this->request->getQuery('include'));
 
         $action = new GetObjectAction(['table' => $this->Table, 'objectType' => $this->objectType]);
-        $entity = $action(['primaryKey' => $id, 'contain' => $contain]);
+        $entity = $action([
+            'primaryKey' => $id,
+            'contain' => $contain,
+            'lang' => $this->request->getQuery('lang'),
+        ]);
 
         if ($this->request->is('delete')) {
             // Delete an entity.

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -2589,4 +2589,59 @@ class ObjectsControllerTest extends IntegrationTestCase
         $response = json_decode((string)$this->_response->getBody(), true);
         static::assertEquals($expected, $response['error']['title']);
     }
+
+    /**
+     * Test 'lang' filter.
+     *
+     * @return void
+     *
+     * @covers ::resource()
+     */
+    public function testLang()
+    {
+        $expected = [
+            [
+                'id' => '2',
+                'type' => 'translations',
+                'attributes' => [
+                    'status' => 'on',
+                    'lang' => 'fr',
+                    'object_id' => 2,
+                    'translated_fields' => [
+                        'description' => 'description ici',
+                        'extra' => [
+                            'list' => ['on', 'deux', 'trois'],
+                        ],
+                    ],
+                ],
+                'meta' => [
+                    'created' => '2018-01-01T00:00:00+00:00',
+                    'modified' => '2018-01-01T00:00:00+00:00',
+                    'created_by' => 1,
+                    'modified_by' => 1,
+                ],
+                'links' => [
+                    'self' => 'http://api.example.com/translations/2',
+                ],
+                'relationships' => [
+                    'object' => [
+                        'links' => [
+                            'related' => 'http://api.example.com/translations/2/object',
+                            'self' => 'http://api.example.com/translations/2/relationships/object',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->configRequestHeaders();
+        $this->get('/documents/2?lang=fr');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        static::assertNotEmpty($result['included']);
+        static::assertEquals($expected, $result['included']);
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Action/GetObjectAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/GetObjectAction.php
@@ -74,6 +74,11 @@ class GetObjectAction extends BaseAction
         if (Configure::check('Status.level')) {
             $query = $query->find('status', [Configure::read('Status.level')]);
         }
+        if (!empty($data['lang'])) {
+            $query->contain('Translations', function ($q) use ($data) {
+                return $q->where(['Translations.lang' => $data['lang']]);
+            });
+        }
 
         return $query->firstOrFail();
     }

--- a/plugins/BEdita/Core/src/Model/Action/GetObjectAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/GetObjectAction.php
@@ -75,9 +75,7 @@ class GetObjectAction extends BaseAction
             $query = $query->find('status', [Configure::read('Status.level')]);
         }
         if (!empty($data['lang'])) {
-            $query->contain('Translations', function ($q) use ($data) {
-                return $q->where(['Translations.lang' => $data['lang']]);
-            });
+            $query = $query->find('translations', ['lang' => $data['lang']]);
         }
 
         return $query->firstOrFail();

--- a/plugins/BEdita/Core/src/Model/Action/ListObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListObjectsAction.php
@@ -85,9 +85,7 @@ class ListObjectsAction extends BaseAction
         }
 
         if (!empty($data['lang'])) {
-            $query->contain('Translations', function ($q) use ($data) {
-                return $q->where(['Translations.lang' => $data['lang']]);
-            });
+            $query = $query->find('translations', ['lang' => $data['lang']]);
         }
 
         return $query;

--- a/plugins/BEdita/Core/src/Model/Action/ListObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListObjectsAction.php
@@ -84,6 +84,12 @@ class ListObjectsAction extends BaseAction
             $query = $query->find('status', [Configure::read('Status.level')]);
         }
 
+        if (!empty($data['lang'])) {
+            $query->contain('Translations', function ($q) use ($data) {
+                return $q->where(['Translations.lang' => $data['lang']]);
+            });
+        }
+
         return $query;
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -375,4 +375,18 @@ class ObjectsTable extends Table
                 throw new BadFilterException(__d('bedita', 'Invalid options for finder "{0}"', 'status'));
         }
     }
+
+    /**
+     * Retrieve object translation for a language.
+     *
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @param array $options Lang options.
+     * @return \Cake\ORM\Query
+     */
+    protected function findTranslations(Query $query, array $options)
+    {
+        return $query->contain('Translations', function (Query $query) use ($options) {
+            return $query->where(['Translations.lang' => $options['lang']]);
+        });
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/GetObjectActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/GetObjectActionTest.php
@@ -37,6 +37,8 @@ class GetObjectActionTest extends TestCase
         'plugin.BEdita/Core.properties',
         'plugin.BEdita/Core.date_ranges',
         'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.profiles',
+        'plugin.BEdita/Core.users',
         'plugin.BEdita/Core.translations',
     ];
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/GetObjectActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/GetObjectActionTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -33,8 +33,11 @@ class GetObjectActionTest extends TestCase
         'plugin.BEdita/Core.object_types',
         'plugin.BEdita/Core.relations',
         'plugin.BEdita/Core.relation_types',
+        'plugin.BEdita/Core.property_types',
+        'plugin.BEdita/Core.properties',
         'plugin.BEdita/Core.date_ranges',
         'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.translations',
     ];
 
     /**
@@ -114,5 +117,24 @@ class GetObjectActionTest extends TestCase
         $action = new GetObjectAction(compact('table'));
 
         $action(['primaryKey' => [1, 2]]);
+    }
+
+    /**
+     * Test command execution with lang query string.
+     *
+     * @return void
+     */
+    public function testLang()
+    {
+        $objectType = TableRegistry::get('ObjectTypes')->get('Documents');
+        $table = TableRegistry::get('Objects');
+        $action = new GetObjectAction(compact('table', 'objectType'));
+
+        $result = $action(['primaryKey' => 2, 'lang' => 'fr']);
+
+        static::assertNotEmpty($result);
+        static::assertNotEmpty($result['translations']);
+        static::assertEquals(1, count($result['translations']));
+        static::assertEquals(2, $result['translations'][0]['id']);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListObjectsActionTest.php
@@ -38,6 +38,8 @@ class ListObjectsActionTest extends TestCase
         'plugin.BEdita/Core.properties',
         'plugin.BEdita/Core.date_ranges',
         'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.profiles',
+        'plugin.BEdita/Core.users',
         'plugin.BEdita/Core.translations',
     ];
 
@@ -143,6 +145,7 @@ class ListObjectsActionTest extends TestCase
 
         static::assertInstanceOf(Query::class, $result);
         static::assertSame(2, $result->count());
+        $result->order(['Objects.id' => 'ASC']);
         $result = $result->toArray();
 
         static::assertNotEmpty($result[0]['translations']);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListObjectsActionTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -34,8 +34,11 @@ class ListObjectsActionTest extends TestCase
         'plugin.BEdita/Core.object_types',
         'plugin.BEdita/Core.relations',
         'plugin.BEdita/Core.relation_types',
+        'plugin.BEdita/Core.property_types',
+        'plugin.BEdita/Core.properties',
         'plugin.BEdita/Core.date_ranges',
         'plugin.BEdita/Core.objects',
+        'plugin.BEdita/Core.translations',
     ];
 
     /**
@@ -121,5 +124,29 @@ class ListObjectsActionTest extends TestCase
 
         static::assertInstanceOf(Query::class, $result);
         static::assertSame(11, $result->count());
+    }
+
+    /**
+     * Test command execution with a `lang` query string.
+     *
+     * @return void
+     */
+    public function testLang()
+    {
+        $objectType = TableRegistry::get('ObjectTypes')->get('Documents');
+        $table = TableRegistry::get('Objects');
+        $action = new ListObjectsAction(compact('table', 'objectType'));
+
+        $result = $action([
+            'lang' => 'fr',
+        ]);
+
+        static::assertInstanceOf(Query::class, $result);
+        static::assertSame(2, $result->count());
+        $result = $result->toArray();
+
+        static::assertNotEmpty($result[0]['translations']);
+        static::assertEquals(1, count($result[0]['translations']));
+        static::assertEquals(2, $result[0]['translations'][0]['id']);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -45,6 +45,7 @@ class ObjectsTableTest extends TestCase
         'plugin.BEdita/Core.profiles',
         'plugin.BEdita/Core.users',
         'plugin.BEdita/Core.date_ranges',
+        'plugin.BEdita/Core.translations',
     ];
 
     /**
@@ -602,5 +603,23 @@ class ObjectsTableTest extends TestCase
         $object = $this->Objects->save($object);
 
         static::assertSame($expected, $object->get('lang'));
+    }
+
+    /**
+     * Test `findTranslations()`.
+     *
+     * @return void
+     *
+     * @covers ::findTranslations()
+     */
+    public function testFindTranslations()
+    {
+        $result = $this->Objects->find('translations', ['lang' => 'fr'])
+            ->where(['Objects.id' => 2])
+            ->toArray();
+
+        static::assertNotEmpty($result);
+        static::assertSame(1, count($result));
+        static::assertSame(2, $result[0]['id']);
     }
 }


### PR DESCRIPTION
This PR solves #1494 

* `lang` query string used on single object and list GET
* only single language tag supported for now
* translation `status` not checked

