### PR TITLE
Populate `meta.media_url` always for media objects

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/MediaControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/MediaControllerTest.php
@@ -471,12 +471,6 @@ class MediaControllerTest extends IntegrationTestCase
                                 'self' => 'http://api.example.com/files/10/relationships/translations',
                             ],
                         ],
-                        'test_abstract' => [
-                            'links' => [
-                                'related' => 'http://api.example.com/files/10/test_abstract',
-                                'self' => 'http://api.example.com/files/10/relationships/test_abstract',
-                            ],
-                        ],
                         'inverse_test_abstract' => [
                             'links' => [
                                 'related' => 'http://api.example.com/files/10/inverse_test_abstract',
@@ -541,12 +535,6 @@ class MediaControllerTest extends IntegrationTestCase
                             'links' => [
                                 'related' => 'http://api.example.com/files/14/translations',
                                 'self' => 'http://api.example.com/files/14/relationships/translations',
-                            ],
-                        ],
-                        'test_abstract' => [
-                            'links' => [
-                                'related' => 'http://api.example.com/files/14/test_abstract',
-                                'self' => 'http://api.example.com/files/14/relationships/test_abstract',
                             ],
                         ],
                         'inverse_test_abstract' => [
@@ -709,12 +697,6 @@ class MediaControllerTest extends IntegrationTestCase
                         'links' => [
                             'related' => 'http://api.example.com/files/14/translations',
                             'self' => 'http://api.example.com/files/14/relationships/translations',
-                        ],
-                    ],
-                    'test_abstract' => [
-                        'links' => [
-                            'related' => 'http://api.example.com/files/14/test_abstract',
-                            'self' => 'http://api.example.com/files/14/relationships/test_abstract',
                         ],
                     ],
                     'inverse_test_abstract' => [

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
@@ -356,7 +356,9 @@ class ObjectTypesControllerTest extends IntegrationTestCase
                     ],
                     'meta' => [
                         'alias' => 'Events',
-                        'relations' => [],
+                        'relations' => [
+                           'test_abstract',
+                        ],
                         'created' => '2017-11-10T09:27:23+00:00',
                         'modified' => '2017-11-10T09:27:23+00:00',
                         'core_type' => true,
@@ -449,7 +451,6 @@ class ObjectTypesControllerTest extends IntegrationTestCase
                     'meta' => [
                         'alias' => 'Files',
                         'relations' => [
-                            'test_abstract',
                             'inverse_test_abstract',
                         ],
                         'created' => '2017-11-10T09:27:23+00:00',

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
@@ -126,9 +126,9 @@ class RelationsControllerTest extends IntegrationTestCase
                     'type' => 'relations',
                     'attributes' => [
                         'name' => 'test_abstract',
-                        'label' => 'Test relation between abstract types',
+                        'label' => 'Test relation involving abstract types',
                         'inverse_name' => 'inverse_test_abstract',
-                        'inverse_label' => 'Inverse test relation between abstract types',
+                        'inverse_label' => 'Inverse test relation involving abstract types',
                         'description' => 'Sample description.',
                         'params' => null,
                     ],

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -426,6 +426,12 @@ class ObjectsControllerTest extends IntegrationTestCase
                         'self' => 'http://api.example.com/events/9',
                     ],
                     'relationships' => [
+                        'test_abstract' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/events/9/test_abstract',
+                                'self' => 'http://api.example.com/events/9/relationships/test_abstract',
+                            ],
+                        ],
                         'parents' => [
                             'links' => [
                                 'related' => 'http://api.example.com/events/9/parents',
@@ -483,12 +489,6 @@ class ObjectsControllerTest extends IntegrationTestCase
                             'links' => [
                                 'related' => 'http://api.example.com/files/10/translations',
                                 'self' => 'http://api.example.com/files/10/relationships/translations',
-                            ],
-                        ],
-                        'test_abstract' => [
-                            'links' => [
-                                'related' => 'http://api.example.com/files/10/test_abstract',
-                                'self' => 'http://api.example.com/files/10/relationships/test_abstract',
                             ],
                         ],
                         'inverse_test_abstract' => [
@@ -679,12 +679,6 @@ class ObjectsControllerTest extends IntegrationTestCase
                             'links' => [
                                 'related' => 'http://api.example.com/files/14/translations',
                                 'self' => 'http://api.example.com/files/14/relationships/translations',
-                            ],
-                        ],
-                        'test_abstract' => [
-                            'links' => [
-                                'related' => 'http://api.example.com/files/14/test_abstract',
-                                'self' => 'http://api.example.com/files/14/relationships/test_abstract',
                             ],
                         ],
                         'inverse_test_abstract' => [

--- a/plugins/BEdita/Core/src/Model/Entity/Media.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Media.php
@@ -46,13 +46,12 @@ class Media extends ObjectEntity
      *
      * @return string|null
      */
-    protected function _getMediaUrl()
+    protected function _getMediaUrl(): ?string
     {
-        $stream = Hash::get((array)$this->get('streams'), '0');
-        if (empty($stream)) {
-            return null;
+        if ($this->streams === null) {
+            $this->getTable()->loadInto($this, ['Streams']);
         }
 
-        return $stream->get('url');
+        return Hash::get((array)$this->streams, '0.url', $this->provider_url);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Entity/Media.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Media.php
@@ -43,6 +43,10 @@ class Media extends ObjectEntity
 
     /**
      * Getter for media url.
+     * Return value:
+     *  - first stream URL if available
+     *  - provider_url as fallback
+     *  - null if no suitable URL is found
      *
      * @return string|null
      */
@@ -52,6 +56,11 @@ class Media extends ObjectEntity
             $this->getTable()->loadInto($this, ['Streams']);
         }
 
-        return Hash::get((array)$this->streams, '0.url', $this->provider_url);
+        $mediaUrl = (string)Hash::get((array)$this->streams, '0.url', $this->provider_url);
+        if (empty($mediaUrl)) {
+            return null;
+        }
+
+        return $mediaUrl;
     }
 }

--- a/plugins/BEdita/Core/tests/Fixture/RelationTypesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/RelationTypesFixture.php
@@ -55,7 +55,7 @@ class RelationTypesFixture extends TestFixture
         ],
         [
             'relation_id' => 3, // test_abstract / inverse_test_abstract
-            'object_type_id' => 9, // files
+            'object_type_id' => 7, // events
             'side' => 'left',
         ],
         [

--- a/plugins/BEdita/Core/tests/Fixture/RelationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/RelationsFixture.php
@@ -46,9 +46,9 @@ class RelationsFixture extends TestFixture
         ],
         [
             'name' => 'test_abstract',
-            'label' => 'Test relation between abstract types',
+            'label' => 'Test relation involving abstract types',
             'inverse_name' => 'inverse_test_abstract',
-            'inverse_label' => 'Inverse test relation between abstract types',
+            'inverse_label' => 'Inverse test relation involving abstract types',
             'description' => 'Sample description.',
             'params' => null,
         ],

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -244,7 +244,7 @@ class ObjectTypeTest extends TestCase
                 'right',
             ],
             'inherited' => [
-                ['test_abstract', 'inverse_test_abstract'],
+                ['inverse_test_abstract'],
                 'files',
             ],
         ];


### PR DESCRIPTION
This PR adds `media_url` information always when `media` object types are read.

In some cases this meta property is not populated: for instance using a query string like `include=has_media` where `has_media` is a relation involving media objects. 
Media objects in `included` array don't have `meta.media_url` populated.

Test cases changes:

* `test_abstract` fixture relation types changed, `events` as left type and `media` as right type
* `AssociatedEntitiesTest::testIncludedMedia` to test `include=` with related media
