### PR TITLE
Make `params` optional when updating relations

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/RelationshipsParamsTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/RelationshipsParamsTest.php
@@ -305,6 +305,6 @@ class RelationshipsParamsTest extends IntegrationTestCase
             ->firstOrFail();
 
         static::assertSame($currentPriority + 1, $objectRelation->get('priority'));
-        static::assertSame(['name' => 'Gustavo'], $objectRelation->get('priority'));
+        static::assertSame(['name' => 'Gustavo'], $objectRelation->get('params'));
     }
 }

--- a/plugins/BEdita/API/tests/IntegrationTest/RelationshipsParamsTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/RelationshipsParamsTest.php
@@ -245,4 +245,66 @@ class RelationshipsParamsTest extends IntegrationTestCase
         static::assertArrayHasKey('detail', $body['error']);
         static::assertContains($expected, $body['error']['detail']);
     }
+
+    /**
+     * Test that updating an existing relation between two objects does not enforce presence of required
+     * parameters that were previously set.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testUpdateParamsNotRequired()
+    {
+        $relation = $this->Relations->find()
+            ->where(['params IS NOT' => null])
+            ->firstOrFail();
+
+        $objectRelation = $this->ObjectRelations->find()
+            ->where(['relation_id' => $relation->id])
+            ->firstOrFail();
+        $objectRelation->set('params', ['name' => 'Gustavo']);
+        $this->ObjectRelations->saveOrFail($objectRelation);
+
+        $currentPriority = $objectRelation->get('priority');
+
+        $ObjectTypes = TableRegistry::get('ObjectTypes');
+        $leftType = $ObjectTypes->find('all')
+            ->where([
+                'id' => $this->ObjectRelations->LeftObjects->get($objectRelation->get('left_id'))->get('object_type_id'),
+            ])
+            ->firstOrFail()
+            ->get('name');
+        $rightType = $ObjectTypes->find('all')
+            ->where([
+                'id' => $this->ObjectRelations->RightObjects->get($objectRelation->get('right_id'))->get('object_type_id'),
+            ])
+            ->firstOrFail()
+            ->get('name');
+
+        $data = [
+            [
+                'id' => $objectRelation->get('right_id'),
+                'type' => $rightType,
+                'meta' => [
+                    'relation' => [
+                        'priority' => $currentPriority + 1,
+                    ],
+                ],
+            ],
+        ];
+
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $endpoint = sprintf('/%s/%d/relationships/%s', $leftType, $objectRelation->get('left_id'), $relation->get('name'));
+        $this->_sendRequest($endpoint, 'POST', json_encode(compact('data')));
+
+        $this->assertResponseSuccess();
+
+        $objectRelation = $this->ObjectRelations->find()
+            ->where($objectRelation->extract(['left_id', 'relation_id', 'right_id']))
+            ->firstOrFail();
+
+        static::assertSame($currentPriority + 1, $objectRelation->get('priority'));
+        static::assertSame(['name' => 'Gustavo'], $objectRelation->get('priority'));
+    }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
@@ -14,7 +14,6 @@
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
-use BEdita\API\Test\TestConstants;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\ResourcesController

--- a/plugins/BEdita/Core/src/Model/Action/AddRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/AddRelatedObjectsAction.php
@@ -15,7 +15,6 @@ namespace BEdita\Core\Model\Action;
 
 use BEdita\Core\ORM\Association\RelatedTo;
 use Cake\Datasource\EntityInterface;
-use Cake\Utility\Hash;
 
 /**
  * Command to add relations between objects.
@@ -25,53 +24,7 @@ use Cake\Utility\Hash;
 class AddRelatedObjectsAction extends UpdateRelatedObjectsAction
 {
 
-    /**
-     * Filter entities to be actually updated.
-     *
-     * @param \Cake\Datasource\EntityInterface $entity Source entity.
-     * @param \Cake\Datasource\EntityInterface[] $relatedEntities Related entities.
-     * @return \Cake\Datasource\EntityInterface[]
-     */
-    protected function diff(EntityInterface $entity, $relatedEntities)
-    {
-        $bindingKey = $this->Association->getBindingKey();
-        $existing = $this->existing($entity)->indexBy($this->Association->getTargetForeignKey())->toArray();
-
-        $junctionEntityClass = $this->Association->junction()->getEntityClass();
-        $ignoredKeys = array_flip(
-            [$this->Association->getForeignKey(), $this->Association->getTargetForeignKey()]
-        );
-
-        $diff = [];
-        foreach ($relatedEntities as $relatedEntity) {
-            $primaryKey = $relatedEntity->get($bindingKey);
-            if (!array_key_exists($primaryKey, $existing)) {
-                // Relation was missing.
-                $diff[] = $relatedEntity;
-
-                continue;
-            }
-
-            // Obtain new join data.
-            $joinData = $this->Association->junction()->newEntity();
-            if (!empty($relatedEntity->_joinData) && $relatedEntity->_joinData instanceof $junctionEntityClass) {
-                $joinData = $relatedEntity->_joinData;
-            }
-
-            // Extract meaningful values from both new and existing.
-            $joinData = array_diff_key($joinData->getOriginalValues(), $ignoredKeys);
-            $existingJoinData = array_diff_key($existing[$primaryKey]->getOriginalValues(), $ignoredKeys);
-
-            // Compare existing and new join data.
-            ksort($joinData);
-            ksort($existingJoinData);
-            if ($joinData !== $existingJoinData) {
-                $diff[] = $relatedEntity;
-            }
-        }
-
-        return $diff;
-    }
+    use AssociatedTrait;
 
     /**
      * {@inheritDoc}
@@ -86,16 +39,16 @@ class AddRelatedObjectsAction extends UpdateRelatedObjectsAction
             return $action->execute(compact('entity', 'relatedEntities'));
         }
 
-        $relatedEntities = $this->prepareRelatedEntities($relatedEntities, $entity);
-
         return $this->Association->getConnection()->transactional(function () use ($entity, $relatedEntities) {
-            $relatedEntities = $this->diff($entity, $relatedEntities);
+            $relatedEntities = $this->diff($entity, $relatedEntities, false);
 
             if (!$this->Association->link($entity, $relatedEntities)) {
                 return false;
             }
 
-            return Hash::extract($relatedEntities, sprintf('{n}.%s', $this->Association->getBindingKey()));
+            return collection($relatedEntities)
+                ->extract($this->Association->getBindingKey())
+                ->toList();
         });
     }
 }

--- a/plugins/BEdita/Core/src/Model/Action/AssociatedTrait.php
+++ b/plugins/BEdita/Core/src/Model/Action/AssociatedTrait.php
@@ -266,7 +266,7 @@ trait AssociatedTrait
      */
     protected function diff(EntityInterface $source, array $targetEntities, $replace, &$affected = [])
     {
-        $existing = $this->existing($source);
+        $existing = (array)$this->existing($source);
         $kept = $this->intersection($existing, $targetEntities);
 
         $added = array_map(

--- a/plugins/BEdita/Core/src/Model/Action/AssociatedTrait.php
+++ b/plugins/BEdita/Core/src/Model/Action/AssociatedTrait.php
@@ -1,0 +1,302 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Model\Action;
+
+use Cake\Datasource\EntityInterface;
+use Cake\Network\Exception\BadRequestException;
+use Cake\ORM\Association\BelongsToMany;
+
+/**
+ * Trait to help with operations on and with associated entities.
+ *
+ * @since 4.0.0
+ *
+ * @property-read \Cake\ORM\Association\BelongsToMany|\Cake\ORM\Association\HasMany $Association
+ */
+trait AssociatedTrait
+{
+
+    /**
+     * Find entity among list of entities.
+     *
+     * @param \Cake\Datasource\EntityInterface $needle Entity being searched.
+     * @param \Cake\Datasource\EntityInterface[] $haystack List of entities.
+     * @return \Cake\Datasource\EntityInterface|null
+     */
+    protected function findMatchingEntity(EntityInterface $needle, array $haystack)
+    {
+        $bindingKey = (array)$this->Association->getBindingKey();
+        foreach ($haystack as $candidate) {
+            $found = array_reduce(
+                $bindingKey,
+                function ($found, $field) use ($candidate, $needle) {
+                    return $found && $candidate->get($field) === $needle->get($field);
+                },
+                true
+            );
+
+            if ($found) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Compute set-theory intersection between multiple sets of entities.
+     *
+     * @param \Cake\Datasource\EntityInterface[] ...$entities Lists of entities.
+     * @return \Cake\Datasource\EntityInterface[]
+     */
+    protected function intersection(array ...$entities)
+    {
+        $setA = array_shift($entities);
+        foreach ($entities as $setB) {
+            $setA = array_filter(
+                $setA,
+                function (EntityInterface $item) use ($setB) {
+                    return $this->findMatchingEntity($item, $setB) !== null;
+                }
+            );
+        }
+
+        return $setA;
+    }
+
+    /**
+     * Compute set-theory difference between multiple sets of entities.
+     *
+     * @param \Cake\Datasource\EntityInterface[] ...$entities Lists of entities.
+     * @return \Cake\Datasource\EntityInterface[]
+     */
+    protected function difference(array ...$entities)
+    {
+        $setA = array_shift($entities);
+        foreach ($entities as $setB) {
+            $setA = array_filter(
+                $setA,
+                function (EntityInterface $item) use ($setB) {
+                    return $this->findMatchingEntity($item, $setB) === null;
+                }
+            );
+        }
+
+        return $setA;
+    }
+
+    /**
+     * Sort an array by copying order from an array that holds analogous elements.
+     *
+     * @param \Cake\Datasource\EntityInterface[] $array Array to sort.
+     * @param \Cake\Datasource\EntityInterface[] $original Array to copy original order from.
+     * @return \Cake\Datasource\EntityInterface[]
+     */
+    protected function sortByOriginalOrder(array $array, array $original)
+    {
+        $original = array_values($original);
+        usort(
+            $array,
+            function (EntityInterface $a, EntityInterface $b) use ($original) {
+                $originalA = $this->findMatchingEntity($a, $original);
+                $originalB = $this->findMatchingEntity($b, $original);
+
+                $idxA = array_search($originalA, $original);
+                $idxB = array_search($originalB, $original);
+
+                return $idxA - $idxB;
+            }
+        );
+
+        return $array;
+    }
+
+    /**
+     * Find existing associations.
+     *
+     * @param \Cake\Datasource\EntityInterface $source Source entity.
+     * @return \Cake\Datasource\EntityInterface|\Cake\Datasource\EntityInterface[]|null
+     */
+    protected function existing(EntityInterface $source)
+    {
+        if (!$source->has(($this->Association->getProperty()))) {
+            $this->Association->getSource()->loadInto($source, [$this->Association->getName()]);
+        }
+
+        return $source->get($this->Association->getProperty());
+    }
+
+    /**
+     * Helper method to get extra fields to be set on junction table, derived from Association's conditions.
+     *
+     * @param \Cake\Datasource\EntityInterface $source Source entity.
+     * @param \Cake\Datasource\EntityInterface $target Target entity.
+     * @return array
+     */
+    protected function getJunctionExtraFields(EntityInterface $source, EntityInterface $target)
+    {
+        $conditions = $this->Association->getConditions();
+        $prefix = sprintf('%s.', $this->Association->junction()->getAlias());
+        $extraFields = [];
+        foreach ($conditions as $field => $value) {
+            if (substr($field, 0, strlen($prefix)) !== $prefix) {
+                continue;
+            }
+            $field = substr($field, strlen($prefix));
+
+            $extraFields[$field] = $value;
+        }
+
+        $extraFields += array_combine(
+            (array)$this->Association->getForeignKey(),
+            $source->extract((array)$this->Association->getSource()->getPrimaryKey())
+        );
+        $extraFields += array_combine(
+            (array)$this->Association->getTargetForeignKey(),
+            $target->extract((array)$this->Association->getTarget()->getPrimaryKey())
+        );
+
+        return $extraFields;
+    }
+
+    /**
+     * Ensure join data is hydrated.
+     *
+     * @param \Cake\Datasource\EntityInterface $source Source entity.
+     * @param \Cake\Datasource\EntityInterface $target Target entity.
+     * @return \Cake\Datasource\EntityInterface
+     */
+    protected function hydrateLink(EntityInterface $source, EntityInterface $target)
+    {
+        if (!($this->Association instanceof BelongsToMany)) {
+            return $target;
+        }
+
+        $data = $target->get('_joinData');
+        $joinData = $this->Association->junction()->newEntity();
+        if ($data instanceof EntityInterface) {
+            $joinData = $data;
+            $data = [];
+        }
+
+        $joinData->set($this->getJunctionExtraFields($source, $target), ['guard' => false]);
+        $this->Association->junction()->patchEntity($joinData, $data ?: []);
+        $errors = $joinData->getErrors();
+        if (!empty($errors)) {
+            throw new BadRequestException([
+                'title' => __d('bedita', 'Invalid data'),
+                'detail' => $errors,
+            ]);
+        }
+
+        $target->set('_joinData', $joinData);
+
+        return $target;
+    }
+
+    /**
+     * Patch an existing link entity if the link itself needs to be updated.
+     *
+     * @param \Cake\Datasource\EntityInterface $source Source entity.
+     * @param \Cake\Datasource\EntityInterface $existing Existing link.
+     * @param \Cake\Datasource\EntityInterface $new New link data.
+     * @return \Cake\Datasource\EntityInterface|false
+     */
+    protected function patchLink(EntityInterface $source, EntityInterface $existing, EntityInterface $new)
+    {
+        if (!($this->Association instanceof BelongsToMany)) {
+            return false;
+        }
+
+        $existingJoin = $existing->get('_joinData');
+        $newJoin = $new->get('_joinData');
+        if ($newJoin === null) {
+            return false;
+        }
+        if ($newJoin instanceof EntityInterface) {
+            $newJoin = $newJoin->toArray();
+        }
+        $newJoin = array_diff_key(
+            $newJoin,
+            array_flip([$this->Association->getForeignKey(), $this->Association->getTargetForeignKey()])
+        );
+
+        $data = [];
+        foreach ($newJoin as $field => $value) {
+            if ($existingJoin->get($field) !== $value) {
+                $data[$field] = $value;
+            }
+        }
+        if (empty($data)) {
+            return false;
+        }
+
+        $existingJoin->set($this->getJunctionExtraFields($source, $new), ['guard' => false]);
+        $existingJoin = $this->Association->junction()->patchEntity($existingJoin, $data);
+        $errors = $existingJoin->getErrors();
+        if (!empty($errors)) {
+            throw new BadRequestException([
+                'title' => __d('bedita', 'Invalid data'),
+                'detail' => $errors,
+            ]);
+        }
+
+        return $existing;
+    }
+
+    /**
+     * Compute difference for the current operation.
+     *
+     * @param \Cake\Datasource\EntityInterface $source Source entity.
+     * @param \Cake\Datasource\EntityInterface[] $targetEntities Target entities.
+     * @param bool $replace Is this a full-replacement operation?
+     * @param \Cake\Datasource\EntityInterface[] $affected Entities affected by this operation.
+     * @return \Cake\Datasource\EntityInterface[]
+     */
+    protected function diff(EntityInterface $source, array $targetEntities, $replace, &$affected = [])
+    {
+        $existing = $this->existing($source);
+        $kept = $this->intersection($existing, $targetEntities);
+
+        $added = array_map(
+            function (EntityInterface $target) use ($source) {
+                return $this->hydrateLink($source, $target);
+            },
+            $this->difference($targetEntities, $existing)
+        );
+        $changed = array_filter(
+            array_map(
+                function (EntityInterface $existing) use ($source, $targetEntities) {
+                    $relatedEntity = $this->findMatchingEntity($existing, $targetEntities);
+
+                    return $this->patchLink($source, $existing, $relatedEntity);
+                },
+                $kept
+            )
+        );
+        $affected = $diff = array_merge($added, $changed);
+
+        if ($replace === true) {
+            $unchanged = $this->difference($kept, $added, $changed);
+            $deleted = $this->difference($existing, $targetEntities);
+
+            $affected = array_merge($affected, $deleted);
+            $diff = array_merge($diff, $unchanged);
+        }
+
+        $diff = $this->sortByOriginalOrder($diff, $targetEntities);
+
+        return $diff;
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Action/RemoveAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/RemoveAssociatedAction.php
@@ -47,7 +47,7 @@ class RemoveAssociatedAction extends UpdateAssociatedAction
             }
 
             return $this->Association->getConnection()->transactional(function () use ($entity, $relatedEntities) {
-                $relatedEntities = $this->intersection($this->existing($entity), $relatedEntities);
+                $relatedEntities = $this->intersection((array)$this->existing($entity), $relatedEntities);
 
                 $this->Association->unlink($entity, $relatedEntities);
 

--- a/plugins/BEdita/Core/src/Model/Action/RemoveAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/RemoveAssociatedAction.php
@@ -27,30 +27,7 @@ use Cake\ORM\Association\HasMany;
 class RemoveAssociatedAction extends UpdateAssociatedAction
 {
 
-    /**
-     * Filter entities to be actually updated.
-     *
-     * @param \Cake\Datasource\EntityInterface $entity Source entity.
-     * @param \Cake\Datasource\EntityInterface[] $relatedEntities Related entities.
-     * @return \Cake\Datasource\EntityInterface[]
-     */
-    protected function diff(EntityInterface $entity, array $relatedEntities)
-    {
-        $bindingKey = (array)$this->Association->getBindingKey();
-        $existing = $this->existing($entity);
-
-        $diff = [];
-        foreach ($relatedEntities as $relatedEntity) {
-            $primaryKey = $relatedEntity->extract($bindingKey);
-            if (!in_array($primaryKey, $existing)) {
-                continue;
-            }
-
-            $diff[] = $relatedEntity;
-        }
-
-        return $diff;
-    }
+    use AssociatedTrait;
 
     /**
      * Remove existing relations.
@@ -70,7 +47,7 @@ class RemoveAssociatedAction extends UpdateAssociatedAction
             }
 
             return $this->Association->getConnection()->transactional(function () use ($entity, $relatedEntities) {
-                $relatedEntities = $this->diff($entity, $relatedEntities);
+                $relatedEntities = $this->intersection($this->existing($entity), $relatedEntities);
 
                 $this->Association->unlink($entity, $relatedEntities);
 

--- a/plugins/BEdita/Core/src/Model/Action/UpdateAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/UpdateAssociatedAction.php
@@ -14,8 +14,6 @@
 namespace BEdita\Core\Model\Action;
 
 use Cake\Datasource\EntityInterface;
-use Cake\Network\Exception\BadRequestException;
-use Cake\ORM\Association\BelongsToMany;
 
 /**
  * Abstract class for updating associations between entities.
@@ -44,6 +42,8 @@ abstract class UpdateAssociatedAction extends BaseAction
 
     /**
      * {@inheritDoc}
+     *
+     * @return array|int|false
      */
     public function execute(array $data = [])
     {
@@ -55,7 +55,7 @@ abstract class UpdateAssociatedAction extends BaseAction
      *
      * @param \Cake\Datasource\EntityInterface $entity Source entity.
      * @param \Cake\Datasource\EntityInterface|\Cake\Datasource\EntityInterface[]|null $relatedEntities Related entity(-ies).
-     * @return int|false
+     * @return array|int|false
      */
     abstract protected function update(EntityInterface $entity, $relatedEntities);
 }

--- a/plugins/BEdita/Core/src/Model/Action/UpdateAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/UpdateAssociatedAction.php
@@ -14,8 +14,8 @@
 namespace BEdita\Core\Model\Action;
 
 use Cake\Datasource\EntityInterface;
+use Cake\Network\Exception\BadRequestException;
 use Cake\ORM\Association\BelongsToMany;
-use Cake\ORM\Query;
 
 /**
  * Abstract class for updating associations between entities.
@@ -40,99 +40,6 @@ abstract class UpdateAssociatedAction extends BaseAction
     protected function initialize(array $config)
     {
         $this->Association = $this->getConfig('association');
-    }
-
-    /**
-     * Find existing associations.
-     *
-     * @param \Cake\Datasource\EntityInterface $entity Source entity.
-     * @return array|null
-     */
-    protected function existing(EntityInterface $entity)
-    {
-        $list = new ListAssociatedAction(['association' => $this->Association]);
-        $sourcePrimaryKey = (array)$this->Association->getSource()->getPrimaryKey();
-        $bindingKey = (array)$this->Association->getBindingKey();
-
-        $existing = $list(['primaryKey' => $entity->extract($sourcePrimaryKey), 'list' => true]);
-
-        if ($existing instanceof EntityInterface) {
-            return $existing
-                ->extract($bindingKey);
-        }
-
-        if (!($existing instanceof Query)) {
-            return null;
-        }
-
-        return $existing
-            ->map(function (EntityInterface $relatedEntity) use ($bindingKey) {
-                return $relatedEntity->extract($bindingKey);
-            })
-            ->toArray();
-    }
-
-    /**
-     * Prepare related entities.
-     *
-     * @param \Cake\Datasource\EntityInterface|\Cake\Datasource\EntityInterface[]|null $relatedEntities Related entities.
-     * @param \Cake\Datasource\EntityInterface $sourceEntity Source entity.
-     * @return \Cake\Datasource\EntityInterface[]
-     */
-    protected function prepareRelatedEntities($relatedEntities, EntityInterface $sourceEntity)
-    {
-        if ($relatedEntities === null) {
-            return [];
-        }
-
-        if (!($this->Association instanceof BelongsToMany)) {
-            return $relatedEntities;
-        }
-
-        $junction = $this->Association->junction();
-
-        $conditions = $this->Association->getConditions();
-        $prefix = sprintf('%s.', $junction->getAlias());
-        $extraFields = [];
-        foreach ($conditions as $field => $value) {
-            if (substr($field, 0, strlen($prefix)) !== $prefix) {
-                continue;
-            }
-            $field = substr($field, strlen($prefix));
-
-            $extraFields[$field] = $value;
-        }
-
-        if (!is_array($relatedEntities)) {
-            $relatedEntities = [$relatedEntities];
-        }
-
-        $junctionEntityClass = $junction->getEntityClass();
-        array_walk(
-            $relatedEntities,
-            function (EntityInterface $entity) use ($sourceEntity, $extraFields, $junction, $junctionEntityClass) {
-                if (empty($entity->_joinData) || !($entity->_joinData instanceof $junctionEntityClass)) {
-                    if (empty($extraFields)) {
-                        return;
-                    }
-                    $entity->_joinData = $junction->newEntity();
-                }
-
-                $joinData = $extraFields;
-                $joinData += array_combine(
-                    (array)$this->Association->getTargetForeignKey(),
-                    $entity->extract((array)$this->Association->getPrimaryKey())
-                );
-                $joinData += array_combine(
-                    (array)$this->Association->getForeignKey(),
-                    $sourceEntity->extract((array)$this->Association->getSource()->getPrimaryKey())
-                );
-
-                $entity->_joinData->set($joinData, ['guard' => false]);
-            }
-        );
-
-        return $relatedEntities;
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/ObjectRelationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectRelationsTable.php
@@ -84,7 +84,7 @@ class ObjectRelationsTable extends Table
                 return static::jsonSchema(null, $context) === true;
             })
             ->requirePresence('params', function ($context) {
-                return static::jsonSchema(null, $context) !== true;
+                return $context['newRecord'] && static::jsonSchema(null, $context) !== true;
             })
             ->add('params', 'valid', [
                 'rule' => 'jsonSchema',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddAssociatedActionTest.php
@@ -23,6 +23,7 @@ use Cake\Utility\Inflector;
 /**
  * @covers \BEdita\Core\Model\Action\AddAssociatedAction
  * @covers \BEdita\Core\Model\Action\UpdateAssociatedAction
+ * @covers \BEdita\Core\Model\Action\AssociatedTrait
  */
 class AddAssociatedActionTest extends TestCase
 {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
@@ -24,6 +24,7 @@ use Cake\Utility\Inflector;
 /**
  * @covers \BEdita\Core\Model\Action\AddRelatedObjectsAction
  * @covers \BEdita\Core\Model\Action\UpdateRelatedObjectsAction
+ * @covers \BEdita\Core\Model\Action\AssociatedTrait
  */
 class AddRelatedObjectsActionTest extends TestCase
 {
@@ -170,7 +171,6 @@ class AddRelatedObjectsActionTest extends TestCase
      * Test invocation of command with fallback to default action.
      *
      * @return void
-     *
      */
     public function testInvocationFallback()
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
@@ -131,7 +131,6 @@ class AddRelatedObjectsActionTest extends TestCase
      * @return void
      *
      * @dataProvider invocationProvider()
-     * @covers \BEdita\Core\Model\Action\UpdateAssociatedAction::prepareRelatedEntities()
      */
     public function testInvocation($expected, $objectType, $relation, $id, array $related)
     {
@@ -172,7 +171,6 @@ class AddRelatedObjectsActionTest extends TestCase
      *
      * @return void
      *
-     * @covers \BEdita\Core\Model\Action\UpdateAssociatedAction::prepareRelatedEntities()
      */
     public function testInvocationFallback()
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveAssociatedActionTest.php
@@ -22,6 +22,7 @@ use Cake\Utility\Inflector;
 /**
  * @covers \BEdita\Core\Model\Action\RemoveAssociatedAction
  * @covers \BEdita\Core\Model\Action\UpdateAssociatedAction
+ * @covers \BEdita\Core\Model\Action\AssociatedTrait
  */
 class RemoveAssociatedActionTest extends TestCase
 {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
@@ -104,9 +104,6 @@ class RemoveRelatedObjectsActionTest extends TestCase
      * @return void
      *
      * @dataProvider invocationProvider()
-     * @covers ::update()
-     * @covers \BEdita\Core\Model\Action\UpdateRelatedObjectsAction::execute()
-     * @covers \BEdita\Core\Model\Action\UpdateRelatedObjectsAction::getEntity()
      */
     public function testInvocation($expected, $table, $association, $entity, $related)
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
@@ -20,7 +20,8 @@ use Cake\TestSuite\TestCase;
 use Cake\Utility\Inflector;
 
 /**
- * @coversDefaultClass \BEdita\Core\Model\Action\RemoveRelatedObjectsAction
+ * @covers \BEdita\Core\Model\Action\RemoveRelatedObjectsAction
+ * @covers \BEdita\Core\Model\Action\AssociatedTrait
  */
 class RemoveRelatedObjectsActionTest extends TestCase
 {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
@@ -105,6 +105,7 @@ class RemoveRelatedObjectsActionTest extends TestCase
      * @return void
      *
      * @dataProvider invocationProvider()
+     * @covers \BEdita\Core\Model\Action\UpdateRelatedObjectsAction::prepareData()
      */
     public function testInvocation($expected, $table, $association, $entity, $related)
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SetAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SetAssociatedActionTest.php
@@ -23,6 +23,7 @@ use Cake\Utility\Inflector;
 /**
  * @covers \BEdita\Core\Model\Action\SetAssociatedAction
  * @covers \BEdita\Core\Model\Action\UpdateAssociatedAction
+ * @covers \BEdita\Core\Model\Action\AssociatedTrait
  */
 class SetAssociatedActionTest extends TestCase
 {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SetAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SetAssociatedActionTest.php
@@ -279,4 +279,65 @@ class SetAssociatedActionTest extends TestCase
             throw $e;
         }
     }
+
+    /**
+     * Data provider for `testInvocationWithValidationErrors` test case.
+     *
+     * @return array
+     */
+    public function invocationWithValidationErrorsProvider()
+    {
+        return [
+            'new link' => [1, 2],
+            'existing link' => [1, 1],
+        ];
+    }
+
+    /**
+     * Test that an exception is raised with details about the validation error.
+     *
+     * @param int $source Source entity ID.
+     * @param int $target Target entity ID.
+     * @return void
+     *
+     * @dataProvider invocationWithValidationErrorsProvider()
+     * @expectedException \Cake\Network\Exception\BadRequestException
+     * @expectedExceptionCode 400
+     */
+    public function testInvocationWithValidationErrors($source, $target)
+    {
+        $field = 'some_field';
+        $validationErrorMessage = 'Invalid email';
+
+        try {
+            $table = TableRegistry::get('FakeArticles');
+            /** @var \Cake\ORM\Association\BelongsToMany $association */
+            $association = $table->association('FakeTags');
+
+            $association->junction()->getValidator()
+                ->email($field, false, $validationErrorMessage);
+
+            $entity = $table->get($source);
+            $relatedEntities = [
+                $association->getTarget()->get($target)
+                    ->set('_joinData', [$field => 'not-an-email']),
+            ];
+
+            $action = new SetAssociatedAction(compact('association'));
+            $action(compact('entity', 'relatedEntities'));
+        } catch (Exception $e) {
+            $expected = [
+                'title' => 'Invalid data',
+                'detail' => [
+                    $field => [
+                        'email' => $validationErrorMessage,
+                    ],
+                ],
+            ];
+
+            static::assertSame($expected, $e->getAttributes());
+
+            throw $e;
+        }
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
@@ -25,6 +25,7 @@ use Cake\Utility\Inflector;
 /**
  * @covers \BEdita\Core\Model\Action\SetRelatedObjectsAction
  * @covers \BEdita\Core\Model\Action\UpdateRelatedObjectsAction
+ * @covers \BEdita\Core\Model\Action\AssociatedTrait
  */
 class SetRelatedObjectsActionTest extends TestCase
 {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
@@ -173,7 +173,6 @@ class SetRelatedObjectsActionTest extends TestCase
      * @return void
      *
      * @dataProvider invocationProvider()
-     * @covers \BEdita\Core\Model\Action\UpdateAssociatedAction::prepareRelatedEntities()
      */
     public function testInvocation($expected, $objectType, $relation, $id, array $related)
     {
@@ -213,8 +212,6 @@ class SetRelatedObjectsActionTest extends TestCase
      * Test invocation of command with fallback to default action.
      *
      * @return void
-     *
-     * @covers \BEdita\Core\Model\Action\UpdateAssociatedAction::prepareRelatedEntities()
      */
     public function testInvocationFallback()
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectRelationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectRelationsTableTest.php
@@ -123,6 +123,12 @@ class ObjectRelationsTableTest extends TestCase
                 ],
                 $schema,
             ],
+            'required params for existing entities' => [
+                [],
+                [],
+                $schema,
+                false,
+            ],
         ];
     }
 
@@ -132,16 +138,19 @@ class ObjectRelationsTableTest extends TestCase
      * @param bool $expected Expected result.
      * @param array $data Data to be validated.
      * @param object|null $jsonSchema JSON Schema.
+     * @param bool $isNew Should entity be treated as new?
      * @return void
      *
      * @dataProvider validationProvider()
      * @coversNothing
      */
-    public function testValidation($expected, array $data, $jsonSchema = null)
+    public function testValidation($expected, array $data, $jsonSchema = null, $isNew = true)
     {
         $this->ObjectRelations->getValidator()->setProvider('jsonSchema', $jsonSchema);
 
-        $objectRelation = $this->ObjectRelations->newEntity($data);
+        $objectRelation = $this->ObjectRelations->newEntity();
+        $objectRelation->isNew($isNew);
+        $this->ObjectRelations->patchEntity($objectRelation, $data);
         $objectRelation->left_id = 1;
         $objectRelation->relation_id = 1;
         $objectRelation->right_id = 1;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,6 +21,9 @@ use Cake\I18n\FrozenDate;
 use Cake\I18n\FrozenTime;
 use Cake\I18n\Time;
 use Cake\Log\Log;
+use Cake\ORM\TableRegistry;
+
+TableRegistry::clear();
 
 if (getenv('db_dsn')) {
     ConnectionManager::drop('test');


### PR DESCRIPTION
This PR fixes #1532 by allowing updates to associations without forcing clients to pass _all_ the required fields in the payload, as long as the link was already present and those fields were previously set.

Due to how CakePHP and us handle links between entities, a significant refactor was required. Most of the logic present in the `*AssociatedAction`s and `*RelatedObjectsAction`s has been extracted into an `AssociatedTrait` that is now being used by all the aforehand mentioned Actions. Said trait is abstract enough to handle all current use cases, but it can be easily extended in the future.

The `UpdateRelatedObjectsAction` and its descendants (`AddRelatedObjectsAction`, `SetRelatedObjectsAction`, `RemoveRelatedObjectsAction`) are now much thinner and have a lot less custom logic. We may want to evaluate whether they can be dismissed in the future. However, this refactor has not been done in this PR.