### PR TITLE
Signup new configuration options

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -424,13 +424,20 @@ return [
      * Signup settings.
      *
      * - `requireActivation` - boolean (default: true) - Are new users required to verify their contact method
-     *      before being "activated"?
+     *      before being "activated"? If true upon creation user will have a `draft` status, otherwise `on`
      * - 'roles' - allowed role names on user signup (this config should be set normally at application level),
      *      requested user roles MUST be included in this array
+     * - 'requireEmail' - require email upon signup (default: true)
+     * - 'requirePassword' - require password upon signup (default: true), can be false in some AUTH schemas like One Time Password
+     * - 'defaultRoles` - roles to add upon signup as default if no roles are passed; they MUST be in allowed `roles` in order to be set
      */
     'Signup' => [
         // 'requireActivation' => true,
-        'roles' => [],
+        // 'roles' => [],
+        // 'requireEmail' => true,
+        // 'requirePassword' => true,
+        // 'activationUrl' => 'https://myapp.com/verify',
+        // 'defaultRoles' => [],
     ],
 
     /**

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -428,6 +428,7 @@ return [
      * - 'roles' - allowed role names on user signup (this config should be set normally at application level),
      *      requested user roles MUST be included in this array
      * - 'requireEmail' - require email upon signup (default: true)
+     * - 'activationUrl' => default activation URL to use if not set by application
      * - 'requirePassword' - require password upon signup (default: true), can be false in some AUTH schemas like One Time Password
      * - 'defaultRoles` - roles to add upon signup as default if no roles are passed; they MUST be in allowed `roles` in order to be set
      */

--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -216,7 +216,10 @@ class LoginController extends AppController
         $this->request->allowMethod('patch');
 
         $entity = $this->userEntity();
-        $entity->setAccess(['username', 'password_hash', 'email'], false);
+        $entity->setAccess(['username', 'password_hash'], false);
+        if (!empty($entity->get('email'))) {
+            $entity->setAccess('email', false);
+        }
 
         $data = $this->request->getData();
         $this->checkPassword($entity, $data);

--- a/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
@@ -443,7 +443,7 @@ class LoginControllerTest extends IntegrationTestCase
         $data = [
             'name' => 'Gustavo',
             'surname' => 'Trump',
-            'email' => 'gustavo@trump.com'
+            'email' => 'gustavotrump@example.com',
         ];
         $this->configRequest(compact('headers'));
         $this->patch('/auth/user', json_encode($data));

--- a/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
@@ -427,6 +427,12 @@ class LoginControllerTest extends IntegrationTestCase
      */
     public function testUpdate(array $meta)
     {
+        // set email to NULL to be able to change it
+        $table = TableRegistry::get('Users');
+        $user = $table->get(1);
+        $user->set('email', null);
+        $table->saveOrFail($user);
+
         $headers = [
             'Host' => 'api.example.com',
             'Accept' => 'application/vnd.api+json',
@@ -437,6 +443,7 @@ class LoginControllerTest extends IntegrationTestCase
         $data = [
             'name' => 'Gustavo',
             'surname' => 'Trump',
+            'email' => 'gustavo@trump.com'
         ];
         $this->configRequest(compact('headers'));
         $this->patch('/auth/user', json_encode($data));
@@ -448,6 +455,7 @@ class LoginControllerTest extends IntegrationTestCase
         static::assertEquals(1, $result['data']['id']);
         static::assertEquals($data['name'], $result['data']['attributes']['name']);
         static::assertEquals($data['surname'], $result['data']['attributes']['surname']);
+        static::assertEquals($data['email'], $result['data']['attributes']['email']);
     }
 
     /**
@@ -472,6 +480,7 @@ class LoginControllerTest extends IntegrationTestCase
 
         $data = [
             'username' => 'gustavo',
+            'email' => 'another@email.com',
         ];
 
         $this->configRequest(compact('headers'));
@@ -483,6 +492,7 @@ class LoginControllerTest extends IntegrationTestCase
         static::assertNotEmpty($result['data']);
         static::assertEquals(1, $result['data']['id']);
         static::assertNotEquals($data['username'], $result['data']['attributes']['username']);
+        static::assertNotEquals($data['email'], $result['data']['attributes']['email']);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -28,6 +28,7 @@ use Cake\Mailer\MailerAwareTrait;
 use Cake\Network\Exception\BadRequestException;
 use Cake\Network\Exception\UnauthorizedException;
 use Cake\ORM\TableRegistry;
+use Cake\Utility\Hash;
 use Cake\Validation\Validator;
 
 /**
@@ -308,10 +309,7 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
      */
     protected function addRoles(User $entity, array $data)
     {
-        $signupRoles = (array)Configure::read('Signup.defaultRoles');
-        if (!empty($data['roles'])) {
-            $signupRoles = $data['roles'];
-        }
+        $signupRoles = Hash::get($data, 'roles', Configure::read('Signup.defaultRoles'));
         if (empty($signupRoles)) {
             return;
         }

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -165,6 +165,7 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
                 ->notEmpty('username');
         } else {
             $validator
+                ->allowEmpty('activation_url')
                 ->requirePresence('provider_username')
                 ->requirePresence('access_token');
         }

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ * Copyright 2019 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -91,6 +91,10 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
     public function execute(array $data = [])
     {
         $data = $this->normalizeInput($data);
+        // add activation url from config if not set
+        if (empty($data['data']['activation_url'])) {
+            $data['data']['activation_url'] = Configure::read('Signup.activationUrl');
+        }
         $errors = $this->validate($data['data']);
         if (!empty($errors)) {
             throw new BadRequestException([
@@ -303,10 +307,14 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
      */
     protected function addRoles(User $entity, array $data)
     {
-        if (empty($data['roles'])) {
+        $signupRoles = (array)Configure::read('Signup.defaultRoles');
+        if (!empty($data['roles'])) {
+            $signupRoles = $data['roles'];
+        }
+        if (empty($signupRoles)) {
             return;
         }
-        $roles = $this->loadRoles($data['roles']);
+        $roles = $this->loadRoles($signupRoles);
         $association = $this->Users->associations()->getByProperty('roles');
         $association->link($entity, $roles);
     }
@@ -367,6 +375,9 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
      */
     public function sendMail(Event $event, User $user, AsyncJob $job, $activationUrl)
     {
+        if (empty($user->get('email'))) {
+            return;
+        }
         $options = [
             'params' => compact('activationUrl', 'user'),
         ];

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -28,6 +28,7 @@ use Cake\Mailer\MailerAwareTrait;
 use Cake\Network\Exception\BadRequestException;
 use Cake\Network\Exception\UnauthorizedException;
 use Cake\ORM\TableRegistry;
+use Cake\Routing\Router;
 use Cake\Utility\Hash;
 use Cake\Validation\Validator;
 
@@ -93,8 +94,8 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
     {
         $data = $this->normalizeInput($data);
         // add activation url from config if not set
-        if (empty($data['data']['activation_url'])) {
-            $data['data']['activation_url'] = Configure::read('Signup.activationUrl');
+        if (Configure::check('Signup.activationUrl') && empty($data['data']['activation_url'])) {
+            $data['data']['activation_url'] = Router::url(Configure::read('Signup.activationUrl'));
         }
         $errors = $this->validate($data['data']);
         if (!empty($errors)) {
@@ -166,7 +167,6 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
                 ->notEmpty('username');
         } else {
             $validator
-                ->allowEmpty('activation_url')
                 ->requirePresence('provider_username')
                 ->requirePresence('access_token');
         }

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -124,15 +124,14 @@ class UsersTable extends Table
             ->email('email')
             ->add('email', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);
 
-        if (Configure::read('Signup.requirePassword', true)) {
-            $validator
-                ->requirePresence('password_hash')
-                ->notEmpty('password_hash');
-        }
+        $validator->requirePresence('password_hash', function () {
+            return Configure::read('Signup.requirePassword', true);
+        });
+        $validator->notEmpty('password_hash');
 
-        if (Configure::read('Signup.requireEmail', true)) {
-            $validator->requirePresence('email');
-        }
+        $validator->requirePresence('email', function () {
+            return Configure::read('Signup.requireEmail', true);
+        });
 
         return $validator;
     }

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -122,11 +122,17 @@ class UsersTable extends Table
 
         $validator
             ->email('email')
-            ->requirePresence('email')
-            ->add('email', 'unique', ['rule' => 'validateUnique', 'provider' => 'table'])
+            ->add('email', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);
 
-            ->requirePresence('password_hash')
-            ->notEmpty('password_hash');
+        if (Configure::read('Signup.requirePassword', true)) {
+            $validator
+                ->requirePresence('password_hash')
+                ->notEmpty('password_hash');
+        }
+
+        if (Configure::read('Signup.requireEmail', true)) {
+            $validator->requirePresence('email');
+        }
 
         return $validator;
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -138,7 +138,7 @@ class SignupUserActionTest extends TestCase
             'missing activation_url' => [
                 new BadRequestException([
                     'title' => 'Invalid data',
-                    'detail' => ['activation_url' => ['_empty' => 'This field cannot be left empty']],
+                    'detail' => ['activation_url' => ['_required' => 'This field is required']],
                 ]),
                 [
                     'data' => [
@@ -414,7 +414,9 @@ class SignupUserActionTest extends TestCase
             ],
         ];
 
-        EventManager::instance()->on('Auth.signup', function (...$arguments) {
+        $invoked = 0;
+        EventManager::instance()->on('Auth.signup', function (...$arguments) use (&$invoked) {
+            $invoked++;
             static::assertCount(4, $arguments);
             $job = $arguments[2];
             $url = sprintf('%s?uuid=%s', Configure::read('Signup.activationUrl'), $job->get('uuid'));
@@ -424,6 +426,7 @@ class SignupUserActionTest extends TestCase
         $action = new SignupUserAction();
         $action($data);
 
+        static::assertSame(1, $invoked);
         $user = TableRegistry::get('Users')->find()->where(['username' => 'testsignup'])->first();
         static::assertEquals('test.signup@example.com', $user->get('email'));
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -138,7 +138,7 @@ class SignupUserActionTest extends TestCase
             'missing activation_url' => [
                 new BadRequestException([
                     'title' => 'Invalid data',
-                    'detail' => ['activation_url' => ['_required' => 'This field is required']],
+                    'detail' => ['activation_url' => ['_empty' => 'This field cannot be left empty']],
                 ]),
                 [
                     'data' => [
@@ -398,6 +398,63 @@ class SignupUserActionTest extends TestCase
     }
 
     /**
+     * Test `Signup.activationUrl` config
+     *
+     * @return void
+     */
+    public function testActivationUrl()
+    {
+        Configure::write('Signup.activationUrl', 'https://my.activation.url');
+
+        $data = [
+            'data' => [
+                'username' => 'testsignup',
+                'password' => 'testsignup',
+                'email' => 'test.signup@example.com',
+            ],
+        ];
+
+        EventManager::instance()->on('Auth.signup', function (...$arguments) {
+            static::assertCount(4, $arguments);
+            $job = $arguments[2];
+            $url = sprintf('%s?uuid=%s', Configure::read('Signup.activationUrl'), $job->get('uuid'));
+            static::assertEquals($url, $arguments[3]);
+        });
+
+        $action = new SignupUserAction();
+        $action($data);
+
+        $user = TableRegistry::get('Users')->find()->where(['username' => 'testsignup'])->first();
+        static::assertEquals('test.signup@example.com', $user->get('email'));
+    }
+
+    /**
+     * Test signup with empty email and password case
+     *
+     * @return void
+     */
+    public function testEmptyPasswordEmail()
+    {
+        Configure::write('Signup', [
+            'requireEmail' => false,
+            'requirePassword' => false,
+        ]);
+
+        $data = [
+            'data' => [
+                'username' => 'testsignup',
+                'activation_url' => 'http://sample.com?confirm=true',
+            ],
+        ];
+
+        $action = new SignupUserAction();
+        $action($data);
+
+        $user = TableRegistry::get('Users')->find()->where(['username' => 'testsignup'])->first();
+        static::assertNull($user->get('email'));
+    }
+
+    /**
      * Data provider for `testRoles()`
      *
      * @return array
@@ -417,7 +474,9 @@ class SignupUserActionTest extends TestCase
                         'redirect_url' => 'http://sample.com/ok',
                     ],
                 ],
-                ['second role'],
+                [
+                    'roles' => ['second role'],
+                ],
             ],
             'failNoRoles' => [
                 new BadRequestException('Role "second role" not allowed on signup'),
@@ -433,6 +492,7 @@ class SignupUserActionTest extends TestCase
                 ],
                 [],
             ],
+            // fail beacause admin role not allowed in signup
             'failAdminRole' => [
                 new BadRequestException('Role "first role" not allowed on signup'),
                 [
@@ -445,7 +505,24 @@ class SignupUserActionTest extends TestCase
                         'redirect_url' => 'http://sample.com/ok',
                     ],
                 ],
-                ['first role'],
+                [
+                    'roles' => ['first role'],
+                ],
+            ],
+            'default role' => [
+                true,
+                [
+                    'data' => [
+                        'username' => 'testsignup',
+                        'password' => 'testsignup',
+                        'email' => 'test.signup@example.com',
+                        'activation_url' => 'http://sample.com?confirm=true',
+                    ],
+                ],
+                [
+                    'roles' => ['first role', 'second role'],
+                    'defaultRoles' => ['second role'],
+                ],
             ],
         ];
     }
@@ -455,23 +532,25 @@ class SignupUserActionTest extends TestCase
      *
      * @param bool|\Exception $expected Expected result.
      * @param array $data Action data.
-     * @param array $allowed Allowe roles to set in configuration.
+     * @param array $config Signup configuration.
      *
      * @dataProvider rolesProvider
      * @return void
      */
-    public function testRoles($expected, array $data, array $allowed)
+    public function testRoles($expected, array $data, array $config = [])
     {
-        Configure::write('Signup.roles', $allowed);
+        Configure::write('Signup', $config);
         if ($expected instanceof \Exception) {
             static::expectException(get_class($expected));
             static::expectExceptionMessage($expected->getMessage());
+            static::expectExceptionCode($expected->getCode());
         }
 
         $action = new SignupUserAction();
         $result = $action($data);
 
         static::assertTrue((bool)$result);
-        static::assertSame($data['data']['roles'], Hash::extract($result->get('roles'), '{n}.name'));
+        $roles = Hash::get($data, 'data.roles', Configure::read('Signup.defaultRoles'));
+        static::assertSame($roles, Hash::extract($result->get('roles'), '{n}.name'));
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -404,9 +404,24 @@ class UsersTableTest extends TestCase
                 false,
                 [
                     'username' => 'some_unique_value',
-                    'password_hash' => null,
                     'email' => 'my@email.com',
-                    'status' => 'draft',
+                ],
+            ],
+            'missing email' => [
+                false,
+                [
+                    'username' => 'some_unique_value',
+                    'password_hash' => 'a great password',
+                ],
+            ],
+            'username only' => [
+                true,
+                [
+                    'username' => 'some_unique_value',
+                ],
+                [
+                    'requireEmail' => false,
+                    'requirePassword' => false,
                 ],
             ],
         ];
@@ -422,8 +437,12 @@ class UsersTableTest extends TestCase
      * @covers ::validationSignup()
      * @dataProvider validationSignupProvider
      */
-    public function testValidationSignup($expected, array $data)
+    public function testValidationSignup($expected, array $data, array $config = [])
     {
+        Configure::write('Signup', []);
+        if ($config) {
+            Configure::write('Signup', $config);
+        }
         $user = $this->Users->newEntity();
         $this->Users->patchEntity($user, $data, ['validate' => 'signup']);
         $user->type = 'users';

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -432,6 +432,7 @@ class UsersTableTest extends TestCase
      *
      * @param bool $expected Expected result.
      * @param array $data Data to be validated.
+     * @param array $config Signup configuration.
      *
      * @return void
      * @covers ::validationSignup()
@@ -439,10 +440,8 @@ class UsersTableTest extends TestCase
      */
     public function testValidationSignup($expected, array $data, array $config = [])
     {
-        Configure::write('Signup', []);
-        if ($config) {
-            Configure::write('Signup', $config);
-        }
+        Configure::write('Signup', $config);
+
         $user = $this->Users->newEntity();
         $this->Users->patchEntity($user, $data, ['validate' => 'signup']);
         $user->type = 'users';


### PR DESCRIPTION
This PR adds new signup configurations and use cases

 * new configuration keys are introduced:
   - `'requireEmail'` - require email upon signup (default: true)
   - `'requirePassword'` - require password upon signup (default: true)
   - `'activationUrl'` - default activation url, used if not passed by client app
   - `'defaultRoles'` - roles to add upon signup as default if no roles are passed (MUST be listed in `roles`)
 * in `PATCH /auth/user` it is now possibile to update a user's email if NULL

