### PR TITLE
[minor] fix: get all children when checks on permissions are disabled

### DIFF
--- a/bedita-app/controllers/api_base_controller.php
+++ b/bedita-app/controllers/api_base_controller.php
@@ -1549,13 +1549,18 @@ abstract class ApiBaseController extends FrontendController {
     }
 
     /**
-     * Get list of parent children with access restricted to $user
+     * Get list of children with access restricted to $user.
+     * If it's set to skip permissions or to show unauthorized objects it returns empty array.
      *
      * @param int $parentId the parent id
      * @param array $user array with user data, empty if no user is logged
      * @return array list of forbidden object ids, may be empty
      */
     protected function forbiddenChildren($parentId, array $user = array()) {
+        if ($this->showUnauthorized || $this->skipCheck) {
+            return array();
+        }
+        
         // add conditions on not accessible objects (frontend_access_with_block)
         // @todo move to FrontendController::loadSectionObjects()?
         $objectsForbidden = array();

--- a/bedita-app/controllers/components/api_validator.php
+++ b/bedita-app/controllers/components/api_validator.php
@@ -457,6 +457,10 @@ class ApiValidatorComponent extends Object {
      * @return boolean
      */
     public function isObjectAccessible($objectId, $parentsCheck = true) {
+        if ($this->controller->getShowUnauthorized() || $this->controller->getSkipCheck()) {
+            return true;
+        }
+
         $permission = ClassRegistry::init('Permission');
         $user = $this->controller->ApiAuth->getUser();
         // if object itself is forbidden to user return false without any other check
@@ -478,6 +482,10 @@ class ApiValidatorComponent extends Object {
      * @return boolean
      */
     public function areObjectParentsAccessible($objectId) {
+        if ($this->controller->getShowUnauthorized() || $this->controller->getSkipCheck()) {
+            return true;
+        }
+        
         $permission = ClassRegistry::init('Permission');
         $user = $this->controller->ApiAuth->getUser();
         $userGroups = !empty($user['groupsIds']) ? $user['groupsIds'] : array();


### PR DESCRIPTION
This PR fixes a bug whereby getting via API a list of section's children with the option to skip permissions failed removing protected objects from the children list.

To test just set a permission  "_group visible, hidden to others_" on a section's child and perform

```http
GET /objects/:section_id/children
```

The object with permission is not shown.

In `ApiController` set the property `protected $skipCheck = true;` and execute again the call above.
In this case the object with permission should be visible.


