### PR TITLE
Google maps settings in config

### DIFF
--- a/bedita-app/config/bedita.cfg.php.sample
+++ b/bedita-app/config/bedita.cfg.php.sample
@@ -372,5 +372,6 @@ $config['objectCakeCache'] = true;
  * Google maps api settings
  */
 // $config['googleMapsApi'] = array(
+//    'url' => 'https://maps.googleapis.com/maps/api/',
 //    'key' => 'my-api-key',
 //);

--- a/bedita-app/config/bedita.cfg.php.sample
+++ b/bedita-app/config/bedita.cfg.php.sample
@@ -367,3 +367,10 @@ $config['objectCakeCache'] = true;
 // $config['multimedia'] = array(
 //    'types' => array('audio', 'image', 'video'),
 //);
+
+/**
+ * Google maps api settings
+ */
+// $config['googleMapsApi'] = array(
+//    'key' => 'my-api-key',
+//);

--- a/bedita-app/views/elements/form_geotag.tpl
+++ b/bedita-app/views/elements/form_geotag.tpl
@@ -1,7 +1,7 @@
+{assign var=googleMapsApi value=$conf->googleMapsApi|default:false}
+
 <!-- Google Maps API key API 3.3 -->
-<script type="text/javascript"
-    src="https://maps.google.com/maps/api/js?sensor=false">
-</script>
+<script type="text/javascript" src="https://maps.google.com/maps/api/js?sensor=false{if $googleMapsApi}&key={$googleMapsApi.key}{/if}"></script>
 
 <script>
 $(document).ready(function(){
@@ -25,7 +25,7 @@ $(document).ready(function(){
 		}
 		window.open("https://maps.google.com/maps?" + q + "&output=classic");
 	});	
-	
+{if $geocodepi}
     try {
         geocoder = new google.maps.Geocoder();
         $('.geocodeme').click(function() {
@@ -33,7 +33,7 @@ $(document).ready(function(){
             if (address == '') {
                 alert('devi prima inserire un indirizzo'); return;
             }
-            geocoder.geocode( { 'address': address}, function(results, status) {
+            geocoder.geocode( { 'address': address }, function(results, status) {
                 if (status == google.maps.GeocoderStatus.OK) {
                     var latlng = '' + results[0].geometry.location + '';
                     var latlng = latlng.replace('(', '').replace(')', '');
@@ -50,6 +50,7 @@ $(document).ready(function(){
         $('.geocodeme, .googlemaptest').attr('disabled', 'disabled');
         console.warn('Google CDN unreachable. Some functionalities have been disabled.');
     }
+{/if}
 });
 </script>
 
@@ -98,15 +99,14 @@ $(document).ready(function(){
 		</select>
 	</td>
 </tr>
-{*
-<tr>
-	<th>{t}Gmaps LookaT{/t}:</th>
-	<td colspan=3><textarea name="data[GeoTag][0][gmaps_lookat]" class="autogrowarea" style="height:16px; width:300px;">{if !empty($d.gmaps_lookat)}{$d.gmaps_lookat}{/if}</textarea></td>
-</tr>
-*}
 <tr>
 	<td></td>
-	<td colspan="3"><input type="button" class="geocodeme" value="{t}Find and fill latlong coords{/t}" /> <input type="button" class="googlemaptest" value="{t}Test on GoogleMaps{/t}" /></td>
+	<td colspan="3">
+		{if $googleMapsApi}
+			<input type="button" class="geocodeme" value="{t}Find and fill latlong coords{/t}" />
+		{/if}
+		<input type="button" class="googlemaptest" value="{t}Test on GoogleMaps{/t}" />
+	</td>
 </tr>
 
 </table>

--- a/bedita-app/views/elements/form_geotag.tpl
+++ b/bedita-app/views/elements/form_geotag.tpl
@@ -1,7 +1,10 @@
-{assign var=googleMapsApi value=$conf->googleMapsApi|default:false}
+{assign var=googleMapsApi value=$conf->googleMapsApi|default:['url' => 'https://maps.googleapis.com/maps/api/']}
+{assign var=googleMapsApiKey value=$googleMapsApi.key|default:''}
 
 <!-- Google Maps API key API 3.3 -->
-<script type="text/javascript" src="https://maps.google.com/maps/api/js?sensor=false{if $googleMapsApi}&key={$googleMapsApi.key}{/if}"></script>
+<script type="text/javascript"
+	src="{$googleMapsApi.url}js{if $googleMapsApiKey}?key={$googleMapsApiKey}{/if}">
+</script>
 
 <script>
 $(document).ready(function(){
@@ -25,7 +28,7 @@ $(document).ready(function(){
 		}
 		window.open("https://maps.google.com/maps?" + q + "&output=classic");
 	});	
-{if $googleMapsApi}
+
     try {
         geocoder = new google.maps.Geocoder();
         $('.geocodeme').click(function() {
@@ -50,7 +53,6 @@ $(document).ready(function(){
         $('.geocodeme, .googlemaptest').attr('disabled', 'disabled');
         console.warn('Google CDN unreachable. Some functionalities have been disabled.');
     }
-{/if}
 });
 </script>
 

--- a/bedita-app/views/elements/form_geotag.tpl
+++ b/bedita-app/views/elements/form_geotag.tpl
@@ -25,7 +25,7 @@ $(document).ready(function(){
 		}
 		window.open("https://maps.google.com/maps?" + q + "&output=classic");
 	});	
-{if $geocodepi}
+{if $googleMapsApi}
     try {
         geocoder = new google.maps.Geocoder();
         $('.geocodeme').click(function() {


### PR DESCRIPTION
This PR provides the use of google maps api key, from config (if set), for geocoding.
If `$config['googleMapsApi']['key'];` is set properly, geocoding tab in object view is set properly; otherwise geocoding not available.

Sample config:

```
/**
 * Google maps api settings
 */
$config['googleMapsApi'] = array(
   'url' => 'https://maps.googleapis.com/maps/api/',
   'key' => '*******************************************',
);
```