### PR TITLE
Update code sniffer rules to PSR-12 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "cakephp/bake": "^1.11",
         "cakephp/debug_kit": "^3.19.0",
-        "cakephp/cakephp-codesniffer": "~3.1.0",
+        "cakephp/cakephp-codesniffer": "^3.1.0",
         "psy/psysh": "@stable",
         "bedita/dev-tools": "1.1.*",
         "phpunit/phpunit": "^6.0"

--- a/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
+++ b/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
@@ -77,9 +77,11 @@ class EndpointAuthorize extends BaseAuthorize
         $this->request = $request;
 
         // if 'blockAnonymousUsers' configuration is true and user unlogged authorization is denied
-        if (!$this->getConfig('defaultAuthorized') &&
+        if (
+            !$this->getConfig('defaultAuthorized') &&
             $this->isAnonymous($user) &&
-            $this->getConfig('blockAnonymousUsers')) {
+            $this->getConfig('blockAnonymousUsers')
+        ) {
             $this->unauthenticated();
         }
 

--- a/plugins/BEdita/API/src/Controller/MediaController.php
+++ b/plugins/BEdita/API/src/Controller/MediaController.php
@@ -75,7 +75,7 @@ class MediaController extends ObjectsController
      * @param array $ids Object ids array
      * @return array
      */
-    protected function getAvailableIds(array $ids) : array
+    protected function getAvailableIds(array $ids): array
     {
         if (empty($ids)) {
             return $ids;
@@ -132,7 +132,7 @@ class MediaController extends ObjectsController
      * @param array $thumbnails Thumbnail array
      * @return void
      */
-    protected function fetchProviderThumbs(array $ids, array &$thumbnails) : void
+    protected function fetchProviderThumbs(array $ids, array &$thumbnails): void
     {
         $mediaIds = array_diff($ids, (array)Hash::extract($thumbnails, '{n}.id'));
         if (empty($mediaIds)) {

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -143,7 +143,8 @@ class ObjectsController extends ResourcesController
      */
     public function beforeFilter(Event $event)
     {
-        if ($this->request->getParam('action') === 'relationships'
+        if (
+            $this->request->getParam('action') === 'relationships'
             && $this->request->getParam('relationship') === 'streams'
             && !$this->request->is('get')
         ) {

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -43,7 +43,6 @@ use Cake\Utility\Inflector;
  */
 abstract class ResourcesController extends AppController
 {
-
     use InstanceConfigTrait;
 
     /**

--- a/plugins/BEdita/API/tests/IntegrationTest/DefaultValuesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/DefaultValuesTest.php
@@ -33,7 +33,7 @@ class DefaultValuesTest extends IntegrationTestCase
      *
      * @return array
      */
-    public function createProvider() : array
+    public function createProvider(): array
     {
         return [
             'files on' => [
@@ -90,7 +90,7 @@ class DefaultValuesTest extends IntegrationTestCase
      * @dataProvider createProvider
      * @coversNothing
      */
-    public function testCreate(array $expected, string $type, array $attributes, array $config) : void
+    public function testCreate(array $expected, string $type, array $attributes, array $config): void
     {
         Configure::write('DefaultValues', $config);
 

--- a/plugins/BEdita/Core/src/Filesystem/FilesystemAdapter.php
+++ b/plugins/BEdita/Core/src/Filesystem/FilesystemAdapter.php
@@ -29,7 +29,6 @@ use League\Flysystem\AdapterInterface;
  */
 abstract class FilesystemAdapter
 {
-
     use InstanceConfigTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Filesystem/FilesystemRegistry.php
+++ b/plugins/BEdita/Core/src/Filesystem/FilesystemRegistry.php
@@ -29,7 +29,6 @@ use League\Flysystem\MountManager;
  */
 class FilesystemRegistry extends ObjectRegistry
 {
-
     use SingletonTrait;
     use StaticConfigTrait;
 

--- a/plugins/BEdita/Core/src/Filesystem/Thumbnail.php
+++ b/plugins/BEdita/Core/src/Filesystem/Thumbnail.php
@@ -29,7 +29,6 @@ use Cake\Utility\Hash;
  */
 class Thumbnail
 {
-
     use StaticConfigTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Filesystem/ThumbnailGenerator.php
+++ b/plugins/BEdita/Core/src/Filesystem/ThumbnailGenerator.php
@@ -22,7 +22,6 @@ use Cake\Core\InstanceConfigTrait;
  */
 abstract class ThumbnailGenerator implements GeneratorInterface
 {
-
     use InstanceConfigTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/AddAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/AddAssociatedAction.php
@@ -27,7 +27,6 @@ use Cake\ORM\Association\HasMany;
  */
 class AddAssociatedAction extends UpdateAssociatedAction
 {
-
     use AssociatedTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/AddRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/AddRelatedObjectsAction.php
@@ -23,7 +23,6 @@ use Cake\Datasource\EntityInterface;
  */
 class AddRelatedObjectsAction extends UpdateRelatedObjectsAction
 {
-
     use AssociatedTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/BaseAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/BaseAction.php
@@ -22,7 +22,6 @@ use Cake\Core\InstanceConfigTrait;
  */
 abstract class BaseAction
 {
-
     use InstanceConfigTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/ChangeCredentialsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ChangeCredentialsAction.php
@@ -26,7 +26,6 @@ use Cake\Validation\Validator;
  */
 class ChangeCredentialsAction extends BaseAction
 {
-
     use EventDispatcherTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/ChangeCredentialsRequestAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ChangeCredentialsRequestAction.php
@@ -39,7 +39,6 @@ use Cake\Validation\Validator;
  */
 class ChangeCredentialsRequestAction extends BaseAction implements EventListenerInterface
 {
-
     use EventDispatcherTrait;
     use MailerAwareTrait;
 

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
@@ -50,8 +50,10 @@ class ListRelatedObjectsAction extends ListAssociatedAction
                 $table->setupRelations($objectType);
             }
             $this->ListAction = new ListObjectsAction(array_filter(compact('table', 'objectType')));
-        } elseif ($this->Association->getTarget() instanceof ObjectsTable
-                || $this->Association->getTarget() instanceof Table) {
+        } elseif (
+            $this->Association->getTarget() instanceof ObjectsTable
+                || $this->Association->getTarget() instanceof Table
+        ) {
             $table = $this->Association->getTarget();
             $this->ListAction = new ListObjectsAction(compact('table'));
         }

--- a/plugins/BEdita/Core/src/Model/Action/RemoveAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/RemoveAssociatedAction.php
@@ -26,7 +26,6 @@ use Cake\ORM\Association\HasMany;
  */
 class RemoveAssociatedAction extends UpdateAssociatedAction
 {
-
     use AssociatedTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/SaveEntityAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SaveEntityAction.php
@@ -25,7 +25,6 @@ use Cake\Utility\Hash;
  */
 class SaveEntityAction extends BaseAction
 {
-
     use LogTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/SetAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SetAssociatedAction.php
@@ -27,7 +27,6 @@ use Cake\ORM\Association\HasOne;
  */
 class SetAssociatedAction extends UpdateAssociatedAction
 {
-
     use AssociatedTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/SetRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SetRelatedObjectsAction.php
@@ -23,7 +23,6 @@ use Cake\Datasource\EntityInterface;
  */
 class SetRelatedObjectsAction extends UpdateRelatedObjectsAction
 {
-
     use AssociatedTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -39,7 +39,6 @@ use Cake\Validation\Validator;
  */
 class SignupUserAction extends BaseAction implements EventListenerInterface
 {
-
     use EventDispatcherTrait;
     use MailerAwareTrait;
 

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserActivationAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserActivationAction.php
@@ -30,7 +30,6 @@ use Cake\ORM\TableRegistry;
  */
 class SignupUserActivationAction extends BaseAction implements EventListenerInterface
 {
-
     use EventDispatcherTrait;
     use MailerAwareTrait;
 

--- a/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
@@ -154,7 +154,7 @@ class TreeBehavior extends CakeTreeBehavior
      * @return void
      * @codeCoverageIgnore
      */
-    public function nonAtomicRecover() : void
+    public function nonAtomicRecover(): void
     {
         $this->_recoverTree();
     }

--- a/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
@@ -76,8 +76,10 @@ class UniqueNameBehavior extends Behavior
             $uname = $this->generateUniqueName($entity);
         }
         $count = 0;
-        while ($this->uniqueNameExists($uname, $entity->get('id'))
-            && ($count++ < self::UNAME_MAX_REGENERATE)) {
+        while (
+            $this->uniqueNameExists($uname, $entity->get('id'))
+            && ($count++ < self::UNAME_MAX_REGENERATE)
+        ) {
             $uname = $this->generateUniqueName($entity, true);
         }
 

--- a/plugins/BEdita/Core/src/Model/Behavior/UserModifiedBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UserModifiedBehavior.php
@@ -93,7 +93,8 @@ class UserModifiedBehavior extends Behavior
                     sprintf('When should be one of "always", "new" or "existing". The passed value "%s" is invalid', $when)
                 );
             }
-            if ($when === 'always' ||
+            if (
+                $when === 'always' ||
                 ($when === 'new' && $new) ||
                 ($when === 'existing' && !$new)
             ) {

--- a/plugins/BEdita/Core/src/Model/Entity/Application.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Application.php
@@ -31,7 +31,6 @@ use Cake\ORM\Entity;
  */
 class Application extends Entity implements JsonApiSerializable
 {
-
     use JsonApiAdminTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Model/Entity/AsyncJob.php
+++ b/plugins/BEdita/Core/src/Model/Entity/AsyncJob.php
@@ -26,7 +26,6 @@ use Cake\ORM\Entity;
  */
 class AsyncJob extends Entity implements JsonApiSerializable
 {
-
     use JsonApiAdminTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Model/Entity/Config.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Config.php
@@ -32,7 +32,6 @@ use Cake\ORM\Entity;
  */
 class Config extends Entity implements JsonApiSerializable
 {
-
     use JsonApiAdminTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Model/Entity/DateRange.php
+++ b/plugins/BEdita/Core/src/Model/Entity/DateRange.php
@@ -207,7 +207,8 @@ class DateRange extends Entity
             $dateRange = clone $dateRange1;
 
             while (($dateRange2 = current($array2)) !== false) {
-                if ($dateRange->end_date === null
+                if (
+                    $dateRange->end_date === null
                     && $dateRange2->end_date === null
                     && $dateRange->start_date->getTimestamp() === $dateRange2->start_date->getTimestamp()
                 ) {

--- a/plugins/BEdita/Core/src/Model/Entity/Endpoint.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Endpoint.php
@@ -34,7 +34,6 @@ use Cake\ORM\Entity;
  */
 class Endpoint extends Entity implements JsonApiSerializable
 {
-
     use JsonApiAdminTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
@@ -352,7 +352,8 @@ trait JsonApiTrait
         foreach ($associations as $association) {
             list(, $associationType) = namespaceSplit(get_class($association));
             $name = $association->getProperty();
-            if (!($association instanceof Association) ||
+            if (
+                !($association instanceof Association) ||
                 in_array($name, $hidden) ||
                 ($associationType === 'HasMany' && in_array($association->getTarget()->getAlias(), $btmJunctionAliases))
             ) {

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
@@ -57,7 +57,6 @@ use Cake\Routing\Router;
  */
 class ObjectEntity extends Entity implements JsonApiSerializable
 {
-
     use JsonApiTrait {
         listAssociations as protected jsonApiListAssociations;
         getMeta as protected jsonApiGetMeta;

--- a/plugins/BEdita/Core/src/Model/Entity/Property.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Property.php
@@ -44,7 +44,6 @@ use Cake\Utility\Inflector;
  */
 class Property extends Entity implements JsonApiSerializable
 {
-
     use JsonApiModelTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Model/Entity/Relation.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Relation.php
@@ -36,7 +36,6 @@ use Cake\Utility\Inflector;
  */
 class Relation extends Entity implements JsonApiSerializable
 {
-
     use JsonApiModelTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Model/Entity/Role.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Role.php
@@ -32,7 +32,6 @@ use Cake\ORM\Entity;
  */
 class Role extends Entity implements JsonApiSerializable
 {
-
     use JsonApiTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Model/Entity/Stream.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Stream.php
@@ -46,7 +46,6 @@ use Zend\Diactoros\Stream as ZendStream;
  */
 class Stream extends Entity implements JsonApiSerializable
 {
-
     use JsonApiTrait;
     use LogTrait;
 

--- a/plugins/BEdita/Core/src/Model/Entity/Translation.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Translation.php
@@ -35,7 +35,6 @@ use Cake\ORM\Entity;
  */
 class Translation extends Entity implements JsonApiSerializable
 {
-
     use JsonApiTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
@@ -125,8 +125,10 @@ class ApplicationsTable extends Table
      */
     public function beforeSave(Event $event, EntityInterface $entity)
     {
-        if (!$entity->isNew() && $entity->get('enabled') == false &&
-            in_array($entity->id, [static::DEFAULT_APPLICATION, CurrentApplication::getApplicationId()])) {
+        if (
+            !$entity->isNew() && $entity->get('enabled') == false &&
+            in_array($entity->id, [static::DEFAULT_APPLICATION, CurrentApplication::getApplicationId()])
+        ) {
             throw new ImmutableResourceException(__d('bedita', 'Could not disable "Application" {0}', $entity->id));
         }
 

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -403,8 +403,10 @@ class UsersTable extends Table
             throw new BadRequestException(__d('bedita', 'Logged users cannot delete their own account'));
         }
         foreach (['username', 'uname'] as $prop) {
-            if (!($entity->get('deleted') && $entity->get('locked')) &&
-                strpos((string)$entity->get($prop), self::DELETED_USER_PREFIX) === 0) {
+            if (
+                !($entity->get('deleted') && $entity->get('locked')) &&
+                strpos((string)$entity->get($prop), self::DELETED_USER_PREFIX) === 0
+            ) {
                 throw new BadRequestException(
                     __d('bedita', '"{0}" cannot start with reserved word "{1}"', $prop, self::DELETED_USER_PREFIX)
                 );

--- a/plugins/BEdita/Core/src/SingletonTrait.php
+++ b/plugins/BEdita/Core/src/SingletonTrait.php
@@ -65,7 +65,7 @@ trait SingletonTrait
     final public static function getInstance()
     {
         if (static::$uniqueInstance === null) {
-            static::$uniqueInstance = new static;
+            static::$uniqueInstance = new static();
         }
 
         return static::$uniqueInstance;

--- a/plugins/BEdita/Core/src/State/CurrentApplication.php
+++ b/plugins/BEdita/Core/src/State/CurrentApplication.php
@@ -26,7 +26,6 @@ use Cake\ORM\TableRegistry;
  */
 class CurrentApplication
 {
-
     use SingletonTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Utility/LoggedUser.php
+++ b/plugins/BEdita/Core/src/Utility/LoggedUser.php
@@ -25,7 +25,6 @@ use Cake\Utility\Hash;
  */
 class LoggedUser
 {
-
     use SingletonTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Utility/Properties.php
+++ b/plugins/BEdita/Core/src/Utility/Properties.php
@@ -47,7 +47,7 @@ class Properties
      * @param array $options Table locator options
      * @return void
      */
-    public static function create(array $properties, array $options = []) : void
+    public static function create(array $properties, array $options = []): void
     {
         $Properties = TableRegistry::getTableLocator()->get('Properties', $options);
 
@@ -71,7 +71,7 @@ class Properties
      * @param array $options Table locator options
      * @return void
      */
-    public static function remove(array $properties, array $options = []) : void
+    public static function remove(array $properties, array $options = []): void
     {
         $Properties = TableRegistry::getTableLocator()->get('Properties', $options);
         $ObjectTypes = TableRegistry::getTableLocator()->get('ObjectTypes', $options);
@@ -98,7 +98,7 @@ class Properties
      * @return void
      * @throws BadRequestException
      */
-    protected static function validate(array $data) : void
+    protected static function validate(array $data): void
     {
         $required = ['name', 'object', 'property'];
         $diff = array_diff_key(array_flip($required), array_filter($data));

--- a/plugins/BEdita/Core/src/Utility/Relations.php
+++ b/plugins/BEdita/Core/src/Utility/Relations.php
@@ -46,7 +46,7 @@ class Relations
      * @param array $options Table locator options
      * @return void
      */
-    public static function create(array $relations, array $options = []) : void
+    public static function create(array $relations, array $options = []): void
     {
         $Relations = TableRegistry::getTableLocator()->get('Relations', $options);
         foreach ($relations as $data) {
@@ -68,7 +68,7 @@ class Relations
      * @param array $options Table locator options
      * @return void
      */
-    protected static function addTypes($relationId, array $types, string $side, array $options = []) : void
+    protected static function addTypes($relationId, array $types, string $side, array $options = []): void
     {
         $RelationTypes = TableRegistry::getTableLocator()->get('RelationTypes', $options);
         $ObjectTypes = TableRegistry::getTableLocator()->get('ObjectTypes', $options);
@@ -92,7 +92,7 @@ class Relations
      * @param array $options Table locator options
      * @return void
      */
-    public static function remove(array $relations, array $options = []) : void
+    public static function remove(array $relations, array $options = []): void
     {
         $Relations = TableRegistry::getTableLocator()->get('Relations', $options);
         foreach ($relations as $r) {
@@ -117,7 +117,7 @@ class Relations
      * @param array $options Table locator options
      * @return void
      */
-    protected static function removeTypes($relationId, array $types, string $side, array $options = []) : void
+    protected static function removeTypes($relationId, array $types, string $side, array $options = []): void
     {
         $RelationTypes = TableRegistry::getTableLocator()->get('RelationTypes', $options);
         $ObjectTypes = TableRegistry::getTableLocator()->get('ObjectTypes', $options);
@@ -144,10 +144,12 @@ class Relations
      * @return void
      * @throws BadRequestException
      */
-    protected static function validate(array $data) : void
+    protected static function validate(array $data): void
     {
-        if (empty($data['left']) || !is_array($data['left']) ||
-            empty($data['right']) || !is_array($data['right'])) {
+        if (
+            empty($data['left']) || !is_array($data['left']) ||
+            empty($data['right']) || !is_array($data['right'])
+        ) {
             throw new BadRequestException(
                 __d('bedita', 'Missing left/right relation types')
             );

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -386,7 +386,7 @@ class SignupUserActionTest extends TestCase
         EventManager::instance()->on('Auth.signup', function () use (&$eventDispatched) {
             $eventDispatched++;
 
-            throw new InternalErrorException;
+            throw new InternalErrorException();
         });
 
         $action = new SignupUserAction();

--- a/src/Application.php
+++ b/src/Application.php
@@ -67,7 +67,7 @@ class Application extends BaseApplication
      *
      * @return void
      */
-    protected function loadFromConfig() : void
+    protected function loadFromConfig(): void
     {
         $plugins = Configure::read('Plugins');
         if ($plugins) {


### PR DESCRIPTION
Via `cakephp/codesniffer` 3.2.1

new rules to consider:
* `The first trait import statement must be declared on the first non-comment line after the class opening brace`
* `There must not be a space before the colon in a return type declaration`
* `The first expression of a multi-line control structure must be on the line after the opening parenthesis`
* `The closing parenthesis of a multi-line control structure must be on the line after the last expression`

