### PR TITLE
Fix fatal error on model save if object cache is disabled

### DIFF
--- a/bedita-app/models/behaviors/cacheable.php
+++ b/bedita-app/models/behaviors/cacheable.php
@@ -191,16 +191,16 @@ class CacheableBehavior extends ModelBehavior {
      * @param bool $reset
      */
     public function clearCache(&$model, $objectId, $reset = true, $descendants = true) {
+        if (!$this->on) {
+            return;
+        }
+
         if ($objectId) {
             if ($reset) {
                 $this->resetObjectsToClean($model);
             }
 
             $this->addObjectsToClean($model, $this->getObjectsToCleanById($model, $objectId));
-        }
-
-        if (!$this->on) {
-            return;
         }
 
         foreach ($this->objectsToClean as $id) {

--- a/bedita-app/models/behaviors/cacheable.php
+++ b/bedita-app/models/behaviors/cacheable.php
@@ -199,6 +199,10 @@ class CacheableBehavior extends ModelBehavior {
             $this->addObjectsToClean($model, $this->getObjectsToCleanById($model, $objectId));
         }
 
+        if (!$this->on) {
+            return;
+        }
+
         foreach ($this->objectsToClean as $id) {
             $this->BeObjectCache->delete($id);
         }


### PR DESCRIPTION
This PR fixes an issue that caused a fatal error ☠️ on model save if objects cache was disabled.