### PR TITLE
Auth operations on blocked/deleted user

### DIFF
--- a/plugins/BEdita/API/src/Auth/JwtAuthenticate.php
+++ b/plugins/BEdita/API/src/Auth/JwtAuthenticate.php
@@ -81,7 +81,7 @@ class JwtAuthenticate extends BaseAuthenticate
         ],
         'userModel' => 'Users',
         'scope' => [],
-        'finder' => 'all',
+        'finder' => 'login',
         'contain' => null,
         'passwordHasher' => 'Default',
         'queryDatasource' => false,

--- a/plugins/BEdita/API/src/Auth/OTPAuthenticate.php
+++ b/plugins/BEdita/API/src/Auth/OTPAuthenticate.php
@@ -60,7 +60,7 @@ class OTPAuthenticate extends BaseAuthenticate
             'password' => null,
         ],
         'userModel' => 'Users',
-        'finder' => 'all',
+        'finder' => 'login',
         'contain' => null,
         'passwordHasher' => 'Default',
         'expiry' => '+15 minutes',

--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -262,7 +262,7 @@ class LoginController extends AppController
      * Read logged user entity including roles and other related objects via `include` query string.
      *
      * @return \BEdita\Core\Model\Entity\User Logged user entity
-     * @throws \Cake\Network\Exception\UnauthorizedException Throws an exception if user not logged.
+     * @throws \Cake\Network\Exception\UnauthorizedException Throws an exception if user not logged or blocked/removed
      */
     protected function userEntity()
     {
@@ -272,8 +272,14 @@ class LoginController extends AppController
         }
         $contain = $this->prepareInclude($this->request->getQuery('include'));
         $contain = array_unique(array_merge($contain, ['Roles']));
+        $conditions = ['id' => $userId];
 
-        return TableRegistry::get('Users')->get($userId, compact('contain'));
+        $result = TableRegistry::get('Users')->find('login', compact('conditions', 'contain'));
+        if (empty($result)) {
+            throw new UnauthorizedException(__('Request not authorized'));
+        }
+
+        return $result->first();
     }
 
     /**

--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -274,12 +274,14 @@ class LoginController extends AppController
         $contain = array_unique(array_merge($contain, ['Roles']));
         $conditions = ['id' => $userId];
 
-        $result = TableRegistry::get('Users')->find('login', compact('conditions', 'contain'));
-        if (empty($result) || $result->count() !== 1) {
+        $user = TableRegistry::get('Users')
+            ->find('login', compact('conditions', 'contain'))
+            ->first();
+        if (empty($user)) {
             throw new UnauthorizedException(__('Request not authorized'));
         }
 
-        return $result->first();
+        return $user;
     }
 
     /**

--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -275,7 +275,7 @@ class LoginController extends AppController
         $conditions = ['id' => $userId];
 
         $result = TableRegistry::get('Users')->find('login', compact('conditions', 'contain'));
-        if (empty($result) || empty($result->first())) {
+        if (empty($result) || $result->count() !== 1) {
             throw new UnauthorizedException(__('Request not authorized'));
         }
 

--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -275,7 +275,7 @@ class LoginController extends AppController
         $conditions = ['id' => $userId];
 
         $result = TableRegistry::get('Users')->find('login', compact('conditions', 'contain'));
-        if (empty($result)) {
+        if (empty($result) || empty($result->first())) {
             throw new UnauthorizedException(__('Request not authorized'));
         }
 

--- a/plugins/BEdita/API/tests/TestCase/Auth/JwtAuthenticateTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/JwtAuthenticateTest.php
@@ -183,6 +183,7 @@ class JwtAuthenticateTest extends TestCase
                 ],
                 [
                     'userModel' => 'BEdita/API.Users',
+                    'finder' => 'all',
                     'queryDatasource' => true,
                 ],
                 new ServerRequest([
@@ -257,6 +258,7 @@ class JwtAuthenticateTest extends TestCase
             $result = $auth->authenticate($request, new Response());
         } catch (\Exception $e) {
             $result = $e;
+            static::assertInstanceOf('Exception', $expected);
             static::assertEquals($expected->getAttributes(), $e->getAttributes());
             static::assertEquals($expected->getCode(), $e->getCode());
         }


### PR DESCRIPTION
This PR fixes some problems on `/auth` actions when a user is `blocked` or `deleted` (trashcan).

Currently only classic `POST /auth` via username / password fails in this use case.
Other actions MUST fail, namely:

* `auth` renew
* `GET /auth/user`
* `OTP` request and access
