### PR TITLE
feat: add provider thumbs to /thumbs

### DIFF
--- a/plugins/BEdita/API/src/Controller/MediaController.php
+++ b/plugins/BEdita/API/src/Controller/MediaController.php
@@ -77,6 +77,9 @@ class MediaController extends ObjectsController
      */
     protected function getAvailableIds(array $ids) : array
     {
+        if (empty($ids)) {
+            return $ids;
+        }
         $available = $this->Table->find('available')
             ->where(['id IN' => $ids])
             ->select(['id'])
@@ -131,8 +134,7 @@ class MediaController extends ObjectsController
      */
     protected function fetchProviderThumbs(array $ids, array &$thumbnails) : void
     {
-        $thumbItems = Hash::combine($thumbnails, '{n}.id', '{n}.*');
-        $mediaIds = array_keys(array_diff_key(array_flip($ids), $thumbItems));
+        $mediaIds = array_diff($ids, Hash::extract($thumbnails, '{n}.id'));
         if (empty($mediaIds)) {
             return;
         }

--- a/plugins/BEdita/API/src/Controller/MediaController.php
+++ b/plugins/BEdita/API/src/Controller/MediaController.php
@@ -134,7 +134,7 @@ class MediaController extends ObjectsController
      */
     protected function fetchProviderThumbs(array $ids, array &$thumbnails) : void
     {
-        $mediaIds = array_diff($ids, Hash::extract($thumbnails, '{n}.id'));
+        $mediaIds = array_diff($ids, (array)Hash::extract($thumbnails, '{n}.id'));
         if (empty($mediaIds)) {
             return;
         }

--- a/plugins/BEdita/API/src/Controller/MediaController.php
+++ b/plugins/BEdita/API/src/Controller/MediaController.php
@@ -66,7 +66,23 @@ class MediaController extends ObjectsController
             throw new BadRequestException(__d('bedita', 'Cannot generate thumbnails for more than {0} media at once', $maxLimit));
         }
 
-        return $ids;
+        return $this->getAvailableIds($ids);
+    }
+
+    /**
+     * Retrieve actual available IDs checking `status` and `deleted`
+     *
+     * @param array $ids Object ids array
+     * @return array
+     */
+    protected function getAvailableIds(array $ids) : array
+    {
+        $available = $this->Table->find('available')
+            ->where(['id IN' => $ids])
+            ->select(['id'])
+            ->toArray();
+
+        return (array)Hash::extract($available, '{n}.id');
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/MediaControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/MediaControllerTest.php
@@ -297,6 +297,45 @@ class MediaControllerTest extends IntegrationTestCase
     }
 
     /**
+     * Test available IDs.
+     *
+     * @return void
+     *
+     * @covers ::getAvailableIds()
+     */
+    public function testAvailableIds()
+    {
+        $data = [
+            'id' => '10',
+            'type' => 'files',
+            'attributes' => [
+                'status' => 'off',
+            ],
+        ];
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $this->patch('/files/10', json_encode(compact('data')));
+        $this->assertResponseCode(200);
+
+        Configure::write('Status.level', 'on');
+
+        $this->configRequestHeaders('GET');
+        $this->get('/media/thumbs?ids=10,14');
+
+        $body = json_decode((string)$this->_response->getBody(), true);
+        $this->assertResponseCode(200);
+        $thumbnails = Hash::get((array)$body, 'meta.thumbnails');
+        $expected = [
+            [
+                'id' => 14,
+                'uuid' => '6aceb0eb-bd30-4f60-ac74-273083b921b6',
+                'ready' => false,
+                'url' => 'https://static.example.org/thumbs/6aceb0eb-bd30-4f60-ac74-273083b921b6-bedita-logo-gray.gif/ef5b382f91ad45aff0e33b89e6677df31fcf6034.gif',
+            ],
+        ];
+        static::assertEquals($expected, $thumbnails);
+    }
+
+    /**
      * Test `thumbs` method with provider thumbnails.
      *
      * @return void

--- a/plugins/BEdita/API/tests/TestCase/Controller/MediaControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/MediaControllerTest.php
@@ -285,6 +285,7 @@ class MediaControllerTest extends IntegrationTestCase
      *
      * @covers ::thumbs()
      * @covers ::getIds()
+     * @covers ::getAvailableIds()
      */
     public function testThumbsNoIds()
     {

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -389,4 +389,21 @@ class ObjectsTable extends Table
             return $query->where(['Translations.lang' => $options['lang']]);
         });
     }
+
+    /**
+     * Finder for available objects based on these rules:
+     *  - `status` should be acceptable (=> via `findStatusLevel`)
+     *  - `deleted` should be 0
+     *
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @return \Cake\ORM\Query
+     */
+    protected function findAvailable(Query $query)
+    {
+        if (Configure::check('Status.level')) {
+            $query = $query->find('statusLevel', [Configure::read('Status.level')]);
+        }
+
+        return $query->where(['deleted' => 0]);
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -625,4 +625,43 @@ class ObjectsTableTest extends TestCase
         static::assertSame(1, count($result));
         static::assertSame(2, $result[0]['id']);
     }
+
+    /**
+     * Data provider for `testFindAvailable`.
+     *
+     * @return array
+     */
+    public function findAvailableProvider()
+    {
+        return [
+            'no status' => [
+                12,
+                ['id > 0']
+            ],
+            'status on' => [
+                7,
+                ['id > 5'],
+                'on',
+            ],
+        ];
+    }
+
+    /**
+     * Test `findAvailable()`.
+     *
+     * @return void
+     *
+     * @dataProvider findAvailableProvider()
+     * @covers ::findAvailable()
+     */
+    public function testFindAvailable(int $expected, array $condition, string $statusLevel = null)
+    {
+        $result = $this->Objects->find('available')
+            ->where($condition)
+            ->toArray();
+        if (!empty($statusLevel)) {
+            Configure::write('Status.level', $statusLevel);
+        }
+        static::assertSame($expected, count($result));
+    }
 }


### PR DESCRIPTION
This PR adds `provider thumbnail` URL to `/media/thumbs` response if no stream thumbnails are available.

This way `/media/thumbs` should return thumb urls also for remote media.
In this case no stream `uuid` will be in the response

**Bonus track**: a check on `status` and `deleted` has been added via new `available` finder
