### PR TITLE
Avoid `status` filter on resources

### DIFF
--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
@@ -65,7 +65,11 @@ class ListRelatedObjectsAction extends ListAssociatedAction
 
         $query = parent::buildQuery($primaryKey, $data, $inverseAssociation);
 
-        if (!empty($data['list']) && $this->Association->getTarget()->hasField('object_type_id')) {
+        if (!$this->Association->getTarget()->hasField('object_type_id')) {
+            return $query;
+        }
+
+        if (!empty($data['list'])) {
             $query = $query->select([
                 $this->Association->getTarget()->aliasField('object_type_id'),
             ]);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsActionTest.php
@@ -39,6 +39,8 @@ class ListRelatedObjectsActionTest extends TestCase
         'plugin.BEdita/Core.object_relations',
         'plugin.BEdita/Core.profiles',
         'plugin.BEdita/Core.locations',
+        'plugin.BEdita/Core.media',
+        'plugin.BEdita/Core.streams',
         'plugin.BEdita/Core.users',
     ];
 
@@ -193,6 +195,20 @@ class ListRelatedObjectsActionTest extends TestCase
                 'Documents',
                 'test',
                 2,
+                true,
+                null,
+                'on',
+            ],
+            [
+                [
+                    [
+                        'uuid' => '6aceb0eb-bd30-4f60-ac74-273083b921b6',
+                        'url' => null
+                    ],
+                ],
+                'Files',
+                'streams',
+                14,
                 true,
                 null,
                 'on',


### PR DESCRIPTION
This PR fixes an error occurring using `ListRelatedObjectsAction` with `status` filter when related items are not objects but resources. 
Currently an `'Unknown finder method "status"` error is thrown in those cases-

A test case has been added in `ListRelatedObjectsActionTest`