### PR TITLE
Refactor object table hieararchy and behaviors

### DIFF
--- a/plugins/BEdita/Core/src/Model/Behavior/ObjectModelBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/ObjectModelBehavior.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2019 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Model\Behavior;
+
+use Cake\ORM\Behavior;
+
+/**
+ * Object Model behavior.
+ *
+ * @since 4.1.0
+ */
+class ObjectModelBehavior extends Behavior
+{
+    /**
+     * Add behaviors common to all tables implementing an object type model
+     *
+     * {@inheritDoc}
+     */
+    public function initialize(array $config)
+    {
+        parent::initialize($config);
+
+        $table = $this->getTable();
+        $table->addBehavior('BEdita/Core.History');
+        $table->addBehavior('Timestamp');
+        $table->addBehavior('BEdita/Core.DataCleanup');
+        $table->addBehavior('BEdita/Core.UserModified');
+        $table->addBehavior('BEdita/Core.CustomProperties');
+        $table->addBehavior('BEdita/Core.UniqueName');
+        $table->addBehavior('BEdita/Core.Relations');
+        $table->addBehavior('BEdita/Core.Searchable', [
+            'fields' => [
+                'title' => 10,
+                'description' => 7,
+                'body' => 5,
+            ],
+        ]);
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Behavior/ObjectModelBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/ObjectModelBehavior.php
@@ -32,7 +32,6 @@ class ObjectModelBehavior extends Behavior
         parent::initialize($config);
 
         $table = $this->getTable();
-        $table->addBehavior('BEdita/Core.History');
         $table->addBehavior('Timestamp');
         $table->addBehavior('BEdita/Core.DataCleanup');
         $table->addBehavior('BEdita/Core.UserModified');

--- a/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
@@ -13,8 +13,8 @@
 
 namespace BEdita\Core\Model\Table;
 
+use BEdita\Core\Model\Table\ObjectsBaseTable as Table;
 use BEdita\Core\Model\Validation\LocationsValidator;
-use BEdita\Core\ORM\Inheritance\Table;
 
 /**
  * Locations Model
@@ -49,12 +49,10 @@ class LocationsTable extends Table
         $this->setDisplayField('id');
         $this->setPrimaryKey('id');
 
-        $this->addBehavior('BEdita/Core.ObjectModel');
-
         $this->extensionOf('Objects');
 
-        if ($this->behaviors()->has('Searchable')) {
-            $this->behaviors()->get('Searchable')->setConfig([
+        if ($this->hasBehavior('Searchable')) {
+            $this->getBehavior('Searchable')->setConfig([
                 'fields' => [
                     'title' => 10,
                     'description' => 7,

--- a/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
@@ -48,27 +48,25 @@ class LocationsTable extends Table
         $this->setTable('locations');
         $this->setDisplayField('id');
         $this->setPrimaryKey('id');
+s
+        $this->addBehavior('BEdita/Core.ObjectModel');
 
         $this->extensionOf('Objects');
 
-        $this->addBehavior('BEdita/Core.Relations');
-
-        $this->addBehavior('BEdita/Core.Searchable', [
-            'fields' => [
-                'title' => 10,
-                'description' => 7,
-                'body' => 5,
-                'address' => 1,
-                'locality' => 2,
-                'country_name' => 2,
-                'region' => 2,
-            ],
-        ]);
+        if ($this->behaviors()->has('Searchable')) {
+            $this->behaviors()->get('Searchable')->setConfig([
+                'fields' => [
+                    'title' => 10,
+                    'description' => 7,
+                    'body' => 5,
+                    'address' => 1,
+                    'locality' => 2,
+                    'country_name' => 2,
+                    'region' => 2,
+                ],
+            ]);
+        }
 
         $this->addBehavior('BEdita/Core.Geometry');
-
-        $this->addBehavior('BEdita/Core.CustomProperties');
-
-        $this->addBehavior('BEdita/Core.DataCleanup');
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
@@ -48,7 +48,7 @@ class LocationsTable extends Table
         $this->setTable('locations');
         $this->setDisplayField('id');
         $this->setPrimaryKey('id');
-s
+
         $this->addBehavior('BEdita/Core.ObjectModel');
 
         $this->extensionOf('Objects');

--- a/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
@@ -51,19 +51,17 @@ class LocationsTable extends Table
 
         $this->extensionOf('Objects');
 
-        if ($this->hasBehavior('Searchable')) {
-            $this->getBehavior('Searchable')->setConfig([
-                'fields' => [
-                    'title' => 10,
-                    'description' => 7,
-                    'body' => 5,
-                    'address' => 1,
-                    'locality' => 2,
-                    'country_name' => 2,
-                    'region' => 2,
-                ],
-            ]);
-        }
+        $this->getBehavior('Searchable')->setConfig([
+            'fields' => [
+                'title' => 10,
+                'description' => 7,
+                'body' => 5,
+                'address' => 1,
+                'locality' => 2,
+                'country_name' => 2,
+                'region' => 2,
+            ],
+        ]);
 
         $this->addBehavior('BEdita/Core.Geometry');
     }

--- a/plugins/BEdita/Core/src/Model/Table/MediaTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/MediaTable.php
@@ -41,24 +41,20 @@ class MediaTable extends Table
 
         $this->extensionOf('Objects');
 
-        if ($this->hasBehavior('UniqueName')) {
-            $this->getBehavior('UniqueName')->setConfig([
-                'sourceField' => 'title',
-                'prefix' => 'media-'
-            ]);
-        }
+        $this->getBehavior('UniqueName')->setConfig([
+            'sourceField' => 'title',
+            'prefix' => 'media-'
+        ]);
 
-        if ($this->hasBehavior('Searchable')) {
-            $this->getBehavior('Searchable')->setConfig([
-                'fields' => [
-                    'title' => 10,
-                    'description' => 7,
-                    'body' => 5,
-                    'provider' => 5,
-                    'name' => 8,
-                ],
-            ]);
-        }
+        $this->getBehavior('Searchable')->setConfig([
+            'fields' => [
+                'title' => 10,
+                'description' => 7,
+                'body' => 5,
+                'provider' => 5,
+                'name' => 8,
+            ],
+        ]);
 
         $this->hasMany('Streams', [
             'foreignKey' => 'object_id',

--- a/plugins/BEdita/Core/src/Model/Table/MediaTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/MediaTable.php
@@ -39,18 +39,28 @@ class MediaTable extends Table
         $this->setPrimaryKey('id');
         $this->setDisplayField('name');
 
+        $this->addBehavior('BEdita/Core.ObjectModel');
+
         $this->extensionOf('Objects');
 
-        $this->addBehavior('BEdita/Core.Relations');
+        if ($this->behaviors()->has('UniqueName')) {
+            $this->behaviors()->get('UniqueName')->setConfig([
+                'sourceField' => 'title',
+                'prefix' => 'media-'
+            ]);
+        }
 
-        $this->addBehavior('BEdita/Core.UniqueName', [
-            'sourceField' => 'title',
-            'prefix' => 'media-'
-        ]);
-
-        $this->addBehavior('BEdita/Core.CustomProperties');
-
-        $this->addBehavior('BEdita/Core.DataCleanup');
+        if ($this->behaviors()->has('Searchable')) {
+            $this->behaviors()->get('Searchable')->setConfig([
+                'fields' => [
+                    'title' => 10,
+                    'description' => 7,
+                    'body' => 5,
+                    'provider' => 5,
+                    'name' => 8,
+                ],
+            ]);
+        }
 
         $this->hasMany('Streams', [
             'foreignKey' => 'object_id',

--- a/plugins/BEdita/Core/src/Model/Table/MediaTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/MediaTable.php
@@ -1,8 +1,8 @@
 <?php
 namespace BEdita\Core\Model\Table;
 
+use BEdita\Core\Model\Table\ObjectsBaseTable as Table;
 use BEdita\Core\Model\Validation\MediaValidator;
-use BEdita\Core\ORM\Inheritance\Table;
 use Cake\Database\Schema\TableSchema;
 
 /**
@@ -39,19 +39,17 @@ class MediaTable extends Table
         $this->setPrimaryKey('id');
         $this->setDisplayField('name');
 
-        $this->addBehavior('BEdita/Core.ObjectModel');
-
         $this->extensionOf('Objects');
 
-        if ($this->behaviors()->has('UniqueName')) {
-            $this->behaviors()->get('UniqueName')->setConfig([
+        if ($this->hasBehavior('UniqueName')) {
+            $this->getBehavior('UniqueName')->setConfig([
                 'sourceField' => 'title',
                 'prefix' => 'media-'
             ]);
         }
 
-        if ($this->behaviors()->has('Searchable')) {
-            $this->behaviors()->get('Searchable')->setConfig([
+        if ($this->hasBehavior('Searchable')) {
+            $this->getBehavior('Searchable')->setConfig([
                 'fields' => [
                     'title' => 10,
                     'description' => 7,

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsBaseTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsBaseTable.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2019 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Core\Model\Table;
+
+use BEdita\Core\ORM\Inheritance\Table;
+
+/**
+ * Base Table class for every Table implementing a BEdita Object
+ * on a table other than `objects`.
+ *
+ * @since 4.1.0
+ */
+abstract class ObjectsBaseTable extends Table
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function initialize(array $config)
+    {
+        parent::initialize($config);
+        $this->addBehavior('BEdita/Core.ObjectModel');
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -75,19 +75,7 @@ class ObjectsTable extends Table
         $this->setPrimaryKey('id');
         $this->setDisplayField('title');
 
-        $this->addBehavior('Timestamp');
-        $this->addBehavior('BEdita/Core.DataCleanup');
-        $this->addBehavior('BEdita/Core.UserModified');
-        $this->addBehavior('BEdita/Core.Relations');
-        $this->addBehavior('BEdita/Core.CustomProperties');
-        $this->addBehavior('BEdita/Core.UniqueName');
-        $this->addBehavior('BEdita/Core.Searchable', [
-            'fields' => [
-                'title' => 10,
-                'description' => 7,
-                'body' => 5,
-            ],
-        ]);
+        $this->addBehavior('BEdita/Core.ObjectModel');
 
         $this->belongsTo('ObjectTypes', [
             'foreignKey' => 'object_type_id',

--- a/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
@@ -13,11 +13,10 @@
 
 namespace BEdita\Core\Model\Table;
 
+use BEdita\Core\Model\Table\ObjectsBaseTable as Table;
 use BEdita\Core\Model\Validation\ProfilesValidator;
-use BEdita\Core\ORM\Inheritance\Table;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
-use Cake\ORM\RulesChecker;
 use Cake\Utility\Hash;
 
 /**
@@ -54,19 +53,17 @@ class ProfilesTable extends Table
         $this->setPrimaryKey('id');
         $this->setDisplayField('name');
 
-        $this->addBehavior('BEdita/Core.ObjectModel');
-
         $this->extensionOf('Objects');
 
-        if ($this->behaviors()->has('UniqueName')) {
-            $this->behaviors()->get('UniqueName')->setConfig([
+        if ($this->hasBehavior('UniqueName')) {
+            $this->getBehavior('UniqueName')->setConfig([
                 'sourceField' => 'title',
                 'prefix' => 'profile-'
             ]);
         }
 
-        if ($this->behaviors()->has('Searchable')) {
-            $this->behaviors()->get('Searchable')->setConfig([
+        if ($this->hasBehavior('Searchable')) {
+            $this->getBehavior('Searchable')->setConfig([
                 'fields' => [
                     'title' => 10,
                     'description' => 7,

--- a/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
@@ -55,30 +55,26 @@ class ProfilesTable extends Table
 
         $this->extensionOf('Objects');
 
-        if ($this->hasBehavior('UniqueName')) {
-            $this->getBehavior('UniqueName')->setConfig([
-                'sourceField' => 'title',
-                'prefix' => 'profile-'
-            ]);
-        }
+        $this->getBehavior('UniqueName')->setConfig([
+            'sourceField' => 'title',
+            'prefix' => 'profile-'
+        ]);
 
-        if ($this->hasBehavior('Searchable')) {
-            $this->getBehavior('Searchable')->setConfig([
-                'fields' => [
-                    'title' => 10,
-                    'description' => 7,
-                    'body' => 5,
-                    'name' => 10,
-                    'surname' => 10,
-                    'email' => 7,
-                    'company_name' => 10,
-                    'street_address' => 1,
-                    'city' => 2,
-                    'country' => 2,
-                    'state_name' => 2,
-                ],
-            ]);
-        }
+        $this->getBehavior('Searchable')->setConfig([
+            'fields' => [
+                'title' => 10,
+                'description' => 7,
+                'body' => 5,
+                'name' => 10,
+                'surname' => 10,
+                'email' => 7,
+                'company_name' => 10,
+                'street_address' => 1,
+                'city' => 2,
+                'country' => 2,
+                'state_name' => 2,
+            ],
+        ]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
@@ -54,34 +54,34 @@ class ProfilesTable extends Table
         $this->setPrimaryKey('id');
         $this->setDisplayField('name');
 
-        $this->addBehavior('BEdita/Core.Relations');
-
-        $this->addBehavior('BEdita/Core.CustomProperties');
-
-        $this->addBehavior('BEdita/Core.DataCleanup');
+        $this->addBehavior('BEdita/Core.ObjectModel');
 
         $this->extensionOf('Objects');
 
-        $this->addBehavior('BEdita/Core.UniqueName', [
-            'sourceField' => 'title',
-            'prefix' => 'profile-'
-        ]);
+        if ($this->behaviors()->has('UniqueName')) {
+            $this->behaviors()->get('UniqueName')->setConfig([
+                'sourceField' => 'title',
+                'prefix' => 'profile-'
+            ]);
+        }
 
-        $this->addBehavior('BEdita/Core.Searchable', [
-            'fields' => [
-                'title' => 10,
-                'description' => 7,
-                'body' => 5,
-                'name' => 10,
-                'surname' => 10,
-                'email' => 7,
-                'company_name' => 10,
-                'street_address' => 1,
-                'city' => 2,
-                'country' => 2,
-                'state_name' => 2,
-            ],
-        ]);
+        if ($this->behaviors()->has('Searchable')) {
+            $this->behaviors()->get('Searchable')->setConfig([
+                'fields' => [
+                    'title' => 10,
+                    'description' => 7,
+                    'body' => 5,
+                    'name' => 10,
+                    'surname' => 10,
+                    'email' => 7,
+                    'company_name' => 10,
+                    'street_address' => 1,
+                    'city' => 2,
+                    'country' => 2,
+                    'state_name' => 2,
+                ],
+            ]);
+        }
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -82,26 +82,22 @@ class UsersTable extends Table
 
         $this->extensionOf('Profiles');
 
-        if ($this->hasBehavior('UniqueName')) {
-            $this->getBehavior('UniqueName')->setConfig([
-                'sourceField' => 'username',
-                'prefix' => 'user-'
-            ]);
-        }
+        $this->getBehavior('UniqueName')->setConfig([
+            'sourceField' => 'username',
+            'prefix' => 'user-'
+        ]);
 
-        if ($this->hasBehavior('Searchable')) {
-            $this->getBehavior('Searchable')->setConfig([
-                'fields' => [
-                    'username' => 10,
-                    'title' => 10,
-                    'name' => 10,
-                    'surname' => 10,
-                    'email' => 7,
-                    'description' => 7,
-                    'body' => 5,
-                    ],
-            ]);
-        }
+        $this->getBehavior('Searchable')->setConfig([
+            'fields' => [
+                'username' => 10,
+                'title' => 10,
+                'name' => 10,
+                'surname' => 10,
+                'email' => 7,
+                'description' => 7,
+                'body' => 5,
+            ],
+        ]);
 
         $this->hasMany('ExternalAuth', [
             'foreignKey' => 'user_id',

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -14,8 +14,8 @@
 namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Exception\ImmutableResourceException;
+use BEdita\Core\Model\Table\ObjectsBaseTable as Table;
 use BEdita\Core\Model\Validation\UsersValidator;
-use BEdita\Core\ORM\Inheritance\Table;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Core\Configure;
 use Cake\Database\Expression\QueryExpression;
@@ -80,19 +80,17 @@ class UsersTable extends Table
         $this->setPrimaryKey('id');
         $this->setDisplayField('username');
 
-        $this->addBehavior('BEdita/Core.ObjectModel');
-
         $this->extensionOf('Profiles');
 
-        if ($this->behaviors()->has('UniqueName')) {
-            $this->behaviors()->get('UniqueName')->setConfig([
+        if ($this->hasBehavior('UniqueName')) {
+            $this->getBehavior('UniqueName')->setConfig([
                 'sourceField' => 'username',
                 'prefix' => 'user-'
             ]);
         }
 
-        if ($this->behaviors()->has('Searchable')) {
-            $this->behaviors()->get('Searchable')->setConfig([
+        if ($this->hasBehavior('Searchable')) {
+            $this->getBehavior('Searchable')->setConfig([
                 'fields' => [
                     'username' => 10,
                     'title' => 10,

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -80,11 +80,30 @@ class UsersTable extends Table
         $this->setPrimaryKey('id');
         $this->setDisplayField('username');
 
-        $this->addBehavior('Timestamp');
+        $this->addBehavior('BEdita/Core.ObjectModel');
 
-        $this->addBehavior('BEdita/Core.DataCleanup');
+        $this->extensionOf('Profiles');
 
-        $this->addBehavior('BEdita/Core.CustomProperties');
+        if ($this->behaviors()->has('UniqueName')) {
+            $this->behaviors()->get('UniqueName')->setConfig([
+                'sourceField' => 'username',
+                'prefix' => 'user-'
+            ]);
+        }
+
+        if ($this->behaviors()->has('Searchable')) {
+            $this->behaviors()->get('Searchable')->setConfig([
+                'fields' => [
+                    'username' => 10,
+                    'title' => 10,
+                    'name' => 10,
+                    'surname' => 10,
+                    'email' => 7,
+                    'description' => 7,
+                    'body' => 5,
+                    ],
+            ]);
+        }
 
         $this->hasMany('ExternalAuth', [
             'foreignKey' => 'user_id',
@@ -92,26 +111,6 @@ class UsersTable extends Table
 
         $this->belongsToMany('Roles', [
             'through' => 'RolesUsers',
-        ]);
-
-        $this->extensionOf('Profiles');
-
-        $this->addBehavior('BEdita/Core.UniqueName', [
-            'sourceField' => 'username',
-            'prefix' => 'user-'
-        ]);
-
-        $this->addBehavior('BEdita/Core.Relations');
-        $this->addBehavior('BEdita/Core.Searchable', [
-            'fields' => [
-                'username' => 10,
-                'title' => 10,
-                'name' => 10,
-                'surname' => 10,
-                'email' => 7,
-                'description' => 7,
-                'body' => 5,
-            ],
         ]);
 
         EventManager::instance()->on('Auth.afterIdentify', [$this, 'login']);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectModelBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectModelBehaviorTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2019 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Behavior;
+
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * @coversDefaultClass \BEdita\Core\Model\Behavior\ObjectModelBehavior
+ */
+class ObjectModelBehaviorTest extends TestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.FakeAnimals',
+        'plugin.BEdita/Core.ObjectTypes',
+    ];
+
+    /**
+     * Test `initialize` method.
+     *
+     * @covers ::initialize()
+     */
+    public function testInitialize()
+    {
+        $table = TableRegistry::get('FakeAnimals');
+        $count = $table->behaviors()->count();
+        static::assertEquals(0, $count);
+        $table->addBehavior('BEdita/Core.ObjectModel');
+        $count = $table->behaviors()->count();
+        static::assertEquals(9, $count);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
@@ -41,7 +41,6 @@ class UniqueNameBehaviorTest extends TestCase
         'plugin.BEdita/Core.Objects',
         'plugin.BEdita/Core.Profiles',
         'plugin.BEdita/Core.Users',
-        'plugin.BEdita/Core.History',
     ];
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
@@ -34,11 +34,14 @@ class UniqueNameBehaviorTest extends TestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.Properties',
         'plugin.BEdita/Core.Relations',
         'plugin.BEdita/Core.RelationTypes',
         'plugin.BEdita/Core.Objects',
         'plugin.BEdita/Core.Profiles',
         'plugin.BEdita/Core.Users',
+        'plugin.BEdita/Core.History',
     ];
 
     /**
@@ -101,7 +104,7 @@ class UniqueNameBehaviorTest extends TestCase
         $Users = TableRegistry::get('Users');
         $user = $Users->newEntity();
 
-        $Users->patchEntity($user, compact('username'));
+        $user = $Users->patchEntity($user, compact('username'));
         $Users->uniqueName($user);
         $user->type = 'users';
         $Users->save($user);


### PR DESCRIPTION
This PR adds 

* a new abstract `ObjectsBaseTable` as base class for tables implementing a BEdita object type
* a new `ObjectModel` behavior to load common behaviors

This way new common behaviors can be introduced without any code change in core and plugin object table classes.

### Caveat

* `ObjectsTable` will not extend `ObjectsBaseTable` but simply load `ObjectModel` behavior.
* any new change in `ObjectsBaseTable` should normally be added to `ObjectsTable`

After this change every Table class implementing a BEdita object on a table other than `objects` MUST 
 * extend `ObjectsBaseTable`
 * invoke `$this->extensionOf('Objects');`  (using `'Objects'` or other objects table class) in `initialize()` 

Have a look at `ProfilesTable` for an example