### PR TITLE
fix: after save section clear only cache of parent

### DIFF
--- a/bedita-app/models/behaviors/cacheable.php
+++ b/bedita-app/models/behaviors/cacheable.php
@@ -190,7 +190,7 @@ class CacheableBehavior extends ModelBehavior {
      * @param integer $objectId
      * @param bool $reset
      */
-    public function clearCache(&$model, $objectId, $reset = true) {
+    public function clearCache(&$model, $objectId, $reset = true, $descendants = true) {
         if ($objectId) {
             if ($reset) {
                 $this->resetObjectsToClean($model);
@@ -205,7 +205,7 @@ class CacheableBehavior extends ModelBehavior {
 
         $notLeafs = array(Configure::read('objectTypes.area.id'), Configure::read('objectTypes.section.id'));
         if (empty($model->data['BEObject']['object_type_id']) || in_array($model->data['BEObject']['object_type_id'], $notLeafs)) {
-            $this->BeObjectCache->deletePathCache($objectId, $this->getDescendantSections($objectId));
+            $this->BeObjectCache->deletePathCache($objectId, $descendants ? $this->getDescendantSections($objectId) : array());
         }
 
         if (!empty($this->objectsToClean)) {

--- a/bedita-app/models/objects/collection/section.php
+++ b/bedita-app/models/objects/collection/section.php
@@ -96,7 +96,7 @@ class Section extends BeditaCollectionModel
 
 	function afterSave($created) {
 	    if (!empty($this->data[$this->name]['parent_id'])) {
-	       $this->BEObject->clearCacheByIds(array($this->data[$this->name]['parent_id']));
+	       $this->BEObject->clearCache($this->data[$this->name]['parent_id'], true, false);
 	    }
 		if (!$created) {
 			return;

--- a/bedita-app/models/objects/collection/section.php
+++ b/bedita-app/models/objects/collection/section.php
@@ -95,6 +95,8 @@ class Section extends BeditaCollectionModel
     public $objectTypesGroups = array('related');
 
 	function afterSave($created) {
+        $this->BEObject->clearCache($this->id);
+
 	    if (!empty($this->data[$this->name]['parent_id'])) {
 	       $this->BEObject->clearCache($this->data[$this->name]['parent_id'], true, false);
 	    }

--- a/bedita-app/models/objects/collection/section.php
+++ b/bedita-app/models/objects/collection/section.php
@@ -95,8 +95,6 @@ class Section extends BeditaCollectionModel
     public $objectTypesGroups = array('related');
 
 	function afterSave($created) {
-        $this->BEObject->clearCache($this->id);
-
 	    if (!empty($this->data[$this->name]['parent_id'])) {
 	       $this->BEObject->clearCache($this->data[$this->name]['parent_id'], true, false);
 	    }


### PR DESCRIPTION
After saving a section, the cache of section's parent and all descending elements was cleaned.
After this pull request only the parent's cache is cleared.