### PR TITLE
Refactor cache using Redis hashes

### DIFF
--- a/bedita-app/controllers/modules/translations_controller.php
+++ b/bedita-app/controllers/modules/translations_controller.php
@@ -109,8 +109,7 @@ class TranslationsController extends ModulesController {
 		// invalidate cache for object master
 		$BEObject = ClassRegistry::init('BEObject');
 		if ($BEObject->isCacheableOn()) {
-	        $BEObject->setObjectsToClean($this->data['master_id']);
-	        $BEObject->clearCache();
+	        $BEObject->clearCache($this->data['master_id']);
     	}
 		$this->userInfoMessage(__("Translation saved", true));
 		$this->eventInfo("translation saved");
@@ -129,8 +128,7 @@ class TranslationsController extends ModulesController {
 		// invalidate cache for object master
 		$BEObject = ClassRegistry::init('BEObject');
 		if ($BEObject->isCacheableOn()) {
-	        $BEObject->setObjectsToClean($id);
-	        $BEObject->clearCache();
+	        $BEObject->clearCache($id);
     	}
 		$this->userInfoMessage(__("Translation deleted", true) . " - $lang,$id ");
 		$this->eventInfo("translation $lang for object $id deleted");

--- a/bedita-app/libs/be_object_cache.php
+++ b/bedita-app/libs/be_object_cache.php
@@ -70,9 +70,15 @@ class BeObjectCache {
         }
     }
 
+    /**
+     * Get prefix for all cache keys relative to an object.
+     *
+     * @param int $id Object ID.
+     * @return string
+     */
     private function cachePrefix($id) {
         if ($this->hasFileEngine()) {
-            return sprintf('%02d/%d-', $id % 1000, $id);
+            return sprintf('%03d/%d-', $id % 1000, $id);
         }
 
         return sprintf('%d/', $id);

--- a/bedita-app/libs/be_object_cache.php
+++ b/bedita-app/libs/be_object_cache.php
@@ -63,6 +63,8 @@ class BeObjectCache {
         if (empty($cacheConf)) {
             // default cache path if not configured
             $this->cacheConfig['path'] = BEDITA_CORE_PATH . DS . 'tmp' . DS . 'cache' . DS . 'objects';
+            Cache::config('objects', $this->cacheConfig);
+            Cache::config('default');
         }
         $this->cacheConfig = $cacheConf + $this->cacheConfig;
         if (!empty($this->cacheConfig['path'])) {

--- a/bedita-app/libs/be_object_cache.php
+++ b/bedita-app/libs/be_object_cache.php
@@ -70,35 +70,12 @@ class BeObjectCache {
         }
     }
 
-    /**
-     * Get cached path by object ID.
-     *
-     * @param int $id Object ID.
-     * @return string
-     */
-    public function getPathById($id) {
-        $id = $id % 1000;
-        $id = str_pad($id, 3, '0', STR_PAD_LEFT);
-
-        return $this->baseCachePath . DS . $id;
-    }
-
-    /**
-     * Prepare cached config for an object to be cached.
-     *
-     * @param int $id Object ID.
-     * @return void
-     */
-    private function setCacheOptions($id) {
-        if (!empty($this->cacheConfig['path'])) {
-            $path = $this->getPathById($id);
-            if (!file_exists($path)) {
-                mkdir($path);
-                chmod($path, 0775);
-            }
-            $this->cacheConfig['path'] = $path;
+    private function cachePrefix($id) {
+        if ($this->hasFileEngine()) {
+            return sprintf('%02d/%d-', $id % 1000, $id);
         }
-        Cache::set($this->cacheConfig);
+
+        return sprintf('%d/', $id);
     }
 
     /**
@@ -111,13 +88,22 @@ class BeObjectCache {
      */
     private function cacheName($id, array $options, $label = null) {
         if (!empty($options['bindings_list'])) {
-            $strOpt = implode('', $options['bindings_list']);
-        } elseif (!empty($options)) {
-            $strOpt = print_r($options, true);
+            $options = implode('', $options['bindings_list']);
+        } else {
+            $options = sha1(serialize($options));
         }
-        $label = empty($label) ? '' : '-' . $label;
-        $strOpt = (!empty($strOpt)) ? '-' . md5($strOpt) : '';
-        return $id . $label . $strOpt;
+
+        return sprintf('%s%s-%s', $this->cachePrefix($id), $label ?: 'NOLABEL', $options);
+    }
+
+    /**
+     * Get cache name for a nickname.
+     *
+     * @param string $nickname Nickname.
+     * @return string
+     */
+    private function cacheNickname($nickname) {
+        return sprintf('nickname-%s', $nickname);
     }
 
     /**
@@ -139,8 +125,8 @@ class BeObjectCache {
         if ($this->hasFileEngine()) {
             return null;
         }
-        $cacheName = 'nickname-' . $nickname;
-        return Cache::read($cacheName, 'objects');
+
+        return Cache::read($this->cacheNickname($nickname), 'objects');
     }
 
     /**
@@ -154,8 +140,22 @@ class BeObjectCache {
         if ($this->hasFileEngine()) {
             return false;
         }
-        $cacheName = 'nickname-' . $nickname;
-        return $this->writeIndexedCache($id, $cacheName, $id);
+
+        return Cache::write($this->cacheNickname($nickname), $id, 'objects');
+    }
+
+    /**
+     * Deletes cache for a nickname.
+     *
+     * @param string $nickname Nickname.
+     * @return bool
+     */
+    public function deleteNicknameCache($nickname) {
+        if ($this->hasFileEngine()) {
+            return true;
+        }
+
+        return Cache::delete($this->cacheNickname($nickname), 'objects');
     }
 
     /**
@@ -206,54 +206,9 @@ class BeObjectCache {
             return false;
         }
 
-        $res = false;
         $cacheName = $this->cacheName($id, $options, $label);
-        // use cache config if not using 'File' engine
-        if ($this->cacheConfig['engine'] !== 'File') {
-            $res = Cache::read($cacheName, 'objects');
-        } else {
-            $this->setCacheOptions($id);
-            $res = Cache::read($cacheName);
-        }
-        return $res;
-    }
 
-    /**
-     * Write related indexes to cache
-     *
-     * @param int $id Object ID.
-     * @param string $cacheName Cache key.
-     * @param mixed $data Cache value to be stored.
-     * @return bool
-     */
-    private function writeIndexedCache($id, $cacheName, $data) {
-        $cacheIdxKey = $id . '_index';
-        $cacheIdx = Cache::read($cacheIdxKey, 'objects');
-        if (empty($cacheIdx)) {
-            $cacheIdx = array();
-        }
-        if (!is_array($cacheIdx)) {
-            CakeLog::write('error', sprintf('Invalid value for cache key %s: array expected, got %s', $cacheIdxKey, var_export($cacheIdx, true)));
-            $cacheIdx = array();
-        }
-        if (!in_array($cacheName, $cacheIdx)) {
-            $cacheIdx[] = $cacheName;
-            $res = Cache::write($cacheIdxKey, $cacheIdx, 'objects');
-            if ($res !== true) {
-                CakeLog::write(
-                    'error',
-                    sprintf(
-                        'Error writing index cache %s for object %s. Cache key %s not persisted.',
-                        $cacheIdxKey,
-                        $id,
-                        $cacheName
-                    )
-                );
-                return false;
-            }
-        }
-        $res = Cache::write($cacheName, $data, 'objects');
-        return $res;
+        return Cache::read($cacheName, 'objects');
     }
 
     /**
@@ -271,15 +226,8 @@ class BeObjectCache {
         }
 
         $cacheName = $this->cacheName($id, $options, $label);
-        $res = false;
-        // store index cache
-        if (!$this->hasFileEngine()) {
-            $res = $this->writeIndexedCache($id, $cacheName, $data);
-        } else {
-            $this->setCacheOptions($id);
-            $res = Cache::write($cacheName, $data);
-        }
-        return $res;
+
+        return Cache::write($cacheName, $data, 'objects');
     }
 
     /**
@@ -287,24 +235,8 @@ class BeObjectCache {
      *
      * @param  integer $id objectId
      */
-    public function delete($id, array $options = null) {
-        if ($this->hasFileEngine()) {
-            $cachePath = $this->getPathById($id);
-            $wildCard = $cachePath . DS . $this->cacheConfig['prefix'] . $id . '-*';
-            $toDelete = glob($wildCard);
-            if (!empty($toDelete)) {
-                array_map('unlink', $toDelete);
-            }
-        } else {
-            $cacheIdxKey = $id . '_index';
-            $cacheIdx = Cache::read($cacheIdxKey, 'objects');
-            if (!empty($cacheIdx)) {
-                foreach ($cacheIdx as $cacheName) {
-                    Cache::delete($cacheName, 'objects');
-                }
-            }
-            Cache::delete($cacheIdxKey, 'objects');
-        }
+    public function delete($id) {
+        return Cache::delete(sprintf('%s*', $this->cachePrefix($id)), 'objects');
     }
 
     /**
@@ -330,7 +262,7 @@ class BeObjectCache {
 
         $publicationId = ($publicationId === null) ? '' : (string)$publicationId;
 
-        return Cache::read(sprintf('path-%d-%s-%s', (int)$id, $status, $publicationId), 'objects');
+        return Cache::read(sprintf('%spath-%s-%s', $this->cachePrefix($id), $status, $publicationId), 'objects');
     }
 
     /**
@@ -357,7 +289,7 @@ class BeObjectCache {
 
         $publicationId = ($publicationId === null) ? '' : (string)$publicationId;
 
-        return $this->writeIndexedCache($id, sprintf('path-%d-%s-%s', (int)$id, $status, $publicationId), $path);
+        return Cache::write(sprintf('%spath-%s-%s', $this->cachePrefix($id), $status, $publicationId), $path, 'objects');
     }
 
     /**
@@ -375,9 +307,7 @@ class BeObjectCache {
         $success = true;
         $descendants = array_merge(array($id), $descendants);
         foreach ($descendants as $descId) {
-            foreach (array('on', 'draft', 'off') as $status) {
-                $success = Cache::delete(sprintf('path-%d-%s', (int)$descId, $status)) && $success;
-            }
+            $success = $this->delete($descId) && $success;
         }
 
         return $success;

--- a/bedita-app/libs/be_object_cache.php
+++ b/bedita-app/libs/be_object_cache.php
@@ -96,12 +96,11 @@ class BeObjectCache {
      */
     private function cacheName($id, array $options, $label = null) {
         if (!empty($options['bindings_list'])) {
-            $options = implode('', $options['bindings_list']);
-        } else {
-            $options = sha1(serialize($options));
+            $options = $options['bindings_list'];
         }
+        $options = sha1(serialize($options));
 
-        return sprintf('%s%s-%s', $this->cachePrefix($id), $label ?: 'NOLABEL', $options);
+        return sprintf('%s%s-%s', $this->cachePrefix($id), $label ?: 'nolabel', $options);
     }
 
     /**

--- a/bedita-app/models/behaviors/cacheable.php
+++ b/bedita-app/models/behaviors/cacheable.php
@@ -191,9 +191,14 @@ class CacheableBehavior extends ModelBehavior {
      * @param bool $reset
      */
     public function clearCache(&$model, $objectId, $reset = true) {
-        if ($objectId && $reset) {
-            $this->setObjectsToClean($model, $objectId);
+        if ($objectId) {
+            if ($reset) {
+                $this->resetObjectsToClean($model);
+            }
+
+            $this->addObjectsToClean($model, $this->getObjectsToCleanById($model, $objectId));
         }
+
         foreach ($this->objectsToClean as $id) {
             $this->BeObjectCache->delete($id);
         }

--- a/bedita-app/models/behaviors/cacheable.php
+++ b/bedita-app/models/behaviors/cacheable.php
@@ -188,9 +188,10 @@ class CacheableBehavior extends ModelBehavior {
      *
      * @param Model $model
      * @param integer $objectId
+     * @param bool $reset
      */
-    public function clearCache(&$model, $objectId = null) {
-        if ($objectId) {
+    public function clearCache(&$model, $objectId, $reset = true) {
+        if ($objectId && $reset) {
             $this->setObjectsToClean($model, $objectId);
         }
         foreach ($this->objectsToClean as $id) {
@@ -199,7 +200,7 @@ class CacheableBehavior extends ModelBehavior {
 
         $notLeafs = array(Configure::read('objectTypes.area.id'), Configure::read('objectTypes.section.id'));
         if (empty($model->data['BEObject']['object_type_id']) || in_array($model->data['BEObject']['object_type_id'], $notLeafs)) {
-            $this->BeObjectCache->deletePathCache($model->id, $this->getDescendantSections($model->id));
+            $this->BeObjectCache->deletePathCache($objectId, $this->getDescendantSections($objectId));
         }
 
         if (!empty($this->objectsToClean)) {
@@ -224,7 +225,9 @@ class CacheableBehavior extends ModelBehavior {
             $allObjectsToClean = array_merge($allObjectsToClean, $this->getObjectsToCleanById($model, $objectId));
         }
         $this->addObjectsToClean($model, $allObjectsToClean);
-        $this->clearCache($model);
+        foreach ($objectIds as $objectId) {
+            $this->clearCache($model, $objectId, false);
+        }
     }
 
     /**
@@ -238,6 +241,10 @@ class CacheableBehavior extends ModelBehavior {
     public function beforeSave(&$model) {
         if ($this->on) {
             $data = $model->data[$model->name];
+
+            if (!empty($data['id'])) {
+                $this->BeObjectCache->deleteNicknameCache($model->getNicknameFromId($data['id']));
+            }
 
             $relatedIds = array();
             if (!empty($data['RelatedObject'])) {
@@ -272,7 +279,7 @@ class CacheableBehavior extends ModelBehavior {
         // if it's an update remove cache
         if ($this->on) {
             $this->addObjectsToClean($model, $model->id);
-            $this->clearCache($model);
+            $this->clearCache($model, $model->id, false);
         }
     }
 
@@ -287,6 +294,7 @@ class CacheableBehavior extends ModelBehavior {
      */
     public function beforeDelete(&$model, $cascade) {
         if ($this->on) {
+            $this->BeObjectCache->deleteNicknameCache($model->getNicknameFromId($model->id));
             $this->setObjectsToClean($model, $model->id);
         }
         return true;
@@ -301,7 +309,7 @@ class CacheableBehavior extends ModelBehavior {
      */
     public function afterDelete(&$model) {
         if ($this->on) {
-            $this->clearCache($model);
+            $this->clearCache($model, $model->id, false);
         }
     }
 

--- a/bedita-app/models/behaviors/delete_object.php
+++ b/bedita-app/models/behaviors/delete_object.php
@@ -124,7 +124,7 @@ class DeleteObjectBehavior extends ModelBehavior {
 
         // clear cache
         if ($model->BEObject->isCacheableOn()) {
-            $model->BEObject->clearCache();
+            $model->BEObject->clearCache($model->id, false);
         }
     }
 

--- a/bedita-app/vendors/shells/cache.php
+++ b/bedita-app/vendors/shells/cache.php
@@ -79,8 +79,7 @@ class CacheShell extends BeditaBaseShell {
      */
     private function cleanupObjectIdCache($id) {
         $BEObject = ClassRegistry::init('BEObject');
-        $objectsToClean = $BEObject->setObjectsToClean($id);
-        $BEObject->clearCache();
+        $BEObject->clearCache($id);
     }
 
     function help() {

--- a/cake/libs/cache/file.php
+++ b/cake/libs/cache/file.php
@@ -139,6 +139,7 @@ class FileEngine extends CacheEngine {
 		$expires = time() + $duration;
 		$contents = $expires . $lineBreak . $data . $lineBreak;
 		$old = umask(0);
+		$this->_File = new File($this->_File->path, true);
 		$handle = fopen($this->_File->path, 'a');
 		umask($old);
 
@@ -204,6 +205,19 @@ class FileEngine extends CacheEngine {
 		if ($this->_setKey($key) === false || !$this->_init) {
 			return false;
 		}
+		if (strpos($key, '*') !== false) {
+			$keys = glob($this->_File->path);
+			$ok = true;
+			foreach ($keys as $key) {
+				$this->_File = new File($key);
+
+				$ok = $this->_File->delete() && $ok;
+			}
+
+			return $ok;
+		}
+
+
 		return $this->_File->delete();
 	}
 
@@ -282,5 +296,20 @@ class FileEngine extends CacheEngine {
 			return false;
 		}
 		return true;
+	}
+
+/**
+ * Generates a safe key for use with cache engine storage engines.
+ *
+ * @param string $key the key passed over
+ * @return mixed string $key or false
+ * @access public
+ */
+	function key($key) {
+		if (empty($key)) {
+			return false;
+		}
+		$key = Inflector::underscore(str_replace(array('/', '.'), array(DS, '_'), strval($key)));
+		return $key;
 	}
 }


### PR DESCRIPTION
This PR introduces a refactor on how cache keys are handled in Redis and File engines.

## Background

Since many cache keys are relative to a single object ID, we used to maintain an "index" that stores a list of cache keys related to that object ID. Such index was then read at the time we needed to invalidate cache for that object to know the list of cache keys that had to be deleted. This is problematic in case of concurrent writes to that index, since some keys could go lost thus never invalidated. Even worse, if the index goes lost for some reason (expired or whatever), all the cache keys generated until that point become orphaned and no one will ever clear them. At a high level, this resulted in inconsistent results in requests and API calls that were caused by outdated cache keys.

Generally speaking, knowing that a cache key's invalidation depends on the correctness of another cache key is, in my opinion, bad practice, as _every_ cache key should be considered ephemeral and volatile, while in our case this was true only for _groups_ of keys.

## Overview of the changes

After this refactor, all the cache keys related to an object ID, with the exception of the nickname-to-ID cache, are grouped under a single cache key, that is either an hash if cache engine is Redis, or a folder if cache engine is File. This means that all cache keys belonging to an object can be invalidated at once by just deleting that cache key, making invalidation process faster and more reliable.

Nickname cache, on the other hand, is now invalidated every time an object is saved or deleted, independently from the other cache keys.

## Considerations about backwards compatibility

All cache keys generated before this refactor become useless, and will then be regenerated. To clear useless cache keys and reclaim cache space, it is advisable to clear cache just after updating BEdita.

## Impact on modules and frontends.

Most modules and frontends do not interact with objects' cache directly, so I expect that the impact of this PR on dependencies' code to be very low.

## Other engines

Other engines supported by CakePHP include Memcache and APCu. Such engines have not been taken into account by these changes, so those are to be considered unsupported.