### PR TITLE
Auth user opt-out #1578

### DIFF
--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -72,6 +72,11 @@ Router::plugin(
             ['_name' => 'login']
         );
         $routes->connect(
+            '/auth/optout',
+            ['controller' => 'Login', 'action' => 'optout', '_method' => 'POST'],
+            ['_name' => 'login:optout']
+        );
+        $routes->connect(
             '/auth/change',
             ['controller' => 'Login', 'action' => 'change'],
             ['_name' => 'login:change']

--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -106,16 +106,16 @@ class LoginController extends AppController
      */
     public function login(): void
     {
+        $this->set('_serialize', []);
         $result = $this->identify();
         // Check if result contains only an authorization code (OTP & 2FA use cases)
         if (!empty($result['authorization_code']) && count($result) === 1) {
-            $meta = ['authorization_code' => $result['authorization_code']];
-        } else {
-            $result = $this->reducedUserData($result);
-            $meta = $this->jwtTokens($result);
-        }
+            $this->set('_meta', ['authorization_code' => $result['authorization_code']]);
 
-        $this->set('_serialize', []);
+            return;
+        }
+        $user = $this->reducedUserData($result);
+        $meta = $this->jwtTokens($user);
         $this->set('_meta', $meta);
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
@@ -47,6 +47,7 @@ class LoginControllerTest extends IntegrationTestCase
      * @return string A valid JWT.
      *
      * @covers ::login()
+     * @covers ::identify()
      * @covers ::reducedUserData()
      * @covers ::jwtTokens()
      */
@@ -101,6 +102,7 @@ class LoginControllerTest extends IntegrationTestCase
      *
      * @depends testLoginOkJson
      * @covers ::login()
+     * @covers ::identify()
      * @covers \BEdita\API\Auth\JwtAuthenticate::authenticate()
      */
     public function testSuccessfulRenew(array $meta)
@@ -130,6 +132,7 @@ class LoginControllerTest extends IntegrationTestCase
      *
      * @depends testLoginOkJson
      * @covers ::login()
+     * @covers ::identify()
      * @covers \BEdita\API\Auth\JwtAuthenticate::authenticate()
      */
     public function testFailedRenew(array $meta)
@@ -165,6 +168,7 @@ class LoginControllerTest extends IntegrationTestCase
      * @return void
      *
      * @covers ::login()
+     * @covers ::identify()
      */
     public function testFailedLogin()
     {
@@ -198,6 +202,7 @@ class LoginControllerTest extends IntegrationTestCase
      * @return void
      *
      * @covers ::login()
+     * @covers ::identify()
      */
     public function testLoginAuthorizationDenied()
     {
@@ -748,6 +753,7 @@ class LoginControllerTest extends IntegrationTestCase
      *
      * @return void
      * @covers ::login()
+     * @covers ::identify()
      */
     public function testOTPRequestLogin()
     {
@@ -782,6 +788,7 @@ class LoginControllerTest extends IntegrationTestCase
      *
      * @return void
      * @covers ::login()
+     * @covers ::identify()
      */
     public function testOTPRequestFail()
     {
@@ -807,6 +814,7 @@ class LoginControllerTest extends IntegrationTestCase
      *
      * @return void
      * @covers ::login()
+     * @covers ::identify()
      */
     public function testOTPLogin()
     {
@@ -850,5 +858,51 @@ class LoginControllerTest extends IntegrationTestCase
         $this->assertResponseCode(401);
         static::assertNotEmpty($result);
         static::assertEquals(self::NOT_SUCCESSFUL_EXPECTED_RESULT, Hash::remove($result, 'error.meta'));
+    }
+
+    /**
+     * Data provider for `testOptout` test case.
+     *
+     * @return array
+     */
+    public function optoutProvider()
+    {
+        return [
+            'ok' => [
+                204,
+                [
+                    'username' => 'second user',
+                    'password' => 'password2',
+                ],
+            ]
+        ];
+    }
+
+    /**
+     * Test `optout` method
+     *
+     * @param mixed $expected Expected result
+     * @param array $data POST data
+     * @return void
+     *
+     * @dataProvider optoutProvider()
+     * @covers ::optout()
+     * @covers ::initialize()
+     * @covers ::identify()
+     */
+    public function testOptout($expected, $data)
+    {
+        $this->configRequestHeaders('POST', ['Content-Type' => 'application/json']);
+        $this->post('/auth/optout', json_encode($data));
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        if (is_int($expected)) {
+            $this->assertResponseCode($expected);
+            static::assertEmpty($result);
+        } else {
+            unset($result['meta'], $result['links']);
+            static::assertEquals($expected, $result);
+            $this->assertResponseCode($result['error']['status']);
+        }
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
@@ -874,6 +874,24 @@ class LoginControllerTest extends IntegrationTestCase
                     'username' => 'second user',
                     'password' => 'password2',
                 ],
+            ],
+            'auth code' => [
+                [
+                    'meta' => [
+                        'authorization_code' => 1,
+                    ],
+                ],
+                [
+                    'username' => 'second user',
+                    'grant_type' => 'otp_request',
+                ],
+            ],
+            'unauth' => [
+                self::NOT_SUCCESSFUL_EXPECTED_RESULT,
+                [
+                    'username' => 'second user',
+                    'password' => 'wrongPassword',
+                ],
             ]
         ];
     }
@@ -899,10 +917,17 @@ class LoginControllerTest extends IntegrationTestCase
         if (is_int($expected)) {
             $this->assertResponseCode($expected);
             static::assertEmpty($result);
-        } else {
-            unset($result['meta'], $result['links']);
+        } elseif (!empty($expected['meta']['authorization_code'])) {
+            $this->assertResponseCode(200);
+            unset($result['links']);
+            static::assertNotEmpty($result['meta']['authorization_code']);
+            $expected['meta']['authorization_code'] = $result['meta']['authorization_code'];
             static::assertEquals($expected, $result);
-            $this->assertResponseCode($result['error']['status']);
+        } else {
+            unset($result['links'], $result['error']['meta']);
+            $this->assertResponseCode((int)$result['error']['status']);
+            unset($expected['links']);
+            static::assertEquals($expected, $result);
         }
     }
 }

--- a/plugins/BEdita/Core/config/reserved.php
+++ b/plugins/BEdita/Core/config/reserved.php
@@ -22,6 +22,7 @@ return [
     'applications',
     'async_job',
     'async_jobs',
+    'auth',
     'categories',
     'category',
     'config',

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -326,7 +326,7 @@ class UsersTable extends Table
         foreach ($this->inheritedTables() as $table) {
             $notNull = array_merge($notNull, $this->notNullableColumns($table));
         }
-        $properties = array_diff((array)$entity->getVisible(), $notNull, ['type']);
+        $properties = array_diff((array)$entity->getVisible(), $notNull, ['type', '_optout']);
         foreach ($properties as $name) {
             $entity->set($name, null);
         }
@@ -381,6 +381,10 @@ class UsersTable extends Table
 
     /**
      * Before save checks: if record is not deletable and deletion is the update type, raise a ImmutableResourceException
+     * Use cases:
+     *  - trying to soft delete ADMIN_USER
+     *  - logged user removing their account, but performing optout via `_optout` special property is allowed
+     *  - `username` or `uname` cannot start with reserved `__deleted-` string 
      *
      * @param \Cake\Event\Event $event The beforeSave event that was fired
      * @param \Cake\Datasource\EntityInterface $entity the entity that is going to be saved
@@ -392,7 +396,7 @@ class UsersTable extends Table
         if ($entity->deleted === true && static::ADMIN_USER === $entity->id) {
             throw new ImmutableResourceException(__d('bedita', 'Could not delete "User" {0}', $entity->id));
         }
-        if ($entity->deleted === true && LoggedUser::id() === $entity->id) {
+        if ($entity->deleted === true && LoggedUser::id() === $entity->id && empty($entity->get('_optout'))) {
             throw new BadRequestException(__d('bedita', 'Logged users cannot delete their own account'));
         }
         foreach (['username', 'uname'] as $prop) {

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -384,7 +384,7 @@ class UsersTable extends Table
      * Use cases:
      *  - trying to soft delete ADMIN_USER
      *  - logged user removing their account, but performing optout via `_optout` special property is allowed
-     *  - `username` or `uname` cannot start with reserved `__deleted-` string 
+     *  - `username` or `uname` cannot start with reserved `__deleted-` string
      *
      * @param \Cake\Event\Event $event The beforeSave event that was fired
      * @param \Cake\Datasource\EntityInterface $entity the entity that is going to be saved


### PR DESCRIPTION
This PR closes #1578 

A new `/auth/optout` endpoint was created in order to definitively be removed as a user from a BE4 Project.

Any user invoking `POST /auth/optout` must pass identification data in request body (via usual methods like classic username/password, OAuth2, OTP, 2FA...). 
If identification is successful:

- user data are completely removed or anonymized - using same logic seen in #1579 
- an `Auth.optout` event is dispatched in order to trigger other actions via plugins

It's up to the client to completely remove access and refresh token from the client app afterwards.


