### PR TITLE
Introduce custom error handler

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -29,6 +29,7 @@ require __DIR__ . '/paths.php';
  */
 require CORE_PATH . 'config' . DS . 'bootstrap.php';
 
+use BEdita\API\Error\ErrorHandler;
 use BEdita\Core\Filesystem\FilesystemRegistry;
 use Cake\Cache\Cache;
 use Cake\Console\ConsoleErrorHandler;
@@ -36,7 +37,6 @@ use Cake\Core\Configure;
 use Cake\Core\Configure\Engine\JsonConfig;
 use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Datasource\ConnectionManager;
-use Cake\Error\ErrorHandler;
 use Cake\Http\ServerRequest;
 use Cake\Log\Log;
 use Cake\Mailer\Email;

--- a/plugins/BEdita/API/src/Error/ErrorHandler.php
+++ b/plugins/BEdita/API/src/Error/ErrorHandler.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2019 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\API\Error;
+
+use Cake\Error\ErrorHandler as CakeErrorHandler;
+use Cake\Utility\Hash;
+
+class ErrorHandler extends CakeErrorHandler
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function _displayError($error, $debug)
+    {
+        if (!$debug) {
+            return;
+        }
+        $msg = Hash::get($error, 'error');
+        $code = Hash::get($error, 'code');
+        $description = Hash::get($error, 'description');
+        throw new \LogicException(sprintf('%s [%s] %s', $msg, $code, $description));
+    }
+}

--- a/plugins/BEdita/API/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Error/ErrorHandlerTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2019 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\API\Test\TestCase\Error;
+
+use BEdita\API\Error\ErrorHandler;
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+
+/**
+ * @coversDefaultClass \BEdita\API\Error\ErrorHandler
+ */
+class ErrorHandlerTest extends TestCase
+{
+
+    /**
+     * Data provider for `testDisplayError` test case.
+     *
+     * @return array
+     */
+    public function displayErrorProvider()
+    {
+        return [
+            'simple' => [
+                new \LogicException(' [8192] Very bad coder!'),
+                8192,
+                'Very bad coder!',
+                true,
+            ],
+            'debug' => [
+                true,
+                1024,
+                'Error',
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * Test `_displayError` method
+     *
+     * @dataProvider displayErrorProvider
+     * @covers ::_displayError()
+     * @return void
+     */
+    public function testDisplayError($expected, $code, $description, $debug)
+    {
+        if ($expected instanceof \Exception) {
+            $this->expectException(get_class($expected));
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+        $current = Configure::read('debug');
+
+        Configure::write('debug', $debug);
+
+        $handler = new ErrorHandler();
+        $result = $handler->handleError($code, $description);
+        static::assertSame($expected, $result);
+
+        Configure::write('debug', $current);
+    }
+}


### PR DESCRIPTION
This PR adds a custom error handler to avoid HTML response on trigger_error().
A specific `\LogicException` is thrown in this case.

