### PR TITLE
Fix Docker permissions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,9 @@
-.idea
-.git
-.vagrant
-.vscode
-config/app.php
-logs
-tmp
-vendor
+/.idea
+/.git
+/.vagrant
+/.vscode
+/config/app.php
+/logs
+/tmp
+/vendor
+/webroot/_files/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,40 @@
-ARG PHP_VERSION=7.1
+ARG PHP_VERSION=7.2
 FROM chialab/php:${PHP_VERSION}-apache
 MAINTAINER dev@chialab.io
 
-# Install Wait-for-it and configure PHP
-RUN curl -o /wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh \
-    && chmod +x /wait-for-it.sh \
-    && echo "[PHP]\noutput_buffering = 4096\nmemory_limit = -1" > /usr/local/etc/php/php.ini
-
-# Copy files
-COPY . /var/www/html
-
+# Default config
 ARG DEBUG
-ENV DEBUG ${DEBUG:-false}
-
-# Setup `webroot/_files` for media files
-WORKDIR /var/www/html
-VOLUME /var/www/html/webroot/_files
-
-# Install dependencies
-RUN if [ ! "$DEBUG" = "true" ]; then export COMPOSER_ARGS='--no-dev'; fi \
-    && composer install $COMPOSER_ARGS --optimize-autoloader --no-interaction
-
-# Activate headers module
-RUN a2enmod headers
-
-# Set CORS headers in .htaccess
-RUN echo "Header Set Access-Control-Allow-Origin \"*\"" >> /var/www/html/webroot/.htaccess \
-    && echo "Header Set Access-Control-Allow-Headers \"content-type, origin, x-api-key, x-requested-with, authorization\"" >> /var/www/html/webroot/.htaccess \
-    && echo "Header Set Access-Control-Allow-Methods \"PUT, GET, POST, PATCH, DELETE, OPTIONS\"" >> /var/www/html/webroot/.htaccess
-
-ENV LOG_DEBUG_URL="console:///?stream=php://stdout" \
+ENV DEBUG=${DEBUG:-false} \
+    LOG_DEBUG_URL="console:///?stream=php://stdout" \
     LOG_ERROR_URL="console:///?stream=php://stderr" \
     DATABASE_URL="sqlite:////var/www/html/bedita.sqlite"
 
+# Install Wait-for-it, copy entrypoint, configure Apache and PHP
+RUN curl -o /wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh \
+    && chmod +x /wait-for-it.sh \
+    && a2enmod headers \
+    && echo "[PHP]\noutput_buffering = 4096\nmemory_limit = -1" > /usr/local/etc/php/php.ini
 COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+
+# Copy files and set user to `www-data`
+COPY . /var/www/html
+WORKDIR /var/www/html
+RUN chown -R www-data:www-data /var/www/html
+USER www-data:www-data
+VOLUME /var/www/html/webroot/_files
+
+# Install dependencies, ensure permissions are correct, and setup permissive CORS rules
+RUN if [ ! "$DEBUG" = "true" ]; then export COMPOSER_ARGS='--no-dev'; fi \
+    && composer install $COMPOSER_ARGS --optimize-autoloader --no-interaction \
+    && chmod -R ug+rwX tmp logs webroot/_files \
+    && tee -a webroot/.htaccess < apache_cors.conf
+
+# Restore user `root` to make sure we can bind to address 0.0.0.0:80
+USER root:root
+
+# Configure healthcheck
 HEALTHCHECK --interval=30s --timeout=3s --start-period=1m \
     CMD curl -f http://localhost/status || exit 1
 
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: vendor/bin/heroku-php-apache2 -C .heroku_apache.conf webroot/
+web: vendor/bin/heroku-php-apache2 -C apache_cors.conf webroot/

--- a/apache_cors.conf
+++ b/apache_cors.conf
@@ -1,7 +1,5 @@
-
-# see Procfile for usage
-<ifmodule mod_headers.c>
+<IfModule mod_headers.c>
     Header Set Access-Control-Allow-Origin "*"
     Header Set Access-Control-Allow-Headers "content-type, origin, x-api-key, x-requested-with, authorization"
     Header Set Access-Control-Allow-Methods "PUT, GET, POST, PATCH, DELETE, OPTIONS"
-</ifmodule>
+</IfModule>

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,18 +18,15 @@ if [ ! -z "${DATABASE_URL}" ]; then
         bin/cake migrations seed -p BEdita/Core --seed AdminFromEnvSeed
     fi
 
-    chmod -R a+rwX webroot/_files
-    chown -R www-data:www-data webroot/_files
-    chmod -R a+rwX tmp
-    chmod -R a+rwX logs
-
     DATABASE_VENDOR=$(php -r "echo explode('://', getenv('DATABASE_URL'))[0];")
     echo "=====> Vendor: ${DATABASE_VENDOR}"
     if [ "$DATABASE_VENDOR" = "sqlite" ]; then
         DATABASE_PATH=$(php -r "echo substr(parse_url(preg_replace('/^([\\w\\\\\\]+)/', 'file', getenv('DATABASE_URL')), PHP_URL_PATH), 1);")
         echo "=====> Path: ${DATABASE_PATH}"
-        chmod a+rwx logs ${DATABASE_PATH}
+        chmod a+rwx ${DATABASE_PATH}
     fi
+
+    bin/cake cache clearAll
 fi
 
 exec "$@"


### PR DESCRIPTION
This PR fixes some issues with permissions in Docker containers.

This refactor ensures some directories (namely `tmp`, `logs` and `webroot/_files`) belong to `www-data`. This helps mitigating situations with BEdita not being able to write cache files or uploaded BLOBs.

Although several files and directories have their owner or permissions changed, there should be no changes in how the image is being used.

**Bonus Track**: PHP upgraded to 7.2 🙃 