### PR TITLE
Apply defaults only on new objects (id available)

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -1152,7 +1152,7 @@ class ObjectsControllerTest extends IntegrationTestCase
         $document = TableRegistry::get('Documents')->get('2');
         static::assertEquals($newTitle, $document->get('title'));
         static::assertEquals('documents', $document->get('type'));
-        static::assertEquals('on', $document->get('status'));;
+        static::assertEquals('on', $document->get('status'));
 
         $result = json_decode((string)$this->_response->getBody(), true);
         static::assertEquals($data['id'], $result['data']['id']);

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -1149,9 +1149,10 @@ class ObjectsControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
-        $Documents = TableRegistry::get('Documents');
-        static::assertEquals($newTitle, $Documents->get(2)->get('title'));
-        static::assertEquals('documents', $Documents->get(2)->get('type'));
+        $document = TableRegistry::get('Documents')->get('2');
+        static::assertEquals($newTitle, $document->get('title'));
+        static::assertEquals('documents', $document->get('type'));
+        static::assertEquals('on', $document->get('status'));;
 
         $result = json_decode((string)$this->_response->getBody(), true);
         static::assertEquals($data['id'], $result['data']['id']);

--- a/plugins/BEdita/Core/src/Model/Behavior/DataCleanupBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/DataCleanupBehavior.php
@@ -54,7 +54,7 @@ class DataCleanupBehavior extends Behavior
     public function beforeMarshal(Event $event, \ArrayObject $data)
     {
         // fill defaults only on new objects
-        if (isset($data['id'])) {
+        if (!empty($data['id'])) {
             return;
         }
         $config = $this->getConfig();

--- a/plugins/BEdita/Core/src/Model/Behavior/DataCleanupBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/DataCleanupBehavior.php
@@ -53,6 +53,10 @@ class DataCleanupBehavior extends Behavior
      */
     public function beforeMarshal(Event $event, \ArrayObject $data)
     {
+        // fill defaults only on new objects
+        if (isset($data['id'])) {
+            return;
+        }
         $config = $this->getConfig();
         $key = Inflector::underscore($this->_table->getAlias());
         if ($this->_table->behaviors()->has('ObjectType') && $this->_table->objectType()) {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/DataCleanupBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/DataCleanupBehaviorTest.php
@@ -117,7 +117,11 @@ class DataCleanupBehaviorTest extends TestCase
                 [
                     'status' => null,
                 ],
-                [],
+                [
+                    'users' => [
+                        'status' => 'on',
+                    ],
+                ],
             ],
 
         ];

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/DataCleanupBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/DataCleanupBehaviorTest.php
@@ -109,10 +109,9 @@ class DataCleanupBehaviorTest extends TestCase
                 ],
                 [],
             ],
-            'status, only new objects' => [
+            'not on existing objects' => [
                 [
                     'id' => 999,
-                    'status' => null,
                 ],
                 [
                     'status' => null,

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/DataCleanupBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/DataCleanupBehaviorTest.php
@@ -109,6 +109,17 @@ class DataCleanupBehaviorTest extends TestCase
                 ],
                 [],
             ],
+            'status, only new objects' => [
+                [
+                    'id' => 999,
+                    'status' => null,
+                ],
+                [
+                    'status' => null,
+                ],
+                [],
+            ],
+
         ];
     }
 


### PR DESCRIPTION
This PR fixes a possible "logical" bug, on saving objects.

Default values should be set only on new objects (POST) and not when updating data (PATCH).
With this patch, if `$data['id']` is found, no defaults are set.
