### PR TITLE
Avoid migrations transaction error on SQlite

### DIFF
--- a/plugins/BEdita/Core/config/Migrations/20171005105447_ObjectTypesInheritance.php
+++ b/plugins/BEdita/Core/config/Migrations/20171005105447_ObjectTypesInheritance.php
@@ -143,7 +143,7 @@ class ObjectTypesInheritance extends AbstractMigration
         ]);
         /* @var \BEdita\Core\Model\Behavior\TreeBehavior $tree */
         $tree = $table->behaviors()->get('Tree');
-        $tree->recover(false);
+        $tree->nonAtomicRecover();
     }
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20171005105447_ObjectTypesInheritance.php
+++ b/plugins/BEdita/Core/config/Migrations/20171005105447_ObjectTypesInheritance.php
@@ -137,13 +137,13 @@ class ObjectTypesInheritance extends AbstractMigration
         );
 
         // Now let's fix NSM (nested-set model) left and right indexes from tree data.
-        $table->addBehavior('Tree', [
+        $table->addBehavior('BEdita/Core.Tree', [
             'left' => 'tree_left',
             'right' => 'tree_right',
         ]);
-        /* @var \Cake\ORM\Behavior\TreeBehavior $tree */
+        /* @var \BEdita\Core\Model\Behavior\TreeBehavior $tree */
         $tree = $table->behaviors()->get('Tree');
-        $tree->recover();
+        $tree->recover(false);
     }
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20171030185447_MediaTypesInheritance.php
+++ b/plugins/BEdita/Core/config/Migrations/20171030185447_MediaTypesInheritance.php
@@ -32,13 +32,13 @@ class MediaTypesInheritance extends AbstractMigration
         );
 
         // Now let's fix NSM (nested-set model) left and right indexes from tree data.
-        $table->addBehavior('Tree', [
+        $table->addBehavior('BEdita/Core.Tree', [
             'left' => 'tree_left',
             'right' => 'tree_right',
         ]);
-        /* @var \Cake\ORM\Behavior\TreeBehavior $tree */
+        /* @var \BEdita\Core\Model\Behavior\TreeBehavior $tree */
         $tree = $table->behaviors()->get('Tree');
-        $tree->recover();
+        $tree->recover(false);
     }
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20171030185447_MediaTypesInheritance.php
+++ b/plugins/BEdita/Core/config/Migrations/20171030185447_MediaTypesInheritance.php
@@ -38,7 +38,7 @@ class MediaTypesInheritance extends AbstractMigration
         ]);
         /* @var \BEdita\Core\Model\Behavior\TreeBehavior $tree */
         $tree = $table->behaviors()->get('Tree');
-        $tree->recover(false);
+        $tree->nonAtomicRecover();
     }
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20171031155829_UsersInheritance.php
+++ b/plugins/BEdita/Core/config/Migrations/20171031155829_UsersInheritance.php
@@ -29,13 +29,13 @@ class UsersInheritance extends AbstractMigration
         );
 
         // Now let's fix NSM (nested-set model) left and right indexes from tree data.
-        $table->addBehavior('Tree', [
+        $table->addBehavior('BEdita/Core.Tree', [
             'left' => 'tree_left',
             'right' => 'tree_right',
         ]);
-        /* @var \Cake\ORM\Behavior\TreeBehavior $tree */
+        /* @var \BEdita\Core\Model\Behavior\TreeBehavior $tree */
         $tree = $table->behaviors()->get('Tree');
-        $tree->recover();
+        $tree->recover(false);
     }
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20171031155829_UsersInheritance.php
+++ b/plugins/BEdita/Core/config/Migrations/20171031155829_UsersInheritance.php
@@ -35,7 +35,7 @@ class UsersInheritance extends AbstractMigration
         ]);
         /* @var \BEdita\Core\Model\Behavior\TreeBehavior $tree */
         $tree = $table->behaviors()->get('Tree');
-        $tree->recover(false);
+        $tree->nonAtomicRecover();
     }
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20180131171902_FoldersType.php
+++ b/plugins/BEdita/Core/config/Migrations/20180131171902_FoldersType.php
@@ -50,13 +50,13 @@ class FoldersType extends AbstractMigration
             'connection' => $adapter->getCakeConnection(),
         ]);
         // Now let's fix NSM (nested-set model) left and right indexes from tree data.
-        $table->addBehavior('Tree', [
+        $table->addBehavior('BEdita/Core.Tree', [
             'left' => 'tree_left',
             'right' => 'tree_right',
         ]);
-        /* @var \Cake\ORM\Behavior\TreeBehavior $tree */
+        /* @var \BEdita\Core\Model\Behavior\TreeBehavior $tree */
         $tree = $table->behaviors()->get('Tree');
-        $tree->recover();
+        $tree->recover(false);
     }
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20180131171902_FoldersType.php
+++ b/plugins/BEdita/Core/config/Migrations/20180131171902_FoldersType.php
@@ -56,7 +56,7 @@ class FoldersType extends AbstractMigration
         ]);
         /* @var \BEdita\Core\Model\Behavior\TreeBehavior $tree */
         $tree = $table->behaviors()->get('Tree');
-        $tree->recover(false);
+        $tree->nonAtomicRecover();
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
@@ -146,4 +146,20 @@ class TreeBehavior extends CakeTreeBehavior
 
         return $position;
     }
+
+    /**
+     * Calls $this->_recoverTree() without transactional(...)
+     *
+     * @param $transactional Execute recover action inside a transaction (default true)
+     * @return void
+     * @codeCoverageIgnore
+     */
+    public function recover($transactional = true)
+    {
+        if ($transactional) {
+            return parent::recover();
+        }
+
+        $this->_recover();
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
@@ -160,6 +160,6 @@ class TreeBehavior extends CakeTreeBehavior
             return parent::recover();
         }
 
-        $this->_recover();
+        $this->_recoverTree();
     }
 }

--- a/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
@@ -150,14 +150,16 @@ class TreeBehavior extends CakeTreeBehavior
     /**
      * Calls $this->_recoverTree() without transactional(...)
      *
-     * @param $transactional Execute recover action inside a transaction (default true)
+     * @param bool $transactional Execute recover action inside a transaction (default true)
      * @return void
      * @codeCoverageIgnore
      */
     public function recover($transactional = true)
     {
         if ($transactional) {
-            return parent::recover();
+            parent::recover();
+
+            return;
         }
 
         $this->_recoverTree();

--- a/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
@@ -149,19 +149,13 @@ class TreeBehavior extends CakeTreeBehavior
 
     /**
      * Calls $this->_recoverTree() without transactional(...)
+     * Warning: you should set up a transactional flow manually if you use this method!
      *
-     * @param bool $transactional Execute recover action inside a transaction (default true)
      * @return void
      * @codeCoverageIgnore
      */
-    public function recover($transactional = true)
+    public function nonAtomicRecover() : void
     {
-        if ($transactional) {
-            parent::recover();
-
-            return;
-        }
-
         $this->_recoverTree();
     }
 }


### PR DESCRIPTION
This PR fixes a problem on migrations with SQlite.

(Subsitutes previous PR #1630)

Launching migrations on an empy SQlite db we get an error like:
```
 == 20171005105447 ObjectTypesInheritance: migrating
PDOException: There is no active transaction in /var/www/bedita4/vendor/robmorgan/phinx/src/Phinx/Db/Adapter/SQLiteAdapter.php:216
Stack trace:
#0 /var/www/bedita4/vendor/robmorgan/phinx/src/Phinx/Db/Adapter/SQLiteAdapter.php(216): PDO->commit()
#1 /var/www/bedita4/vendor/robmorgan/phinx/src/Phinx/Db/Adapter/AdapterWrapper.php(329): Phinx\Db\Adapter\SQLiteAdapter->commitTransaction()
#2 /var/www/bedita4/vendor/robmorgan/phinx/src/Phinx/Db/Adapter/AdapterWrapper.php(329): Phinx\Db\Adapter\AdapterWrapper->commitTransaction()
#3 /var/www/bedita4/vendor/robmorgan/phinx/src/Phinx/Migration/Manager/Environment.php(133): Phinx\Db\Adapter\AdapterWrapper->commitTransaction()
```

This is caused by a `PDO->commit()` call where a previous `commit()` has already been called from `TreeBehavior::recover()`

Current solution is to override `recover` with an option to avoid `transactional(...)` callback


