### PR TITLE
`parent` filter using name

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -200,6 +200,27 @@ class FilterQueryStringTest extends IntegrationTestCase
     }
 
     /**
+     * Test finder of object types by parent name.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testFindParent()
+    {
+        $this->configRequestHeaders();
+
+        $this->get('/model/object_types?filter[parent]=media');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        static::assertArrayHasKey('data', $result);
+        static::assertCount(1, $result['data']);
+    }
+
+    /**
      * Data provider for `testSearchFilter` test case.
      *
      * @return array

--- a/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
@@ -349,6 +349,24 @@ class ObjectTypesTable extends Table
     }
 
     /**
+     * Find object types having a parent by `name` or `id`
+     *
+     * @param \Cake\ORM\Query $query Query object.
+     * @param array $options Additional options. The first element containing `id` or `name` is required.
+     * @return \Cake\ORM\Query
+     * @throws \BEdita\Core\Exception\BadFilterException When missing required parameters.
+     */
+    public function findParent(Query $query, array $options)
+    {
+        if (empty($options[0])) {
+            throw new BadFilterException(__d('bedita', 'Missing required parameter "{0}"', 'parent'));
+        }
+        $parentId = $this->get($options[0])->get('id');
+
+        return $query->where([$this->aliasField('parent_id') => $parentId]);
+    }
+
+    /**
      * Find allowed object types by relation name and side.
      *
      * This finder returns a list of object types that are allowed for the

--- a/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
@@ -361,7 +361,10 @@ class ObjectTypesTable extends Table
         if (empty($options[0])) {
             throw new BadFilterException(__d('bedita', 'Missing required parameter "{0}"', 'parent'));
         }
-        $parentId = $this->get($options[0])->get('id');
+        $parentId = $options[0];
+        if (!is_numeric($parentId)) {
+            $parentId = $this->get($parentId)->id;
+        }
 
         return $query->where([$this->aliasField('parent_id') => $parentId]);
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
@@ -833,11 +833,11 @@ class ObjectTypesTableTest extends TestCase
             ],
             'find id' => [
                 'documents',
-                ['id' => 1],
+                [1],
             ],
             'find by name' => [
                 'files',
-                ['id' => 'media'],
+                ['media'],
             ],
         ];
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
@@ -818,4 +818,48 @@ class ObjectTypesTableTest extends TestCase
         $type = $this->ObjectTypes->find('objectId', $options)->firstOrFail();
         static::assertEquals($expected, $type->name);
     }
+
+    /**
+     * Data provider for `findParent()`
+     *
+     * @return array
+     */
+    public function findParentProvider()
+    {
+        return [
+            'missing' => [
+                new BadFilterException('Missing required parameter "parent"'),
+                [],
+            ],
+            'find id' => [
+                'documents',
+                ['id' => 1],
+            ],
+            'find by name' => [
+                'files',
+                ['id' => 'media'],
+            ],
+        ];
+    }
+
+    /**
+     * Test `findParent()` finder method
+     *
+     * @param mixed $expected The expected result.
+     * @param array $options The option passed to finder.
+     * @return void
+     *
+     * @covers ::findParent()
+     * @dataProvider findParentProvider
+     */
+    public function testFindParent($expected, array $options)
+    {
+        if ($expected instanceof \Exception) {
+            $this->expectException(get_class($expected));
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+
+        $type = $this->ObjectTypes->find('parent', $options)->order(['name' => 'ASC'])->firstOrFail();
+        static::assertEquals($expected, $type->name);
+    }
 }


### PR DESCRIPTION
Current `parent` filter works only by `id` via `parent` association.

A new `parent` finder method has been introduced in order to use either `name` or `id`.

