### PR TITLE
fix: `/` => `/home` redirect using path

### DIFF
--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -48,7 +48,7 @@ Router::plugin(
         // Home.
         $routes->redirect(
             '/',
-            ['_name' => 'api:home'],
+            '/home',
             ['persist' => true]
         );
         $routes->connect(


### PR DESCRIPTION
This PR fixes a redirect routing error when pointing to `/` root path
 
