### PR TITLE
Issue/1561 status filter

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -422,6 +422,11 @@ class FilterQueryStringTest extends IntegrationTestCase
                    '5',
                 ],
             ],
+            'status' => [
+                '/documents',
+                'filter[status]=off',
+                [],
+            ],
             'emptyRoles' => [
                 '/roles',
                 'filter[name]=gustavo',

--- a/plugins/BEdita/API/tests/IntegrationTest/StatusLevelTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/StatusLevelTest.php
@@ -44,6 +44,16 @@ class StatusLevelTest extends IntegrationTestCase
                 null,
                 '/documents',
             ],
+            'status filter off' => [
+                [],
+                'on',
+                '/documents?filter[status]=off',
+            ],
+            'status filter draft' => [
+                ['3'],
+                'draft',
+                '/documents?filter[status]=draft',
+            ],
         ];
     }
 

--- a/plugins/BEdita/Core/src/Model/Action/GetObjectAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/GetObjectAction.php
@@ -72,7 +72,7 @@ class GetObjectAction extends BaseAction
             $query = $query->find('type', (array)$this->objectType->id);
         }
         if (Configure::check('Status.level')) {
-            $query = $query->find('status', [Configure::read('Status.level')]);
+            $query = $query->find('statusLevel', [Configure::read('Status.level')]);
         }
         if (!empty($data['lang'])) {
             $query = $query->find('translations', ['lang' => $data['lang']]);

--- a/plugins/BEdita/Core/src/Model/Action/ListObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListObjectsAction.php
@@ -81,7 +81,7 @@ class ListObjectsAction extends BaseAction
             $query = $query->find('type', (array)$type);
         }
         if (Configure::check('Status.level')) {
-            $query = $query->find('status', [Configure::read('Status.level')]);
+            $query = $query->find('statusLevel', [Configure::read('Status.level')]);
         }
 
         if (!empty($data['lang'])) {

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
@@ -75,7 +75,7 @@ class ListRelatedObjectsAction extends ListAssociatedAction
             ]);
         }
         if (Configure::check('Status.level')) {
-            $query = $query->find('status', [Configure::read('Status.level')]);
+            $query = $query->find('statusLevel', [Configure::read('Status.level')]);
         }
 
         return $query;

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -349,7 +349,7 @@ class ObjectsTable extends Table
      * @throws \BEdita\Core\Exception\BadFilterException Throws an exception if an invalid set of options is passed to
      *      the finder.
      */
-    protected function findStatus(Query $query, array $options)
+    protected function findStatusLevel(Query $query, array $options)
     {
         if (empty($options[0])) {
             throw new BadFilterException(__d('bedita', 'Invalid options for finder "{0}"', 'status'));

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -489,7 +489,7 @@ class ObjectsTableTest extends TestCase
      *
      * @return array
      */
-    public function findStatusProvider()
+    public function findStatusLevelProvider()
     {
         return [
             'too many options' => [
@@ -524,14 +524,14 @@ class ObjectsTableTest extends TestCase
     }
 
     /**
-     * Test `findStatus()`.
+     * Test `findStatusLevel()`.
      *
      * @param array|\Exception $expected Expected result.
      * @param array $options Finder options.
      * @return void
      *
-     * @dataProvider findStatusProvider()
-     * @covers ::findStatus()
+     * @dataProvider findStatusLevelProvider()
+     * @covers ::findStatusLevel()
      */
     public function testFindStatus($expected, array $options)
     {
@@ -547,7 +547,7 @@ class ObjectsTableTest extends TestCase
         }
 
         $actual = $this->Objects->find('list')
-            ->find('status', $options)
+            ->find('statusLevel', $options)
             ->toArray();
         ksort($actual);
 


### PR DESCRIPTION
This PR fixes #1561 

* `status` finder was renamed to avoid conflict with query string `filter[status]`
* tests with `filter[status]` query string have been added 