### PR TITLE
 #1045 fix: allow user auth if APIs are protected

### DIFF
--- a/bedita-app/controllers/api_base_controller.php
+++ b/bedita-app/controllers/api_base_controller.php
@@ -472,7 +472,16 @@ abstract class ApiBaseController extends FrontendController {
     protected function checkLogin() {
         if ($this->ApiAuth->identify()) {
             $this->logged = true;
-        } elseif (Configure::read('api.protected')) {
+
+            return;
+        }
+
+        // allow POST /auth also with `api.protected === true`
+        if ($this->params['url']['url'] === 'auth' && $this->requestMethod === 'post') {
+            return;
+        }
+
+        if (Configure::read('api.protected')) {
             throw new BeditaUnauthorizedException();
         }
     }


### PR DESCRIPTION
This PR fixes #1045 allowing to perform API authentication also when APIs are in protected mode.

Previously no auth was allowed and API always respond with `401 Unauthorized`.
