### PR TITLE
#1531 fix update children position

### DIFF
--- a/plugins/BEdita/API/src/Controller/FoldersController.php
+++ b/plugins/BEdita/API/src/Controller/FoldersController.php
@@ -120,14 +120,11 @@ class FoldersController extends ObjectsController
      * - positive desc (i.e. 5, 3, 1)
      * - negative desc (i.e. -1, -3, -5)
      *
-     * @return null|string|array
+     * @return array
      */
     protected function getDataSortedByPosition()
     {
         $data = $this->request->getData();
-        if (!is_array($data)) {
-            return $data;
-        }
 
         usort($data, function ($a, $b) {
             $positionA = Hash::get($a, '_meta.relation.position');

--- a/plugins/BEdita/API/src/Model/Action/UpdateAssociatedAction.php
+++ b/plugins/BEdita/API/src/Model/Action/UpdateAssociatedAction.php
@@ -105,6 +105,14 @@ class UpdateAssociatedAction extends BaseAction
 
         $targetEntities = $targetEntities->indexBy($primaryKeyField)->toArray();
 
+        // sort following the original order
+        uksort(
+            $targetEntities,
+            function ($a, $b) use ($targetPrimaryKeys) {
+                return array_search($a, $targetPrimaryKeys) - array_search($b, $targetPrimaryKeys);
+            }
+        );
+
         foreach ($data as $datum) {
             $id = Hash::get($datum, 'id');
             $type = Hash::get($datum, 'type');

--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -1145,7 +1145,7 @@ class FoldersControllerTest extends IntegrationTestCase
      * @param array $objData The data for object to create as child and move.
      * @param array $orphansToAdd The data for object to add as new children.
      * @return void
-     * @return void
+     *
      * @dataProvider moveChildrenProvider
      * @covers ::relationships()
      * @covers ::getDataSortedByPosition()

--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -14,6 +14,8 @@ namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
 use BEdita\API\Test\TestConstants;
+use BEdita\Core\Utility\LoggedUser;
+use Cake\Collection\Collection;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 
@@ -680,7 +682,8 @@ class FoldersControllerTest extends IntegrationTestCase
      *
      * @return void
      *
-     * @coversNothing
+     * @covers ::relationships()
+     * @covers ::getDataSortedByPosition()
      */
     public function testSetChildren()
     {
@@ -1025,5 +1028,204 @@ class FoldersControllerTest extends IntegrationTestCase
         $childrenIds = Hash::extract($folder->children, '{n}.id');
 
         static::assertEquals([2, 12], $childrenIds);
+    }
+
+    /**
+     * Data provider for `testMoveChildren()`
+     *
+     * @return array
+     */
+    public function moveChildrenProvider()
+    {
+        return [
+            'noMove' => [
+                [
+                    'doc one',
+                    'doc two',
+                    'doc three',
+                ],
+                [
+                    // object title => move to position (null to not set a position)
+                    'doc one' => '1',
+                    'doc two' => '2',
+                    'doc three' => '3',
+                ],
+            ],
+            'moveOne' => [
+                [
+                    'doc two',
+                    'doc one',
+                    'doc three',
+                ],
+                [
+                    'doc one' => '2',
+                    'doc two' => null,
+                    'doc three' => null,
+                ],
+            ],
+            'moveTwo' => [
+                [
+                    'doc three',
+                    'doc one',
+                    'doc two',
+                ],
+                [
+                    'doc one' => '2',
+                    'doc two' => '3',
+                    'doc three' => null,
+                ],
+            ],
+            'swicthFirstAndLast' => [
+                [
+                    'doc three',
+                    'doc two',
+                    'doc one',
+                ],
+                [
+                    'doc one' => '3',
+                    'doc two' => '2',
+                    'doc three' => '1',
+                ],
+            ],
+            'changeAll' => [
+                [
+                    'doc three',
+                    'doc one',
+                    'doc two',
+                ],
+                [
+                    'doc one' => '2',
+                    'doc two' => '3',
+                    'doc three' => '1',
+                ],
+            ],
+            'changeAll2' => [
+                [
+                    'doc five',
+                    'doc three',
+                    'doc one',
+                    'doc four',
+                    'doc two',
+                ],
+                [
+                    'doc one' => '-3',
+                    'doc two' => '-1',
+                    'doc three' => '2',
+                    'doc four' => '-2',
+                    'doc five' => '1',
+                ],
+            ],
+            'moveAndAddNew' => [
+                [
+                    'doc four',
+                    'orphan doc two',
+                    'doc two',
+                    'orphan doc one',
+                    'doc one',
+                    'doc three',
+                ],
+                [
+                    'doc one' => '-2',
+                    'doc two' => null,
+                    'doc three' => 'last',
+                    'doc four' => 'first',
+                ],
+                [
+                    'orphan doc one' => null,
+                    'orphan doc two' => '2',
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * Test moving children position.
+     *
+     * @param array $expected The expected children order.
+     * @param array $objData The data for object to create as child and move.
+     * @param array $orphansToAdd The data for object to add as new children.
+     * @return void
+     * @return void
+     * @dataProvider moveChildrenProvider
+     * @covers ::relationships()
+     * @covers ::getDataSortedByPosition()
+     * @covers ::positionToInt()
+     */
+    public function testMoveChildren(array $expected, array $objData, array $orphansToAdd = [])
+    {
+        $folder = $this->Folders->get(13);
+        $data = [];
+
+        // create children doc and prepare data for API call
+        foreach ($objData as $title => $position) {
+            $docData = [
+                'title' => $title,
+                'parents' => ['_ids' => [$folder->id]],
+            ];
+            $document = $this->createDocument($docData);
+
+            $relData = [
+                'type' => 'documents',
+                'id' => (string)$document->id,
+            ];
+
+            if ($position !== null) {
+                $relData['meta'] = [
+                    'relation' => ['position' => $position],
+                ];
+            }
+
+            $data[] = $relData;
+        }
+
+        // create orphan doc and prepare data for API call
+        foreach ($orphansToAdd as $title => $position) {
+            $docData = ['title' => $title];
+            $document = $this->createDocument($docData);
+
+            $relData = [
+                'type' => 'documents',
+                'id' => (string)$document->id,
+            ];
+
+            if ($position !== null) {
+                $relData['meta'] = [
+                    'relation' => ['position' => $position],
+                ];
+            }
+
+            $data[] = $relData;
+        }
+
+        $authHeader = $this->getUserAuthHeader();
+        $endpoint = sprintf('/folders/%s/relationships/children', $folder->id);
+        $this->configRequestHeaders('POST', $authHeader);
+        $this->post($endpoint, json_encode(compact('data')));
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        $this->Folders->loadInto($folder, ['Children']);
+        $children = new Collection($folder->children);
+        $actual = $children->extract('title')->toList();
+
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Create a new document with passed data
+     *
+     * @param array $data The document data
+     * @return \BEdita\Core\Model\Entity\ObjectEntity
+     */
+    protected function createDocument(array $data)
+    {
+        if (LoggedUser::id() === null) {
+            LoggedUser::setUser(['id' => 1]);
+        }
+
+        $documentsTable = TableRegistry::get('Documents');
+        $document = $documentsTable->newEntity($data);
+
+        return $documentsTable->saveOrFail($document);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
@@ -82,6 +82,11 @@ class TreeBehavior extends CakeTreeBehavior
                 return false;
             }
 
+            // ensure to use actual left and right fields
+            $node->unsetProperty($this->getConfig('left'));
+            $node->unsetProperty($this->getConfig('right'));
+            $this->_ensureFields($node);
+
             $currentPosition = $this->getCurrentPosition($node);
             if ($position === $currentPosition) {
                 // Do not perform extra queries. Position must still be normalized, so we'll need to re-check later.

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -4,6 +4,7 @@ namespace BEdita\Core\Test\TestCase\Model\Behavior;
 use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 
 /**
  * @coversDefaultClass \BEdita\Core\Model\Behavior\TreeBehavior
@@ -205,5 +206,48 @@ class TreeBehaviorTest extends TestCase
                 self::assertNotSame($previousIndexes, $finalIndexes);
             }
         }
+    }
+
+    /**
+     * Test that when a node is moved in another position
+     * the actual node position is used.
+     *
+     * To test it:
+     * 1. first get all children of a parent node
+     * 2. reverse the position of the children in a loop of prevoius results.
+     *
+     * When a child is moved to another position its siblings are moved too.
+     * So the next child in the loop will have '`left_idx` and `right_idx` not updated.
+     * The test assures that `left_idx` and `right_idx` are the actual values and not those stored in the entities.
+     *
+     * @return void
+     * @covers ::moveAt()
+     */
+    public function testMoveAtUseActualNodePosition()
+    {
+        $parentNode = $this->Table->find()
+            ->where(['name' => 'Mathematics'])
+            ->firstOrFail();
+
+        $children = $this->Table
+            ->find('children', ['for' => $parentNode->id])
+            ->all();
+
+        $currentPositions = $children->extract('id')->toList();
+
+        $count = count($currentPositions);
+        $expected = array_reverse($currentPositions);
+
+        foreach ($children as $child) {
+            $this->Table->moveAt($child, $count--);
+        }
+
+        $actual = $this->Table
+            ->find('children', ['for' => $parentNode->id])
+            ->all()
+            ->extract('id')
+            ->toList();
+
+        static::assertEquals($expected, $actual);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -4,7 +4,6 @@ namespace BEdita\Core\Test\TestCase\Model\Behavior;
 use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
-use Cake\Utility\Hash;
 
 /**
  * @coversDefaultClass \BEdita\Core\Model\Behavior\TreeBehavior


### PR DESCRIPTION
This PR fixes #1531 

There were two issues that prevent to save correctly the children position.

The first one was that saving tree nodes in a loop the actual left and right position was not used. The previous value in the entity was used instead.
The second one was that the data in the payload had to be ordered to reach the expected behavior.

The children data of the request is now sort following this schema

1. `null`
2. positive integer desc
3. negative integer desc

