### PR TITLE
Fix pagination `maxLimit` configuration

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -400,16 +400,16 @@ return [
     ],
 
     /**
-     * Default pagination settings.
+     * Default pagination settings. Uncomment to change.
      *
      * - `limit` - Default number of items per page (page_size). Defaults to 20.
      * - `maxLimit` - The maximum numer of items retrievable using a `page_size` request per call. Defaults to 100.
-     *   This value cannot exceed a superlimit (@see \BEdita\API\Controller\Component\PaginatorComponent::MAX_LIMIT))
+     *   This value cannot exceed a superlimit (@see \BEdita\API\Datasource\JsonApiPaginator::MAX_LIMIT))
      */
-    'Pagination' => [
-        'limit' => 20,
-        'maxLimit' => 100,
-    ],
+    // 'Pagination' => [
+    //     'limit' => 20,
+    //     'maxLimit' => 100,
+    // ],
 
     /**
      * Project information.

--- a/plugins/BEdita/API/src/Controller/AppController.php
+++ b/plugins/BEdita/API/src/Controller/AppController.php
@@ -34,15 +34,24 @@ use Cake\Routing\Router;
  */
 class AppController extends Controller
 {
-
     /**
      * {@inheritDoc}
      */
     public $paginate = [
-        'maxLimit' => 100,
         'order' => [
             'id' => 'asc',
         ],
+    ];
+
+    /**
+     * Default pagination options.
+     * May be overridden in configuration.
+     *
+     * @var array
+     */
+    public $defaultPagination = [
+        'limit' => 20,
+        'maxLimit' => 100,
     ];
 
     /**
@@ -56,7 +65,7 @@ class AppController extends Controller
 
         $this->getApplication();
 
-        $this->loadComponent('Paginator', (array)Configure::read('Pagination'));
+        $this->loadComponent('Paginator', (array)Configure::read('Pagination', $this->defaultPagination));
         $this->loadComponent('RequestHandler');
         if ($this->request->is(['json', 'jsonapi'])) {
             $this->loadComponent('BEdita/API.JsonApi', [

--- a/plugins/BEdita/API/tests/IntegrationTest/PaginationTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/PaginationTest.php
@@ -57,8 +57,22 @@ class PaginationTest extends IntegrationTestCase
                 ],
                 [
                     'limit' => 5,
+                ],
+            ],
+            // set 10 as maxLimit, page_size of 20 not allowed
+            'low max limit' => [
+                [
+                    'count' => 12,
+                    'page' => 1,
+                    'page_count' => 2,
+                    'page_items' => 10,
+                    'page_size' => 10,
+                ],
+                [
+                    'limit' => 5,
                     'maxLimit' => 10,
                 ],
+                'page_size=20',
             ],
             'higher' => [
                 [
@@ -72,24 +86,55 @@ class PaginationTest extends IntegrationTestCase
                     'limit' => 50,
                 ],
             ],
+            // set 200 as maxLimit, page_size of 200 allowed
+            'increase max' => [
+                [
+                    'count' => 12,
+                    'page' => 1,
+                    'page_count' => 1,
+                    'page_items' => 12,
+                    'page_size' => 200,
+                ],
+                [
+                    'maxLimit' => 200,
+                ],
+                'page_size=200',
+            ],
+            // try to set an invalid limit of 1000
+            // BEdita\API\Datasource\JsonApiPaginator::MAX_LIMIT (500) is used instead
             'too high' => [
                 [
                     'count' => 12,
                     'page' => 1,
                     'page_count' => 1,
                     'page_items' => 12,
-                    'page_size' => 100,
+                    'page_size' => 500,
                 ],
                 [
                     'limit' => 1000,
                     'maxLimit' => 1000,
                 ],
+                'page_size=600',
+            ],
+            // set 500 as maxLimit, page_size of 300 is allowed
+            'not too high' => [
+                [
+                    'count' => 12,
+                    'page' => 1,
+                    'page_count' => 1,
+                    'page_items' => 12,
+                    'page_size' => 300,
+                ],
+                [
+                    'maxLimit' => 500,
+                ],
+                'page_size=300',
             ],
         ];
     }
 
     /**
-     * Test that pagination options are applied correctly..
+     * Test that pagination options are applied correctly.
      *
      * @param array $expected Expected pagination.
      * @param array $options Pagination options.
@@ -98,12 +143,12 @@ class PaginationTest extends IntegrationTestCase
      * @dataProvider optionsProvider
      * @coversNothing
      */
-    public function testOptions(array $expected, array $options = [])
+    public function testOptions(array $expected, array $options = [], string $query = '')
     {
         Configure::write('Pagination', $options);
 
         $this->configRequestHeaders('GET');
-        $this->get('/objects');
+        $this->get('/objects?' . $query);
 
         $body = json_decode((string)$this->_response->getBody(), true);
         $this->assertResponseCode(200);


### PR DESCRIPTION
This PR fixes a problem setting `Pagination.maxLimit` in configuration.

Problem description: in AppController `$this->paginate['maxLimit']` takes precedence over `Pagination.maxLimit`. Trying to set a configuration a different configuration has no effect.

Some tests have been addedo `PaginationTest` integration test to demonstrate it.

Having `$this->paginate['maxLimit']` set in AppController will cause test failures in `PaginationTest::testOptions` with data set `"low max limit" "increase max" "too high" "not too high"`.
 
**Bonus track**: `Pagination` config in `app.default.php` commented, this configuration should be present only in case of change.
