### PR TITLE
Restore optional parameters for new relations that allow empty objects #1582

### DIFF
--- a/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
@@ -26,6 +26,8 @@ use BEdita\Core\ORM\Inheritance\Table;
  * @method \BEdita\Core\Model\Entity\Location patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \BEdita\Core\Model\Entity\Location[] patchEntities($entities, array $data, array $options = [])
  * @method \BEdita\Core\Model\Entity\Location findOrCreate($search, callable $callback = null, $options = [])
+ *
+ * @mixin \BEdita\Core\Model\Behavior\RelationsBehavior
  */
 class LocationsTable extends Table
 {

--- a/plugins/BEdita/Core/src/Model/Table/ObjectRelationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectRelationsTable.php
@@ -107,7 +107,13 @@ class ObjectRelationsTable extends Table
             return true;
         }
 
-        return Validation::jsonSchema($value, $context['providers']['jsonSchema']);
+        $success = Validation::jsonSchema($value, $context['providers']['jsonSchema']);
+        if ($success !== true && $value === null && Validation::jsonSchema(new \stdClass(), $context['providers']['jsonSchema']) === true) {
+            // For the sake of validation, `null` is equivalent to empty object.
+            $success = true;
+        }
+
+        return $success;
     }
 
     /**


### PR DESCRIPTION
This PR fixes #1582 by restoring the ability to create new relations without passing `params` as long as an empty object (`{}`) validates against the JSON Schema specified for the relation.