### PR TITLE
Fix usage of return value from Video provider helper

### DIFF
--- a/bedita-app/views/helpers/be_embed_media.php
+++ b/bedita-app/views/helpers/be_embed_media.php
@@ -424,8 +424,8 @@ class BeEmbedMediaHelper extends AppHelper {
         $helper = $this->getProviderHelper($obj);
         if ($helper) {
             $source = $helper->source($obj);
-            if (!empty($source)) {
-                $obj['uri'] = $source;
+            if (!empty($source['url'])) {
+                $obj['uri'] = $source['url'];
             }
         }
         $obj['uri'] = ($this->checkURL($obj['uri'])) ? $obj['uri'] : Configure::read('mediaUrl') . $obj['uri'];


### PR DESCRIPTION
This PR fixes a minor issue caused by an inconsistent use of `MediaProviderInterface`: the return value of `MediaProviderInterface::source()` is documented to be an array, but was being used as a string in one occurrence. 🙃 