### PR TITLE
fix: allow missing `Bake` plugin w --no-dev

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -55,9 +55,10 @@ class Application extends BaseApplication
     {
         $this->addPlugin('Migrations');
         try {
-            // allow missing `bake` plugin in no-dev environment
             $this->addPlugin('Bake');
         } catch (MissingPluginException $e) {
+            // intentionally empty catch block
+            // allow missing `bake` plugin in no-dev environment
         }
     }
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -15,6 +15,7 @@
 namespace BEdita\App;
 
 use Cake\Core\Configure;
+use Cake\Core\Exception\MissingPluginException;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
 use Cake\Http\BaseApplication;
 use Cake\Routing\Middleware\AssetMiddleware;
@@ -52,8 +53,12 @@ class Application extends BaseApplication
      */
     protected function bootstrapCli()
     {
-        $this->addPlugin('Bake');
         $this->addPlugin('Migrations');
+        try {
+            // allow missing `bake` plugin in no-dev environment
+            $this->addPlugin('Bake');
+        } catch (MissingPluginException $e) {
+        }
     }
 
     /**


### PR DESCRIPTION
This PR a systematic CLI error after composer install with `--no-dev`

Currently an error is displayed:

```Exception: Plugin Bake could not be found.```

But `Bake` plugin is in composer `require-dev` section.