### PR TITLE
feat: Allow to append HTML before/after filters

### DIFF
--- a/bedita-app/views/elements/filters.tpl
+++ b/bedita-app/views/elements/filters.tpl
@@ -29,7 +29,10 @@
     'customProp' => ['showObjectTypes' => false],
     'categories' => true,
     'mediaTypes' => false,
-    'url' => $html->url("/")|cat:$view->params.controller|cat:'/'|cat:$view->params.action,
+    'url' => $html->url([
+        'controller' => $view->params.controller,
+        'action' => $view->params.action
+    ]),
     'tags' => true,
     'status' => false,
     'append' => [

--- a/bedita-app/views/elements/filters.tpl
+++ b/bedita-app/views/elements/filters.tpl
@@ -1,8 +1,8 @@
 {*
-	override default filter options defining an array of options in view that calls this element
-	i.e.
+    override default filter options defining an array of options in view that calls this element
+    i.e.
 
-	{$view->element("filters", [
+    {$view->element("filters", [
             'options' => [
                 'type' => true,
                 'url' => ...
@@ -12,29 +12,35 @@
 *}
 
 {*
-	- if you want to customize the label for categories pass an array('label' => 'mylabel') instead of true
-	- if you want to customize the label for statuses pass an array('on' => 'myOnLabel', 'draft' => 'myDraftLabel, 'off' => 'myOffLabel) instead of true
-	  [if you don't want to see one of the status from the filer menu don't put it in the array]
+    - if you want to customize the label for categories pass an array('label' => 'mylabel') instead of true
+    - if you want to customize the label for statuses pass an array('on' => 'myOnLabel', 'draft' => 'myDraftLabel, 'off' => 'myOffLabel) instead of true
+      [if you don't want to see one of the status from the filer menu don't put it in the array]
+
+    - 'append' is used to add custom HTML 'before' and/or 'after' core filters.
 *}
 
 {$defaultOptions = [
-		'word' => true,
-		'tree' => true,
-		'treeDescendants' => true,
-        'relations' => true,
-		'type' => false,
-		'language' => true,
-		'customProp' => ['showObjectTypes' => false],
-		'categories' => true,
-		'mediaTypes' => false,
-		'url' => $html->url("/")|cat:$view->params.controller|cat:'/'|cat:$view->params.action,
-		'tags' => true,
-		'status' => false
-	]
-}
+    'word' => true,
+    'tree' => true,
+    'treeDescendants' => true,
+    'relations' => true,
+    'type' => false,
+    'language' => true,
+    'customProp' => ['showObjectTypes' => false],
+    'categories' => true,
+    'mediaTypes' => false,
+    'url' => $html->url("/")|cat:$view->params.controller|cat:'/'|cat:$view->params.action,
+    'tags' => true,
+    'status' => false,
+    'append' => [
+        'before' => '',
+        'after' => ''
+    ]
+]}
+
 {$options = array_merge($defaultOptions, $options|default:[])}
 
 <div class="tab{if $view->SessionFilter->check()} open filteractive{/if}"><h2>{t}filters{/t}</h2></div>
 <div id="filterView">
-	{$view->element("filters_form", ['filters' => $options])}
+    {$view->element("filters_form", ['filters' => $options])}
 </div>

--- a/bedita-app/views/elements/filters_form.tpl
+++ b/bedita-app/views/elements/filters_form.tpl
@@ -51,6 +51,10 @@ available options:
 {strip}
 	<div class="filters" style="width:100%">
 
+		{if !empty($filters.append.before) }
+			{$filters.append.before}
+		{/if}
+
 		{if !empty($filters.word)}
 			<div class="cell word">
 				<label>{t}search word{/t}:</label>
@@ -247,6 +251,10 @@ available options:
 					<option value="false" {if $view->SessionFilter->read('editorial') === 'false'}selected="selected"{/if}>{t}user contents{/t}</option>
 				</select>
 			</div>
+		{/if}
+
+		{if !empty($filters.append.after) }
+			{$filters.append.after}
 		{/if}
 
 		<div class="formbuttons">


### PR DESCRIPTION
This PR introduce an option in `filters` element to append HTML before and/or after the default filters.
