### PR TITLE
Fix/v4/uploading xml or json

### DIFF
--- a/plugins/BEdita/API/src/Controller/StreamsController.php
+++ b/plugins/BEdita/API/src/Controller/StreamsController.php
@@ -65,8 +65,15 @@ class StreamsController extends ResourcesController
      */
     public function beforeFilter(Event $event)
     {
+        if ($this->request->getParam('action') !== 'upload') {
+            return parent::beforeFilter($event);
+        }
+
+        // avoid that RequestHandler tries to parse body
+        $this->RequestHandler->setConfig('inputTypeMap', [], false);
+
         // Decode base64-encoded body.
-        if ($this->request->getParam('action') === 'upload' && $this->request->getHeaderLine('Content-Transfer-Encoding') === 'base64') {
+        if ($this->request->getHeaderLine('Content-Transfer-Encoding') === 'base64') {
             // Append filter to stream.
             $body = $this->request->getBody();
 
@@ -99,8 +106,8 @@ class StreamsController extends ResourcesController
             'mime_type' => $this->request->contentType(),
             'contents' => $this->request->getBody(),
         ];
-        $data = $action(compact('entity', 'data'));
 
+        $data = $action(compact('entity', 'data'));
         $action = new GetEntityAction(['table' => $this->Table]);
         $data = $action(['primaryKey' => $data->get($this->Table->getPrimaryKey())]);
 

--- a/plugins/BEdita/API/src/Controller/StreamsController.php
+++ b/plugins/BEdita/API/src/Controller/StreamsController.php
@@ -106,8 +106,8 @@ class StreamsController extends ResourcesController
             'mime_type' => $this->request->contentType(),
             'contents' => $this->request->getBody(),
         ];
-
         $data = $action(compact('entity', 'data'));
+
         $action = new GetEntityAction(['table' => $this->Table]);
         $data = $action(['primaryKey' => $data->get($this->Table->getPrimaryKey())]);
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/StreamsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/StreamsControllerTest.php
@@ -16,6 +16,7 @@ namespace BEdita\API\Test\TestCase\Controller;
 use BEdita\API\TestSuite\IntegrationTestCase;
 use BEdita\Core\Filesystem\FilesystemRegistry;
 use Cake\Core\Configure;
+use Cake\Utility\Hash;
 use Cake\Validation\Validation;
 
 /**
@@ -139,18 +140,52 @@ class StreamsControllerTest extends IntegrationTestCase
     }
 
     /**
+     * Upload data provider for testUpload()
+     *
+     * @return array
+     */
+    public function uploadProvider()
+    {
+        return [
+            'javascript' => [
+                [
+                    'fileName' => 'synapse.js',
+                    'contents' => 'exports.synapse = Promise.resolve();',
+                    'contentType' => 'text/javascript',
+                ],
+            ],
+            'xml' => [
+                [
+                    'fileName' => 'gustavo.xml',
+                    'contents' => '<?xml version="1.0" encoding="utf-8"?><items><item>one</item><item>two</item></items>',
+                    'contentType' => 'text/xml',
+                ],
+            ],
+            'json' => [
+                [
+                    'fileName' => 'gustavo.json',
+                    'contents' => '{"name":"Gustavo","surname":"Supporto"}',
+                    'contentType' => 'application/json',
+                ],
+            ],
+        ];
+    }
+
+    /**
      * Test upload method.
      *
+     * @param array $data The file data.
      * @return void
      *
+     * @dataProvider uploadProvider
      * @covers ::upload()
      * @covers ::beforeFilter()
      */
-    public function testUpload()
+    public function testUpload($data)
     {
-        $fileName = 'synapse.js';
-        $contents = 'exports.synapse = Promise.resolve();';
-        $contentType = 'text/javascript';
+        $fileName = Hash::get($data, 'fileName');
+        $contents = Hash::get($data, 'contents');
+        $contentType = Hash::get($data, 'contentType');
 
         $attributes = [
             'file_name' => $fileName,
@@ -181,7 +216,7 @@ class StreamsControllerTest extends IntegrationTestCase
 
         $id = $response['data']['id'];
         $url = sprintf('http://api.example.com/streams/%s', $id);
-        $meta['url'] = sprintf('https://static.example.org/files/%s-synapse.js', $id);
+        $meta['url'] = sprintf('https://static.example.org/files/%s-%s', $id, $fileName);
         static::assertTrue(Validation::uuid($id));
         static::assertSame('streams', $response['data']['type']);
         static::assertEquals($attributes, $response['data']['attributes']);


### PR DESCRIPTION
This PR fixes an issue trying  to upload files that are XML or JSON.

For those particular content types the `RequestHandler` parses body trying to set up `Request::$data` and upload fails.

The solution was to remove the `RequestHandler` map type conf to avoid useless parsing of uploaded file.
