### PR TITLE
refactor: use `TableRegistry::getTableLocator()`

### DIFF
--- a/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
+++ b/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
@@ -160,7 +160,7 @@ class EndpointAuthorize extends BaseAuthorize
         $path = array_values(array_filter(explode('/', $this->request->getPath())));
         $endpointName = Hash::get($path, '0', '');
 
-        $Endpoints = TableRegistry::get('Endpoints');
+        $Endpoints = TableRegistry::getTableLocator()->get('Endpoints');
         $this->endpoint = $Endpoints->find()
             ->where([
                 'Endpoints.name' => $endpointName,
@@ -197,7 +197,7 @@ class EndpointAuthorize extends BaseAuthorize
         $applicationId = CurrentApplication::getApplicationId();
         $endpointIds = $this->endpoint && !$this->endpoint->isNew() ? [$this->endpoint->id] : [];
 
-        $query = TableRegistry::get('EndpointPermissions')
+        $query = TableRegistry::getTableLocator()->get('EndpointPermissions')
             ->find('byApplication', compact('applicationId', 'strict'))
             ->find('byEndpoint', compact('endpointIds', 'strict'));
 

--- a/plugins/BEdita/API/src/Auth/OTPAuthenticate.php
+++ b/plugins/BEdita/API/src/Auth/OTPAuthenticate.php
@@ -125,7 +125,7 @@ class OTPAuthenticate extends BaseAuthenticate
             'token_type' => 'otp',
         ];
 
-        $UserTokens = TableRegistry::get('UserTokens');
+        $UserTokens = TableRegistry::getTableLocator()->get('UserTokens');
         $userToken = $UserTokens->find('valid')->where($data)->first();
         if (!empty($userToken)) {
             $UserTokens->deleteOrFail($userToken);
@@ -158,7 +158,7 @@ class OTPAuthenticate extends BaseAuthenticate
             'expires' => new Time($this->getConfig('expiry')),
         ];
 
-        $UserTokens = TableRegistry::get('UserTokens');
+        $UserTokens = TableRegistry::getTableLocator()->get('UserTokens');
         $entity = $UserTokens->newEntity($data);
         $UserTokens->saveOrFail($entity);
         $this->dispatchEvent('Auth.userToken', [$entity]);

--- a/plugins/BEdita/API/src/Auth/UuidAuthenticate.php
+++ b/plugins/BEdita/API/src/Auth/UuidAuthenticate.php
@@ -91,7 +91,7 @@ class UuidAuthenticate extends BaseAuthenticate
             return $externalAuth;
         }
 
-        $Table = TableRegistry::get($this->_config['userModel']);
+        $Table = TableRegistry::getTableLocator()->get($this->_config['userModel']);
         $providerUsername = $username;
         $Table->dispatchEvent('Auth.externalAuth', compact('authProvider', 'providerUsername'));
 

--- a/plugins/BEdita/API/src/Controller/HomeController.php
+++ b/plugins/BEdita/API/src/Controller/HomeController.php
@@ -144,7 +144,7 @@ class HomeController extends AppController
      */
     protected function objectTypesEndpoints()
     {
-        $allTypes = TableRegistry::get('ObjectTypes')
+        $allTypes = TableRegistry::getTableLocator()->get('ObjectTypes')
                         ->find('list', ['keyField' => 'name', 'valueField' => 'is_abstract'])
                         ->where(['enabled' => true])
                         ->toArray();

--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -79,7 +79,7 @@ class LoginController extends AppController
                 ],
             ];
 
-            $authenticationComponents += TableRegistry::get('AuthProviders')
+            $authenticationComponents += TableRegistry::getTableLocator()->get('AuthProviders')
                 ->find('authenticate')
                 ->toArray();
 
@@ -220,7 +220,7 @@ class LoginController extends AppController
         $data = $this->request->getData();
         $this->checkPassword($entity, $data);
 
-        $action = new SaveEntityAction(['table' => TableRegistry::get('Users')]);
+        $action = new SaveEntityAction(['table' => TableRegistry::getTableLocator()->get('Users')]);
         $action(compact('entity', 'data'));
 
         // reload entity to cancel previous `setAccess` (otherwise `username` and `email` will appear in `meta`)
@@ -270,7 +270,7 @@ class LoginController extends AppController
         $contain = array_unique(array_merge($contain, ['Roles']));
         $conditions = ['id' => $userId];
 
-        $user = TableRegistry::get('Users')
+        $user = TableRegistry::getTableLocator()->get('Users')
             ->find('login', compact('conditions', 'contain'))
             ->first();
         if (empty($user)) {
@@ -286,7 +286,7 @@ class LoginController extends AppController
     protected function findAssociation($relationship)
     {
         $relationship = Inflector::underscore($relationship);
-        $association = TableRegistry::get('Users')->associations()->getByProperty($relationship);
+        $association = TableRegistry::getTableLocator()->get('Users')->associations()->getByProperty($relationship);
         if (empty($association)) {
             throw new NotFoundException(__d('bedita', 'Relationship "{0}" does not exist', $relationship));
         }

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -71,7 +71,7 @@ class ObjectsController extends ResourcesController
     {
         if (in_array($this->request->getParam('action'), ['related', 'relationships'])) {
             $name = $this->request->getParam('relationship');
-            $allowedTypes = TableRegistry::get('ObjectTypes')
+            $allowedTypes = TableRegistry::getTableLocator()->get('ObjectTypes')
                 ->find('list')
                 ->find('byRelation', compact('name') + ['descendants' => true])
                 ->toArray();
@@ -114,7 +114,7 @@ class ObjectsController extends ResourcesController
         $type = $this->request->getParam('object_type', Inflector::underscore($this->request->getParam('controller')));
         try {
             /** @var \BEdita\Core\Model\Entity\ObjectType $this->objectType */
-            $this->objectType = TableRegistry::get('ObjectTypes')->get($type);
+            $this->objectType = TableRegistry::getTableLocator()->get('ObjectTypes')->get($type);
             if ($type !== $this->objectType->name) {
                 $this->log(
                     sprintf('Bad object type name "%s", could be "%s"', $type, $this->objectType->name),
@@ -130,7 +130,7 @@ class ObjectsController extends ResourcesController
                 ));
             }
             $this->modelClass = $this->objectType->alias;
-            $this->Table = TableRegistry::get($this->modelClass);
+            $this->Table = TableRegistry::getTableLocator()->get($this->modelClass);
         } catch (RecordNotFoundException $e) {
             $this->log(sprintf('Object type "%s" does not exist', $type), 'warning', ['request' => $this->request]);
 
@@ -226,7 +226,7 @@ class ObjectsController extends ResourcesController
     {
         $this->request->allowMethod(['get', 'patch', 'delete']);
 
-        $id = TableRegistry::get('Objects')->getId($id);
+        $id = TableRegistry::getTableLocator()->get('Objects')->getId($id);
         $contain = $this->prepareInclude($this->request->getQuery('include'));
 
         $action = new GetObjectAction(['table' => $this->Table, 'objectType' => $this->objectType]);
@@ -285,7 +285,7 @@ class ObjectsController extends ResourcesController
         $this->request->allowMethod(['get']);
 
         $relationship = $this->request->getParam('relationship');
-        $relatedId = TableRegistry::get('Objects')->getId($this->request->getParam('related_id'));
+        $relatedId = TableRegistry::getTableLocator()->get('Objects')->getId($this->request->getParam('related_id'));
 
         $association = $this->findAssociation($relationship);
         $filter = (array)$this->request->getQuery('filter') + array_filter(['query' => $this->request->getQuery('q')]);
@@ -312,7 +312,7 @@ class ObjectsController extends ResourcesController
      */
     public function relationships()
     {
-        $id = TableRegistry::get('Objects')->getId($this->request->getParam('id'));
+        $id = TableRegistry::getTableLocator()->get('Objects')->getId($this->request->getParam('id'));
         $relationship = $this->request->getParam('relationship');
 
         $association = $this->findAssociation($relationship);

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -85,7 +85,7 @@ abstract class ResourcesController extends AppController
             }
         }
 
-        $this->Table = TableRegistry::get($this->modelClass);
+        $this->Table = TableRegistry::getTableLocator()->get($this->modelClass);
     }
 
     /**

--- a/plugins/BEdita/API/src/Controller/StreamsController.php
+++ b/plugins/BEdita/API/src/Controller/StreamsController.php
@@ -51,7 +51,7 @@ class StreamsController extends ResourcesController
     public function initialize()
     {
         /** @var \BEdita\Core\Model\Table\ObjectTypesTable $ObjectTypes */
-        $ObjectTypes = TableRegistry::get('ObjectTypes');
+        $ObjectTypes = TableRegistry::getTableLocator()->get('ObjectTypes');
         $allowed = $ObjectTypes->find('list')
             ->where(['parent_id' => $ObjectTypes->get('media')->id])
             ->toList();

--- a/plugins/BEdita/API/src/Controller/TrashController.php
+++ b/plugins/BEdita/API/src/Controller/TrashController.php
@@ -50,10 +50,10 @@ class TrashController extends AppController
         $id = $this->request->getParam('id');
         if ($id) {
             /** @var \BEdita\Core\Model\Entity\ObjectType $objectType */
-            $objectType = TableRegistry::get('ObjectTypes')->find('objectId', compact('id'))
+            $objectType = TableRegistry::getTableLocator()->get('ObjectTypes')->find('objectId', compact('id'))
                 ->firstOrFail();
             $this->modelClass = $objectType->alias;
-            $this->Table = TableRegistry::get($this->modelClass);
+            $this->Table = TableRegistry::getTableLocator()->get($this->modelClass);
         }
     }
 

--- a/plugins/BEdita/API/src/TestSuite/IntegrationTestCase.php
+++ b/plugins/BEdita/API/src/TestSuite/IntegrationTestCase.php
@@ -238,7 +238,7 @@ abstract class IntegrationTestCase extends CakeIntegrationTestCase
      */
     public function lastObjectId()
     {
-        return TableRegistry::get('Objects')
+        return TableRegistry::getTableLocator()->get('Objects')
             ->find()
             ->select('id')
             ->order(['id' => 'DESC'])

--- a/plugins/BEdita/API/tests/IntegrationTest/AssociatedEntitiesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/AssociatedEntitiesTest.php
@@ -161,7 +161,7 @@ class AssociatedEntitiesTest extends IntegrationTestCase
      */
     public function testRelatedDeleted()
     {
-        $table = TableRegistry::get('Documents');
+        $table = TableRegistry::getTableLocator()->get('Documents');
         $entity = $table->get(3);
         $entity->set('deleted', true);
         $table->save($entity);
@@ -179,7 +179,7 @@ class AssociatedEntitiesTest extends IntegrationTestCase
      */
     public function testIncludedDeleted()
     {
-        $table = TableRegistry::get('Documents');
+        $table = TableRegistry::getTableLocator()->get('Documents');
         $entity = $table->get(3);
         $entity->set('deleted', true);
         $table->save($entity);

--- a/plugins/BEdita/API/tests/IntegrationTest/DeleteFolderTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/DeleteFolderTest.php
@@ -87,7 +87,7 @@ class DeleteFolderTest extends IntegrationTestCase
         $this->patch(sprintf('/trash/%s', $folderId), json_encode(compact('data')));
         $this->assertResponseCode(204);
         $this->assertContentType('application/vnd.api+json');
-        $trash = TableRegistry::get('Objects')->get($folderId);
+        $trash = TableRegistry::getTableLocator()->get('Objects')->get($folderId);
         $this->assertFalse($trash['deleted']);
 
         // check that all children are restored

--- a/plugins/BEdita/API/tests/IntegrationTest/NewObjectTypesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/NewObjectTypesTest.php
@@ -80,7 +80,7 @@ class NewObjectTypesTest extends IntegrationTestCase
         $this->post('/model/object_types', json_encode(compact('data')));
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertTrue(TableRegistry::get('ObjectTypes')->exists(['name' => $type]));
+        $this->assertTrue(TableRegistry::getTableLocator()->get('ObjectTypes')->exists(['name' => $type]));
 
         // ADD OBJECT
         $data = [

--- a/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
@@ -38,7 +38,7 @@ class ParentsRelationshipTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $this->Trees = TableRegistry::get('Trees');
+        $this->Trees = TableRegistry::getTableLocator()->get('Trees');
     }
 
     /**
@@ -77,7 +77,7 @@ class ParentsRelationshipTest extends IntegrationTestCase
         static::assertEquals(0, $this->countTrees($docId));
 
         // POST: add 3 folders as parents relationships
-        $foldersTable = TableRegistry::get('Folders');
+        $foldersTable = TableRegistry::getTableLocator()->get('Folders');
         $folders = $foldersTable
             ->find('list', [
                 'keyField' => 'uname',
@@ -190,7 +190,7 @@ class ParentsRelationshipTest extends IntegrationTestCase
     public function testDeletedParent()
     {
         // a deleted folder must not be listed in `parents`
-        $foldersTable = TableRegistry::get('Folders');
+        $foldersTable = TableRegistry::getTableLocator()->get('Folders');
         $folder = $foldersTable->get(12);
         $folder->deleted = true;
         $foldersTable->saveOrFail($folder);

--- a/plugins/BEdita/API/tests/IntegrationTest/RelationshipsParamsTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/RelationshipsParamsTest.php
@@ -56,10 +56,10 @@ class RelationshipsParamsTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $this->Locations = TableRegistry::get('Locations');
-        $this->Users = TableRegistry::get('Users');
-        $this->Relations = TableRegistry::get('Relations');
-        $this->ObjectRelations = TableRegistry::get('ObjectRelations');
+        $this->Locations = TableRegistry::getTableLocator()->get('Locations');
+        $this->Users = TableRegistry::getTableLocator()->get('Users');
+        $this->Relations = TableRegistry::getTableLocator()->get('Relations');
+        $this->ObjectRelations = TableRegistry::getTableLocator()->get('ObjectRelations');
     }
 
     /**
@@ -268,7 +268,7 @@ class RelationshipsParamsTest extends IntegrationTestCase
 
         $currentPriority = $objectRelation->get('priority');
 
-        $ObjectTypes = TableRegistry::get('ObjectTypes');
+        $ObjectTypes = TableRegistry::getTableLocator()->get('ObjectTypes');
         $leftType = $ObjectTypes->find('all')
             ->where([
                 'id' => $this->ObjectRelations->LeftObjects->get($objectRelation->get('left_id'))->get('object_type_id'),

--- a/plugins/BEdita/API/tests/IntegrationTest/UniqueNameTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/UniqueNameTest.php
@@ -125,6 +125,6 @@ class UniqueNameTest extends IntegrationTestCase
         $designatedUname = 'profile-my-profile';
         static::assertSame($designatedUname, $body['data']['attributes']['uname']);
 
-        static::assertSame($designatedUname, TableRegistry::get('Profiles')->get($id)->get('uname'));
+        static::assertSame($designatedUname, TableRegistry::getTableLocator()->get('Profiles')->get($id)->get('uname'));
     }
 }

--- a/plugins/BEdita/API/tests/IntegrationTest/UuidLoginTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/UuidLoginTest.php
@@ -48,7 +48,7 @@ class UuidLoginTest extends IntegrationTestCase
         static::assertNotNull($jwt);
         $payload = json_decode(base64_decode(explode('.', $jwt)[1]), true);
 
-        $exists = TableRegistry::get('ExternalAuth')->exists([
+        $exists = TableRegistry::getTableLocator()->get('ExternalAuth')->exists([
             'provider_username' => $uuid,
             'user_id' => $payload['id'],
             'auth_provider_id' => 2,
@@ -63,7 +63,7 @@ class UuidLoginTest extends IntegrationTestCase
      */
     public function testLoginUuidDisabled()
     {
-        TableRegistry::get('AuthProviders')->delete(TableRegistry::get('AuthProviders')->get(2));
+        TableRegistry::getTableLocator()->get('AuthProviders')->delete(TableRegistry::getTableLocator()->get('AuthProviders')->get(2));
 
         $uuid = Text::uuid();
         $this->configRequestHeaders('POST', [
@@ -79,7 +79,7 @@ class UuidLoginTest extends IntegrationTestCase
         $jwt = Hash::get($body, 'meta.jwt');
         static::assertNull($jwt);
 
-        $exists = TableRegistry::get('ExternalAuth')->exists([
+        $exists = TableRegistry::getTableLocator()->get('ExternalAuth')->exists([
             'provider_username' => $uuid,
         ]);
         static::assertFalse($exists);
@@ -102,7 +102,7 @@ class UuidLoginTest extends IntegrationTestCase
         $this->assertContentType('application/vnd.api+json');
         $this->assertResponseNotEmpty();
 
-        $exists = TableRegistry::get('ExternalAuth')->exists([
+        $exists = TableRegistry::getTableLocator()->get('ExternalAuth')->exists([
             'provider_username' => $uuid,
         ]);
         static::assertFalse($exists);

--- a/plugins/BEdita/API/tests/TestCase/Auth/EndpointAuthorizeTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/EndpointAuthorizeTest.php
@@ -117,7 +117,7 @@ class EndpointAuthorizeTest extends TestCase
         $authorize->authorize([], $request);
 
         if (is_int($expected)) {
-            $expected = TableRegistry::get('Endpoints')->get($expected);
+            $expected = TableRegistry::getTableLocator()->get('Endpoints')->get($expected);
         }
 
         static::assertAttributeEquals($expected, 'endpoint', $authorize);
@@ -223,7 +223,7 @@ class EndpointAuthorizeTest extends TestCase
             static::expectExceptionMessage($expected->getMessage());
         }
 
-        CurrentApplication::setApplication(TableRegistry::get('Applications')->get(2));
+        CurrentApplication::setApplication(TableRegistry::getTableLocator()->get('Applications')->get(2));
 
         $environment = [
             'REQUEST_METHOD' => $requestMethod,
@@ -262,8 +262,8 @@ class EndpointAuthorizeTest extends TestCase
     public function testAllowByDefault()
     {
         // Ensure no permissions apply to `/home` endpoint.
-        TableRegistry::get('EndpointPermissions')->deleteAll(['role_id IS' => null]);
-        TableRegistry::get('EndpointPermissions')->deleteAll(['endpoint_id' => 2]);
+        TableRegistry::getTableLocator()->get('EndpointPermissions')->deleteAll(['role_id IS' => null]);
+        TableRegistry::getTableLocator()->get('EndpointPermissions')->deleteAll(['endpoint_id' => 2]);
 
         $environment = [
             'REQUEST_METHOD' => 'GET',
@@ -306,7 +306,7 @@ class EndpointAuthorizeTest extends TestCase
     public function testAllowByDefaultUnknownEndpoint()
     {
         // Ensure no permissions apply to anonymous user.
-        TableRegistry::get('EndpointPermissions')->deleteAll(['role_id IS' => null]);
+        TableRegistry::getTableLocator()->get('EndpointPermissions')->deleteAll(['role_id IS' => null]);
 
         $environment = [
             'REQUEST_METHOD' => 'GET',
@@ -353,7 +353,7 @@ class EndpointAuthorizeTest extends TestCase
     public function testBlockAnonymousWritesByDefault()
     {
         // Ensure no permissions apply to anonymous user on `/home` endpoint.
-        TableRegistry::get('EndpointPermissions')->deleteAll(['role_id IS' => null, 'endpoint_id' => 2]);
+        TableRegistry::getTableLocator()->get('EndpointPermissions')->deleteAll(['role_id IS' => null, 'endpoint_id' => 2]);
 
         $environment = [
             'REQUEST_METHOD' => 'POST',
@@ -394,7 +394,7 @@ class EndpointAuthorizeTest extends TestCase
     public function testBlockUnloggedByDefault()
     {
         // Ensure no permissions apply to anonymous user on `/home` endpoint.
-        TableRegistry::get('EndpointPermissions')->deleteAll(['role_id IS' => null, 'endpoint_id' => 2]);
+        TableRegistry::getTableLocator()->get('EndpointPermissions')->deleteAll(['role_id IS' => null, 'endpoint_id' => 2]);
 
         $environment = [
             'REQUEST_METHOD' => 'GET',

--- a/plugins/BEdita/API/tests/TestCase/Auth/OAuth2AuthenticateTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/OAuth2AuthenticateTest.php
@@ -136,7 +136,7 @@ class OAuth2AuthenticateTest extends TestCase
      */
     public function testAuthenticate($expected, ServerRequest $request, array $oauthResponse = [])
     {
-        $authConfig = TableRegistry::get('AuthProviders')
+        $authConfig = TableRegistry::getTableLocator()->get('AuthProviders')
             ->find('authenticate')
             ->toArray();
 

--- a/plugins/BEdita/API/tests/TestCase/Auth/OTPAuthenticateTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/OTPAuthenticateTest.php
@@ -163,12 +163,12 @@ class OTPAuthenticateTest extends TestCase
     public function testAuthenticate($expected, ServerRequest $request)
     {
         $dispatchedEvent = 0;
-        TableRegistry::get('Users')->getEventManager()->on('Auth.userToken', function () use (&$dispatchedEvent) {
+        TableRegistry::getTableLocator()->get('Users')->getEventManager()->on('Auth.userToken', function () use (&$dispatchedEvent) {
             $dispatchedEvent++;
             static::assertInstanceOf(UserToken::class, func_get_arg(1));
         });
 
-        CurrentApplication::setApplication(TableRegistry::get('Applications')->get(1));
+        CurrentApplication::setApplication(TableRegistry::getTableLocator()->get('Applications')->get(1));
 
         $auth = new OTPAuthenticate(new ComponentRegistry(), []);
         $result = $auth->authenticate($request, new Response());
@@ -220,7 +220,7 @@ class OTPAuthenticateTest extends TestCase
      */
     public function testGenerateSecretAuthProvider()
     {
-        $AuthProviders = TableRegistry::get('AuthProviders');
+        $AuthProviders = TableRegistry::getTableLocator()->get('AuthProviders');
         $authProvider = $AuthProviders->get(4);
         $authProvider->set('params', ['generator' => 'time']);
         $AuthProviders->saveOrFail($authProvider);

--- a/plugins/BEdita/API/tests/TestCase/Auth/UuidAuthenticateTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/UuidAuthenticateTest.php
@@ -186,7 +186,7 @@ class UuidAuthenticateTest extends TestCase
      */
     public function testAuthenticate($expected, $newUser, ServerRequest $request)
     {
-        $Users = TableRegistry::get('Users');
+        $Users = TableRegistry::getTableLocator()->get('Users');
         $count = $Users->find()->count();
 
         $dispatchedEvent = 0;
@@ -197,7 +197,7 @@ class UuidAuthenticateTest extends TestCase
             static::assertTrue(is_string(func_get_arg(2)));
         });
 
-        $authConfig = TableRegistry::get('AuthProviders')
+        $authConfig = TableRegistry::getTableLocator()->get('AuthProviders')
             ->find('authenticate')
             ->toArray();
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/ApplicationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/ApplicationsControllerTest.php
@@ -135,9 +135,9 @@ class ApplicationsControllerTest extends IntegrationTestCase
             'data' => [],
         ];
 
-        TableRegistry::get('EndpointPermissions')->deleteAll([]);
-        TableRegistry::get('Config')->deleteAll(['application_id IS NOT NULL']);
-        TableRegistry::get('Applications')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('EndpointPermissions')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('Config')->deleteAll(['application_id IS NOT NULL']);
+        TableRegistry::getTableLocator()->get('Applications')->deleteAll([]);
 
         $this->configRequestHeaders('GET', $this->getUserAuthHeader());
         $this->get('/admin/applications');
@@ -257,7 +257,7 @@ class ApplicationsControllerTest extends IntegrationTestCase
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
 
-        $application = TableRegistry::get('Applications')
+        $application = TableRegistry::getTableLocator()->get('Applications')
             ->find()
             ->order(['id' => 'DESC'])
             ->first();
@@ -285,7 +285,7 @@ class ApplicationsControllerTest extends IntegrationTestCase
             ],
         ];
 
-        $Applications = TableRegistry::get('Applications');
+        $Applications = TableRegistry::getTableLocator()->get('Applications');
         $count = $Applications->find()->count();
 
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
@@ -320,7 +320,7 @@ class ApplicationsControllerTest extends IntegrationTestCase
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
 
-        $Applications = TableRegistry::get('Applications');
+        $Applications = TableRegistry::getTableLocator()->get('Applications');
         $entity = $Applications->get(1);
         static::assertEquals('new name', $entity->get('name'));
     }
@@ -343,7 +343,7 @@ class ApplicationsControllerTest extends IntegrationTestCase
             ],
         ];
 
-        $Applications = TableRegistry::get('Applications');
+        $Applications = TableRegistry::getTableLocator()->get('Applications');
         $expected = $Applications->get(1)->get('name');
 
         $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
@@ -369,6 +369,6 @@ class ApplicationsControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(204);
         $this->assertContentType('application/vnd.api+json');
-        static::assertFalse(TableRegistry::get('Applications')->exists(['id' => 2]));
+        static::assertFalse(TableRegistry::getTableLocator()->get('Applications')->exists(['id' => 2]));
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/AsyncJobsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/AsyncJobsControllerTest.php
@@ -33,7 +33,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
      */
     public function testIndex()
     {
-        $AsyncJobs = TableRegistry::get('AsyncJobs');
+        $AsyncJobs = TableRegistry::getTableLocator()->get('AsyncJobs');
         $expected = [
             'links' => [
                 'self' => 'http://api.example.com/admin/async_jobs?sort=uuid',
@@ -288,7 +288,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
             'data' => [],
         ];
 
-        TableRegistry::get('AsyncJobs')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('AsyncJobs')->deleteAll([]);
 
         $this->configRequestHeaders('GET', $this->getUserAuthHeader());
         $this->get('/admin/async_jobs');
@@ -407,7 +407,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
 
-        $asyncJob = TableRegistry::get('AsyncJobs')
+        $asyncJob = TableRegistry::getTableLocator()->get('AsyncJobs')
             ->find()
             ->order(['created' => 'DESC'])
             ->first();
@@ -435,7 +435,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
             ],
         ];
 
-        $AsyncJobs = TableRegistry::get('AsyncJobs');
+        $AsyncJobs = TableRegistry::getTableLocator()->get('AsyncJobs');
         $count = $AsyncJobs->find()->count();
 
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
@@ -470,7 +470,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
 
-        $AsyncJobs = TableRegistry::get('AsyncJobs');
+        $AsyncJobs = TableRegistry::getTableLocator()->get('AsyncJobs');
         $entity = $AsyncJobs->get('e533e1cf-b12c-4dbe-8fb7-b25fafbd2f76');
         static::assertEquals(99, $entity->get('priority'));
     }
@@ -493,7 +493,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
             ],
         ];
 
-        $AsyncJobs = TableRegistry::get('AsyncJobs');
+        $AsyncJobs = TableRegistry::getTableLocator()->get('AsyncJobs');
         $expected = $AsyncJobs->get('d6bb8c84-6b29-432e-bb84-c3c4b2c1b99c')->get('priority');
 
         $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
@@ -519,6 +519,6 @@ class AsyncJobsControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(204);
         $this->assertContentType('application/vnd.api+json');
-        static::assertFalse(TableRegistry::get('AsyncJobs')->exists(['uuid' => 'd6bb8c84-6b29-432e-bb84-c3c4b2c1b99c']));
+        static::assertFalse(TableRegistry::getTableLocator()->get('AsyncJobs')->exists(['uuid' => 'd6bb8c84-6b29-432e-bb84-c3c4b2c1b99c']));
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/ConfigControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/ConfigControllerTest.php
@@ -124,7 +124,7 @@ class ConfigControllerTest extends IntegrationTestCase
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
 
-        $entity = TableRegistry::get('Config')->get('Name1');
+        $entity = TableRegistry::getTableLocator()->get('Config')->get('Name1');
         static::assertEquals('data2', $entity->get('content'));
     }
 
@@ -143,6 +143,6 @@ class ConfigControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(204);
         $this->assertContentType('application/vnd.api+json');
-        static::assertFalse(TableRegistry::get('Config')->exists(['name' => 'Name2']));
+        static::assertFalse(TableRegistry::getTableLocator()->get('Config')->exists(['name' => 'Name2']));
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/EndpointsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/EndpointsControllerTest.php
@@ -145,8 +145,8 @@ class EndpointsControllerTest extends IntegrationTestCase
             'data' => [],
         ];
 
-        TableRegistry::get('EndpointPermissions')->deleteAll([]);
-        TableRegistry::get('Endpoints')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('EndpointPermissions')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('Endpoints')->deleteAll([]);
 
         $this->configRequestHeaders('GET', $this->getUserAuthHeader());
         $this->get('/admin/endpoints');
@@ -257,7 +257,7 @@ class EndpointsControllerTest extends IntegrationTestCase
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
 
-        $endpoint = TableRegistry::get('Endpoints')
+        $endpoint = TableRegistry::getTableLocator()->get('Endpoints')
             ->find()
             ->order(['id' => 'DESC'])
             ->first();
@@ -285,7 +285,7 @@ class EndpointsControllerTest extends IntegrationTestCase
             ],
         ];
 
-        $Endpoints = TableRegistry::get('Endpoints');
+        $Endpoints = TableRegistry::getTableLocator()->get('Endpoints');
         $count = $Endpoints->find()->count();
 
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
@@ -320,7 +320,7 @@ class EndpointsControllerTest extends IntegrationTestCase
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
 
-        $Endpoints = TableRegistry::get('Endpoints');
+        $Endpoints = TableRegistry::getTableLocator()->get('Endpoints');
         $entity = $Endpoints->get(1);
         static::assertEquals('magic', $entity->get('name'));
     }
@@ -343,7 +343,7 @@ class EndpointsControllerTest extends IntegrationTestCase
             ],
         ];
 
-        $Endpoints = TableRegistry::get('Endpoints');
+        $Endpoints = TableRegistry::getTableLocator()->get('Endpoints');
         $expected = $Endpoints->get(1)->get('name');
 
         $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
@@ -369,6 +369,6 @@ class EndpointsControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(204);
         $this->assertContentType('application/vnd.api+json');
-        static::assertFalse(TableRegistry::get('Endpoints')->exists(['id' => 2]));
+        static::assertFalse(TableRegistry::getTableLocator()->get('Endpoints')->exists(['id' => 2]));
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/AnnotationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AnnotationsControllerTest.php
@@ -232,7 +232,7 @@ class AnnotationsControllerTest extends IntegrationTestCase
         $this->delete('/annotations/1');
         $this->assertResponseCode(204);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertFalse(TableRegistry::get('Annotations')->exists(['id' => 1]));
+        $this->assertFalse(TableRegistry::getTableLocator()->get('Annotations')->exists(['id' => 1]));
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
@@ -227,7 +227,7 @@ class JsonApiComponentTest extends TestCase
             'query' => $query,
         ]);
         $controller = new Controller($request);
-        $controller->paginate(TableRegistry::get('Roles'));
+        $controller->paginate(TableRegistry::getTableLocator()->get('Roles'));
         $component = new JsonApiComponent(new ComponentRegistry($controller), []);
 
         static::assertEquals($expectedLinks, $component->getLinks());
@@ -263,7 +263,7 @@ class JsonApiComponentTest extends TestCase
             'query' => $query,
         ]);
         $controller = new Controller($request);
-        $controller->paginate(TableRegistry::get('Roles'));
+        $controller->paginate(TableRegistry::getTableLocator()->get('Roles'));
         $controller->set([
             '_links' => $base,
             '_meta' => $base,

--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -39,7 +39,7 @@ class FoldersControllerTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $this->Folders = TableRegistry::get('Folders');
+        $this->Folders = TableRegistry::getTableLocator()->get('Folders');
     }
 
     /**
@@ -269,8 +269,8 @@ class FoldersControllerTest extends IntegrationTestCase
             'data' => [],
         ];
 
-        TableRegistry::get('Translations')->deleteAll([]);
-        TableRegistry::get('Folders')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('Translations')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('Folders')->deleteAll([]);
 
         $this->configRequestHeaders();
         $this->get('/folders');
@@ -416,7 +416,7 @@ class FoldersControllerTest extends IntegrationTestCase
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
         $this->assertHeader('Location', 'http://api.example.com/folders/' . $folderId);
-        static::assertTrue(TableRegistry::get('Folders')->exists(['id' => $folderId]));
+        static::assertTrue(TableRegistry::getTableLocator()->get('Folders')->exists(['id' => $folderId]));
     }
 
     /**
@@ -441,8 +441,8 @@ class FoldersControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
-        static::assertEquals('Radice', TableRegistry::get('Folders')->get(11)->get('title'));
-        static::assertEquals('folders', TableRegistry::get('Folders')->get(11)->get('type'));
+        static::assertEquals('Radice', TableRegistry::getTableLocator()->get('Folders')->get(11)->get('title'));
+        static::assertEquals('folders', TableRegistry::getTableLocator()->get('Folders')->get(11)->get('type'));
 
         $result = json_decode((string)$this->_response->getBody(), true);
         static::assertEquals($data['id'], $result['data']['id']);
@@ -459,7 +459,7 @@ class FoldersControllerTest extends IntegrationTestCase
      */
     public function testDelete()
     {
-        $foldersTable = TableRegistry::get('Folders');
+        $foldersTable = TableRegistry::getTableLocator()->get('Folders');
         $folderId = 11;
         $children = $foldersTable
             ->find('ancestor', [$folderId])
@@ -553,7 +553,7 @@ class FoldersControllerTest extends IntegrationTestCase
         $this->get('/folders/11/children');
         $result = json_decode((string)$this->_response->getBody(), true);
 
-        $treesTable = TableRegistry::get('Trees');
+        $treesTable = TableRegistry::getTableLocator()->get('Trees');
         $node = $treesTable->find()->where(['object_id' => 11])->first();
         $children = $treesTable
             ->find('children', ['for' => $node->id, 'direct' => true])
@@ -720,7 +720,7 @@ class FoldersControllerTest extends IntegrationTestCase
     public function testDeletedChildren()
     {
         // add a deleted object to folder and verify it's not listed in `childrens`
-        $treesTable = TableRegistry::get('Trees');
+        $treesTable = TableRegistry::getTableLocator()->get('Trees');
         $entity = $treesTable->newEntity([
                 'object_id' => 6,
             ]);
@@ -797,8 +797,8 @@ class FoldersControllerTest extends IntegrationTestCase
      */
     public function testGetOrphanFolder($id = null)
     {
-        TableRegistry::get('Trees')->deleteAll(['object_id' => 12]);
-        TableRegistry::get('Trees')->recover();
+        TableRegistry::getTableLocator()->get('Trees')->deleteAll(['object_id' => 12]);
+        TableRegistry::getTableLocator()->get('Trees')->recover();
 
         $endpoint = '/folders';
         if ($id) {
@@ -850,7 +850,7 @@ class FoldersControllerTest extends IntegrationTestCase
      */
     public function testMoveFolder($folderId, $parentId)
     {
-        $foldersTable = TableRegistry::get('Folders');
+        $foldersTable = TableRegistry::getTableLocator()->get('Folders');
 
         $getDescendants = function () use ($folderId, $foldersTable) {
             return $foldersTable
@@ -859,7 +859,7 @@ class FoldersControllerTest extends IntegrationTestCase
                 ->toArray();
         };
 
-        $treesTable = TableRegistry::get('Trees');
+        $treesTable = TableRegistry::getTableLocator()->get('Trees');
         $folderTreeNode = $treesTable->find()->where(['object_id' => $folderId])->first();
 
         $getTreeList = function () use ($treesTable, $folderTreeNode) {
@@ -1223,7 +1223,7 @@ class FoldersControllerTest extends IntegrationTestCase
             LoggedUser::setUser(['id' => 1]);
         }
 
-        $documentsTable = TableRegistry::get('Documents');
+        $documentsTable = TableRegistry::getTableLocator()->get('Documents');
         $document = $documentsTable->newEntity($data);
 
         return $documentsTable->saveOrFail($document);

--- a/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
@@ -62,7 +62,7 @@ class LoginControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(200);
 
-        $lastLogin = TableRegistry::get('Users')->get(1)->get('last_login');
+        $lastLogin = TableRegistry::getTableLocator()->get('Users')->get(1)->get('last_login');
         static::assertNotNull($lastLogin);
         static::assertEquals(Time::now()->timestamp, $lastLogin->timestamp, '', 1);
 
@@ -137,7 +137,7 @@ class LoginControllerTest extends IntegrationTestCase
         sleep(1);
 
         // block user
-        $usersTable = TableRegistry::get('Users');
+        $usersTable = TableRegistry::getTableLocator()->get('Users');
         $user = $usersTable->get(1);
         $user->blocked = true;
         $usersTable->saveOrFail($user);
@@ -203,7 +203,7 @@ class LoginControllerTest extends IntegrationTestCase
     {
         // Permissions on endpoint `/auth` for application id 2 and role 2 is 0b0001 --> write NO, read MINE
         // POST /auth with role id 2 on application id 2 MUST fail
-        CurrentApplication::setApplication(TableRegistry::get('Applications')->get(2));
+        CurrentApplication::setApplication(TableRegistry::getTableLocator()->get('Applications')->get(2));
 
         $this->configRequestHeaders('POST', ['Content-Type' => 'application/json']);
 
@@ -270,7 +270,7 @@ class LoginControllerTest extends IntegrationTestCase
         sleep(1);
 
         // block user
-        $usersTable = TableRegistry::get('Users');
+        $usersTable = TableRegistry::getTableLocator()->get('Users');
         $user = $usersTable->get(1);
         $user->blocked = true;
         $usersTable->saveOrFail($user);
@@ -375,8 +375,8 @@ class LoginControllerTest extends IntegrationTestCase
      */
     protected function removePermissions()
     {
-        TableRegistry::get('EndpointPermissions')->deleteAll(['endpoint_id' => 1]);
-        TableRegistry::get('EndpointPermissions')->deleteAll(['endpoint_id IS NULL']);
+        TableRegistry::getTableLocator()->get('EndpointPermissions')->deleteAll(['endpoint_id' => 1]);
+        TableRegistry::getTableLocator()->get('EndpointPermissions')->deleteAll(['endpoint_id IS NULL']);
     }
 
     /**
@@ -410,10 +410,10 @@ class LoginControllerTest extends IntegrationTestCase
      */
     protected function createTestJob()
     {
-        $action = new SaveEntityAction(['table' => TableRegistry::get('AsyncJobs')]);
+        $action = new SaveEntityAction(['table' => TableRegistry::getTableLocator()->get('AsyncJobs')]);
 
         return $action([
-            'entity' => TableRegistry::get('AsyncJobs')->newEntity(),
+            'entity' => TableRegistry::getTableLocator()->get('AsyncJobs')->newEntity(),
             'data' => [
                 'service' => 'credentials_change',
                 'payload' => [
@@ -500,7 +500,7 @@ class LoginControllerTest extends IntegrationTestCase
     public function testUpdate(array $meta)
     {
         // set email to NULL to be able to change it
-        $table = TableRegistry::get('Users');
+        $table = TableRegistry::getTableLocator()->get('Users');
         $user = $table->get(1);
         $user->set('email', null);
         $table->saveOrFail($user);
@@ -599,7 +599,7 @@ class LoginControllerTest extends IntegrationTestCase
      */
     public function testBlockedLogin()
     {
-        $usersTable = TableRegistry::get('Users');
+        $usersTable = TableRegistry::getTableLocator()->get('Users');
         $user = $usersTable->get(5);
         $user->blocked = true;
         $usersTable->saveOrFail($user);
@@ -648,7 +648,7 @@ class LoginControllerTest extends IntegrationTestCase
      */
     public function testStatus($expected, $status)
     {
-        $usersTable = TableRegistry::get('Users');
+        $usersTable = TableRegistry::getTableLocator()->get('Users');
         $user = $usersTable->get(5);
         $user->set('status', $status);
         $usersTable->saveOrFail($user);
@@ -785,7 +785,7 @@ class LoginControllerTest extends IntegrationTestCase
      */
     public function testOTPRequestFail()
     {
-        $usersTable = TableRegistry::get('Users');
+        $usersTable = TableRegistry::getTableLocator()->get('Users');
         $user = $usersTable->get(5);
         $user->deleted = true;
         $usersTable->saveOrFail($user);
@@ -833,7 +833,7 @@ class LoginControllerTest extends IntegrationTestCase
      */
     public function testOTPFail()
     {
-        $usersTable = TableRegistry::get('Users');
+        $usersTable = TableRegistry::getTableLocator()->get('Users');
         $user = $usersTable->get(5);
         $user->status = 'off';
         $usersTable->saveOrFail($user);

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
@@ -577,10 +577,10 @@ class ObjectTypesControllerTest extends IntegrationTestCase
             'data' => [],
         ];
 
-        TableRegistry::get('Properties')->deleteAll([]);
-        TableRegistry::get('Translations')->deleteAll([]);
-        TableRegistry::get('Objects')->deleteAll([]);
-        TableRegistry::get('ObjectTypes')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('Properties')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('Translations')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('Objects')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('ObjectTypes')->deleteAll([]);
 
         $this->configRequestHeaders();
         $this->get('/model/object_types');
@@ -734,7 +734,7 @@ class ObjectTypesControllerTest extends IntegrationTestCase
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
         $this->assertHeader('Location', 'http://api.example.com/model/object_types/11');
-        $this->assertTrue(TableRegistry::get('ObjectTypes')->exists(['singular' => 'my_object_type']));
+        $this->assertTrue(TableRegistry::getTableLocator()->get('ObjectTypes')->exists(['singular' => 'my_object_type']));
     }
 
     /**
@@ -755,12 +755,12 @@ class ObjectTypesControllerTest extends IntegrationTestCase
             ],
         ];
 
-        $count = TableRegistry::get('ObjectTypes')->find()->count();
+        $count = TableRegistry::getTableLocator()->get('ObjectTypes')->find()->count();
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
         $this->post('/model/object_types', json_encode(compact('data')));
         $this->assertResponseCode(400);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertEquals($count, TableRegistry::get('ObjectTypes')->find()->count());
+        $this->assertEquals($count, TableRegistry::getTableLocator()->get('ObjectTypes')->find()->count());
     }
 
     /**
@@ -782,12 +782,12 @@ class ObjectTypesControllerTest extends IntegrationTestCase
             ],
         ];
 
-        $count = TableRegistry::get('ObjectTypes')->find()->count();
+        $count = TableRegistry::getTableLocator()->get('ObjectTypes')->find()->count();
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
         $this->post('/model/object_types', json_encode(compact('data')));
         $this->assertResponseCode(400);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertEquals($count, TableRegistry::get('ObjectTypes')->find()->count());
+        $this->assertEquals($count, TableRegistry::getTableLocator()->get('ObjectTypes')->find()->count());
     }
 
     /**
@@ -809,12 +809,12 @@ class ObjectTypesControllerTest extends IntegrationTestCase
             ],
         ];
 
-        $count = TableRegistry::get('ObjectTypes')->find()->count();
+        $count = TableRegistry::getTableLocator()->get('ObjectTypes')->find()->count();
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
         $this->post('/model/object_types', json_encode(compact('data')));
         $this->assertResponseCode(400);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertEquals($count, TableRegistry::get('ObjectTypes')->find()->count());
+        $this->assertEquals($count, TableRegistry::getTableLocator()->get('ObjectTypes')->find()->count());
     }
 
     /**
@@ -841,7 +841,7 @@ class ObjectTypesControllerTest extends IntegrationTestCase
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
 
-        $ObjectTypes = TableRegistry::get('ObjectTypes');
+        $ObjectTypes = TableRegistry::getTableLocator()->get('ObjectTypes');
         $entity = $ObjectTypes->get(2);
         $this->assertEquals('document new', $entity->get('singular'));
 
@@ -900,8 +900,8 @@ class ObjectTypesControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(409);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertEquals('document', TableRegistry::get('ObjectTypes')->get(2)->get('singular'));
-        $this->assertEquals('profile', TableRegistry::get('ObjectTypes')->get(3)->get('singular'));
+        $this->assertEquals('document', TableRegistry::getTableLocator()->get('ObjectTypes')->get(2)->get('singular'));
+        $this->assertEquals('profile', TableRegistry::getTableLocator()->get('ObjectTypes')->get(3)->get('singular'));
     }
 
     /**
@@ -919,6 +919,6 @@ class ObjectTypesControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(204);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertFalse(TableRegistry::get('ObjectTypes')->exists(['id' => 5]));
+        $this->assertFalse(TableRegistry::getTableLocator()->get('ObjectTypes')->exists(['id' => 5]));
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertiesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertiesControllerTest.php
@@ -276,7 +276,7 @@ class PropertiesControllerTest extends IntegrationTestCase
             'data' => [],
         ];
 
-        TableRegistry::get('Properties')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('Properties')->deleteAll([]);
 
         $this->configRequestHeaders();
         $this->get('/model/properties?filter[type]=dynamic');
@@ -391,7 +391,7 @@ class PropertiesControllerTest extends IntegrationTestCase
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
         $this->assertHeader('Location', 'http://api.example.com/model/properties/10');
-        static::assertTrue(TableRegistry::get('Properties')->exists(['name' => 'yet_another_body']));
+        static::assertTrue(TableRegistry::getTableLocator()->get('Properties')->exists(['name' => 'yet_another_body']));
     }
 
     /**
@@ -411,14 +411,14 @@ class PropertiesControllerTest extends IntegrationTestCase
             ],
         ];
 
-        $count = TableRegistry::get('Properties')->find()->count();
+        $count = TableRegistry::getTableLocator()->get('Properties')->find()->count();
 
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
         $this->post('/model/properties', json_encode(compact('data')));
 
         $this->assertResponseCode(400);
         $this->assertContentType('application/vnd.api+json');
-        static::assertEquals($count, TableRegistry::get('Properties')->find()->count());
+        static::assertEquals($count, TableRegistry::getTableLocator()->get('Properties')->find()->count());
     }
 
     /**
@@ -456,7 +456,7 @@ class PropertiesControllerTest extends IntegrationTestCase
         ];
         static::assertEquals($data, $result['data']);
 
-        static::assertEquals('nice description', TableRegistry::get('Properties')->get(1)->get('description'));
+        static::assertEquals('nice description', TableRegistry::getTableLocator()->get('Properties')->get(1)->get('description'));
     }
 
     /**
@@ -482,8 +482,8 @@ class PropertiesControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(409);
         $this->assertContentType('application/vnd.api+json');
-        static::assertEquals('another_title', TableRegistry::get('Properties')->get(1)->get('name'));
-        static::assertEquals('another_description', TableRegistry::get('Properties')->get(2)->get('name'));
+        static::assertEquals('another_title', TableRegistry::getTableLocator()->get('Properties')->get(1)->get('name'));
+        static::assertEquals('another_description', TableRegistry::getTableLocator()->get('Properties')->get(2)->get('name'));
     }
 
     /**
@@ -501,6 +501,6 @@ class PropertiesControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(204);
         $this->assertContentType('application/vnd.api+json');
-        static::assertFalse(TableRegistry::get('Properties')->exists(['id' => 1]));
+        static::assertFalse(TableRegistry::getTableLocator()->get('Properties')->exists(['id' => 1]));
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
@@ -427,7 +427,7 @@ class PropertyTypesControllerTest extends IntegrationTestCase
             'data' => [],
         ];
 
-        TableRegistry::get('PropertyTypes')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('PropertyTypes')->deleteAll([]);
 
         $this->configRequestHeaders();
         $this->get('/model/property_types');
@@ -546,8 +546,8 @@ class PropertyTypesControllerTest extends IntegrationTestCase
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
         $this->assertHeader('Location', 'http://api.example.com/model/property_types/13');
-        static::assertTrue(TableRegistry::get('PropertyTypes')->exists(['name' => 'gustavo']));
-        static::assertFalse(TableRegistry::get('PropertyTypes')->get(13)->get('core_type'));
+        static::assertTrue(TableRegistry::getTableLocator()->get('PropertyTypes')->exists(['name' => 'gustavo']));
+        static::assertFalse(TableRegistry::getTableLocator()->get('PropertyTypes')->get(13)->get('core_type'));
     }
 
     /**
@@ -567,14 +567,14 @@ class PropertyTypesControllerTest extends IntegrationTestCase
             ],
         ];
 
-        $count = TableRegistry::get('PropertyTypes')->find()->count();
+        $count = TableRegistry::getTableLocator()->get('PropertyTypes')->find()->count();
 
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
         $this->post('/model/property_types', json_encode(compact('data')));
 
         $this->assertResponseCode(400);
         $this->assertContentType('application/vnd.api+json');
-        static::assertEquals($count, TableRegistry::get('PropertyTypes')->find()->count());
+        static::assertEquals($count, TableRegistry::getTableLocator()->get('PropertyTypes')->find()->count());
     }
 
     /**
@@ -607,7 +607,7 @@ class PropertyTypesControllerTest extends IntegrationTestCase
         $this->assertContentType('application/vnd.api+json');
         unset($result['data']['relationships'], $result['data']['meta']);
         static::assertEquals($data, $result['data']);
-        static::assertEquals($data['attributes']['params'], TableRegistry::get('PropertyTypes')->get(12)->get('params'));
+        static::assertEquals($data['attributes']['params'], TableRegistry::getTableLocator()->get('PropertyTypes')->get(12)->get('params'));
     }
 
     /**
@@ -633,8 +633,8 @@ class PropertyTypesControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(409);
         $this->assertContentType('application/vnd.api+json');
-        static::assertEquals('string', TableRegistry::get('PropertyTypes')->get(1)->get('name'));
-        static::assertEquals('text', TableRegistry::get('PropertyTypes')->get(2)->get('name'));
+        static::assertEquals('string', TableRegistry::getTableLocator()->get('PropertyTypes')->get(1)->get('name'));
+        static::assertEquals('text', TableRegistry::getTableLocator()->get('PropertyTypes')->get(2)->get('name'));
     }
 
     /**
@@ -667,7 +667,7 @@ class PropertyTypesControllerTest extends IntegrationTestCase
         ];
         unset($result['error']['meta'], $result['links']);
         static::assertEquals($expected, $result);
-        static::assertEquals('string', TableRegistry::get('PropertyTypes')->get(1)->get('name'));
+        static::assertEquals('string', TableRegistry::getTableLocator()->get('PropertyTypes')->get(1)->get('name'));
     }
 
     /**
@@ -685,6 +685,6 @@ class PropertyTypesControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(204);
         $this->assertContentType('application/vnd.api+json');
-        static::assertFalse(TableRegistry::get('PropertyTypes')->exists(['id' => 12]));
+        static::assertFalse(TableRegistry::getTableLocator()->get('PropertyTypes')->exists(['id' => 12]));
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
@@ -193,7 +193,7 @@ class RelationsControllerTest extends IntegrationTestCase
             'data' => [],
         ];
 
-        TableRegistry::get('Relations')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('Relations')->deleteAll([]);
 
         $this->configRequestHeaders();
         $this->get('/model/relations');
@@ -323,7 +323,7 @@ class RelationsControllerTest extends IntegrationTestCase
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
 
-        $relation = TableRegistry::get('Relations')
+        $relation = TableRegistry::getTableLocator()->get('Relations')
             ->find()
             ->order(['id' => 'DESC'])
             ->first();
@@ -351,7 +351,7 @@ class RelationsControllerTest extends IntegrationTestCase
             ],
         ];
 
-        $Relations = TableRegistry::get('Relations');
+        $Relations = TableRegistry::getTableLocator()->get('Relations');
         $count = $Relations->find()->count();
 
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
@@ -386,7 +386,7 @@ class RelationsControllerTest extends IntegrationTestCase
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
 
-        $Relations = TableRegistry::get('Relations');
+        $Relations = TableRegistry::getTableLocator()->get('Relations');
         $entity = $Relations->get(1);
         $this->assertEquals('new label', $entity->get('label'));
     }
@@ -409,7 +409,7 @@ class RelationsControllerTest extends IntegrationTestCase
             ],
         ];
 
-        $Relations = TableRegistry::get('Relations');
+        $Relations = TableRegistry::getTableLocator()->get('Relations');
         $expected = $Relations->get(1)->get('label');
 
         $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
@@ -435,7 +435,7 @@ class RelationsControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(204);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertFalse(TableRegistry::get('Relations')->exists(['id' => 1]));
+        $this->assertFalse(TableRegistry::getTableLocator()->get('Relations')->exists(['id' => 1]));
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -738,8 +738,8 @@ class ObjectsControllerTest extends IntegrationTestCase
             'data' => [],
         ];
 
-        TableRegistry::get('Translations')->deleteAll([]);
-        TableRegistry::get('Objects')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('Translations')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('Objects')->deleteAll([]);
 
         $this->configRequestHeaders();
         $this->get('/objects');
@@ -917,7 +917,7 @@ class ObjectsControllerTest extends IntegrationTestCase
         $this->assertContentType('application/vnd.api+json');
 
         // restore object -> deleted = false
-        $objectsTable = TableRegistry::get('Objects');
+        $objectsTable = TableRegistry::getTableLocator()->get('Objects');
         $object = $objectsTable->get(6);
         $object->deleted = false;
         $this->authUser();
@@ -1002,7 +1002,7 @@ class ObjectsControllerTest extends IntegrationTestCase
         static::assertArrayHasKey('attributes', $result['data']);
         static::assertArrayHasKey('status', $result['data']['attributes']);
         $this->assertHeader('Location', 'http://api.example.com/documents/' . $newId);
-        static::assertTrue(TableRegistry::get('Documents')->exists($data['attributes']));
+        static::assertTrue(TableRegistry::getTableLocator()->get('Documents')->exists($data['attributes']));
     }
 
     /**
@@ -1034,7 +1034,7 @@ class ObjectsControllerTest extends IntegrationTestCase
         $this->assertContentType('application/vnd.api+json');
         static::assertArrayHasKey('error', $result);
         static::assertArraySubset($expected, $result['error']);
-        static::assertFalse(TableRegistry::get('Documents')->exists($data['attributes']));
+        static::assertFalse(TableRegistry::getTableLocator()->get('Documents')->exists($data['attributes']));
     }
 
     /**
@@ -1066,7 +1066,7 @@ class ObjectsControllerTest extends IntegrationTestCase
         $this->assertContentType('application/vnd.api+json');
         static::assertArrayHasKey('error', $result);
         static::assertArraySubset($expected, $result['error']);
-        static::assertFalse(TableRegistry::get('Documents')->exists($data['attributes']));
+        static::assertFalse(TableRegistry::getTableLocator()->get('Documents')->exists($data['attributes']));
     }
 
     /**
@@ -1149,7 +1149,7 @@ class ObjectsControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
-        $document = TableRegistry::get('Documents')->get('2');
+        $document = TableRegistry::getTableLocator()->get('Documents')->get('2');
         static::assertEquals($newTitle, $document->get('title'));
         static::assertEquals('documents', $document->get('type'));
         static::assertEquals('on', $document->get('status'));
@@ -1185,8 +1185,8 @@ class ObjectsControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(409);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertEquals('title two', TableRegistry::get('Documents')->get(3)->get('title'));
-        $this->assertEquals('title one', TableRegistry::get('Documents')->get(2)->get('title'));
+        $this->assertEquals('title two', TableRegistry::getTableLocator()->get('Documents')->get(3)->get('title'));
+        $this->assertEquals('title one', TableRegistry::getTableLocator()->get('Documents')->get(2)->get('title'));
 
         $this->configRequestHeaders('PATCH', $authHeader);
         $this->patch('/profiles/3', json_encode(compact('data')));
@@ -1220,7 +1220,7 @@ class ObjectsControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(400);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertEquals('title-one', TableRegistry::get('Documents')->get(2)->get('uname'));
+        $this->assertEquals('title-one', TableRegistry::getTableLocator()->get('Documents')->get(2)->get('uname'));
 
         $this->configRequestHeaders('PATCH', $authHeader);
         $data['id'] = 33;
@@ -1253,7 +1253,7 @@ class ObjectsControllerTest extends IntegrationTestCase
         $this->assertResponseCode(404);
         $this->assertContentType('application/vnd.api+json');
 
-        $docDeleted = TableRegistry::get('Documents')->get(7);
+        $docDeleted = TableRegistry::getTableLocator()->get('Documents')->get(7);
         $this->assertEquals($docDeleted->deleted, 1);
 
         $this->configRequestHeaders('DELETE', $authHeader);

--- a/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
@@ -147,8 +147,8 @@ class RolesControllerTest extends IntegrationTestCase
             'data' => [],
         ];
 
-        TableRegistry::get('EndpointPermissions')->updateAll(['role_id' => null], ['role_id IS NOT' => null]);
-        TableRegistry::get('Roles')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('EndpointPermissions')->updateAll(['role_id' => null], ['role_id IS NOT' => null]);
+        TableRegistry::getTableLocator()->get('Roles')->deleteAll([]);
 
         $this->configRequestHeaders();
         $this->get('/roles');
@@ -275,7 +275,7 @@ class RolesControllerTest extends IntegrationTestCase
         $this->assertContentType('application/vnd.api+json');
         static::assertArrayHasKey('data', $result);
         $this->assertHeader('Location', 'http://api.example.com/roles/3');
-        static::assertTrue(TableRegistry::get('Roles')->exists(['name' => 'head_of_support']));
+        static::assertTrue(TableRegistry::getTableLocator()->get('Roles')->exists(['name' => 'head_of_support']));
     }
 
     /**
@@ -295,14 +295,14 @@ class RolesControllerTest extends IntegrationTestCase
             ],
         ];
 
-        $count = TableRegistry::get('Roles')->find()->count();
+        $count = TableRegistry::getTableLocator()->get('Roles')->find()->count();
 
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
         $this->post('/roles', json_encode(compact('data')));
 
         $this->assertResponseCode(400);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertEquals($count, TableRegistry::get('Roles')->find()->count());
+        $this->assertEquals($count, TableRegistry::getTableLocator()->get('Roles')->find()->count());
     }
 
     /**
@@ -328,7 +328,7 @@ class RolesControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertEquals('new_name', TableRegistry::get('Roles')->get(1)->get('name'));
+        $this->assertEquals('new_name', TableRegistry::getTableLocator()->get('Roles')->get(1)->get('name'));
     }
 
     /**
@@ -354,8 +354,8 @@ class RolesControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(409);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertEquals('first role', TableRegistry::get('Roles')->get(1)->get('name'));
-        $this->assertEquals('second role', TableRegistry::get('Roles')->get(2)->get('name'));
+        $this->assertEquals('first role', TableRegistry::getTableLocator()->get('Roles')->get(1)->get('name'));
+        $this->assertEquals('second role', TableRegistry::getTableLocator()->get('Roles')->get(2)->get('name'));
     }
 
     /**
@@ -381,7 +381,7 @@ class RolesControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(400);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertEquals('first role', TableRegistry::get('Roles')->get(1)->get('name'));
+        $this->assertEquals('first role', TableRegistry::getTableLocator()->get('Roles')->get(1)->get('name'));
     }
 
     /**
@@ -399,14 +399,14 @@ class RolesControllerTest extends IntegrationTestCase
         $this->delete('/roles/1');
         $this->assertResponseCode(403);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertTrue(TableRegistry::get('Roles')->exists(['id' => 1]));
+        $this->assertTrue(TableRegistry::getTableLocator()->get('Roles')->exists(['id' => 1]));
 
         // delete role 2
         $this->configRequestHeaders('DELETE', $this->getUserAuthHeader());
         $this->delete('/roles/2');
         $this->assertResponseCode(204);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertFalse(TableRegistry::get('Roles')->exists(['id' => 2]));
+        $this->assertFalse(TableRegistry::getTableLocator()->get('Roles')->exists(['id' => 2]));
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
@@ -385,7 +385,7 @@ class SignupControllerTest extends IntegrationTestCase
         ];
         $this->post('/signup', json_encode($data));
 
-        $asyncJob = TableRegistry::get('AsyncJobs')->find()
+        $asyncJob = TableRegistry::getTableLocator()->get('AsyncJobs')->find()
             ->order(['AsyncJobs.created' => 'DESC'])
             ->first();
 
@@ -423,13 +423,13 @@ class SignupControllerTest extends IntegrationTestCase
         ];
         $this->post('/signup', json_encode($data));
 
-        $asyncJob = TableRegistry::get('AsyncJobs')->find()
+        $asyncJob = TableRegistry::getTableLocator()->get('AsyncJobs')->find()
             ->order(['AsyncJobs.created' => 'DESC'])
             ->first();
 
         $activationData = ['uuid' => $asyncJob->uuid];
 
-        $Users = TableRegistry::get('Users');
+        $Users = TableRegistry::getTableLocator()->get('Users');
         $user = $Users->find()
             ->order(['created' => 'DESC'])
             ->first();

--- a/plugins/BEdita/API/tests/TestCase/Controller/TranslationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TranslationsControllerTest.php
@@ -256,7 +256,7 @@ class TranslationsControllerTest extends IntegrationTestCase
         $this->delete('/translations/2');
         $this->assertResponseCode(204);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertFalse(TableRegistry::get('Translations')->exists(['id' => 2]));
+        $this->assertFalse(TableRegistry::getTableLocator()->get('Translations')->exists(['id' => 2]));
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/TrashControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TrashControllerTest.php
@@ -36,7 +36,7 @@ class TrashControllerTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $this->Objects = TableRegistry::get('Objects');
+        $this->Objects = TableRegistry::getTableLocator()->get('Objects');
     }
 
     /**
@@ -173,8 +173,8 @@ class TrashControllerTest extends IntegrationTestCase
             'data' => [],
         ];
 
-        TableRegistry::get('Translations')->deleteAll([]);
-        TableRegistry::get('Objects')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('Translations')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('Objects')->deleteAll([]);
 
         $this->configRequestHeaders();
         $this->get('/trash');

--- a/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
@@ -257,8 +257,8 @@ class UsersControllerTest extends IntegrationTestCase
             'data' => [],
         ];
 
-        TableRegistry::get('Translations')->deleteAll([]);
-        TableRegistry::get('Users')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('Translations')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('Users')->deleteAll([]);
 
         $this->configRequestHeaders();
         $this->get('/users');
@@ -439,7 +439,7 @@ class UsersControllerTest extends IntegrationTestCase
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
         $this->assertHeader('Location', 'http://api.example.com/users/' . $newId);
-        static::assertTrue(TableRegistry::get('Users')->exists(['username' => 'gustavo_supporto']));
+        static::assertTrue(TableRegistry::getTableLocator()->get('Users')->exists(['username' => 'gustavo_supporto']));
     }
 
     /**
@@ -459,14 +459,14 @@ class UsersControllerTest extends IntegrationTestCase
             ],
         ];
 
-        $count = TableRegistry::get('Users')->find()->count();
+        $count = TableRegistry::getTableLocator()->get('Users')->find()->count();
 
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
         $this->post('/users', json_encode(compact('data')));
 
         $this->assertResponseCode(400);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertEquals($count, TableRegistry::get('Users')->find()->count());
+        $this->assertEquals($count, TableRegistry::getTableLocator()->get('Users')->find()->count());
     }
 
     /**
@@ -492,8 +492,8 @@ class UsersControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
-        static::assertEquals('new_username', TableRegistry::get('Users')->get(1)->get('username'));
-        static::assertEquals('users', TableRegistry::get('Users')->get(1)->get('type'));
+        static::assertEquals('new_username', TableRegistry::getTableLocator()->get('Users')->get(1)->get('username'));
+        static::assertEquals('users', TableRegistry::getTableLocator()->get('Users')->get(1)->get('type'));
 
         $result = json_decode((string)$this->_response->getBody(), true);
         static::assertEquals($data['id'], $result['data']['id']);
@@ -525,8 +525,8 @@ class UsersControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(409);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertEquals('first user', TableRegistry::get('Users')->get(1)->get('username'));
-        $this->assertEquals('second user', TableRegistry::get('Users')->get(5)->get('username'));
+        $this->assertEquals('first user', TableRegistry::getTableLocator()->get('Users')->get(1)->get('username'));
+        $this->assertEquals('second user', TableRegistry::getTableLocator()->get('Users')->get(5)->get('username'));
     }
 
     /**
@@ -552,7 +552,7 @@ class UsersControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(400);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertEquals('first user', TableRegistry::get('Users')->get(1)->get('username'));
+        $this->assertEquals('first user', TableRegistry::getTableLocator()->get('Users')->get(1)->get('username'));
     }
 
     /**
@@ -581,7 +581,7 @@ class UsersControllerTest extends IntegrationTestCase
         $this->get('/users/5');
         $this->assertResponseCode(404);
 
-        $userDeleted = TableRegistry::get('Users')->get(5);
+        $userDeleted = TableRegistry::getTableLocator()->get('Users')->get(5);
         $this->assertEquals($userDeleted->deleted, 1);
     }
 
@@ -682,7 +682,7 @@ class UsersControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(201);
 
-        $user = TableRegistry::get('Users')->get($this->lastObjectId());
+        $user = TableRegistry::getTableLocator()->get('Users')->get($this->lastObjectId());
         static::assertEquals('gustavo_supporto', $user['username']);
         static::assertNull($user['email']);
     }

--- a/plugins/BEdita/API/tests/TestCase/Datasource/JsonApiPaginatorTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Datasource/JsonApiPaginatorTest.php
@@ -150,7 +150,7 @@ class JsonApiPaginatorTest extends TestCase
         }
 
         $paginator = new JsonApiPaginator();
-        $repository = TableRegistry::get('Roles')->find()->getRepository();
+        $repository = TableRegistry::getTableLocator()->get('Roles')->find()->getRepository();
 
         $options = $paginator->validateSort($repository, compact('sort'));
 

--- a/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateAssociatedActionTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateAssociatedActionTest.php
@@ -48,24 +48,24 @@ class UpdateAssociatedActionTest extends TestCase
     {
         parent::setUp();
 
-        TableRegistry::get('FakeTags')
+        TableRegistry::getTableLocator()->get('FakeTags')
             ->belongsToMany('FakeArticles', [
                 'joinTable' => 'fake_articles_tags',
             ]);
         /* @var \Cake\ORM\Association\BelongsToMany $association */
-        $association = TableRegistry::get('FakeTags')->getAssociation('FakeArticles');
+        $association = TableRegistry::getTableLocator()->get('FakeTags')->getAssociation('FakeArticles');
         $association->junction()
             ->getValidator()
             ->email('fake_params');
 
-        TableRegistry::get('FakeArticles')
+        TableRegistry::getTableLocator()->get('FakeArticles')
             ->belongsToMany('FakeTags', [
                 'joinTable' => 'fake_articles_tags',
             ])
             ->getSource()
             ->belongsTo('FakeAnimals');
 
-        TableRegistry::get('FakeAnimals')
+        TableRegistry::getTableLocator()->get('FakeAnimals')
             ->hasMany('FakeArticles');
     }
 
@@ -221,7 +221,7 @@ class UpdateAssociatedActionTest extends TestCase
 
         $request = new ServerRequest();
         $request = $request->withParsedBody($data);
-        $association = TableRegistry::get($table)->getAssociation($association);
+        $association = TableRegistry::getTableLocator()->get($table)->getAssociation($association);
         $parentAction = new SetAssociatedAction(compact('association'));
         $action = new UpdateAssociatedAction(['action' => $parentAction, 'request' => $request]);
 
@@ -253,7 +253,7 @@ class UpdateAssociatedActionTest extends TestCase
     public function testKeepJunctionData()
     {
         // Prepare link with junction data.
-        $junction = TableRegistry::get('FakeArticlesTags');
+        $junction = TableRegistry::getTableLocator()->get('FakeArticlesTags');
         $junctionEntity = $junction->newEntity();
         $junction->patchEntity($junctionEntity, [
             'fake_article_id' => 2,
@@ -271,7 +271,7 @@ class UpdateAssociatedActionTest extends TestCase
                 'id' => 2,
             ],
         ]);
-        $association = TableRegistry::get('FakeArticles')->getAssociation('FakeTags');
+        $association = TableRegistry::getTableLocator()->get('FakeArticles')->getAssociation('FakeTags');
         $parentAction = new SetAssociatedAction(compact('association'));
         $action = new UpdateAssociatedAction(['action' => $parentAction, 'request' => $request]);
 

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -60,7 +60,7 @@ class JsonApiTest extends TestCase
     {
         parent::setUp();
 
-        $this->Roles = TableRegistry::get('Roles');
+        $this->Roles = TableRegistry::getTableLocator()->get('Roles');
 
         $this->loadPlugins(['BEdita/API' => ['routes' => true]]);
     }
@@ -454,7 +454,7 @@ class JsonApiTest extends TestCase
                     ],
                 ],
                 function () {
-                    return TableRegistry::get('Documents')->get(2, ['contain' => ['Test']]);
+                    return TableRegistry::getTableLocator()->get('Documents')->get(2, ['contain' => ['Test']]);
                 },
             ],
         ];
@@ -682,7 +682,7 @@ class JsonApiTest extends TestCase
             ]
         ];
 
-        $result = JsonApi::formatData(TableRegistry::get('Documents')->get(2));
+        $result = JsonApi::formatData(TableRegistry::getTableLocator()->get('Documents')->get(2));
         $result = json_decode(json_encode($result), true);
 
         static::assertEquals($expected, $result);

--- a/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
+++ b/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
@@ -60,7 +60,7 @@ class JsonApiViewTest extends TestCase
     {
         parent::setUp();
 
-        $this->Roles = TableRegistry::get('Roles');
+        $this->Roles = TableRegistry::getTableLocator()->get('Roles');
         $this->loadPlugins(['BEdita/API' => ['routes' => true]]);
     }
 

--- a/plugins/BEdita/Core/src/Configure/Engine/DatabaseConfig.php
+++ b/plugins/BEdita/Core/src/Configure/Engine/DatabaseConfig.php
@@ -67,7 +67,7 @@ class DatabaseConfig implements ConfigEngineInterface
     public function read($key = null)
     {
         $values = [];
-        $config = TableRegistry::get('Config');
+        $config = TableRegistry::getTableLocator()->get('Config');
         $query = $config->find()->select(['name', 'context', 'content']);
         $query->where(function (QueryExpression $exp) {
             return $exp->notIn('name', $this->reservedKeys);
@@ -104,7 +104,7 @@ class DatabaseConfig implements ConfigEngineInterface
     {
         $context = $key;
         $entities = [];
-        $table = TableRegistry::get('Config');
+        $table = TableRegistry::getTableLocator()->get('Config');
         foreach ($data as $name => $content) {
             if (in_array($name, $this->reservedKeys)) {
                 continue;

--- a/plugins/BEdita/Core/src/Filesystem/Thumbnail/AsyncGenerator.php
+++ b/plugins/BEdita/Core/src/Filesystem/Thumbnail/AsyncGenerator.php
@@ -59,7 +59,7 @@ class AsyncGenerator extends ThumbnailGenerator
     public function generate(Stream $stream, array $options = [])
     {
         /* @var \BEdita\Core\Model\Table\AsyncJobsTable $table */
-        $table = TableRegistry::get('AsyncJobs');
+        $table = TableRegistry::getTableLocator()->get('AsyncJobs');
 
         $asyncJob = $table->newEntity();
         $asyncJob->service = $this->getConfig('service');

--- a/plugins/BEdita/Core/src/Job/Service/ThumbnailService.php
+++ b/plugins/BEdita/Core/src/Job/Service/ThumbnailService.php
@@ -35,7 +35,7 @@ class ThumbnailService implements JobService
     {
         try {
             /** @var \BEdita\Core\Model\Table\StreamsTable $table */
-            $table = TableRegistry::get('Streams');
+            $table = TableRegistry::getTableLocator()->get('Streams');
             $stream = $table->get(Hash::get($payload, 'uuid'));
 
             $generator = Thumbnail::getGenerator(Hash::get($payload, 'generator', 'default'));

--- a/plugins/BEdita/Core/src/Mailer/Transport/AsyncJobsTransport.php
+++ b/plugins/BEdita/Core/src/Mailer/Transport/AsyncJobsTransport.php
@@ -43,7 +43,7 @@ class AsyncJobsTransport extends AbstractTransport
     public function send(Email $email)
     {
         /* @var \BEdita\Core\Model\Table\AsyncJobsTable $table */
-        $table = TableRegistry::get('AsyncJobs');
+        $table = TableRegistry::getTableLocator()->get('AsyncJobs');
 
         $asyncJob = $table->newEntity();
         $asyncJob->service = $this->getConfig('service');

--- a/plugins/BEdita/Core/src/Model/Action/ChangeCredentialsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ChangeCredentialsAction.php
@@ -48,8 +48,8 @@ class ChangeCredentialsAction extends BaseAction
      */
     protected function initialize(array $config)
     {
-        $this->Users = TableRegistry::get('Users');
-        $this->AsyncJobs = TableRegistry::get('AsyncJobs');
+        $this->Users = TableRegistry::getTableLocator()->get('Users');
+        $this->AsyncJobs = TableRegistry::getTableLocator()->get('AsyncJobs');
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/ChangeCredentialsRequestAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ChangeCredentialsRequestAction.php
@@ -61,8 +61,8 @@ class ChangeCredentialsRequestAction extends BaseAction implements EventListener
      */
     protected function initialize(array $config)
     {
-        $this->Users = TableRegistry::get('Users');
-        $this->AsyncJobs = TableRegistry::get('AsyncJobs');
+        $this->Users = TableRegistry::getTableLocator()->get('Users');
+        $this->AsyncJobs = TableRegistry::getTableLocator()->get('AsyncJobs');
 
         $this->getEventManager()->on($this);
     }
@@ -146,7 +146,7 @@ class ChangeCredentialsRequestAction extends BaseAction implements EventListener
      */
     protected function createJob(User $user)
     {
-        $asyncJobsTable = TableRegistry::get('AsyncJobs');
+        $asyncJobsTable = TableRegistry::getTableLocator()->get('AsyncJobs');
         $action = new SaveEntityAction(['table' => $asyncJobsTable]);
 
         return $action([

--- a/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
@@ -132,7 +132,7 @@ class ListAssociatedAction extends BaseAction
     protected function buildInverseAssociation()
     {
         $sourceTable = $this->Association->getTarget();
-        $targetTable = TableRegistry::get(static::INVERSE_ASSOCIATION_NAME, [
+        $targetTable = TableRegistry::getTableLocator()->get(static::INVERSE_ASSOCIATION_NAME, [
             'className' => $this->Association->getSource()->getRegistryAlias(),
         ]);
         $targetTable->setTable($this->Association->getSource()->getTable());

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
@@ -36,7 +36,7 @@ class ListRelatedObjectsAction extends ListAssociatedAction
         parent::initialize($config);
 
         if ($this->Association instanceof RelatedTo) {
-            $objectTypes = TableRegistry::get('ObjectTypes')
+            $objectTypes = TableRegistry::getTableLocator()->get('ObjectTypes')
                 ->find('byRelation', [
                     'name' => $this->Association->getName(),
                     'side' => 'right',

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -75,9 +75,9 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
      */
     protected function initialize(array $config)
     {
-        $this->Users = TableRegistry::get('Users');
-        $this->AsyncJobs = TableRegistry::get('AsyncJobs');
-        $this->Roles = TableRegistry::get('Roles');
+        $this->Users = TableRegistry::getTableLocator()->get('Users');
+        $this->AsyncJobs = TableRegistry::getTableLocator()->get('AsyncJobs');
+        $this->Roles = TableRegistry::getTableLocator()->get('Roles');
 
         $this->getEventManager()->on($this);
     }
@@ -271,7 +271,7 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
     protected function checkExternalAuth(array $data)
     {
         /** @var \BEdita\Core\Model\Entity\AuthProvider $authProvider */
-        $authProvider = TableRegistry::get('AuthProviders')->find('enabled')
+        $authProvider = TableRegistry::getTableLocator()->get('AuthProviders')->find('enabled')
             ->where(['name' => $data['auth_provider']])
             ->first();
         if (empty($authProvider)) {

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserActivationAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserActivationAction.php
@@ -52,8 +52,8 @@ class SignupUserActivationAction extends BaseAction implements EventListenerInte
      */
     protected function initialize(array $config)
     {
-        $this->Users = TableRegistry::get('Users');
-        $this->AsyncJobs = TableRegistry::get('AsyncJobs');
+        $this->Users = TableRegistry::getTableLocator()->get('Users');
+        $this->AsyncJobs = TableRegistry::getTableLocator()->get('AsyncJobs');
 
         $this->getEventManager()->on($this);
     }

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -81,7 +81,7 @@ class CustomPropertiesBehavior extends Behavior
 
         try {
             $objectType = $this->objectType($this->getTable()->getAlias());
-            $properties = TableRegistry::get('Properties')->find('type', ['dynamic'])
+            $properties = TableRegistry::getTableLocator()->get('Properties')->find('type', ['dynamic'])
                 ->find('objectType', [$objectType->id])
                 ->where(['enabled' => true])
                 ->all();

--- a/plugins/BEdita/Core/src/Model/Behavior/ObjectTypeBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/ObjectTypeBehavior.php
@@ -55,7 +55,7 @@ class ObjectTypeBehavior extends Behavior
         }
 
         if (!($objectType instanceof ObjectType)) {
-            $objectType = TableRegistry::get($this->getConfig('table'))
+            $objectType = TableRegistry::getTableLocator()->get($this->getConfig('table'))
                 ->get($objectType);
         }
 

--- a/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
@@ -115,7 +115,7 @@ class RelationsBehavior extends Behavior
                 $className = $relation->right_object_types[0]->table;
             }
 
-            $through = TableRegistry::get(
+            $through = TableRegistry::getTableLocator()->get(
                 $relation->alias . 'ObjectRelations',
                 ['className' => 'ObjectRelations']
             );
@@ -150,7 +150,7 @@ class RelationsBehavior extends Behavior
                 $className = $relation->left_object_types[0]->table;
             }
 
-            $through = TableRegistry::get(
+            $through = TableRegistry::getTableLocator()->get(
                 $relation->inverse_alias . 'ObjectRelations',
                 ['className' => 'ObjectRelations']
             );

--- a/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
@@ -151,7 +151,7 @@ class UniqueNameBehavior extends Behavior
             $options['id <>'] = $id;
         }
 
-        return TableRegistry::get('Objects')->exists($options);
+        return TableRegistry::getTableLocator()->get('Objects')->exists($options);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Entity/AuthProvider.php
+++ b/plugins/BEdita/Core/src/Model/Entity/AuthProvider.php
@@ -71,7 +71,7 @@ class AuthProvider extends Entity
             return [];
         }
 
-        $table = TableRegistry::get('Roles');
+        $table = TableRegistry::getTableLocator()->get('Roles');
 
         return $table->find()
             ->where(function (QueryExpression $exp) use ($table, $roles) {

--- a/plugins/BEdita/Core/src/Model/Entity/Folder.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Folder.php
@@ -99,7 +99,7 @@ class Folder extends ObjectEntity
             return null;
         }
 
-        $table = TableRegistry::get($this->getSource());
+        $table = TableRegistry::getTableLocator()->get($this->getSource());
         $this->parent = $table
             ->find()
             ->where([
@@ -122,7 +122,7 @@ class Folder extends ObjectEntity
             return null;
         }
 
-        $trees = TableRegistry::get('Trees');
+        $trees = TableRegistry::getTableLocator()->get('Trees');
         try {
             $node = $trees->find()
                 ->where(['object_id' => $this->id])

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
@@ -76,7 +76,7 @@ trait JsonApiTrait
      */
     public function getTable()
     {
-        return TableRegistry::get($this->getSource());
+        return TableRegistry::getTableLocator()->get($this->getSource());
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
@@ -105,7 +105,7 @@ class ObjectEntity extends Entity implements JsonApiSerializable
      */
     public function getTable()
     {
-        return TableRegistry::get($this->type ?: $this->getSource());
+        return TableRegistry::getTableLocator()->get($this->type ?: $this->getSource());
     }
 
     /**
@@ -241,7 +241,7 @@ class ObjectEntity extends Entity implements JsonApiSerializable
         if (!$this->object_type) {
             try {
                 $typeId = $this->object_type_id ?: $this->getSource();
-                $this->object_type = TableRegistry::get('ObjectTypes')->get($typeId);
+                $this->object_type = TableRegistry::getTableLocator()->get('ObjectTypes')->get($typeId);
             } catch (RecordNotFoundException $e) {
             } catch (InvalidPrimaryKeyException $e) {
             }
@@ -272,7 +272,7 @@ class ObjectEntity extends Entity implements JsonApiSerializable
     protected function _setType($type)
     {
         try {
-            $this->object_type = TableRegistry::get('ObjectTypes')->get($type);
+            $this->object_type = TableRegistry::getTableLocator()->get('ObjectTypes')->get($type);
             $this->object_type_id = $this->object_type->id;
             $this->setDirty('object_type_id', true);
         } catch (RecordNotFoundException $e) {

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
@@ -199,7 +199,7 @@ class ObjectType extends Entity implements JsonApiSerializable
         $objectType = $this;
         $relations = (array)$this->get($property);
         while ($objectType->has('parent_id')) {
-            $objectType = TableRegistry::get($this->getSource())->get($objectType->get('parent_id'));
+            $objectType = TableRegistry::getTableLocator()->get($this->getSource())->get($objectType->get('parent_id'));
             $relations = array_merge($relations, (array)$objectType->get($property));
         }
 
@@ -248,7 +248,7 @@ class ObjectType extends Entity implements JsonApiSerializable
             return $this->parent->get('name');
         }
 
-        return TableRegistry::get('ObjectTypes')->get($this->parent_id)->get('name');
+        return TableRegistry::getTableLocator()->get('ObjectTypes')->get($this->parent_id)->get('name');
     }
 
     /**
@@ -260,7 +260,7 @@ class ObjectType extends Entity implements JsonApiSerializable
     protected function _setParentName($parentName)
     {
         try {
-            $objectType = TableRegistry::get('ObjectTypes')->get($parentName);
+            $objectType = TableRegistry::getTableLocator()->get('ObjectTypes')->get($parentName);
             if (!$objectType->get('is_abstract') || !$objectType->get('enabled')) {
                 return null;
             }
@@ -288,10 +288,10 @@ class ObjectType extends Entity implements JsonApiSerializable
         }
 
         /** @var \BEdita\Core\Model\Entity\Property[] $allProperties */
-        $allProperties = TableRegistry::get('Properties')
+        $allProperties = TableRegistry::getTableLocator()->get('Properties')
             ->find('objectType', [$this->id])
             ->toArray();
-        $entity = TableRegistry::get($this->name)->newEntity();
+        $entity = TableRegistry::getTableLocator()->get($this->name)->newEntity();
         $hiddenProperties = $entity->getHidden();
         $typeHidden = !empty($this->hidden) ? $this->hidden : [];
 

--- a/plugins/BEdita/Core/src/Model/Entity/Property.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Property.php
@@ -96,7 +96,7 @@ class Property extends Entity implements JsonApiSerializable
         }
 
         try {
-            $this->_properties['property_type'] = TableRegistry::get('PropertyTypes')
+            $this->_properties['property_type'] = TableRegistry::getTableLocator()->get('PropertyTypes')
                 ->get($this->property_type_id, [
                     'cache' => ObjectTypesTable::CACHE_CONFIG,
                 ]);
@@ -135,7 +135,7 @@ class Property extends Entity implements JsonApiSerializable
         $propertyTypes = Cache::remember(
             'property_types',
             function () {
-                return TableRegistry::get('PropertyTypes')->find()
+                return TableRegistry::getTableLocator()->get('PropertyTypes')->find()
                     ->indexBy('name')
                     ->toArray();
             },
@@ -165,7 +165,7 @@ class Property extends Entity implements JsonApiSerializable
     {
         if (!$this->object_type) {
             try {
-                $this->object_type = TableRegistry::get('ObjectTypes')->get($this->object_type_id);
+                $this->object_type = TableRegistry::getTableLocator()->get('ObjectTypes')->get($this->object_type_id);
             } catch (RecordNotFoundException $e) {
                 return null;
             } catch (InvalidPrimaryKeyException $e) {
@@ -185,7 +185,7 @@ class Property extends Entity implements JsonApiSerializable
     protected function _setObjectTypeName($objectTypeName)
     {
         try {
-            $this->object_type = TableRegistry::get('ObjectTypes')->get($objectTypeName);
+            $this->object_type = TableRegistry::getTableLocator()->get('ObjectTypes')->get($objectTypeName);
             $this->object_type_id = $this->object_type->id;
         } catch (RecordNotFoundException $e) {
             $this->object_type = null;

--- a/plugins/BEdita/Core/src/Model/Entity/StaticProperty.php
+++ b/plugins/BEdita/Core/src/Model/Entity/StaticProperty.php
@@ -73,7 +73,7 @@ class StaticProperty extends Property
     protected function _setTable($table)
     {
         if (!($table instanceof Table)) {
-            $table = TableRegistry::get($table);
+            $table = TableRegistry::getTableLocator()->get($table);
         }
 
         $this->inferFromSchema($this->name, $table);
@@ -90,11 +90,11 @@ class StaticProperty extends Property
     {
         if (isset($this->_properties['table'])) {
             // Explicitly set.
-            return TableRegistry::get($this->_properties['table']);
+            return TableRegistry::getTableLocator()->get($this->_properties['table']);
         }
 
         if ($this->object_type_id) {
-            return TableRegistry::get($this->object_type_name);
+            return TableRegistry::getTableLocator()->get($this->object_type_name);
         }
 
         return null;
@@ -133,7 +133,7 @@ class StaticProperty extends Property
 
         // Property type.
         /** @var \BEdita\Core\Model\Table\PropertyTypesTable $propertyTypesTable */
-        $propertyTypesTable = TableRegistry::get('PropertyTypes');
+        $propertyTypesTable = TableRegistry::getTableLocator()->get('PropertyTypes');
         $this->property_type_name = $propertyTypesTable->detect($name, $table)->name;
 
         // Description and nullability.

--- a/plugins/BEdita/Core/src/Model/Entity/Tree.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Tree.php
@@ -81,7 +81,7 @@ class Tree extends Entity
         }
 
         // set root_id and parent_node_id
-        $table = TableRegistry::get($this->getSource());
+        $table = TableRegistry::getTableLocator()->get($this->getSource());
         $parentNode = $table
             ->find()
             ->where(['object_id' => $parentId])

--- a/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
@@ -110,7 +110,7 @@ class ObjectTypesTable extends Table
             'dependent' => true,
         ]);
 
-        $through = TableRegistry::get('LeftRelationTypes', ['className' => 'RelationTypes']);
+        $through = TableRegistry::getTableLocator()->get('LeftRelationTypes', ['className' => 'RelationTypes']);
         $this->belongsToMany('LeftRelations', [
             'className' => 'Relations',
             'through' => $through,
@@ -120,7 +120,7 @@ class ObjectTypesTable extends Table
                 $through->aliasField('side') => 'left',
             ],
         ]);
-        $through = TableRegistry::get('RightRelationTypes', ['className' => 'RelationTypes']);
+        $through = TableRegistry::getTableLocator()->get('RightRelationTypes', ['className' => 'RelationTypes']);
         $this->belongsToMany('RightRelations', [
             'className' => 'Relations',
             'through' => $through,
@@ -313,7 +313,7 @@ class ObjectTypesTable extends Table
      */
     protected function objectsExist($typeId)
     {
-        return TableRegistry::get('Objects')->exists(['object_type_id' => $typeId]);
+        return TableRegistry::getTableLocator()->get('Objects')->exists(['object_type_id' => $typeId]);
     }
 
     /**
@@ -386,17 +386,17 @@ class ObjectTypesTable extends Table
      *
      * ```php
      * // Find object types allowed on the "right" side:
-     * TableRegistry::get('ObjectTypes')
+     * TableRegistry::getTableLocator()->get('ObjectTypes')
      *     ->find('byRelation', ['name' => 'my_relation']);
      *
      * // Find a list of object type names allowed on the "left" side of the inverse relation:
-     * TableRegistry::get('ObjectTypes')
+     * TableRegistry::getTableLocator()->get('ObjectTypes')
      *     ->find('byRelation', ['name' => 'my_inverse_relation', 'side' => 'left'])
      *     ->find('list')
      *     ->toArray();
      *
      * // Include also descendants of the allowed object types (e.g.: return **Images** whereas **Media** are allowed):
-     * TableRegistry::get('ObjectTypes')
+     * TableRegistry::getTableLocator()->get('ObjectTypes')
      *     ->find('byRelation', ['name' => 'my_relation', 'descendants' => true]);
      * ```
      *

--- a/plugins/BEdita/Core/src/Model/Table/PropertiesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/PropertiesTable.php
@@ -185,7 +185,7 @@ class PropertiesTable extends Table
 
         switch ($options[0]) {
             case 'static':
-                $table = TableRegistry::get('StaticProperties')
+                $table = TableRegistry::getTableLocator()->get('StaticProperties')
                     ->setAlias($this->getAlias());
                 $from = $table->getTable();
                 break;
@@ -196,7 +196,7 @@ class PropertiesTable extends Table
 
             case 'both':
             default:
-                $table = TableRegistry::get('StaticProperties')
+                $table = TableRegistry::getTableLocator()->get('StaticProperties')
                     ->setAlias($this->getAlias());
 
                 // Build CTE sub-query.

--- a/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
@@ -58,7 +58,7 @@ class RelationsTable extends Table
 
         $this->hasMany('ObjectRelations');
 
-        $through = TableRegistry::get('LeftRelationTypes', ['className' => 'RelationTypes']);
+        $through = TableRegistry::getTableLocator()->get('LeftRelationTypes', ['className' => 'RelationTypes']);
         $this->belongsToMany('LeftObjectTypes', [
             'className' => 'ObjectTypes',
             'through' => $through,
@@ -68,7 +68,7 @@ class RelationsTable extends Table
                 $through->aliasField('side') => 'left',
             ],
         ]);
-        $through = TableRegistry::get('RightRelationTypes', ['className' => 'RelationTypes']);
+        $through = TableRegistry::getTableLocator()->get('RightRelationTypes', ['className' => 'RelationTypes']);
         $this->belongsToMany('RightObjectTypes', [
             'className' => 'ObjectTypes',
             'through' => $through,

--- a/plugins/BEdita/Core/src/Model/Table/StaticPropertiesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/StaticPropertiesTable.php
@@ -99,7 +99,7 @@ class StaticPropertiesTable extends Table
         Log::debug('Using temporary table for static properties'); // Log for statistics purposes... :/
 
         $tableName = $this->getTable();
-        $parentTable = TableRegistry::get('Properties');
+        $parentTable = TableRegistry::getTableLocator()->get('Properties');
         $safeRename = function ($indexOrConstraint) use ($tableName) {
             return preg_replace(
                 '/^properties_/',
@@ -193,7 +193,7 @@ class StaticPropertiesTable extends Table
      */
     protected function listOwnTables(ObjectType $objectType)
     {
-        $table = TableRegistry::get($objectType->alias);
+        $table = TableRegistry::getTableLocator()->get($objectType->alias);
         $tables = [$table];
         if ($table instanceof InheritanceTable) {
             $tables = array_merge($tables, $table->inheritedTables());
@@ -204,7 +204,7 @@ class StaticPropertiesTable extends Table
             return $tables;
         }
 
-        $parentTable = TableRegistry::get($objectType->parent->alias);
+        $parentTable = TableRegistry::getTableLocator()->get($objectType->parent->alias);
         if ($parentTable->getTable() === $table->getTable()) {
             // Same physical table as parent object: nothing to do. This happens for
             // "null extensions", like documents that extend objects, but don't have

--- a/plugins/BEdita/Core/src/Model/Table/TreesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TreesTable.php
@@ -246,7 +246,7 @@ class TreesTable extends Table
     {
         static $foldersType = null;
         if ($foldersType === null) {
-            $foldersType = TableRegistry::get('ObjectTypes')->get('folders')->id;
+            $foldersType = TableRegistry::getTableLocator()->get('ObjectTypes')->get('folders')->id;
         }
 
         return $this->Objects->exists([

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -367,7 +367,7 @@ class UsersTable extends Table
      */
     public function delete(EntityInterface $entity, $options = [])
     {
-        $exists = TableRegistry::get('Objects')->exists([
+        $exists = TableRegistry::getTableLocator()->get('Objects')->exists([
             'OR' => ['created_by' => $entity->get('id'), 'modified_by' => $entity->get('id')],
         ]);
         if (!$exists) {

--- a/plugins/BEdita/Core/src/Model/Validation/ObjectTypesValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/ObjectTypesValidator.php
@@ -32,7 +32,7 @@ class ObjectTypesValidator extends Validator
     {
         parent::__construct();
 
-        $this->setProvider('table', TableRegistry::get('ObjectTypes'));
+        $this->setProvider('table', TableRegistry::getTableLocator()->get('ObjectTypes'));
         $this->setProvider('bedita', Validation::class);
 
         $this

--- a/plugins/BEdita/Core/src/Model/Validation/ObjectsValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/ObjectsValidator.php
@@ -33,7 +33,7 @@ class ObjectsValidator extends Validator
     {
         parent::__construct();
 
-        $this->setProvider('objectsTable', TableRegistry::get('Objects'));
+        $this->setProvider('objectsTable', TableRegistry::getTableLocator()->get('Objects'));
 
         $this
             ->naturalNumber('id')

--- a/plugins/BEdita/Core/src/Model/Validation/UsersValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/UsersValidator.php
@@ -32,7 +32,7 @@ class UsersValidator extends ProfilesValidator
     {
         parent::__construct();
 
-        $this->setProvider('usersTable', TableRegistry::get('Users'));
+        $this->setProvider('usersTable', TableRegistry::getTableLocator()->get('Users'));
 
         $this
             ->add('username', 'unique', ['rule' => 'validateUnique', 'provider' => 'usersTable'])

--- a/plugins/BEdita/Core/src/ORM/Inheritance/Table.php
+++ b/plugins/BEdita/Core/src/ORM/Inheritance/Table.php
@@ -76,7 +76,7 @@ class Table extends CakeTable
     {
         // If it is an alias, immediately load the instance.
         if (is_string($associated)) {
-            $associated = TableRegistry::get($associated);
+            $associated = TableRegistry::getTableLocator()->get($associated);
         }
         $this->inheritedTable = $associated;
 
@@ -123,7 +123,7 @@ class Table extends CakeTable
     public function inheritedTable()
     {
         if (is_string($this->inheritedTable)) {
-            $this->extensionOf(TableRegistry::get($this->inheritedTable));
+            $this->extensionOf(TableRegistry::getTableLocator()->get($this->inheritedTable));
         }
 
         return $this->inheritedTable;

--- a/plugins/BEdita/Core/src/Shell/ResourcesShell.php
+++ b/plugins/BEdita/Core/src/Shell/ResourcesShell.php
@@ -135,7 +135,7 @@ class ResourcesShell extends Shell
     {
         $modelName = Inflector::camelize($this->param('type'));
 
-        return TableRegistry::get($modelName);
+        return TableRegistry::getTableLocator()->get($modelName);
     }
 
     /**
@@ -196,7 +196,7 @@ class ResourcesShell extends Shell
         foreach ($fieldsTables as $field => $table) {
             $id = $this->in(sprintf('%s id or name', $table));
             if ($id && !is_numeric($id)) {
-                $id = TableRegistry::get($table)->find()->where(['name' => $id])->firstOrFail()->id;
+                $id = TableRegistry::getTableLocator()->get($table)->find()->where(['name' => $id])->firstOrFail()->id;
             }
             $entity->set($field, $id);
         }

--- a/plugins/BEdita/Core/src/State/CurrentApplication.php
+++ b/plugins/BEdita/Core/src/State/CurrentApplication.php
@@ -125,7 +125,7 @@ class CurrentApplication
     public static function setFromApiKey($apiKey)
     {
         static::getInstance()->set(
-            TableRegistry::get('Applications')->find('apiKey', compact('apiKey'))->firstOrFail()
+            TableRegistry::getTableLocator()->get('Applications')->find('apiKey', compact('apiKey'))->firstOrFail()
         );
     }
 

--- a/plugins/BEdita/Core/src/Utility/JsonSchema.php
+++ b/plugins/BEdita/Core/src/Utility/JsonSchema.php
@@ -86,7 +86,7 @@ class JsonSchema
         }
 
         /* @var \BEdita\Core\Model\Table\ObjectTypesTable $ObjectTypes */
-        $ObjectTypes = TableRegistry::get('ObjectTypes');
+        $ObjectTypes = TableRegistry::getTableLocator()->get('ObjectTypes');
         try {
             $objectType = $ObjectTypes->get($type);
 
@@ -147,7 +147,7 @@ class JsonSchema
      */
     public static function resourceSchema($resource)
     {
-        $table = TableRegistry::get((string)Inflector::camelize($resource));
+        $table = TableRegistry::getTableLocator()->get((string)Inflector::camelize($resource));
         $entity = $table->newEntity();
         $schema = $table->getSchema();
         $hiddenProperties = $entity->getHidden();

--- a/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
+++ b/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
@@ -74,8 +74,8 @@ class ObjectsHandler
         }
         LoggedUser::setUser($user);
 
-        $objectType = TableRegistry::get('ObjectTypes')->get($type);
-        $table = TableRegistry::get($objectType->model);
+        $objectType = TableRegistry::getTableLocator()->get('ObjectTypes')->get($type);
+        $table = TableRegistry::getTableLocator()->get($objectType->model);
         if (!empty($data['id'])) {
             $entity = $table->get($data['id']);
         } else {
@@ -105,7 +105,7 @@ class ObjectsHandler
     public static function remove($id)
     {
         static::checkEnvironment();
-        $objectsTable = TableRegistry::get('Objects');
+        $objectsTable = TableRegistry::getTableLocator()->get('Objects');
         $entity = $objectsTable->get($id);
 
         return $objectsTable->delete($entity);

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/AsyncGeneratorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/AsyncGeneratorTest.php
@@ -94,8 +94,8 @@ class AsyncGeneratorTest extends TestCase
 
         Thumbnail::setConfig('test', ['className' => TestGenerator::class]);
 
-        $this->AsyncJobs = TableRegistry::get('AsyncJobs');
-        $this->Streams = TableRegistry::get('Streams');
+        $this->AsyncJobs = TableRegistry::getTableLocator()->get('AsyncJobs');
+        $this->Streams = TableRegistry::getTableLocator()->get('Streams');
         $this->generator = new AsyncGenerator();
         $this->generator->initialize(['baseGenerator' => 'test']);
     }

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/GlideGeneratorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/GlideGeneratorTest.php
@@ -68,7 +68,7 @@ class GlideGeneratorTest extends TestCase
         parent::setUp();
 
         FilesystemRegistry::setConfig(Configure::read('Filesystem'));
-        $this->Streams = TableRegistry::get('Streams');
+        $this->Streams = TableRegistry::getTableLocator()->get('Streams');
 
         $this->generator = new GlideGenerator();
         $this->generator->initialize([]);

--- a/plugins/BEdita/Core/tests/TestCase/Job/Service/ThumbnailServiceTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/Service/ThumbnailServiceTest.php
@@ -79,7 +79,7 @@ class ThumbnailServiceTest extends TestCase
             Thumbnail::drop($config);
         }
 
-        $this->Streams = TableRegistry::get('Streams');
+        $this->Streams = TableRegistry::getTableLocator()->get('Streams');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/Transport/AsyncJobsTransportTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/Transport/AsyncJobsTransportTest.php
@@ -62,7 +62,7 @@ class AsyncJobsTransportTest extends TestCase
             ],
         ]);
 
-        $this->AsyncJobs = TableRegistry::get('AsyncJobs');
+        $this->AsyncJobs = TableRegistry::getTableLocator()->get('AsyncJobs');
 
         parent::setUp();
     }

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTest.php
@@ -84,7 +84,7 @@ class UserMailerTest extends TestCase
 
         $this->Email = new Email('test');
 
-        $this->Users = TableRegistry::get('Users');
+        $this->Users = TableRegistry::getTableLocator()->get('Users');
     }
 
     /**
@@ -184,7 +184,7 @@ class UserMailerTest extends TestCase
      */
     public function testSignupMissingUserEmail()
     {
-        $Users = TableRegistry::get('Users');
+        $Users = TableRegistry::getTableLocator()->get('Users');
         $user = $Users->get(5);
         $user->email = null;
         $Users->save($user);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddAssociatedActionTest.php
@@ -47,19 +47,19 @@ class AddAssociatedActionTest extends TestCase
     {
         parent::setUp();
 
-        TableRegistry::get('FakeTags')
+        TableRegistry::getTableLocator()->get('FakeTags')
             ->belongsToMany('FakeArticles', [
                 'joinTable' => 'fake_articles_tags',
             ]);
 
-        TableRegistry::get('FakeArticles')
+        TableRegistry::getTableLocator()->get('FakeArticles')
             ->belongsToMany('FakeTags', [
                 'joinTable' => 'fake_articles_tags',
             ])
             ->getSource()
             ->belongsTo('FakeAnimals');
 
-        TableRegistry::get('FakeAnimals')
+        TableRegistry::getTableLocator()->get('FakeAnimals')
             ->hasMany('FakeArticles');
     }
 
@@ -130,7 +130,7 @@ class AddAssociatedActionTest extends TestCase
             $this->expectExceptionMessage($expected->getMessage());
         }
 
-        $association = TableRegistry::get($table)->getAssociation($association);
+        $association = TableRegistry::getTableLocator()->get($table)->getAssociation($association);
         $action = new AddAssociatedAction(compact('association'));
 
         $entity = $association->getSource()->get($entity, ['contain' => [$association->getName()]]);
@@ -180,7 +180,7 @@ class AddAssociatedActionTest extends TestCase
     public function testInvocationWithLinkErrors()
     {
         try {
-            $table = TableRegistry::get('FakeArticles');
+            $table = TableRegistry::getTableLocator()->get('FakeArticles');
             /** @var \Cake\ORM\Association\BelongsToMany $association */
             $association = $table->getAssociation('FakeTags');
 
@@ -229,7 +229,7 @@ class AddAssociatedActionTest extends TestCase
         ];
 
         /** @var \Cake\ORM\Association\BelongsToMany $association */
-        $association = TableRegistry::get('FakeArticles')->getAssociation('FakeTags');
+        $association = TableRegistry::getTableLocator()->get('FakeArticles')->getAssociation('FakeTags');
         $action = new AddAssociatedAction(compact('association'));
 
         $entity = $association->getSource()->get(1, ['contain' => [$association->getName()]]);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
@@ -141,7 +141,7 @@ class AddRelatedObjectsActionTest extends TestCase
         }
 
         $alias = Inflector::camelize(Inflector::underscore($relation));
-        $association = TableRegistry::get($objectType)->getAssociation($alias);
+        $association = TableRegistry::getTableLocator()->get($objectType)->getAssociation($alias);
         $action = new AddRelatedObjectsAction(compact('association'));
 
         $entity = $association->getSource()->get($id);
@@ -174,7 +174,7 @@ class AddRelatedObjectsActionTest extends TestCase
      */
     public function testInvocationFallback()
     {
-        $association = TableRegistry::get('Users')->getAssociation('Roles');
+        $association = TableRegistry::getTableLocator()->get('Users')->getAssociation('Roles');
         $entity = $association->getSource()->get(1);
         $relatedEntities = $association->getTarget()->find()->toArray();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ChangeCredentialsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ChangeCredentialsActionTest.php
@@ -70,10 +70,10 @@ class ChangeCredentialsActionTest extends TestCase
      */
     protected function createTestJob()
     {
-        $action = new SaveEntityAction(['table' => TableRegistry::get('AsyncJobs')]);
+        $action = new SaveEntityAction(['table' => TableRegistry::getTableLocator()->get('AsyncJobs')]);
 
         return $action([
-            'entity' => TableRegistry::get('AsyncJobs')->newEntity(),
+            'entity' => TableRegistry::getTableLocator()->get('AsyncJobs')->newEntity(),
             'data' => [
                 'service' => 'credentials_change',
                 'payload' => [
@@ -114,7 +114,7 @@ class ChangeCredentialsActionTest extends TestCase
         $action = new ChangeCredentialsAction();
         $res = $action($data);
 
-        $user = TableRegistry::get('Users')->get(1, ['contain' => ['Roles']]);
+        $user = TableRegistry::getTableLocator()->get('Users')->get(1, ['contain' => ['Roles']]);
         static::assertEquals($res->id, $user->id);
         static::assertEquals($res->username, $user->username);
         static::assertSame(1, $eventDispatched, 'Event not dispatched');

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteEntityActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteEntityActionTest.php
@@ -44,7 +44,7 @@ class DeleteEntityActionTest extends TestCase
      */
     public function testExecute()
     {
-        $table = TableRegistry::get('FakeAnimals');
+        $table = TableRegistry::getTableLocator()->get('FakeAnimals');
         $action = new DeleteEntityAction(compact('table'));
 
         $entity = $table->get(1);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteObjectActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteObjectActionTest.php
@@ -68,7 +68,7 @@ class DeleteObjectActionTest extends TestCase
      */
     public function testExecute()
     {
-        $table = TableRegistry::get('Documents');
+        $table = TableRegistry::getTableLocator()->get('Documents');
         $action = new DeleteObjectAction(compact('table'));
 
         $entity = $table->get(2);
@@ -87,7 +87,7 @@ class DeleteObjectActionTest extends TestCase
      */
     public function testExecuteHardDelete()
     {
-        $table = TableRegistry::get('Documents');
+        $table = TableRegistry::getTableLocator()->get('Documents');
         $action = new DeleteObjectAction(compact('table'));
 
         $entity = $table->get(2);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/GetEntityActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/GetEntityActionTest.php
@@ -41,7 +41,7 @@ class GetEntityActionTest extends TestCase
     {
         parent::setUp();
 
-        TableRegistry::get('FakeAnimals', ['className' => Table::class])
+        TableRegistry::getTableLocator()->get('FakeAnimals', ['className' => Table::class])
             ->hasMany('FakeArticles');
     }
 
@@ -52,7 +52,7 @@ class GetEntityActionTest extends TestCase
      */
     public function testExecute()
     {
-        $table = TableRegistry::get('FakeAnimals');
+        $table = TableRegistry::getTableLocator()->get('FakeAnimals');
         $action = new GetEntityAction(compact('table'));
 
         $result = $action(['primaryKey' => 1]);
@@ -67,7 +67,7 @@ class GetEntityActionTest extends TestCase
      */
     public function testExecuteContain()
     {
-        $table = TableRegistry::get('FakeAnimals');
+        $table = TableRegistry::getTableLocator()->get('FakeAnimals');
         $action = new GetEntityAction(compact('table'));
 
         $result = $action(['primaryKey' => 1, 'contain' => ['FakeArticles']]);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/GetObjectActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/GetObjectActionTest.php
@@ -49,7 +49,7 @@ class GetObjectActionTest extends TestCase
      */
     public function testExecute()
     {
-        $table = TableRegistry::get('Objects');
+        $table = TableRegistry::getTableLocator()->get('Objects');
         $action = new GetObjectAction(compact('table'));
 
         $result = $action(['primaryKey' => 9]);
@@ -66,8 +66,8 @@ class GetObjectActionTest extends TestCase
      */
     public function testExecuteObjectTypeFilter()
     {
-        $objectType = TableRegistry::get('ObjectTypes')->get('Events');
-        $table = TableRegistry::get('Objects');
+        $objectType = TableRegistry::getTableLocator()->get('ObjectTypes')->get('Events');
+        $table = TableRegistry::getTableLocator()->get('Objects');
         $action = new GetObjectAction(compact('table', 'objectType'));
 
         $action(['primaryKey' => 8]);
@@ -82,7 +82,7 @@ class GetObjectActionTest extends TestCase
      */
     public function testExecuteObjectDeleted()
     {
-        $table = TableRegistry::get('Objects');
+        $table = TableRegistry::getTableLocator()->get('Objects');
         $action = new GetObjectAction(compact('table'));
 
         $action(['primaryKey' => 2, 'deleted' => true]);
@@ -97,7 +97,7 @@ class GetObjectActionTest extends TestCase
      */
     public function testExecuteObjectDeletedLocked()
     {
-        $table = TableRegistry::get('Objects');
+        $table = TableRegistry::getTableLocator()->get('Objects');
         $action = new GetObjectAction(compact('table'));
 
         $action(['primaryKey' => 15, 'deleted' => true, 'locked' => false]);
@@ -114,7 +114,7 @@ class GetObjectActionTest extends TestCase
     {
         Configure::write('Status.level', 'on');
 
-        $table = TableRegistry::get('Objects');
+        $table = TableRegistry::getTableLocator()->get('Objects');
         $action = new GetObjectAction(compact('table'));
 
         $action(['primaryKey' => 3]);
@@ -130,7 +130,7 @@ class GetObjectActionTest extends TestCase
      */
     public function testExecuteInvalidPrimaryKey()
     {
-        $table = TableRegistry::get('Objects');
+        $table = TableRegistry::getTableLocator()->get('Objects');
         $action = new GetObjectAction(compact('table'));
 
         $action(['primaryKey' => [1, 2]]);
@@ -143,8 +143,8 @@ class GetObjectActionTest extends TestCase
      */
     public function testLang()
     {
-        $objectType = TableRegistry::get('ObjectTypes')->get('Documents');
-        $table = TableRegistry::get('Objects');
+        $objectType = TableRegistry::getTableLocator()->get('ObjectTypes')->get('Documents');
+        $table = TableRegistry::getTableLocator()->get('Objects');
         $action = new GetObjectAction(compact('table', 'objectType'));
 
         $result = $action(['primaryKey' => 2, 'lang' => 'fr']);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
@@ -47,25 +47,25 @@ class ListAssociatedActionTest extends TestCase
     {
         parent::setUp();
 
-        TableRegistry::get('FakeTags')
+        TableRegistry::getTableLocator()->get('FakeTags')
             ->belongsToMany('FakeArticles', [
                 'joinTable' => 'fake_articles_tags',
             ]);
 
-        TableRegistry::get('FakeArticles')
+        TableRegistry::getTableLocator()->get('FakeArticles')
             ->belongsToMany('FakeTags', [
                 'joinTable' => 'fake_articles_tags',
             ])
             ->getSource()
             ->belongsTo('FakeAnimals');
 
-        TableRegistry::get('FakeAnimals')
+        TableRegistry::getTableLocator()->get('FakeAnimals')
             ->hasMany('FakeArticles');
 
-        TableRegistry::get('FakeMammals', ['className' => Table::class])
+        TableRegistry::getTableLocator()->get('FakeMammals', ['className' => Table::class])
             ->extensionOf('FakeAnimals');
 
-        TableRegistry::get('FakeMammalArticles')
+        TableRegistry::getTableLocator()->get('FakeMammalArticles')
             ->setTable('fake_articles')
             ->belongsTo('FakeMammals', ['foreignKey' => 'fake_animal_id']);
     }
@@ -199,7 +199,7 @@ class ListAssociatedActionTest extends TestCase
         if ($options === null) {
             $options = ['list' => true];
         }
-        $association = TableRegistry::get($table)->getAssociation($association);
+        $association = TableRegistry::getTableLocator()->get($table)->getAssociation($association);
         $action = new ListAssociatedAction(compact('association'));
 
         $result = $action(['primaryKey' => $id] + $options);
@@ -218,7 +218,7 @@ class ListAssociatedActionTest extends TestCase
      */
     public function testUnknownAssociationType()
     {
-        $sourceTable = TableRegistry::get('FakeArticles');
+        $sourceTable = TableRegistry::getTableLocator()->get('FakeArticles');
         $association = static::getMockForAbstractClass(Association::class, [
             'TestAssociation',
             compact('sourceTable'),

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListEntitiesActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListEntitiesActionTest.php
@@ -50,9 +50,9 @@ class ListEntitiesActionTest extends TestCase
     {
         parent::setUp();
 
-        TableRegistry::get('FakeAnimals', ['className' => Table::class])
+        TableRegistry::getTableLocator()->get('FakeAnimals', ['className' => Table::class])
             ->hasMany('FakeArticles');
-        TableRegistry::get('FakeMammals', ['className' => Table::class])
+        TableRegistry::getTableLocator()->get('FakeMammals', ['className' => Table::class])
             ->extensionOf('FakeAnimals');
     }
 
@@ -234,7 +234,7 @@ class ListEntitiesActionTest extends TestCase
      */
     public function testExecute(array $expected, $filter, $table = 'FakeAnimals')
     {
-        $table = TableRegistry::get($table);
+        $table = TableRegistry::getTableLocator()->get($table);
         $action = new ListEntitiesAction(compact('table'));
 
         $result = $action(compact('filter'));
@@ -291,7 +291,7 @@ class ListEntitiesActionTest extends TestCase
             ],
         ];
 
-        $table = TableRegistry::get('FakeAnimals');
+        $table = TableRegistry::getTableLocator()->get('FakeAnimals');
         $contain = ['FakeArticles'];
         $action = new ListEntitiesAction(compact('table'));
 
@@ -311,7 +311,7 @@ class ListEntitiesActionTest extends TestCase
      */
     public function testBadFilter()
     {
-        $table = TableRegistry::get('FakeAnimals');
+        $table = TableRegistry::getTableLocator()->get('FakeAnimals');
         $action = new ListEntitiesAction(compact('table'));
 
         static::expectException('BEdita\Core\Exception\BadFilterException');

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListObjectsActionTest.php
@@ -50,7 +50,7 @@ class ListObjectsActionTest extends TestCase
      */
     public function testExecute()
     {
-        $table = TableRegistry::get('Objects');
+        $table = TableRegistry::getTableLocator()->get('Objects');
         $action = new ListObjectsAction(compact('table'));
 
         $result = $action();
@@ -66,8 +66,8 @@ class ListObjectsActionTest extends TestCase
      */
     public function testExecuteObjectTypeFilter()
     {
-        $objectType = TableRegistry::get('ObjectTypes')->get('Events');
-        $table = TableRegistry::get('Objects');
+        $objectType = TableRegistry::getTableLocator()->get('ObjectTypes')->get('Events');
+        $table = TableRegistry::getTableLocator()->get('Objects');
         $action = new ListObjectsAction(compact('table', 'objectType'));
 
         $result = $action();
@@ -83,7 +83,7 @@ class ListObjectsActionTest extends TestCase
      */
     public function testExecuteDeleted()
     {
-        $table = TableRegistry::get('Objects');
+        $table = TableRegistry::getTableLocator()->get('Objects');
         $action = new ListObjectsAction(compact('table'));
 
         $result = $action(['deleted' => true]);
@@ -99,7 +99,7 @@ class ListObjectsActionTest extends TestCase
      */
     public function testExecuteCustomFilter()
     {
-        $table = TableRegistry::get('Objects');
+        $table = TableRegistry::getTableLocator()->get('Objects');
         $action = new ListObjectsAction(compact('table'));
 
         $result = $action([
@@ -119,7 +119,7 @@ class ListObjectsActionTest extends TestCase
     {
         Configure::write('Status.level', 'on');
 
-        $table = TableRegistry::get('Objects');
+        $table = TableRegistry::getTableLocator()->get('Objects');
         $action = new ListObjectsAction(compact('table'));
 
         $result = $action();
@@ -135,8 +135,8 @@ class ListObjectsActionTest extends TestCase
      */
     public function testLang()
     {
-        $objectType = TableRegistry::get('ObjectTypes')->get('Documents');
-        $table = TableRegistry::get('Objects');
+        $objectType = TableRegistry::getTableLocator()->get('ObjectTypes')->get('Documents');
+        $table = TableRegistry::getTableLocator()->get('Objects');
         $action = new ListObjectsAction(compact('table', 'objectType'));
 
         $result = $action([

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedFoldersActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedFoldersActionTest.php
@@ -52,7 +52,7 @@ class ListRelatedFoldersActionTest extends TestCase
      */
     public function testExecuteParents()
     {
-        $association = TableRegistry::get('Folders')->getAssociation('Parents');
+        $association = TableRegistry::getTableLocator()->get('Folders')->getAssociation('Parents');
         $action = new ListRelatedFoldersAction(compact('association'));
         $result = $action(['primaryKey' => 12]);
         static::assertInstanceOf(Folder::class, $result);
@@ -69,7 +69,7 @@ class ListRelatedFoldersActionTest extends TestCase
      */
     public function testExecuteChildren()
     {
-        $association = TableRegistry::get('Folders')->getAssociation('Children');
+        $association = TableRegistry::getTableLocator()->get('Folders')->getAssociation('Children');
         $action = new ListRelatedFoldersAction(compact('association'));
         $result = $action(['primaryKey' => 11]);
 
@@ -80,7 +80,7 @@ class ListRelatedFoldersActionTest extends TestCase
         $actual = Hash::extract($children, '{n}.id');
         sort($actual);
 
-        $treesTable = TableRegistry::get('Trees');
+        $treesTable = TableRegistry::getTableLocator()->get('Trees');
         $node = $treesTable->find()->where(['object_id' => 11])->first();
         $expected = $treesTable
             ->find('children', ['for' => $node->id, 'direct' => true])

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsActionTest.php
@@ -240,7 +240,7 @@ class ListRelatedObjectsActionTest extends TestCase
         Configure::write('Status.level', $statusLevel);
 
         $alias = Inflector::camelize(Inflector::underscore($relation));
-        $association = TableRegistry::get($objectType)->getAssociation($alias);
+        $association = TableRegistry::getTableLocator()->get($objectType)->getAssociation($alias);
         $action = new ListRelatedObjectsAction(compact('association'));
 
         $result = $action(['primaryKey' => $id] + compact('list', 'only'));

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveAssociatedActionTest.php
@@ -46,19 +46,19 @@ class RemoveAssociatedActionTest extends TestCase
     {
         parent::setUp();
 
-        TableRegistry::get('FakeTags')
+        TableRegistry::getTableLocator()->get('FakeTags')
             ->belongsToMany('FakeArticles', [
                 'joinTable' => 'fake_articles_tags',
             ]);
 
-        TableRegistry::get('FakeArticles')
+        TableRegistry::getTableLocator()->get('FakeArticles')
             ->belongsToMany('FakeTags', [
                 'joinTable' => 'fake_articles_tags',
             ])
             ->getSource()
             ->belongsTo('FakeAnimals');
 
-        TableRegistry::get('FakeAnimals')
+        TableRegistry::getTableLocator()->get('FakeAnimals')
             ->hasMany('FakeArticles');
     }
 
@@ -129,7 +129,7 @@ class RemoveAssociatedActionTest extends TestCase
             $this->expectExceptionMessage($expected->getMessage());
         }
 
-        $association = TableRegistry::get($table)->getAssociation($association);
+        $association = TableRegistry::getTableLocator()->get($table)->getAssociation($association);
         $action = new RemoveAssociatedAction(compact('association'));
 
         $entity = $association->getSource()->get($entity, ['contain' => [$association->getName()]]);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
@@ -114,7 +114,7 @@ class RemoveRelatedObjectsActionTest extends TestCase
             $this->expectExceptionMessage($expected->getMessage());
         }
 
-        $association = TableRegistry::get($table)->getAssociation($association);
+        $association = TableRegistry::getTableLocator()->get($table)->getAssociation($association);
         $action = new RemoveRelatedObjectsAction(compact('association'));
 
         $entity = $association->getSource()->get($entity, ['contain' => [$association->getName()]]);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SaveEntityActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SaveEntityActionTest.php
@@ -46,7 +46,7 @@ class SaveEntityActionTest extends TestCase
      */
     public function testExecute()
     {
-        $table = TableRegistry::get('FakeAnimals');
+        $table = TableRegistry::getTableLocator()->get('FakeAnimals');
         $action = new SaveEntityAction(compact('table'));
 
         $entity = $table->newEntity();
@@ -72,7 +72,7 @@ class SaveEntityActionTest extends TestCase
      */
     public function testExecuteValitationErrors()
     {
-        $table = TableRegistry::get('FakeAnimals');
+        $table = TableRegistry::getTableLocator()->get('FakeAnimals');
         $table->setValidator(
             $table::DEFAULT_VALIDATOR,
             (new Validator())
@@ -100,7 +100,7 @@ class SaveEntityActionTest extends TestCase
      */
     public function testExecuteSaveErrors()
     {
-        $entity = TableRegistry::get('FakeAnimals')->get(1);
+        $entity = TableRegistry::getTableLocator()->get('FakeAnimals')->get(1);
 
         $table = $this->getMockBuilder(Table::class)
             ->getMock();

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SetAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SetAssociatedActionTest.php
@@ -48,24 +48,24 @@ class SetAssociatedActionTest extends TestCase
     {
         parent::setUp();
 
-        TableRegistry::get('FakeLabels')
+        TableRegistry::getTableLocator()->get('FakeLabels')
             ->belongsTo('FakeTags');
 
-        TableRegistry::get('FakeTags')
+        TableRegistry::getTableLocator()->get('FakeTags')
             ->belongsToMany('FakeArticles', [
                 'joinTable' => 'fake_articles_tags',
             ])
             ->getSource()
             ->hasOne('FakeLabels');
 
-        TableRegistry::get('FakeArticles')
+        TableRegistry::getTableLocator()->get('FakeArticles')
             ->belongsToMany('FakeTags', [
                 'joinTable' => 'fake_articles_tags',
             ])
             ->getSource()
             ->belongsTo('FakeAnimals');
 
-        TableRegistry::get('FakeAnimals')
+        TableRegistry::getTableLocator()->get('FakeAnimals')
             ->hasMany('FakeArticles');
     }
 
@@ -192,7 +192,7 @@ class SetAssociatedActionTest extends TestCase
             $this->expectExceptionMessage($expected->getMessage());
         }
 
-        $association = TableRegistry::get($table)->getAssociation($association);
+        $association = TableRegistry::getTableLocator()->get($table)->getAssociation($association);
         $action = new SetAssociatedAction(compact('association'));
 
         $entity = $association->getSource()->get($entity, ['contain' => [$association->getName()]]);
@@ -244,7 +244,7 @@ class SetAssociatedActionTest extends TestCase
     public function testInvocationWithLinkErrors()
     {
         try {
-            $table = TableRegistry::get('FakeArticles');
+            $table = TableRegistry::getTableLocator()->get('FakeArticles');
             /** @var \Cake\ORM\Association\BelongsToMany $association */
             $association = $table->getAssociation('FakeTags');
 
@@ -310,7 +310,7 @@ class SetAssociatedActionTest extends TestCase
         $validationErrorMessage = 'Invalid email';
 
         try {
-            $table = TableRegistry::get('FakeArticles');
+            $table = TableRegistry::getTableLocator()->get('FakeArticles');
             /** @var \Cake\ORM\Association\BelongsToMany $association */
             $association = $table->getAssociation('FakeTags');
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
@@ -183,7 +183,7 @@ class SetRelatedObjectsActionTest extends TestCase
         }
 
         $alias = Inflector::camelize(Inflector::underscore($relation));
-        $association = TableRegistry::get($objectType)->getAssociation($alias);
+        $association = TableRegistry::getTableLocator()->get($objectType)->getAssociation($alias);
         $action = new SetRelatedObjectsAction(compact('association'));
 
         $entity = $association->getSource()->get($id);
@@ -216,7 +216,7 @@ class SetRelatedObjectsActionTest extends TestCase
      */
     public function testInvocationFallback()
     {
-        $association = TableRegistry::get('Users')->getAssociation('Roles');
+        $association = TableRegistry::getTableLocator()->get('Users')->getAssociation('Roles');
         $entity = $association->getSource()->get(1);
         $relatedEntities = $association->getTarget()->find()->toArray();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -396,7 +396,7 @@ class SignupUserActionTest extends TestCase
             $action($data);
         } finally {
             static::assertSame(1, $eventDispatched, 'Event not dispatched');
-            static::assertFalse(TableRegistry::get('Users')->exists(['username' => 'testsignup']));
+            static::assertFalse(TableRegistry::getTableLocator()->get('Users')->exists(['username' => 'testsignup']));
         }
     }
 
@@ -430,7 +430,7 @@ class SignupUserActionTest extends TestCase
         $action($data);
 
         static::assertSame(1, $invoked);
-        $user = TableRegistry::get('Users')->find()->where(['username' => 'testsignup'])->first();
+        $user = TableRegistry::getTableLocator()->get('Users')->find()->where(['username' => 'testsignup'])->first();
         static::assertEquals('test.signup@example.com', $user->get('email'));
     }
 
@@ -456,7 +456,7 @@ class SignupUserActionTest extends TestCase
         $action = new SignupUserAction();
         $action($data);
 
-        $user = TableRegistry::get('Users')->find()->where(['username' => 'testsignup'])->first();
+        $user = TableRegistry::getTableLocator()->get('Users')->find()->where(['username' => 'testsignup'])->first();
         static::assertNull($user->get('email'));
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActivationActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActivationActionTest.php
@@ -77,8 +77,8 @@ class SignupUserActivationActionTest extends TestCase
     {
         parent::setUp();
 
-        $this->AsyncJobs = TableRegistry::get('AsyncJobs');
-        $this->Users = TableRegistry::get('Users');
+        $this->AsyncJobs = TableRegistry::getTableLocator()->get('AsyncJobs');
+        $this->Users = TableRegistry::getTableLocator()->get('Users');
 
         Configure::write('Signup', []);
         TransportFactory::drop('default');
@@ -156,7 +156,7 @@ class SignupUserActivationActionTest extends TestCase
 
         $user->status = 'on';
         $user->verified = new Time();
-        $Users = TableRegistry::get('Users');
+        $Users = TableRegistry::getTableLocator()->get('Users');
         $Users->save($user);
 
         EventManager::instance()->on('Auth.signupActivation', function () {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
@@ -50,7 +50,7 @@ class CustomPropertiesBehaviorTest extends TestCase
      */
     public function testInitialize()
     {
-        $table = TableRegistry::get('FakeObjects', [
+        $table = TableRegistry::getTableLocator()->get('FakeObjects', [
             'className' => Table::class,
         ]);
         static::assertFalse($table->hasBehavior('BEdita/Core.ObjectType'));
@@ -114,7 +114,7 @@ class CustomPropertiesBehaviorTest extends TestCase
      */
     public function testGetAvailable(array $expected, $tableName)
     {
-        $table = TableRegistry::get($tableName);
+        $table = TableRegistry::getTableLocator()->get($tableName);
         $behavior = $table->behaviors()->get('CustomProperties');
         $result = $behavior->getAvailable();
         $result = array_keys($result);
@@ -139,7 +139,7 @@ class CustomPropertiesBehaviorTest extends TestCase
     public function testGetAvailableTypeNotFound()
     {
         // test try/catch failure on `objectType` load
-        $Relations = TableRegistry::get('Relations');
+        $Relations = TableRegistry::getTableLocator()->get('Relations');
         $Relations->addBehavior('BEdita/Core.CustomProperties', ['field' => 'description']);
         $rel = $Relations->get(1);
         $result = $rel->toArray();
@@ -155,7 +155,7 @@ class CustomPropertiesBehaviorTest extends TestCase
      */
     public function testEmpty()
     {
-        $table = TableRegistry::get('Locations');
+        $table = TableRegistry::getTableLocator()->get('Locations');
         $result = $table->behaviors()->get('CustomProperties')->getDefaultValues();
         static::assertEmpty($result);
     }
@@ -173,7 +173,7 @@ class CustomPropertiesBehaviorTest extends TestCase
             'media_property' => null,
             'files_property' => null,
         ];
-        $user = TableRegistry::get('Files');
+        $user = TableRegistry::getTableLocator()->get('Files');
         $result = $user->behaviors()->get('CustomProperties')->getDefaultValues();
         static::assertEquals($expected, $result);
     }
@@ -221,7 +221,7 @@ class CustomPropertiesBehaviorTest extends TestCase
      */
     public function testBeforeFind(array $expectedProperties, $id, $table, $hydrate = true)
     {
-        $result = TableRegistry::get($table)->find()
+        $result = TableRegistry::getTableLocator()->get($table)->find()
             ->where(compact('id'))
             ->enableHydration($hydrate)
             ->first();
@@ -246,7 +246,7 @@ class CustomPropertiesBehaviorTest extends TestCase
      */
     public function testBeforeFindOtherType()
     {
-        $result = TableRegistry::get('Objects')
+        $result = TableRegistry::getTableLocator()->get('Objects')
             ->find('list')
             ->find('type', ['documents'])
             ->toArray();
@@ -325,7 +325,7 @@ class CustomPropertiesBehaviorTest extends TestCase
      */
     public function testBeforeSave(array $expected, array $data, $id, $table)
     {
-        $table = TableRegistry::get($table);
+        $table = TableRegistry::getTableLocator()->get($table);
         $entity = $table->get($id);
 
         $table->patchEntity($entity, $data);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/DataCleanupBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/DataCleanupBehaviorTest.php
@@ -140,7 +140,7 @@ class DataCleanupBehaviorTest extends TestCase
     public function testDataCleanup(array $inputData, array $expected, array $defaultValues)
     {
         Configure::write('DefaultValues', $defaultValues);
-        $Users = TableRegistry::get('Users');
+        $Users = TableRegistry::getTableLocator()->get('Users');
 
         $user = $Users->newEntity($inputData);
         foreach ($expected as $k => $v) {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/GeometryBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/GeometryBehaviorTest.php
@@ -53,7 +53,7 @@ class GeometryBehaviorTest extends TestCase
     {
         parent::setUp();
 
-        $this->Locations = TableRegistry::get('Locations');
+        $this->Locations = TableRegistry::getTableLocator()->get('Locations');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/HistoryBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/HistoryBehaviorTest.php
@@ -72,7 +72,7 @@ class HistoryBehaviorTest extends TestCase
 
         // pass config via `Configure`
         Configure::write('History.exclude', ['id']);
-        $Documents = TableRegistry::get('Documents');
+        $Documents = TableRegistry::getTableLocator()->get('Documents');
         $behavior = $Documents->getBehavior('History');
         static::assertEquals(['id'], $behavior->getConfig('exclude'));
         static::assertNotEmpty($behavior->Table);
@@ -94,7 +94,7 @@ class HistoryBehaviorTest extends TestCase
      */
     public function testBeforeMarshal()
     {
-        $Documents = TableRegistry::get('Documents');
+        $Documents = TableRegistry::getTableLocator()->get('Documents');
         $data = [
             'type' => 'Documents',
             'title' => 'hello history',
@@ -114,7 +114,7 @@ class HistoryBehaviorTest extends TestCase
      */
     public function testBeforeSave()
     {
-        $Users = TableRegistry::get('Users');
+        $Users = TableRegistry::getTableLocator()->get('Users');
         $doc = $Users->get(5);
         $data = [
             'username' => 'second user',
@@ -124,7 +124,7 @@ class HistoryBehaviorTest extends TestCase
         $entity = $Users->patchEntity($doc, $data);
         $Users->save($entity);
 
-        $history = TableRegistry::get('History')->find()
+        $history = TableRegistry::getTableLocator()->get('History')->find()
                 ->where(['resource_id' => '5', 'resource_type' => 'objects'])
                 ->last();
         static::assertNotEmpty($history);
@@ -144,7 +144,7 @@ class HistoryBehaviorTest extends TestCase
      */
     public function testAfterSave()
     {
-        $Documents = TableRegistry::get('Documents');
+        $Documents = TableRegistry::getTableLocator()->get('Documents');
         $doc = $Documents->get(2);
         $data = [
             'description' => 'new history desc'
@@ -155,7 +155,7 @@ class HistoryBehaviorTest extends TestCase
         $behavior = $Documents->getBehavior('History');
         static::assertEquals($data, $behavior->getChanged());
 
-        $history = TableRegistry::get('History')->find()
+        $history = TableRegistry::getTableLocator()->get('History')->find()
                 ->where(['resource_id' => '2', 'resource_type' => 'objects'])
                 ->order(['id' => 'ASC'])
                 ->last()
@@ -184,12 +184,12 @@ class HistoryBehaviorTest extends TestCase
      */
     public function testTrashRestore()
     {
-        $Documents = TableRegistry::get('Documents');
+        $Documents = TableRegistry::getTableLocator()->get('Documents');
         $entity = $Documents->get(2);
         $entity->deleted = true;
         $entity = $Documents->saveOrFail($entity);
 
-        $History = TableRegistry::get('History');
+        $History = TableRegistry::getTableLocator()->get('History');
         $history = $History->find()
                 ->where(['resource_id' => '2', 'resource_type' => 'objects'])
                 ->order(['id' => 'ASC'])
@@ -213,7 +213,7 @@ class HistoryBehaviorTest extends TestCase
      */
     public function testCreate()
     {
-        $Users = TableRegistry::get('Users');
+        $Users = TableRegistry::getTableLocator()->get('Users');
         $entity = $Users->newEntity();
         $data = [
             'username' => 'aurelio',
@@ -223,7 +223,7 @@ class HistoryBehaviorTest extends TestCase
         $Users->patchEntity($entity, $data);
         $entity = $Users->saveOrFail($entity);
 
-        $history = TableRegistry::get('History')->find()
+        $history = TableRegistry::getTableLocator()->get('History')->find()
                 ->where(['resource_id' => $entity->get('id'), 'resource_type' => 'objects'])
                 ->toArray();
         static::assertNotEmpty($history);
@@ -241,11 +241,11 @@ class HistoryBehaviorTest extends TestCase
      */
     public function testAfterDelete()
     {
-        $Documents = TableRegistry::get('Documents');
+        $Documents = TableRegistry::getTableLocator()->get('Documents');
         $entity = $Documents->get(2);
         $Documents->delete($entity);
 
-        $history = TableRegistry::get('History')->find()
+        $history = TableRegistry::getTableLocator()->get('History')->find()
                 ->where(['resource_id' => '2', 'resource_type' => 'objects'])
                 ->order(['id' => 'ASC'])
                 ->last()
@@ -274,11 +274,11 @@ class HistoryBehaviorTest extends TestCase
     public function testAfterDeleteEmpty()
     {
         Configure::write('History', ['table' => null]);
-        $Documents = TableRegistry::get('Documents');
+        $Documents = TableRegistry::getTableLocator()->get('Documents');
         $entity = $Documents->get(2);
         $Documents->delete($entity);
 
-        $history = TableRegistry::get('History')->find()
+        $history = TableRegistry::getTableLocator()->get('History')->find()
                 ->where(['resource_id' => '2', 'resource_type' => 'objects'])
                 ->toArray();
         static::assertNotEmpty($history);
@@ -293,12 +293,12 @@ class HistoryBehaviorTest extends TestCase
     public function testAfterSaveEmpty()
     {
         Configure::write('History', ['table' => null]);
-        $Documents = TableRegistry::get('Documents');
+        $Documents = TableRegistry::getTableLocator()->get('Documents');
         $entity = $Documents->get(2);
         $Documents->patchEntity($entity, ['title' => 'new title']);
         $Documents->saveOrFail($entity);
 
-        $history = TableRegistry::get('History')->find()
+        $history = TableRegistry::getTableLocator()->get('History')->find()
                 ->where(['resource_id' => '2', 'resource_type' => 'objects'])
                 ->toArray();
         static::assertNotEmpty($history);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectModelBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectModelBehaviorTest.php
@@ -38,7 +38,7 @@ class ObjectModelBehaviorTest extends TestCase
      */
     public function testInitialize()
     {
-        $table = TableRegistry::get('FakeAnimals');
+        $table = TableRegistry::getTableLocator()->get('FakeAnimals');
         $count = $table->behaviors()->count();
         static::assertEquals(0, $count);
         $table->addBehavior('BEdita/Core.ObjectModel');

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectTypeBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectTypeBehaviorTest.php
@@ -73,7 +73,7 @@ class ObjectTypeBehaviorTest extends TestCase
      */
     public function testObjectType($expected, $table, $objectType = null)
     {
-        $table = TableRegistry::get($table);
+        $table = TableRegistry::getTableLocator()->get($table);
         if (!$table->hasBehavior('ObjectType')) {
             $table->addBehavior('BEdita/Core.ObjectType');
         }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/PriorityBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/PriorityBehaviorTest.php
@@ -86,7 +86,7 @@ class PriorityBehaviorTest extends TestCase
      */
     public function testInitialize(array $expected, array $config = [])
     {
-        $table = TableRegistry::get('MyTable', ['className' => Table::class]);
+        $table = TableRegistry::getTableLocator()->get('MyTable', ['className' => Table::class]);
         $table->addBehavior('BEdita/Core.Priority', $config);
 
         $behavior = $table->behaviors()->get('Priority');
@@ -104,7 +104,7 @@ class PriorityBehaviorTest extends TestCase
      */
     public function testBeforeSave()
     {
-        $table = TableRegistry::get('MyTable', ['className' => Table::class]);
+        $table = TableRegistry::getTableLocator()->get('MyTable', ['className' => Table::class]);
         $table->addBehavior('BEdita/Core.Priority', [
             'fields' => [
                 '_all' => [

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/RelationsBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/RelationsBehaviorTest.php
@@ -54,9 +54,9 @@ class RelationsBehaviorTest extends TestCase
     {
         TableRegistry::clear();
 
-        $Documents = TableRegistry::get('Documents');
-        $Profiles = TableRegistry::get('Profiles');
-        $Locations = TableRegistry::get('Locations');
+        $Documents = TableRegistry::getTableLocator()->get('Documents');
+        $Profiles = TableRegistry::getTableLocator()->get('Profiles');
+        $Locations = TableRegistry::getTableLocator()->get('Locations');
 
         static::assertTrue($Documents->hasBehavior('ObjectType'));
         static::assertTrue($Profiles->hasBehavior('ObjectType'));
@@ -90,7 +90,7 @@ class RelationsBehaviorTest extends TestCase
      */
     public function testUnknownObjectType()
     {
-        $FakeArticles = TableRegistry::get('FakeArticles');
+        $FakeArticles = TableRegistry::getTableLocator()->get('FakeArticles');
 
         $before = count($FakeArticles->associations()->keys());
         $FakeArticles->addBehavior('BEdita/Core.Relations');
@@ -113,7 +113,7 @@ class RelationsBehaviorTest extends TestCase
             'inverse_test',
         ];
 
-        $Documents = TableRegistry::get('Documents');
+        $Documents = TableRegistry::getTableLocator()->get('Documents');
 
         static::assertTrue($Documents->behaviors()->hasMethod('getRelations'));
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
@@ -44,10 +44,10 @@ class SearchableBehaviorTest extends TestCase
     {
         parent::setUp();
 
-        TableRegistry::get('FakeMammals', ['className' => Table::class])
+        TableRegistry::getTableLocator()->get('FakeMammals', ['className' => Table::class])
             ->setDisplayField('name')
             ->extensionOf('FakeAnimals');
-        TableRegistry::get('FakeFelines', ['className' => Table::class])
+        TableRegistry::getTableLocator()->get('FakeFelines', ['className' => Table::class])
             ->setDisplayField('name')
             ->extensionOf('FakeMammals');
     }
@@ -68,7 +68,7 @@ class SearchableBehaviorTest extends TestCase
             'my_field' => 17,
         ];
 
-        $table = TableRegistry::get('FakeAnimals');
+        $table = TableRegistry::getTableLocator()->get('FakeAnimals');
         $table->addBehavior('BEdita/Core.Searchable', compact('columnTypes', 'fields'));
 
         /* @var \BEdita\Core\Model\Behavior\SearchableBehavior $behavior */
@@ -134,7 +134,7 @@ class SearchableBehaviorTest extends TestCase
      */
     public function testGetFields(array $expected, array $config = [], $table = 'FakeAnimals')
     {
-        $table = TableRegistry::get($table);
+        $table = TableRegistry::getTableLocator()->get($table);
         $table->addBehavior('BEdita/Core.Searchable', $config);
 
         /* @var \BEdita\Core\Model\Behavior\SearchableBehavior $behavior */
@@ -213,7 +213,7 @@ class SearchableBehaviorTest extends TestCase
             $this->expectExceptionMessage($expected->getMessage());
         }
 
-        $table = TableRegistry::get($table);
+        $table = TableRegistry::getTableLocator()->get($table);
         $table->addBehavior('BEdita/Core.Searchable');
 
         static::assertTrue($table->hasFinder('query'));

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -34,7 +34,7 @@ class TreeBehaviorTest extends TestCase
     {
         parent::setUp();
 
-        $this->Table = TableRegistry::get('FakeCategories');
+        $this->Table = TableRegistry::getTableLocator()->get('FakeCategories');
         $this->Table->addBehavior('BEdita/Core.Tree', [
             'left' => 'left_idx',
             'right' => 'right_idx',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
@@ -100,7 +100,7 @@ class UniqueNameBehaviorTest extends TestCase
      */
     public function testUniqueUser($username, $uname)
     {
-        $Users = TableRegistry::get('Users');
+        $Users = TableRegistry::getTableLocator()->get('Users');
         $user = $Users->newEntity();
 
         $user = $Users->patchEntity($user, compact('username'));
@@ -167,7 +167,7 @@ class UniqueNameBehaviorTest extends TestCase
      */
     public function testGenerateUniqueName($username, $name, $config)
     {
-        $Users = TableRegistry::get('Users');
+        $Users = TableRegistry::getTableLocator()->get('Users');
         $user = $Users->newEntity();
         $Users->patchEntity($user, compact('username', 'name'));
         $behavior = $Users->behaviors()->get('UniqueName');
@@ -225,7 +225,7 @@ class UniqueNameBehaviorTest extends TestCase
      */
     public function testUniqueNameExists($uname, $id, $expected)
     {
-        $Users = TableRegistry::get('Users');
+        $Users = TableRegistry::getTableLocator()->get('Users');
         $behavior = $Users->behaviors()->get('UniqueName');
         $result = $behavior->uniqueNameExists($uname, $id);
 
@@ -281,7 +281,7 @@ class UniqueNameBehaviorTest extends TestCase
      */
     public function testUniqueNameFromValue($value, $expected, array $cfg, $regenerate)
     {
-        $behavior = TableRegistry::get('Objects')->behaviors()->get('UniqueName');
+        $behavior = TableRegistry::getTableLocator()->get('Objects')->behaviors()->get('UniqueName');
         $result = $behavior->uniqueNameFromValue($value, $regenerate, $cfg);
 
         if ($regenerate) {
@@ -300,7 +300,7 @@ class UniqueNameBehaviorTest extends TestCase
      */
     public function testUniqueNameMissing()
     {
-        $Documents = TableRegistry::get('Documents');
+        $Documents = TableRegistry::getTableLocator()->get('Documents');
         $behavior = $Documents->behaviors()->get('UniqueName');
 
         $data = ['title' => 'Some data', 'uname' => 'some-data'];
@@ -328,7 +328,7 @@ class UniqueNameBehaviorTest extends TestCase
      */
     public function testBeforeSave()
     {
-        $Documents = TableRegistry::get('Documents');
+        $Documents = TableRegistry::getTableLocator()->get('Documents');
         $entity = $Documents->newEntity([
             'title' => 'uh là la'
         ]);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
@@ -59,7 +59,7 @@ class UploadableBehaviorTest extends TestCase
         parent::setUp();
 
         FilesystemRegistry::setConfig(Configure::read('Filesystem'));
-        $this->Streams = TableRegistry::get('Streams');
+        $this->Streams = TableRegistry::getTableLocator()->get('Streams');
 
         $mountManager = FilesystemRegistry::getMountManager();
         $this->keep = collection($mountManager->listContents('default://'))

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UserModifiedBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UserModifiedBehaviorTest.php
@@ -55,7 +55,7 @@ class UserModifiedBehaviorTest extends TestCase
         parent::setUp();
 
         LoggedUser::setUser(['id' => 1]);
-        $this->Objects = TableRegistry::get('Objects');
+        $this->Objects = TableRegistry::getTableLocator()->get('Objects');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ApplicationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ApplicationTest.php
@@ -48,7 +48,7 @@ class ApplicationTest extends TestCase
     {
         parent::setUp();
 
-        $this->Applications = TableRegistry::get('Applications');
+        $this->Applications = TableRegistry::getTableLocator()->get('Applications');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/AsyncJobTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/AsyncJobTest.php
@@ -57,7 +57,7 @@ class AsyncJobTest extends TestCase
     {
         parent::setUp();
 
-        $this->AsyncJobs = TableRegistry::get('AsyncJobs');
+        $this->AsyncJobs = TableRegistry::getTableLocator()->get('AsyncJobs');
 
         if (in_array('async_jobs', ConnectionManager::configured())) {
             $this->connection = ConnectionManager::getConfig('async_jobs');

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/AuthProviderTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/AuthProviderTest.php
@@ -51,7 +51,7 @@ class AuthProviderTest extends TestCase
     {
         parent::setUp();
 
-        $this->AuthProviders = TableRegistry::get('AuthProviders');
+        $this->AuthProviders = TableRegistry::getTableLocator()->get('AuthProviders');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ConfigTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ConfigTest.php
@@ -47,7 +47,7 @@ class ConfigTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->Config = TableRegistry::get('Config');
+        $this->Config = TableRegistry::getTableLocator()->get('Config');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/DateRangeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/DateRangeTest.php
@@ -49,7 +49,7 @@ class DateRangeTest extends TestCase
     {
         parent::setUp();
 
-        $this->DateRanges = TableRegistry::get('DateRanges');
+        $this->DateRanges = TableRegistry::getTableLocator()->get('DateRanges');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointPermissionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointPermissionTest.php
@@ -54,7 +54,7 @@ class EndpointPermissionTest extends TestCase
     {
         parent::setUp();
 
-        $this->EndpointPermissions = TableRegistry::get('EndpointPermissions');
+        $this->EndpointPermissions = TableRegistry::getTableLocator()->get('EndpointPermissions');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointTest.php
@@ -49,7 +49,7 @@ class EndpointTest extends TestCase
     {
         parent::setUp();
 
-        $this->Endpoints = TableRegistry::get('Endpoints');
+        $this->Endpoints = TableRegistry::getTableLocator()->get('Endpoints');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ExternalAuthTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ExternalAuthTest.php
@@ -53,7 +53,7 @@ class ExternalAuthTest extends TestCase
     {
         parent::setUp();
 
-        $this->ExternalAuth = TableRegistry::get('ExternalAuth');
+        $this->ExternalAuth = TableRegistry::getTableLocator()->get('ExternalAuth');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
@@ -56,7 +56,7 @@ class FolderTest extends TestCase
     {
         parent::setUp();
 
-        $this->Folders = TableRegistry::get('Folders');
+        $this->Folders = TableRegistry::getTableLocator()->get('Folders');
 
         $this->loadPlugins(['BEdita/API' => ['routes' => true]]);
     }
@@ -231,8 +231,8 @@ class FolderTest extends TestCase
      */
     public function testGetPathOrphanFolder()
     {
-        TableRegistry::get('Trees')->deleteAll(['object_id' => 12]);
-        TableRegistry::get('Trees')->recover();
+        TableRegistry::getTableLocator()->get('Trees')->deleteAll(['object_id' => 12]);
+        TableRegistry::getTableLocator()->get('Trees')->recover();
 
         $this->Folders->get(12);
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiAdminTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiAdminTraitTest.php
@@ -47,7 +47,7 @@ class JsonApiAdminTraitTest extends TestCase
     {
         parent::setUp();
 
-        $this->Applications = TableRegistry::get('Applications');
+        $this->Applications = TableRegistry::getTableLocator()->get('Applications');
 
         $this->loadPlugins(['BEdita/API' => ['routes' => true]]);
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -67,8 +67,8 @@ class JsonApiTraitTest extends TestCase
     {
         parent::setUp();
 
-        $this->Roles = TableRegistry::get('Roles');
-        $this->ObjectTypes = TableRegistry::get('ObjectTypes');
+        $this->Roles = TableRegistry::getTableLocator()->get('Roles');
+        $this->ObjectTypes = TableRegistry::getTableLocator()->get('ObjectTypes');
 
         $this->loadPlugins(['BEdita/API' => ['routes' => true]]);
     }
@@ -326,14 +326,14 @@ class JsonApiTraitTest extends TestCase
     public function testGetRelationshipsIncludedEmpty()
     {
         // This is needed in order to permanently remove user with id 5
-        $usersTable = TableRegistry::get('Users');
+        $usersTable = TableRegistry::getTableLocator()->get('Users');
         $user = $usersTable->get(5);
         $user->created_by = 1;
         $user->modified_by = 1;
         $user = $usersTable->saveOrFail($user);
-        $doc = TableRegistry::get('Objects')->get(3);
+        $doc = TableRegistry::getTableLocator()->get('Objects')->get(3);
         $doc->modified_by = 1;
-        $doc = TableRegistry::get('Objects')->saveOrFail($doc);
+        $doc = TableRegistry::getTableLocator()->get('Objects')->saveOrFail($doc);
 
         $usersTable->delete($usersTable->get(5));
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/LocationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/LocationTest.php
@@ -49,7 +49,7 @@ class LocationTest extends TestCase
     {
         parent::setUp();
 
-        $this->Locations = TableRegistry::get('Locations');
+        $this->Locations = TableRegistry::getTableLocator()->get('Locations');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/MediaTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/MediaTest.php
@@ -71,7 +71,7 @@ class MediaTest extends TestCase
      */
     public function testMediaUrl()
     {
-        $media = TableRegistry::get('Files')->get(14, ['contain' => ['Streams']]);
+        $media = TableRegistry::getTableLocator()->get('Files')->get(14, ['contain' => ['Streams']]);
 
         $url = $media->get('media_url');
         static::assertNotEmpty($url);
@@ -86,7 +86,7 @@ class MediaTest extends TestCase
      */
     public function testEmptyMediaUrl()
     {
-        $Files = TableRegistry::get('Files');
+        $Files = TableRegistry::getTableLocator()->get('Files');
         $entity = $Files->newEntity(['title' => 'New file']);
         $entity->created_by = 1;
         $entity->modified_by = 1;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectEntityTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectEntityTest.php
@@ -60,7 +60,7 @@ class ObjectEntityTest extends TestCase
     {
         parent::setUp();
 
-        $this->Objects = TableRegistry::get('Objects');
+        $this->Objects = TableRegistry::getTableLocator()->get('Objects');
 
         $this->loadPlugins(['BEdita/API' => ['routes' => true]]);
     }
@@ -392,7 +392,7 @@ class ObjectEntityTest extends TestCase
             'translations',
         ];
 
-        $entity = TableRegistry::get('Documents')->newEntity();
+        $entity = TableRegistry::getTableLocator()->get('Documents')->newEntity();
         $entity->set('type', 'documents');
         $entity = $entity->jsonApiSerialize();
 
@@ -439,7 +439,7 @@ class ObjectEntityTest extends TestCase
             ],
         ];
 
-        $entity = TableRegistry::get('Users')->newEntity();
+        $entity = TableRegistry::getTableLocator()->get('Users')->newEntity();
         $entity->set('id', 1);
         $entity->set('type', 'users');
         $entity = $entity->jsonApiSerialize();
@@ -465,7 +465,7 @@ class ObjectEntityTest extends TestCase
             'translations',
         ];
 
-        $entity = TableRegistry::get('Documents')->getAssociation('Test')->newEntity();
+        $entity = TableRegistry::getTableLocator()->get('Documents')->getAssociation('Test')->newEntity();
         $entity->set('type', 'profile');
         $entity = $entity->jsonApiSerialize();
 
@@ -492,7 +492,7 @@ class ObjectEntityTest extends TestCase
             'translations',
         ];
 
-        $entity = TableRegistry::get('Objects')->newEntity();
+        $entity = TableRegistry::getTableLocator()->get('Objects')->newEntity();
         $entity->set('type', 'folders');
         $entity = $entity->jsonApiSerialize();
 
@@ -512,7 +512,7 @@ class ObjectEntityTest extends TestCase
      */
     public function testGetRelationshipsDeleted()
     {
-        $entity = TableRegistry::get('Documents')->newEntity();
+        $entity = TableRegistry::getTableLocator()->get('Documents')->newEntity();
         $entity->set('type', 'documents');
         $entity->set('deleted', true);
         $entity = $entity->jsonApiSerialize();
@@ -529,7 +529,7 @@ class ObjectEntityTest extends TestCase
      */
     public function testGetRelationshipsIncluded()
     {
-        $entity = TableRegistry::get('Documents')->get(2, ['contain' => ['Test']]);
+        $entity = TableRegistry::getTableLocator()->get('Documents')->get(2, ['contain' => ['Test']]);
         $entity = $entity->jsonApiSerialize();
 
         static::assertArrayHasKey('relationships', $entity);
@@ -549,7 +549,7 @@ class ObjectEntityTest extends TestCase
      */
     public function testGetRelationshipsSingleIncluded()
     {
-        $entity = TableRegistry::get('Folders')->get(12, ['contain' => ['Parents']]);
+        $entity = TableRegistry::getTableLocator()->get('Folders')->get(12, ['contain' => ['Parents']]);
         $entity = $entity->jsonApiSerialize();
 
         static::assertArrayHasKey('relationships', $entity);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -57,7 +57,7 @@ class ObjectTypeTest extends TestCase
     {
         parent::setUp();
 
-        $this->ObjectTypes = TableRegistry::get('ObjectTypes');
+        $this->ObjectTypes = TableRegistry::getTableLocator()->get('ObjectTypes');
 
         $this->loadPlugins(['BEdita/API' => ['routes' => true]]);
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ProfileTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ProfileTest.php
@@ -51,7 +51,7 @@ class ProfileTest extends TestCase
     {
         parent::setUp();
 
-        $this->Profiles = TableRegistry::get('Profiles');
+        $this->Profiles = TableRegistry::getTableLocator()->get('Profiles');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/PropertyTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/PropertyTest.php
@@ -58,7 +58,7 @@ class PropertyTest extends TestCase
     {
         parent::setUp();
 
-        $this->Properties = TableRegistry::get('Properties');
+        $this->Properties = TableRegistry::getTableLocator()->get('Properties');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/PropertyTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/PropertyTypeTest.php
@@ -46,7 +46,7 @@ class PropertyTypeTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->PropertyTypes = TableRegistry::get('PropertyTypes');
+        $this->PropertyTypes = TableRegistry::getTableLocator()->get('PropertyTypes');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/RelationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/RelationTest.php
@@ -48,7 +48,7 @@ class RelationTest extends TestCase
     {
         parent::setUp();
 
-        $this->Relations = TableRegistry::get('Relations');
+        $this->Relations = TableRegistry::getTableLocator()->get('Relations');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/RoleTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/RoleTest.php
@@ -48,7 +48,7 @@ class RoleTest extends TestCase
     {
         parent::setUp();
 
-        $this->Roles = TableRegistry::get('Roles');
+        $this->Roles = TableRegistry::getTableLocator()->get('Roles');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/StaticPropertyTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/StaticPropertyTest.php
@@ -62,7 +62,7 @@ class StaticPropertyTest extends TestCase
     {
         parent::setUp();
 
-        $this->Properties = TableRegistry::get('Properties');
+        $this->Properties = TableRegistry::getTableLocator()->get('Properties');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/StreamTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/StreamTest.php
@@ -62,7 +62,7 @@ class StreamTest extends TestCase
         parent::setUp();
 
         FilesystemRegistry::setConfig(Configure::read('Filesystem'));
-        $this->Streams = TableRegistry::get('Streams');
+        $this->Streams = TableRegistry::getTableLocator()->get('Streams');
 
         $mountManager = FilesystemRegistry::getMountManager();
         $this->keep = collection($mountManager->listContents('default://'))

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/TreeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/TreeTest.php
@@ -56,7 +56,7 @@ class TreeTest extends TestCase
     {
         parent::setUp();
 
-        $this->Trees = TableRegistry::get('Trees');
+        $this->Trees = TableRegistry::getTableLocator()->get('Trees');
     }
 
     /**
@@ -106,7 +106,7 @@ class TreeTest extends TestCase
         $tree->parent_object = null;
         static::assertNull($tree->parent_id);
 
-        $parentFolder = TableRegistry::get('Folders')->get(13);
+        $parentFolder = TableRegistry::getTableLocator()->get('Folders')->get(13);
         $tree->parent_object = $parentFolder;
         static::assertEquals(13, $tree->parent_id);
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/UserTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/UserTest.php
@@ -56,7 +56,7 @@ class UserTest extends TestCase
     {
         parent::setUp();
 
-        $this->Users = TableRegistry::get('Users');
+        $this->Users = TableRegistry::getTableLocator()->get('Users');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/AnnotationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/AnnotationsTableTest.php
@@ -45,7 +45,7 @@ class AnnotationsTableTest extends TestCase
     {
         parent::setUp();
 
-        $this->Annotations = TableRegistry::get('Annotations');
+        $this->Annotations = TableRegistry::getTableLocator()->get('Annotations');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ApplicationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ApplicationsTableTest.php
@@ -61,7 +61,7 @@ class ApplicationsTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->Applications = TableRegistry::get('Applications');
+        $this->Applications = TableRegistry::getTableLocator()->get('Applications');
         $this->currentApplication = CurrentApplication::getApplication();
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/AsyncJobsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/AsyncJobsTableTest.php
@@ -45,7 +45,7 @@ class AsyncJobsTableTest extends TestCase
     {
         parent::setUp();
 
-        $this->AsyncJobs = TableRegistry::get('AsyncJobs');
+        $this->AsyncJobs = TableRegistry::getTableLocator()->get('AsyncJobs');
 
         if (in_array('async_jobs', ConnectionManager::configured())) {
             $this->connection = ConnectionManager::getConfig('async_jobs');

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/AuthProvidersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/AuthProvidersTableTest.php
@@ -47,7 +47,7 @@ class AuthProvidersTableTest extends TestCase
     {
         parent::setUp();
 
-        $this->AuthProviders = TableRegistry::get('AuthProviders');
+        $this->AuthProviders = TableRegistry::getTableLocator()->get('AuthProviders');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
@@ -49,7 +49,7 @@ class ConfigTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->Config = TableRegistry::get('Config');
+        $this->Config = TableRegistry::getTableLocator()->get('Config');
     }
 
     /**
@@ -145,7 +145,7 @@ class ConfigTableTest extends TestCase
         // `appVal` must not be present
         static::assertFalse(in_array('appVal', $names));
 
-        CurrentApplication::setApplication(TableRegistry::get('Applications')->get(1));
+        CurrentApplication::setApplication(TableRegistry::getTableLocator()->get('Applications')->get(1));
 
         $config = $this->Config->find('mine')->toArray();
         $names = Hash::extract($config, '{n}.name');

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/DateRangesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/DateRangesTableTest.php
@@ -49,7 +49,7 @@ class DateRangesTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->DateRanges = TableRegistry::get('DateRanges');
+        $this->DateRanges = TableRegistry::getTableLocator()->get('DateRanges');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointPermissionsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointPermissionsTableTest.php
@@ -54,7 +54,7 @@ class EndpointPermissionsTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->EndpointPermissions = TableRegistry::get('EndpointPermissions');
+        $this->EndpointPermissions = TableRegistry::getTableLocator()->get('EndpointPermissions');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointsTableTest.php
@@ -50,7 +50,7 @@ class EndpointsTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->Endpoints = TableRegistry::get('Endpoints');
+        $this->Endpoints = TableRegistry::getTableLocator()->get('Endpoints');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ExternalAuthTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ExternalAuthTableTest.php
@@ -64,7 +64,7 @@ class ExternalAuthTableTest extends TestCase
     {
         parent::setUp();
 
-        $this->ExternalAuth = TableRegistry::get('ExternalAuth');
+        $this->ExternalAuth = TableRegistry::getTableLocator()->get('ExternalAuth');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
@@ -60,7 +60,7 @@ class FoldersTableTest extends TestCase
     {
         parent::setUp();
 
-        $this->Folders = TableRegistry::get('Folders');
+        $this->Folders = TableRegistry::getTableLocator()->get('Folders');
         LoggedUser::setUser(['id' => 1]);
     }
 
@@ -244,7 +244,7 @@ class FoldersTableTest extends TestCase
      */
     public function testSave($expected, $data)
     {
-        $trees = TableRegistry::get('Trees');
+        $trees = TableRegistry::getTableLocator()->get('Trees');
         if (!empty($data['id'])) {
             $node = $trees->find()->where(['object_id' => $data['id']])->first();
             $descendants = $trees->childCount($node);
@@ -379,8 +379,8 @@ class FoldersTableTest extends TestCase
             })
             ->toArray();
 
-        $Trees = TableRegistry::get('Trees');
-        $Objects = TableRegistry::get('Objects');
+        $Trees = TableRegistry::getTableLocator()->get('Trees');
+        $Objects = TableRegistry::getTableLocator()->get('Objects');
 
         // all descendants exist and are on tree
         foreach (array_merge($notFoldersIds, $folderIds) as $id) {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
@@ -53,7 +53,7 @@ class LocationsTableTest extends TestCase
     {
         parent::setUp();
 
-        $this->Locations = TableRegistry::get('Locations');
+        $this->Locations = TableRegistry::getTableLocator()->get('Locations');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/MediaTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/MediaTableTest.php
@@ -39,7 +39,7 @@ class MediaTableTest extends TestCase
     {
         parent::setUp();
         $config = TableRegistry::exists('Media') ? [] : ['className' => 'BEdita\Core\Model\Table\MediaTable'];
-        $this->Media = TableRegistry::get('Media', $config);
+        $this->Media = TableRegistry::getTableLocator()->get('Media', $config);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectPermissionsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectPermissionsTableTest.php
@@ -39,7 +39,7 @@ class ObjectPermissionsTableTest extends TestCase
     {
         parent::setUp();
         $config = TableRegistry::exists('ObjectPermissions') ? [] : ['className' => 'BEdita\Core\Model\Table\ObjectPermissionsTable'];
-        $this->ObjectPermissions = TableRegistry::get('ObjectPermissions', $config);
+        $this->ObjectPermissions = TableRegistry::getTableLocator()->get('ObjectPermissions', $config);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectPropertiesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectPropertiesTableTest.php
@@ -39,7 +39,7 @@ class ObjectPropertiesTableTest extends TestCase
     {
         parent::setUp();
         $config = TableRegistry::exists('ObjectProperties') ? [] : ['className' => 'BEdita\Core\Model\Table\ObjectPropertiesTable'];
-        $this->ObjectProperties = TableRegistry::get('ObjectProperties', $config);
+        $this->ObjectProperties = TableRegistry::getTableLocator()->get('ObjectProperties', $config);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectRelationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectRelationsTableTest.php
@@ -41,7 +41,7 @@ class ObjectRelationsTableTest extends TestCase
     {
         parent::setUp();
 
-        $this->ObjectRelations = TableRegistry::get('ObjectRelations');
+        $this->ObjectRelations = TableRegistry::getTableLocator()->get('ObjectRelations');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
@@ -68,7 +68,7 @@ class ObjectTypesTableTest extends TestCase
         Cache::drop('_bedita_object_types_');
         Cache::setConfig('_bedita_object_types_', ['className' => 'File']);
 
-        $this->ObjectTypes = TableRegistry::get('ObjectTypes');
+        $this->ObjectTypes = TableRegistry::getTableLocator()->get('ObjectTypes');
     }
 
     /**
@@ -666,7 +666,7 @@ class ObjectTypesTableTest extends TestCase
         $data = [
             'title' => 'Foo',
         ];
-        $table = TableRegistry::get('Foos');
+        $table = TableRegistry::getTableLocator()->get('Foos');
         $entity = $table->newEntity();
         $entity = $table->patchEntity($entity, $data);
         $entity->created_by = 1;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -55,7 +55,7 @@ class ObjectsTableTest extends TestCase
     {
         parent::setUp();
 
-        $this->Objects = TableRegistry::get('Objects');
+        $this->Objects = TableRegistry::getTableLocator()->get('Objects');
         LoggedUser::setUser(['id' => 1]);
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
@@ -60,7 +60,7 @@ class ProfilesTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->Profiles = TableRegistry::get('Profiles');
+        $this->Profiles = TableRegistry::getTableLocator()->get('Profiles');
         LoggedUser::setUser(['id' => 1]);
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertiesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertiesTableTest.php
@@ -48,7 +48,7 @@ class PropertiesTableTest extends TestCase
     {
         parent::setUp();
 
-        $this->Properties = TableRegistry::get('Properties');
+        $this->Properties = TableRegistry::getTableLocator()->get('Properties');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertyTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertyTypesTableTest.php
@@ -65,7 +65,7 @@ class PropertyTypesTableTest extends TestCase
         Cache::drop('_bedita_object_types_');
         Cache::setConfig('_bedita_object_types_', ['className' => 'File']);
 
-        $this->PropertyTypes = TableRegistry::get('PropertyTypes');
+        $this->PropertyTypes = TableRegistry::getTableLocator()->get('PropertyTypes');
     }
 
     /**
@@ -293,7 +293,7 @@ class PropertyTypesTableTest extends TestCase
      */
     public function testDetect($expected, $name, $table, $overrideType = null)
     {
-        $table = TableRegistry::get($table);
+        $table = TableRegistry::getTableLocator()->get($table);
         if ($overrideType !== null) {
             $table
                 ->setValidator('default', new Validator())

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationTypesTableTest.php
@@ -54,7 +54,7 @@ class RelationTypesTableTest extends TestCase
         Cache::drop('_bedita_object_types_');
         Cache::setConfig('_bedita_object_types_', ['className' => 'File']);
 
-        $this->RelationTypes = TableRegistry::get('RelationTypes');
+        $this->RelationTypes = TableRegistry::getTableLocator()->get('RelationTypes');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
@@ -58,7 +58,7 @@ class RelationsTableTest extends TestCase
         Cache::drop('_bedita_object_types_');
         Cache::setConfig('_bedita_object_types_', ['className' => 'File']);
 
-        $this->Relations = TableRegistry::get('Relations');
+        $this->Relations = TableRegistry::getTableLocator()->get('Relations');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
@@ -59,7 +59,7 @@ class RolesTableTest extends TestCase
     {
         parent::setUp();
 
-        $this->Roles = TableRegistry::get('Roles');
+        $this->Roles = TableRegistry::getTableLocator()->get('Roles');
         LoggedUser::setUser(['id' => 1]);
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesUsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesUsersTableTest.php
@@ -54,7 +54,7 @@ class RolesUsersTableTest extends TestCase
     {
         parent::setUp();
 
-        $this->RolesUsers = TableRegistry::get('RolesUsers');
+        $this->RolesUsers = TableRegistry::getTableLocator()->get('RolesUsers');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/StaticPropertiesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/StaticPropertiesTableTest.php
@@ -82,12 +82,12 @@ class StaticPropertiesTableTest extends TestCase
      */
     public function testInitialize()
     {
-        $this->StaticProperties = TableRegistry::get('StaticProperties');
+        $this->StaticProperties = TableRegistry::getTableLocator()->get('StaticProperties');
 
         static::assertSame(StaticProperty::class, $this->StaticProperties->getEntityClass());
         static::assertRegExp('/^(?:[\w_]+\.)?static_properties_[a-f0-9]{16}$/', $this->StaticProperties->getTable());
 
-        $otherInstance = TableRegistry::get('BEdita/Core.StaticProperties');
+        $otherInstance = TableRegistry::getTableLocator()->get('BEdita/Core.StaticProperties');
 
         static::assertNotSame($otherInstance->getTable(), $this->StaticProperties->getTable());
     }
@@ -101,9 +101,9 @@ class StaticPropertiesTableTest extends TestCase
      */
     public function testCreateTable()
     {
-        $this->StaticProperties = TableRegistry::get('StaticProperties');
+        $this->StaticProperties = TableRegistry::getTableLocator()->get('StaticProperties');
 
-        $Properties = TableRegistry::get('Properties');
+        $Properties = TableRegistry::getTableLocator()->get('Properties');
 
         $staticPropSchema = $this->StaticProperties->getSchema();
         $propSchema = $Properties->getSchema();
@@ -259,7 +259,7 @@ class StaticPropertiesTableTest extends TestCase
      */
     public function testAddSchemaDetails(array $expected = null, array $conditions)
     {
-        $result = TableRegistry::get('StaticProperties')->find()
+        $result = TableRegistry::getTableLocator()->get('StaticProperties')->find()
             ->where($conditions)
             ->enableHydration(false)
             ->first();
@@ -273,7 +273,7 @@ class StaticPropertiesTableTest extends TestCase
         static::assertNotNull($result);
         static::assertArraySubset($expected, $result);
 
-        $secondResult = TableRegistry::get('BEdita/Core.StaticProperties')->find()
+        $secondResult = TableRegistry::getTableLocator()->get('BEdita/Core.StaticProperties')->find()
             ->where($conditions)
             ->enableHydration(false)
             ->first();

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/StreamsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/StreamsTableTest.php
@@ -63,7 +63,7 @@ class StreamsTableTest extends TestCase
         parent::setUp();
 
         FilesystemRegistry::setConfig(Configure::read('Filesystem'));
-        $this->Streams = TableRegistry::get('Streams');
+        $this->Streams = TableRegistry::getTableLocator()->get('Streams');
 
         $mountManager = FilesystemRegistry::getMountManager();
         $this->keep = collection($mountManager->listContents('default://'))

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/TranslationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/TranslationsTableTest.php
@@ -51,7 +51,7 @@ class TranslationsTableTest extends TestCase
     {
         parent::setUp();
 
-        $this->Translations = TableRegistry::get('Translations');
+        $this->Translations = TableRegistry::getTableLocator()->get('Translations');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/TreesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/TreesTableTest.php
@@ -64,7 +64,7 @@ class TreesTableTest extends TestCase
     {
         parent::setUp();
 
-        $this->Trees = TableRegistry::get('Trees');
+        $this->Trees = TableRegistry::getTableLocator()->get('Trees');
     }
 
     /**
@@ -286,7 +286,7 @@ class TreesTableTest extends TestCase
     {
         // create new Folder
         LoggedUser::setUser(['id' => 1]);
-        $Folders = TableRegistry::get('Folders');
+        $Folders = TableRegistry::getTableLocator()->get('Folders');
         $entity = $Folders->newEntity(['title' => 'subsub folder']);
         $entity->type = 'folders';
         $entity->parent = $Folders->get(12);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UserTokensTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UserTokensTableTest.php
@@ -42,7 +42,7 @@ class UserTokensTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->UserTokens = TableRegistry::get('UserTokens');
+        $this->UserTokens = TableRegistry::getTableLocator()->get('UserTokens');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -65,7 +65,7 @@ class UsersTableTest extends TestCase
     {
         parent::setUp();
 
-        $this->Users = TableRegistry::get('Users');
+        $this->Users = TableRegistry::getTableLocator()->get('Users');
         LoggedUser::setUser(['id' => 1]);
     }
 
@@ -238,7 +238,7 @@ class UsersTableTest extends TestCase
     public function testExternalAuthLogin()
     {
         //1. Add external auth and create new user
-        $authProvider = TableRegistry::get('AuthProviders')->get(2);
+        $authProvider = TableRegistry::getTableLocator()->get('AuthProviders')->get(2);
         $providerUsername = 'gustavo';
         $params = ['job' => 'head of technical support'];
         $userId = null;
@@ -253,7 +253,7 @@ class UsersTableTest extends TestCase
         static::assertEquals(16, $externalAuth->user_id);
 
         // 2. Add external auth to current user
-        $authProvider = TableRegistry::get('AuthProviders')->get(1);
+        $authProvider = TableRegistry::getTableLocator()->get('AuthProviders')->get(1);
         $providerUsername = 'friend of gustavo';
         $params = ['job' => 'support of technical support'];
         $userId = 5;
@@ -724,7 +724,7 @@ class UsersTableTest extends TestCase
         $user->modified_by = 1;
         $user = $this->Users->saveOrFail($user);
 
-        $table = TableRegistry::get('Objects');
+        $table = TableRegistry::getTableLocator()->get('Objects');
         $doc = $table->get(3);
         $doc->modified_by = 1;
         $doc = $table->saveOrFail($doc);

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Association/RelatedToTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Association/RelatedToTest.php
@@ -106,7 +106,7 @@ class RelatedToTest extends TestCase
      */
     public function testGetSubQueryForMatching(array $expected, $table, $association, array $options = [])
     {
-        $table = TableRegistry::get($table);
+        $table = TableRegistry::getTableLocator()->get($table);
         $association = $table->getAssociation($association);
         if (!($association instanceof RelatedTo)) {
             static::fail('Wrong association type');
@@ -164,7 +164,7 @@ class RelatedToTest extends TestCase
     public function testIsSourceAbstract($expected, $table)
     {
         $relatedTo = new RelatedTo('SourceAbstract');
-        $relatedTo->setSource(TableRegistry::get($table));
+        $relatedTo->setSource(TableRegistry::getTableLocator()->get($table));
         static::assertSame($expected, $relatedTo->isSourceAbstract());
     }
 
@@ -182,7 +182,7 @@ class RelatedToTest extends TestCase
     public function testIsTargetAbstract($expected, $table)
     {
         $relatedTo = new RelatedTo('SourceAbstract');
-        $relatedTo->setTarget(TableRegistry::get($table));
+        $relatedTo->setTarget(TableRegistry::getTableLocator()->get($table));
         static::assertSame($expected, $relatedTo->isTargetAbstract());
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/FakeAnimalsTrait.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/FakeAnimalsTrait.php
@@ -65,9 +65,9 @@ trait FakeAnimalsTrait
      */
     public function setupTables()
     {
-        $this->fakeFelines = TableRegistry::get('FakeFelines', $this->tableOptions);
-        $this->fakeMammals = TableRegistry::get('FakeMammals', $this->tableOptions);
-        $this->fakeAnimals = TableRegistry::get('FakeAnimals');
+        $this->fakeFelines = TableRegistry::getTableLocator()->get('FakeFelines', $this->tableOptions);
+        $this->fakeMammals = TableRegistry::getTableLocator()->get('FakeMammals', $this->tableOptions);
+        $this->fakeAnimals = TableRegistry::getTableLocator()->get('FakeAnimals');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/InheritanceEventHandlerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/InheritanceEventHandlerTest.php
@@ -359,7 +359,7 @@ class InheritanceEventHandlerTest extends TestCase
     public function testApplicationRulesErrorsPropagation($expected, $rulesConfig)
     {
         foreach ($rulesConfig as $rule) {
-            $table = TableRegistry::get($rule['table']);
+            $table = TableRegistry::getTableLocator()->get($rule['table']);
             $options = $rule['options'];
             $table->getEventManager()->on(
                 'Model.buildRules',

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/MarshallerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/MarshallerTest.php
@@ -47,7 +47,7 @@ class MarshallerTest extends TestCase
     public function testBuildPropertyMapWithoutInheritance()
     {
         $tableOptions = $this->tableOptions + ['table' => 'fake_felines'];
-        $table = TableRegistry::get('FakeTiger', $tableOptions);
+        $table = TableRegistry::getTableLocator()->get('FakeTiger', $tableOptions);
         $marshaller = new Marshaller($table);
         $data = [
             'name' => 'tiger',

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/TableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/TableTest.php
@@ -128,7 +128,7 @@ class TableTest extends TestCase
         static::assertSame($expected, $common);
         static::assertSame($expected, $symmetricCommon);
 
-        static::assertSame([], $this->fakeMammals->commonInheritance(TableRegistry::get('FakeArticles')));
+        static::assertSame([], $this->fakeMammals->commonInheritance(TableRegistry::getTableLocator()->get('FakeArticles')));
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
@@ -50,7 +50,7 @@ class QueryFilterTraitTest extends TestCase
     {
         parent::setUp();
 
-        $this->fakeAnimals = TableRegistry::get('FakeAnimals');
+        $this->fakeAnimals = TableRegistry::getTableLocator()->get('FakeAnimals');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Shell/ResourcesShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/ResourcesShellTest.php
@@ -87,7 +87,7 @@ class ResourcesShellTest extends ConsoleIntegrationTestCase
         );
         $this->exec(sprintf('resources add -t %s', $type), $input);
 
-        $exists = TableRegistry::get(Inflector::camelize($type))->exists(compact('name'));
+        $exists = TableRegistry::getTableLocator()->get(Inflector::camelize($type))->exists(compact('name'));
         if ($expected === true) {
             static::assertTrue($exists);
             $this->assertExitCode(Shell::CODE_SUCCESS);
@@ -146,7 +146,7 @@ class ResourcesShellTest extends ConsoleIntegrationTestCase
         $this->assertExitCode(Shell::CODE_SUCCESS);
         $this->assertErrorEmpty();
 
-        $endpointPermission = TableRegistry::get('EndpointPermissions')->find()->last();
+        $endpointPermission = TableRegistry::getTableLocator()->get('EndpointPermissions')->find()->last();
 
         $read = EndpointPermission::decode(EndpointPermission::encode($read));
         $write = EndpointPermission::decode(EndpointPermission::encode($write));
@@ -193,7 +193,7 @@ class ResourcesShellTest extends ConsoleIntegrationTestCase
      */
     public function testEdit($type, $resId, $field, $value = null)
     {
-        $table = TableRegistry::get(Inflector::camelize($type));
+        $table = TableRegistry::getTableLocator()->get(Inflector::camelize($type));
         if (is_numeric($resId)) {
             $entity = $table->get($resId);
         } else {
@@ -301,11 +301,11 @@ class ResourcesShellTest extends ConsoleIntegrationTestCase
      */
     public function testRemove($expected, $id, $answer)
     {
-        $countBefore = TableRegistry::get('Applications')->find()->count();
+        $countBefore = TableRegistry::getTableLocator()->get('Applications')->find()->count();
 
         $this->exec(sprintf('resources rm -t applications %s', $id), [$answer]);
 
-        $countAfter = TableRegistry::get('Applications')->find()->count();
+        $countAfter = TableRegistry::getTableLocator()->get('Applications')->find()->count();
 
         if ($expected) {
             $this->assertExitCode(Shell::CODE_SUCCESS);

--- a/plugins/BEdita/Core/tests/TestCase/Shell/StreamsShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/StreamsShellTest.php
@@ -44,7 +44,7 @@ class StreamsShellTest extends ConsoleIntegrationTestCase
         parent::setUp();
 
         FilesystemRegistry::setConfig(Configure::read('Filesystem'));
-        $this->Streams = TableRegistry::get('Streams');
+        $this->Streams = TableRegistry::getTableLocator()->get('Streams');
 
         $mountManager = FilesystemRegistry::getMountManager();
         $this->keep = collection($mountManager->listContents('default://'))
@@ -116,13 +116,13 @@ class StreamsShellTest extends ConsoleIntegrationTestCase
      */
     public function testRemoveOrphans($expected, $days)
     {
-        $count = TableRegistry::get('Streams')->find()->count();
+        $count = TableRegistry::getTableLocator()->get('Streams')->find()->count();
         $this->exec(sprintf('streams removeOrphans --days %d', $days));
 
         $this->assertExitCode(Shell::CODE_SUCCESS);
         $this->assertErrorEmpty();
 
-        $count -= TableRegistry::get('Streams')->find()->count();
+        $count -= TableRegistry::getTableLocator()->get('Streams')->find()->count();
         static::assertEquals($expected, $count);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckApiKeyTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckApiKeyTaskTest.php
@@ -48,7 +48,7 @@ class CheckApiKeyTaskTest extends ConsoleIntegrationTestCase
     {
         parent::setUp();
 
-        $this->Applications = TableRegistry::get('Applications');
+        $this->Applications = TableRegistry::getTableLocator()->get('Applications');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckTreeTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckTreeTaskTest.php
@@ -56,7 +56,7 @@ class CheckTreeTaskTest extends ConsoleIntegrationTestCase
     {
         parent::setUp();
 
-        $this->Trees = TableRegistry::get('Trees');
+        $this->Trees = TableRegistry::getTableLocator()->get('Trees');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/InitSchemaTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/InitSchemaTaskTest.php
@@ -107,7 +107,7 @@ class InitSchemaTaskTest extends ConsoleIntegrationTestCase
         $this->assertErrorEmpty();
         static::assertCount(count($schema) + 1, $connection->getSchemaCollection()->listTables());
 
-        return TableRegistry::get('ObjectTypes')->find()->count();
+        return TableRegistry::getTableLocator()->get('ObjectTypes')->find()->count();
     }
 
     /**
@@ -187,6 +187,6 @@ class InitSchemaTaskTest extends ConsoleIntegrationTestCase
         $this->assertErrorEmpty();
         static::assertCount(count($schema) + 1, $connection->getSchemaCollection()->listTables());
 
-        static::assertEquals($notSeededCount, TableRegistry::get('ObjectTypes')->find()->count());
+        static::assertEquals($notSeededCount, TableRegistry::getTableLocator()->get('ObjectTypes')->find()->count());
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/RecoverTreeTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/RecoverTreeTaskTest.php
@@ -53,7 +53,7 @@ class RecoverTreeTaskTest extends ConsoleIntegrationTestCase
     {
         parent::setUp();
 
-        $this->Trees = TableRegistry::get('Trees');
+        $this->Trees = TableRegistry::getTableLocator()->get('Trees');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/SetupAdminUserTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/SetupAdminUserTaskTest.php
@@ -55,7 +55,7 @@ class SetupAdminUserTaskTest extends ConsoleIntegrationTestCase
     {
         parent::setUp();
 
-        $this->Users = TableRegistry::get('Users');
+        $this->Users = TableRegistry::getTableLocator()->get('Users');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/State/CurrentApplicationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/State/CurrentApplicationTest.php
@@ -50,7 +50,7 @@ class CurrentApplicationTest extends TestCase
     {
         parent::setUp();
 
-        $this->Applications = TableRegistry::get('Applications');
+        $this->Applications = TableRegistry::getTableLocator()->get('Applications');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Utility/JsonSchemaTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/JsonSchemaTest.php
@@ -250,7 +250,7 @@ class JsonSchemaTest extends TestCase
         static::assertNotEmpty($revision);
 
         // add custom property and check schema revision change
-        $properties = TableRegistry::get('Properties');
+        $properties = TableRegistry::getTableLocator()->get('Properties');
         $data = [
             'name' => 'gustavo',
             'description' => '',


### PR DESCRIPTION
This PR fixes `TableRegistry::get()` deprecation => massive substitution with `TableRegistry::getTableLocator()->get()`
