### PR TITLE
Fix created_by/modified_by foreign key check

### DIFF
--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -25,6 +25,7 @@ use Cake\Event\EventManager;
 use Cake\Network\Exception\BadRequestException;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
+use Cake\ORM\TableRegistry;
 use Cake\Validation\Validator;
 
 /**
@@ -360,7 +361,7 @@ class UsersTable extends Table
      */
     public function delete(EntityInterface $entity, $options = [])
     {
-        $exists = $this->exists([
+        $exists = TableRegistry::get('Objects')->exists([
             'OR' => ['created_by' => $entity->get('id'), 'modified_by' => $entity->get('id')],
         ]);
         if (!$exists) {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -321,12 +321,15 @@ class JsonApiTraitTest extends TestCase
      */
     public function testGetRelationshipsIncludedEmpty()
     {
-        $usersTable = TableRegistry::get('Users');
         // This is needed in order to permanently remove user with id 5
+        $usersTable = TableRegistry::get('Users');
         $user = $usersTable->get(5);
         $user->created_by = 1;
         $user->modified_by = 1;
         $user = $usersTable->saveOrFail($user);
+        $doc = TableRegistry::get('Objects')->get(3);
+        $doc->modified_by = 1;
+        $doc = TableRegistry::get('Objects')->saveOrFail($doc);
 
         $usersTable->delete($usersTable->get(5));
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -652,6 +652,31 @@ class UsersTableTest extends TestCase
     }
 
     /**
+     * Test delete method with anonymization when
+     * created_by/modified_by fk is set on other objects
+     *
+     * @return void
+     * @covers ::delete()
+     * @covers ::anonymizeUser()
+     * @covers ::notNullableColumns()
+     */
+    public function testAnonymousDeleteOther()
+    {
+        $user = $this->Users->get(5);
+        $user->created_by = 1;
+        $user->modified_by = 1;
+        $user = $this->Users->saveOrFail($user);
+
+        $result = $this->Users->delete($user);
+        static::assertTrue($result);
+        $result = $this->Users->get(5);
+        static::assertEquals('__deleted-5', $result->get('username'));
+        static::assertEquals('__deleted-5', $result->get('uname'));
+        static::assertEquals(true, $result->get('locked'));
+        static::assertNull($result->get('last_login'));
+    }
+
+    /**
      * Test delete method without anonymization
      *
      * @return void
@@ -663,6 +688,11 @@ class UsersTableTest extends TestCase
         $user->created_by = 1;
         $user->modified_by = 1;
         $user = $this->Users->saveOrFail($user);
+
+        $table = TableRegistry::get('Objects');
+        $doc = $table->get(3);
+        $doc->modified_by = 1;
+        $doc = $table->saveOrFail($doc);
 
         $result = $this->Users->delete($user);
         static::assertTrue($result);


### PR DESCRIPTION
This PR fixes a problem checking `created_by/modified_by` possible conflicts in `Users` delete.

A new test `UsersTableTest::testAnonymousDeleteOther()` was added to test this problem.

See #1579 #1556  