### PR TITLE
#1575 update tree paths of section's children

### DIFF
--- a/bedita-app/controllers/api_base_controller.php
+++ b/bedita-app/controllers/api_base_controller.php
@@ -1099,6 +1099,8 @@ abstract class ApiBaseController extends FrontendController {
             }
         }
 
+        $objectType = Configure::read('objectTypes.' . $this->data['object_type_id'] . '.name');
+
         $this->data['status'] = 'on';
         if (empty($this->data['id'])) {
             $this->data['user_created'] = $user['id'];
@@ -1110,7 +1112,7 @@ abstract class ApiBaseController extends FrontendController {
         $this->data = $this->ApiFormatter->formatObjectForSave($this->data);
 
         // #883 skip tree update when saving section
-        if ($this->data['object_type'] == 'section') {
+        if ($objectType == 'section') {
             $this->data['skipTreeUpdate'] = true;
         }
 
@@ -1128,7 +1130,7 @@ abstract class ApiBaseController extends FrontendController {
                 )
             );
 
-            if ($this->data['object_type'] == 'section') {
+            if ($objectType == 'section') {
                 $menu = (isset($this->data[$this->name]['menu']) && $this->data[$this->name]['menu'] == 0) ? 0 : 1;
                 $tree->saveMenuVisibility($beModel->id, $this->data['parents'][0], $menu);
             }

--- a/bedita-app/models/tree.php
+++ b/bedita-app/models/tree.php
@@ -263,11 +263,11 @@ class Tree extends BEAppModel
         }
 
         $objectTypeId = ClassRegistry::init('BEObject')->field('object_type_id', array('BEObject.id' => $id));
-        if ($objectTypeId === Configure::read('objectTypes.area.id')) {
+        if ($objectTypeId == Configure::read('objectTypes.area.id')) {
             throw new BeditaBadRequestException(__('Publication cannot be moved to destination', true));
         }
 
-        $isSection = $objectTypeId === Configure::read('objectTypes.section.id');
+        $isSection = $objectTypeId == Configure::read('objectTypes.section.id');
         
         $excludeFromTreeIds = Configure::read('excludeFromTreeIds');
         if ($options['mantain_hidden_branch'] === true && !empty($excludeFromTreeIds)) {

--- a/bedita-app/models/tree.php
+++ b/bedita-app/models/tree.php
@@ -242,39 +242,70 @@ class Tree extends BEAppModel
      *
      * Possible values are:
      * - `area_id` to limit parents to some publication.
-     * - `status` to limit parents with specific status
+     * - `status` to limit parents with specific status.
+     * - `mantain_hidden_branch` if hidden branches are to mantain. Default true.
      *
-     * @param integer $id
-     * @param array $options
-     * @param array $destination
+     * @param int $id The object id
+     * @param array|int $destination An array of parents or a parent.
+     * @param array $options Options.
+     * @return void
+     * @throws BeditaException If $id is an area or a section with too much destination.
+     * @throws BeditaBadRequestException If errors happen moving a section.
      */
     public function updateTree($id, $destination, array $options = array()) {
         $options += array(
             'area_id' => null,
             'status' => array(),
-			'mantain_hidden_branch' => true
+            'mantain_hidden_branch' => true
         );
         if (!is_array($destination)) {
             $destination = (empty($destination))? array() : array($destination);
         }
-		$excludeFromTreeIds = Configure::read('excludeFromTreeIds');
-		if ($options['mantain_hidden_branch'] === true && !empty($excludeFromTreeIds)) {
-			foreach ($excludeFromTreeIds as $excludeFromTreeId) {
-				$result = $this->find('list', array(
-					'fields' => array('parent_id'),
-					'conditions' => array(
-						'id' => $id,
-						'object_path LIKE' => '%/' . $excludeFromTreeId . '/%'
-					)
-				));
-				if (!empty($result)) {
-					$destination = array_merge($destination, $result);
-				}
-			}
-		}
+
+        $objectTypeId = ClassRegistry::init('BEObject')->field('object_type_id', array('BEObject.id' => $id));
+        if ($objectTypeId === Configure::read('objectTypes.area.id')) {
+            throw new BeditaBadRequestException(__('Publication cannot be moved to destination', true));
+        }
+
+        $isSection = $objectTypeId === Configure::read('objectTypes.section.id');
+        
+        $excludeFromTreeIds = Configure::read('excludeFromTreeIds');
+        if ($options['mantain_hidden_branch'] === true && !empty($excludeFromTreeIds)) {
+            foreach ($excludeFromTreeIds as $excludeFromTreeId) {
+                $result = $this->find('list', array(
+                    'fields' => array('parent_id'),
+                    'conditions' => array(
+                        'id' => $id,
+                        'object_path LIKE' => '%/' . $excludeFromTreeId . '/%'
+                    )
+                ));
+                if (!empty($result)) {
+                    $destination = array_merge($destination, $result);
+                }
+            }
+        }
+
+        // if section with none or too much destination
+        if ($isSection && count($destination) !== 1) {
+            throw new BeditaBadRequestException(__('Section can have just one parent.', true));
+        }
+
         $currParents = $this->getParents($id, $options['area_id'], $options['status'], false);
+
         // remove
-        $remove = array_diff($currParents, $destination) ;
+        $remove = array_diff($currParents, $destination);
+
+        // section to move
+        if ($isSection && !empty($remove)) {
+            $newParent = current($destination);
+            $oldParent = current($currParents);
+            if (!$this->move($newParent, $oldParent, $id)) {
+                throw new BeditaException(__('Failing to move section', true));
+            }
+
+            return;
+        }
+
         foreach ($remove as $parent_id) {
             $this->removeChildWorker($id, $parent_id);
             $this->dispatchUpdatedTreeEvent($parent_id, static::EVENT_CHILDREN_UPDATED);
@@ -285,7 +316,7 @@ class Tree extends BEAppModel
             $this->appendChildWorker($id, $parent_id);
             $this->dispatchUpdatedTreeEvent($parent_id, static::EVENT_CHILDREN_UPDATED);
         }
-        
+
         $this->dispatchUpdatedTreeEvent($id, static::EVENT_PARENTS_UPDATED);
     }
 
@@ -516,12 +547,12 @@ class Tree extends BEAppModel
 	
 	
 	/**
-	 * move branch to another parent
+	 * Move branch to another parent
 	 *
-	 * @param int $idNewParent
-	 * @param int $idOldParent
-	 * @param int $id
-	 * @return boolean
+	 * @param int $idNewParent The new parent id.
+	 * @param int $idOldParent The old parent id.
+	 * @param int $id The object id to move.
+	 * @return bool
 	 */
 	public function move($idNewParent, $idOldParent, $id) {
 		// avoid recursive move (item inside itself)
@@ -582,8 +613,12 @@ class Tree extends BEAppModel
 			$this->create();
 			if (!$this->save($child)) {
 				return false;
-			}
-		}
+            }
+            
+            $this->dispatchUpdatedTreeEvent($child['Tree']['parent_id'], static::EVENT_CHILDREN_UPDATED);
+        }
+        
+        $this->dispatchUpdatedTreeEvent($id, static::EVENT_PARENTS_UPDATED);
 
 		return true;
 	}

--- a/bedita-app/models/tree.php
+++ b/bedita-app/models/tree.php
@@ -546,73 +546,73 @@ class Tree extends BEAppModel
 	}
 	
 	
-	/**
-	 * Move branch to another parent
-	 *
-	 * @param int $idNewParent The new parent id.
-	 * @param int $idOldParent The old parent id.
-	 * @param int $id The object id to move.
-	 * @return bool
-	 */
-	public function move($idNewParent, $idOldParent, $id) {
-		// avoid recursive move (item inside itself)
-		if ($id == $idNewParent) {
-			return false;
-		}
-		// Verify that new parent is not a descendant on the tree to move
-		if ($this->isParent($id, $idNewParent)) {
-			return false;
-		}
+    /**
+     * Move branch to another parent.
+     *
+     * @param int $idNewParent The new parent id.
+     * @param int $idOldParent The old parent id.
+     * @param int $id The object id to move.
+     * @return bool
+     */
+    public function move($idNewParent, $idOldParent, $id) {
+        // avoid recursive move (item inside itself)
+        if ($id == $idNewParent) {
+            return false;
+        }
+        // Verify that new parent is not a descendant on the tree to move
+        if ($this->isParent($id, $idNewParent)) {
+            return false;
+        }
 
-		$rowToMove = $this->find("first", array(
-			"conditions" => array(
-				"id" => $id,
-				"parent_id" => $idOldParent
-			)
-		));
+        $rowToMove = $this->find('first', array(
+            'conditions' => array(
+                'id' => $id,
+                'parent_id' => $idOldParent
+            )
+        ));
 
-		$newParentRow = $this->find("first", array(
-			"conditions" => array(
-				"id" => $idNewParent
-			)
-		));
+        $newParentRow = $this->find('first', array(
+            'conditions' => array(
+                'id' => $idNewParent
+            )
+        ));
 
-		$newParentPath = $newParentRow["Tree"]["object_path"];
-		$newPath = $newParentPath . "/" . $rowToMove["Tree"]["id"];
-		$oldPath = $rowToMove["Tree"]["object_path"];
+        $newParentPath = $newParentRow['Tree']['object_path'];
+        $newPath = $newParentPath . '/' . $rowToMove['Tree']['id'];
+        $oldPath = $rowToMove['Tree']['object_path'];
 
-		$children = $this->find("all", array(
-			"conditions" => array("object_path LIKE" => $oldPath."/%")
-		));
+        $children = $this->find('all', array(
+            'conditions' => array('object_path LIKE' => $oldPath.'/%')
+        ));
 
-		if (!$this->delete($rowToMove["Tree"]["object_path"])) {
-			return false;
-		}
+        if (!$this->delete($rowToMove['Tree']['object_path'])) {
+            return false;
+        }
 
-		$area_id = $this->getAreaIdByPath($newPath);
-		$rowToMove["Tree"]["parent_path"] = $newParentPath;
-		$rowToMove["Tree"]["object_path"] = $newPath;
-		$rowToMove["Tree"]["parent_id"] = $idNewParent;
-		$rowToMove["Tree"]["area_id"] = $area_id;
+        $area_id = $this->getAreaIdByPath($newPath);
+        $rowToMove['Tree']['parent_path'] = $newParentPath;
+        $rowToMove['Tree']['object_path'] = $newPath;
+        $rowToMove['Tree']['parent_id'] = $idNewParent;
+        $rowToMove['Tree']['area_id'] = $area_id;
 
-		$maxBranchPriority = $this->field("priority", array("parent_id" => $idNewParent), "priority DESC");
-		$rowToMove["Tree"]["priority"] = (empty($maxBranchPriority))? 1 : $maxBranchPriority + 1;
+        $maxBranchPriority = $this->field('priority', array('parent_id' => $idNewParent), 'priority DESC');
+        $rowToMove['Tree']['priority'] = empty($maxBranchPriority) ? 1 : $maxBranchPriority + 1;
 
-		$this->create();
-		if (!$this->save($rowToMove)) {
-			return false;
-		}
+        $this->create();
+        if (!$this->save($rowToMove)) {
+            return false;
+        }
 
-		foreach ($children as $child) {
-			if (!$this->delete($child["Tree"]["object_path"])) {
-				return false;
-			}
-			$child["Tree"]["parent_path"] = str_replace($oldPath, $newPath, $child["Tree"]["parent_path"]);
-			$child["Tree"]["object_path"] = str_replace($oldPath."/", $newPath."/", $child["Tree"]["object_path"]);
-			$child["Tree"]["area_id"] = $area_id;
-			$this->create();
-			if (!$this->save($child)) {
-				return false;
+        foreach ($children as $child) {
+            if (!$this->delete($child['Tree']['object_path'])) {
+                return false;
+            }
+            $child['Tree']['parent_path'] = str_replace($oldPath, $newPath, $child['Tree']['parent_path']);
+            $child['Tree']['object_path'] = str_replace($oldPath . '/', $newPath . '/', $child['Tree']['object_path']);
+            $child['Tree']['area_id'] = $area_id;
+            $this->create();
+            if (!$this->save($child)) {
+                return false;
             }
             
             $this->dispatchUpdatedTreeEvent($child['Tree']['parent_id'], static::EVENT_CHILDREN_UPDATED);
@@ -620,8 +620,8 @@ class Tree extends BEAppModel
         
         $this->dispatchUpdatedTreeEvent($id, static::EVENT_PARENTS_UPDATED);
 
-		return true;
-	}
+        return true;
+    }
 
 	/**
 	 * get all tree roots objects (publications)


### PR DESCRIPTION
This PR fixes #1575 

Now `Tree::updateTree()` method can be used consistently with every object type. Before this PR using that method with `section` object led to corrupted `object_path` and `parent_path` in section's children.

