### PR TITLE
fix: move check and creation of cache dir when resample images

### DIFF
--- a/bedita-app/libs/be_thumb.php
+++ b/bedita-app/libs/be_thumb.php
@@ -315,7 +315,6 @@ class BeThumb {
      * Setup internal imageInfo data array
      * On error $data['error'] is populated with:
      *    - 'notFund' if image is missing or unreachable
-     *    - 'fileSys' on a local filesystem related error
      *    - 'unsupported' if image format is not supported 
      * 
      * @param array $data
@@ -354,14 +353,6 @@ class BeThumb {
 
         // #769 - avoid file access / read from cache
         $cacheData = $this->readCacheImageInfo();
-        if (empty($cacheData)) {
-            // check directory and create if not found
-            if (!$this->checkCacheDirectory()) {
-                $this->triggerError("Error creating/reading cache directory " . $this->imageInfo['cacheDirectory']);
-                $data['error'] = 'fileSys';
-                return false;
-            }
-        }
         $data = array_merge($data, $cacheData);
 
         // check mime type
@@ -727,6 +718,11 @@ class BeThumb {
 	 * @return boolean
 	 */
 	private function resample() {
+        if (!$this->checkCacheDirectory()) {
+            $this->triggerError("Error creating/reading cache directory " . $this->imageInfo['cacheDirectory']);
+
+            return false;
+        }
 
 	    $imageFilePath = $this->imageInfo['filepath'];
 	    if($this->imageInfo["remote"] && Configure::read("proxyOptions") != null) {

--- a/bedita-app/libs/be_thumb.php
+++ b/bedita-app/libs/be_thumb.php
@@ -94,11 +94,12 @@ class BeThumb {
     private $knownMimeTypes = array();
     
     /**
-     * It says if cache dir for thumbnail has been already checked and eventually created.
+     * It says if cache dir for thumbnail has been already checked and created.
+     * Its value is `null` when it hasn't evaluated yet.
      *
-     * @var boolean
+     * @var bool|null
      */
-    private $cacheDirChecked = false;
+    private $cacheDirChecked = null;
 	
 	function __construct() {
 		$this->imgMissingFile = Configure::read('imgMissingFile');
@@ -165,7 +166,7 @@ class BeThumb {
         $this->mediaRoot = Configure::read('mediaRoot');
         $this->localThumbRoot = Configure::read('localThumbRoot');
 
-        $this->cacheDirChecked = false;
+        $this->cacheDirChecked = null;
     }
 
 	/**
@@ -890,8 +891,8 @@ class BeThumb {
      * @return boolean
      */
     private function checkCacheDirectory() {
-        if ($this->cacheDirChecked === true) {
-            return true;
+        if ($this->cacheDirChecked !== null) {
+            return $this->cacheDirChecked;
         }
 
         if (file_exists($this->imageInfo['cacheDirectory'])) {


### PR DESCRIPTION
This PR fixes an issue checking and creating cache directory for thumbs.

That directory is now checked and created just when a resample is executed and when image info data is put in `.imginfo` dir.
