### PR TITLE
Add and use mask utility

### DIFF
--- a/bedita-app/app_controller.php
+++ b/bedita-app/app_controller.php
@@ -495,7 +495,7 @@ class AppController extends Controller {
                     $msg .= ': ' . $extUserId;
                 }
                 // avoid userid in logs / use ID instead or partially hide userid
-                $this->eventWarn(sprintf('external login failed: %s******', substr($userid, 0, -3)));
+                $this->eventWarn(sprintf('external login failed: %s', Mask::email($extUserId)));
                 $this->userWarnMessage($msg);
                 $this->Session->delete('externalLoginRequestFailed');
             };

--- a/bedita-app/config/bootstrap.php
+++ b/bedita-app/config/bootstrap.php
@@ -222,3 +222,5 @@ if (!$isCli) {
 
     set_exception_handler($exceptionHandler);
 }
+
+App::import('Lib', 'Mask');

--- a/bedita-app/controllers/components/api_auth.php
+++ b/bedita-app/controllers/components/api_auth.php
@@ -166,7 +166,7 @@ class ApiAuthComponent extends Object implements ApiAuthInterface {
 
         if ($authorized === false) {
             // avoid userid in logs / use ID instead or partially hide userid
-            $this->log(sprintf('User login not authorized: %s******', substr($username, 0, -3)));
+            $this->log(sprintf('User login not authorized: %s', Mask::email($username)));
 
             return false;
         }

--- a/bedita-app/controllers/components/be_auth.php
+++ b/bedita-app/controllers/components/be_auth.php
@@ -569,7 +569,7 @@ class BeAuthComponent extends Object {
         $u = $user->findByUserid($userData['User']['userid']);
         if (!empty($u['User'])) {
             // avoid userid in logs / use ID instead or partially hide userid
-            $this->log(sprintf('User %s****** already created', substr($userData['User']['userid'], 0, -3)));
+            $this->log(sprintf('User %s already created', Mask::email($userData['User']['userid'])));
 
             throw new BeditaException(__('User already created', true));
         }

--- a/bedita-app/libs/mask.php
+++ b/bedita-app/libs/mask.php
@@ -1,0 +1,68 @@
+<?php
+/*-----8<--------------------------------------------------------------------
+ *
+ * BEdita - a semantic content management framework
+ *
+ * Copyright 2019 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * BEdita is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * version 3 along with BEdita (see LICENSE.LGPL).
+ * If not, see <http://gnu.org/licenses/lgpl-3.0.html>.
+ *
+ *------------------------------------------------------------------->8-----
+ */
+
+/**
+ * Utility to mask sensitive data.
+ */
+class Mask {
+
+    /**
+     * Completely mask a value.
+     *
+     * @param string $value Value to mask.
+     * @param int $maxUnmaskedChars Keep at most N characters unmasked.
+     * @return string
+     */
+    public static function hide($value, $maxUnmaskedChars = 0) {
+        if (!is_string($value)) {
+            return $value;
+        }
+
+        $len = mb_strlen($value);
+        $maxUnmaskedChars = min($maxUnmaskedChars, $len - 1);
+
+        return mb_substr($value, 0, $maxUnmaskedChars) . str_repeat('*', $len - $maxUnmaskedChars);
+    }
+
+    /**
+     * Mask email.
+     *
+     * @param string $email Value to mask.
+     * @param int $userMaxUnmaskedChars Keep at most N characters unmasked for the username.
+     * @param bool $maskDomain Set to `true` to mask domain part.
+     * @return string
+     */
+    public static function email($email, $userMaxUnmaskedChars = 3, $maskDomain = false)
+    {
+        if (!is_string($email) || filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+            return $email;
+        }
+
+        list($user, $domain) = explode('@', $email, 2);
+
+        $user = static::hide($user, $userMaxUnmaskedChars);
+        if ($maskDomain) {
+            $domain = static::hide($domain);
+        }
+
+        return implode('@', array($user, $domain));
+    }
+}


### PR DESCRIPTION
This PR improves the anonymization of email addresses in logs.

Right now, emails are anonymized by just masking the last three characters. However, due to how an email address is built, the last three characters are the least-significant ones:

- `alice@example.com` would be "masked" as `alice@example.******`
- `bob@example.net` would be "masked" as `bob@example.******`

This PR introduces a `Mask` utility class that helps masking email addresses and make them less- or un-guessable:

- `alice@example.com` is masked as `ali**@example.com`
- `bob@example.com` is masked as `bo*@example.com`

However, the helper library can be configured to mask more characters or to mask the domain part as well (`ali**@***********`).