### PR TITLE
Relations and Properties utilities

### DIFF
--- a/plugins/BEdita/Core/src/Utility/Properties.php
+++ b/plugins/BEdita/Core/src/Utility/Properties.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2019 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Utility;
+
+use Cake\ORM\TableRegistry;
+use Cake\Utility\Inflector;
+
+/**
+ * Utility class to handle properties in migrations, shell scripts and other scenarios
+ *
+ * Provides static methods to create and remove properties using an array format
+ *
+ * Example:
+ *   [
+ *     [
+ *       'name' => 'custom_one',
+ *       'object' => 'documents',
+ *       'property' => 'boolean',
+ *       'description' => 'my custom description', // optional
+ *     ],
+ *     [
+ *       'name' => 'custom_two',
+ *       'object' => 'documents',
+ *       'property' => 'string',
+ *     ],
+ *   ]
+ */
+class Properties
+{
+    /**
+     * Create new properties in `properties` table using input `$properties` array
+     *
+     * @param array $properties Properties data
+     * @param array $options Table locator options
+     * @return void
+     */
+    public static function create(array $properties, array $options = []) : void
+    {
+        $Properties = TableRegistry::getTableLocator()->get('Properties', $options);
+
+        foreach ($properties as $p) {
+            $property = $Properties->newEntity([
+                'name' => $p['name'],
+                'property_type_name' => $p['property'],
+                'object_type_name' => $p['object'],
+            ]);
+
+            $Properties->saveOrFail($property);
+        }
+    }
+
+    /**
+     * Remove properties from `properties` table using `$properties` array
+     *
+     * @param array $properties Properties data
+     * @param array $options Table locator options
+     * @return void
+     */
+    public static function remove(array $properties, array $options = []) : void
+    {
+        $Properties = TableRegistry::getTableLocator()->get('Properties', $options);
+        $ObjectTypes = TableRegistry::getTableLocator()->get('ObjectTypes', $options);
+
+        foreach ($properties as $p) {
+            $objectType = $ObjectTypes->get(Inflector::camelize($p['object']));
+
+            $property = $Properties->find()
+                ->where([
+                    'name' => $p['name'],
+                    'object_type_id' => $objectType->get('id'),
+                ])
+                ->firstOrFail();
+
+            $Properties->deleteOrFail($property);
+        }
+    }
+}

--- a/plugins/BEdita/Core/src/Utility/Relations.php
+++ b/plugins/BEdita/Core/src/Utility/Relations.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2019 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Utility;
+
+use Cake\ORM\TableRegistry;
+use Cake\Utility\Inflector;
+
+/**
+ * Utility class to handle relations in migrations, shell scripts and other scenarios
+ *
+ * Provides static methods to create and remove relations using an array format
+ *
+ * Example:
+ *   [
+ *     [
+ *      'name' => 'poster',
+ *      'label' => 'Poster',
+ *      'inverse_name' => 'poster_of',
+ *      'inverse_label' => 'Poster of',
+ *      'description' => 'Document or event has a poster image',
+ *      'params' => '{...}', // optional JSON SCHEMA definition
+ *      'left' => ['documents', 'events'],
+ *      'right' => ['images'],
+ *     ],
+ *    ]
+ */
+class Relations
+{
+    /**
+     * Create new relations in `relations` table using input `$relations` array
+     *
+     * @param array $relations Relation data
+     * @param array $options Table locator options
+     * @return void
+     */
+    public static function create(array $relations, array $options = []) : void
+    {
+        $Relations = TableRegistry::getTableLocator()->get('Relations', $options);
+        foreach ($relations as $data) {
+            $relation = $Relations->newEntity($data);
+            $relation = $Relations->saveOrFail($relation);
+
+            static::addTypes($relation->get('id'), $data['left'], 'left', $options);
+            static::addTypes($relation->get('id'), $data['right'], 'right', $options);
+        }
+    }
+
+    /**
+     * Add relation types to relation
+     *
+     * @param string|int $relationId Relation id
+     * @param array $types Object type names
+     * @param string $side Relation side, 'left' or 'right'
+     * @param array $options Table locator options
+     * @return void
+     */
+    protected static function addTypes($relationId, array $types, string $side, array $options = []) : void
+    {
+        $RelationTypes = TableRegistry::getTableLocator()->get('RelationTypes', $options);
+        $ObjectTypes = TableRegistry::getTableLocator()->get('ObjectTypes', $options);
+
+        foreach ($types as $name) {
+            $objectType = $ObjectTypes->get(Inflector::camelize($name));
+
+            $entity = $RelationTypes->newEntity([
+                'relation_id' => $relationId,
+                'object_type_id' => $objectType->get('id'),
+                'side' => $side,
+            ]);
+            $RelationTypes->saveOrFail($entity);
+        }
+    }
+
+    /**
+     * Remove relations from `relations` table using `$this->relations` array
+     *
+     * @param array $relations Relation data
+     * @param array $options Table locator options
+     * @return void
+     */
+    public static function remove(array $relations, array $options = []) : void
+    {
+        $Relations = TableRegistry::getTableLocator()->get('Relations', $options);
+        foreach ($relations as $r) {
+            $relation = $Relations->find()
+                ->where(['name' => $r['name']])
+                ->firstOrFail();
+
+            static::removeTypes($relation->get('id'), $r['left'], 'left', $options);
+            static::removeTypes($relation->get('id'), $r['right'], 'right', $options);
+
+            $Relations->deleteOrFail($relation);
+        }
+    }
+
+    /**
+     * Remove relation types from relation
+     *
+     * @param string|int $relationId Relation id
+     * @param array $types Object type names
+     * @param string $side Relation side, 'left' or 'right'
+     * @param array $options Table locator options
+     * @return void
+     */
+    protected static function removeTypes($relationId, array $types, string $side, array $options = []) : void
+    {
+        $RelationTypes = TableRegistry::getTableLocator()->get('RelationTypes', $options);
+        $ObjectTypes = TableRegistry::getTableLocator()->get('ObjectTypes', $options);
+
+        foreach ($types as $name) {
+            $objectType = $ObjectTypes->get(Inflector::camelize($name));
+
+            $relationType = $RelationTypes->find()
+                ->where([
+                    'relation_id' => $relationId,
+                    'object_type_id' => $objectType->get('id'),
+                    'side' => $side,
+                ])
+                ->firstOrFail();
+
+            $RelationTypes->deleteOrFail($relationType);
+        }
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Utility/PropertiesTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/PropertiesTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2019 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Utility;
+
+use BEdita\Core\Utility\Properties;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\Core\Utility\Properties} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Utility\Properties
+ */
+class PropertiesTest extends TestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.property_types',
+        'plugin.BEdita/Core.properties',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
+    ];
+
+    /**
+     * Test properties
+     *
+     * @return array
+     */
+    protected $properties = [
+        [
+            'name' => 'custom_one',
+            'object' => 'documents',
+            'property' => 'boolean',
+            'description' => 'my custom description',
+        ],
+        [
+            'name' => 'custom_two',
+            'object' => 'documents',
+            'property' => 'string',
+        ],
+    ];
+
+    /**
+     * Test `create` method.
+     *
+     * @covers ::create()
+     */
+    public function testCreate()
+    {
+        Properties::create($this->properties);
+
+        $newProperties = TableRegistry::getTableLocator()->get('Properties')
+            ->find()
+            ->where(['name IN' => ['custom_one', 'custom_two']])
+            ->toArray();
+        static::assertEquals(2, count($newProperties));
+    }
+
+    /**
+     * Test `remove` method.
+     *
+     * @covers ::remove()
+     */
+    public function testRemove()
+    {
+        Properties::create($this->properties);
+
+        Properties::remove($this->properties);
+        $newProperties = TableRegistry::getTableLocator()->get('Properties')
+            ->find()
+            ->where(['name IN' => ['custom_one', 'custom_two']])
+            ->toArray();
+        static::assertEquals(0, count($newProperties));
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Utility/PropertiesTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/PropertiesTest.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Test\TestCase\Utility;
 
 use BEdita\Core\Utility\Properties;
+use Cake\Network\Exception\BadRequestException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -60,6 +61,7 @@ class PropertiesTest extends TestCase
      * Test `create` method.
      *
      * @covers ::create()
+     * @covers ::validate()
      */
     public function testCreate()
     {
@@ -87,5 +89,19 @@ class PropertiesTest extends TestCase
             ->where(['name IN' => ['custom_one', 'custom_two']])
             ->toArray();
         static::assertEquals(0, count($newProperties));
+    }
+
+    /**
+     * Test `validate` failure.
+     *
+     * @covers ::validate()
+     */
+    public function testValidate()
+    {
+        static::expectException(BadRequestException::class);
+        static::expectExceptionMessage('Missing mandatory property data "name"');
+
+        unset($this->properties[0]['name']);
+        Properties::create($this->properties);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Utility/RelationsTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/RelationsTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2019 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Utility;
+
+use BEdita\Core\Utility\Relations;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\Core\Utility\Relations} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Utility\Relations
+ */
+class RelationsTest extends TestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.object_types',
+        'plugin.BEdita/Core.relations',
+        'plugin.BEdita/Core.relation_types',
+    ];
+
+    /**
+     * Test relations
+     *
+     * @return array
+     */
+    protected $relations = [
+        [
+            'name' => 'poster',
+            'label' => 'Poster',
+            'inverse_name' => 'poster_of',
+            'inverse_label' => 'Poster of',
+            'description' => 'Document or event has a poster file',
+            'left' => ['documents', 'events'],
+            'right' => ['files'],
+        ]
+    ];
+
+    /**
+     * Test `create` method.
+     *
+     * @covers ::create()
+     * @covers ::addTypes()
+     */
+    public function testCreate()
+    {
+        Relations::create($this->relations);
+
+        $allRelations = TableRegistry::getTableLocator()->get('Relations')->find()->toArray();
+        static::assertEquals(4, count($allRelations));
+        static::assertEquals('poster', $allRelations[3]['name']);
+    }
+
+    /**
+     * Test `remove` method.
+     *
+     * @covers ::remove()
+     * @covers ::removeTypes()
+     */
+    public function testRemove()
+    {
+        Relations::create($this->relations);
+
+        Relations::remove($this->relations);
+        $allRelations = TableRegistry::getTableLocator()->get('Relations')->find()->toArray();
+        static::assertEquals(3, count($allRelations));
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Utility/RelationsTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/RelationsTest.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Test\TestCase\Utility;
 
 use BEdita\Core\Utility\Relations;
+use Cake\Network\Exception\BadRequestException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -56,6 +57,7 @@ class RelationsTest extends TestCase
      * Test `create` method.
      *
      * @covers ::create()
+     * @covers ::validate()
      * @covers ::addTypes()
      */
     public function testCreate()
@@ -80,5 +82,19 @@ class RelationsTest extends TestCase
         Relations::remove($this->relations);
         $allRelations = TableRegistry::getTableLocator()->get('Relations')->find()->toArray();
         static::assertEquals(3, count($allRelations));
+    }
+
+    /**
+     * Test `validate` failure.
+     *
+     * @covers ::validate()
+     */
+    public function testValidate()
+    {
+        static::expectException(BadRequestException::class);
+        static::expectExceptionMessage('Missing left/right relation types');
+
+        unset($this->relations[0]['left']);
+        Relations::create($this->relations);
     }
 }


### PR DESCRIPTION
This PR adds simple utility classes to be added in migrations, shell scripts and other scenarios to easily handle `relations` and custom `properties` creation.

Migration use case:

 * define a `$relations` array like:
```
    protected $relations = [
        [
            // docs_media (media_of_doc): documents / media
            'name' => 'docs_media',
            'label' => 'Docs media',
            'inverse_name' => 'media_of_docs',
            'inverse_label' => 'Media of Docs',
            'description' => 'docs having media',
            'left' => ['documents'],
            'right' => ['media'],
        ],
    ];
```
Then a simple call like
```
        Relations::create(
            $this->relations,
            ['connection' => $this->getAdapter()->getCakeConnection()]
        );
```
will create the relations using migration transaction
