### PR TITLE
Avoid errors on `status` check with relations and `lang` filter

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/StatusLevelTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/StatusLevelTest.php
@@ -90,6 +90,11 @@ class StatusLevelTest extends IntegrationTestCase
                 'draft',
                 '/documents/3',
             ],
+            'related with lang' => [
+                200,
+                'on',
+                '/documents/3/test?lang=fr',
+            ],
         ];
     }
 

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -351,7 +351,7 @@ class ObjectsTable extends Table
      */
     protected function findStatus(Query $query, array $options)
     {
-        if (count($options) !== 1 || array_keys($options) !== [0]) {
+        if (empty($options[0])) {
             throw new BadFilterException(__d('bedita', 'Invalid options for finder "{0}"', 'status'));
         }
 


### PR DESCRIPTION
This PR fixes an error occurring in cases like `GET /documents/3/test?lang=fr` - related objects with `lang` query string and `Status` level filter
 