### PR TITLE
Inverse relation priority

### DIFF
--- a/plugins/BEdita/API/src/Model/Action/UpdateAssociatedAction.php
+++ b/plugins/BEdita/API/src/Model/Action/UpdateAssociatedAction.php
@@ -126,10 +126,33 @@ class UpdateAssociatedAction extends BaseAction
 
             $meta = Hash::get($datum, '_meta.relation');
             if (!$this->request->is('delete') && $association instanceof BelongsToMany && $meta !== null) {
-                $targetEntities[$id]->_joinData = $meta;
+                $targetEntities[$id]->_joinData = $this->setupPriority($meta, $association);
             }
         }
 
         return $targetEntities;
+    }
+
+    /**
+     * Setup `priority` on `joinData` on ObjectRelation associations.
+     * If relation is inverse set `priority` as `inv_priority` and remove `priority`
+     * If relation is direct unset `inv_priority`.
+     *
+     * @param array $meta Meta input data.
+     * @param \Cake\ORM\Association $association Association.
+     * @return array
+     */
+    protected function setupPriority(array $meta, Association $association): array
+    {
+        if ($association->getForeignKey() === 'right_id') {
+            $meta['inv_priority'] = Hash::get($meta, 'priority');
+            unset($meta['priority']);
+
+            return $meta;
+        }
+
+        unset($meta['inv_priority']);
+
+        return $meta;
     }
 }

--- a/plugins/BEdita/API/src/Model/Action/UpdateAssociatedAction.php
+++ b/plugins/BEdita/API/src/Model/Action/UpdateAssociatedAction.php
@@ -126,33 +126,10 @@ class UpdateAssociatedAction extends BaseAction
 
             $meta = Hash::get($datum, '_meta.relation');
             if (!$this->request->is('delete') && $association instanceof BelongsToMany && $meta !== null) {
-                $targetEntities[$id]->_joinData = $this->setupPriority($meta, $association);
+                $targetEntities[$id]->_joinData = $meta;
             }
         }
 
         return $targetEntities;
-    }
-
-    /**
-     * Setup `priority` on `joinData` on ObjectRelation associations.
-     * If relation is inverse set `priority` as `inv_priority` and remove `priority`
-     * If relation is direct unset `inv_priority`.
-     *
-     * @param array $meta Meta input data.
-     * @param \Cake\ORM\Association $association Association.
-     * @return array
-     */
-    protected function setupPriority(array $meta, Association $association): array
-    {
-        if ($association->getForeignKey() === 'right_id') {
-            $meta['inv_priority'] = Hash::get($meta, 'priority');
-            unset($meta['priority']);
-
-            return $meta;
-        }
-
-        unset($meta['inv_priority']);
-
-        return $meta;
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -1369,8 +1369,7 @@ class ObjectsControllerTest extends IntegrationTestCase
                         'created_by' => 1,
                         'modified_by' => 1,
                         'relation' => [
-                            'priority' => 2,
-                            'inv_priority' => 1,
+                            'priority' => 1,
                             'params' => null,
                         ],
                     ],
@@ -1459,7 +1458,6 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'meta' => [
                         'relation' => [
                             'priority' => 1,
-                            'inv_priority' => 2,
                             'params' => null,
                         ],
                     ],
@@ -1499,7 +1497,6 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'meta' => [
                         'relation' => [
                             'priority' => 2,
-                            'inv_priority' => 1,
                             'params' => null,
                         ],
                     ],
@@ -1665,7 +1662,6 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'meta' => [
                         'relation' => [
                             'priority' => 1,
-                            'inv_priority' => 2,
                             'params' => [
                                 'gustavo' => 'supporto',
                             ],
@@ -1686,7 +1682,6 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'meta' => [
                     'relation' => [
                         'priority' => 1,
-                        'inv_priority' => 2,
                         'params' => [
                             'gustavo' => 'supporto',
                         ],
@@ -1767,7 +1762,6 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'meta' => [
                     'relation' => [
                         'priority' => 1,
-                        'inv_priority' => 2,
                         'params' => [
                             'gustavo' => 'supporto',
                         ],
@@ -1780,7 +1774,6 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'meta' => [
                     'relation' => [
                         'priority' => 1,
-                        'inv_priority' => 2,
                         'params' => [
                             'gustavo' => 'supporto',
                         ],
@@ -1939,7 +1932,6 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'meta' => [
                         'relation' => [
                             'priority' => 1,
-                            'inv_priority' => 2,
                             'params' => [
                                 'gustavo' => 'supporto',
                             ],
@@ -1960,7 +1952,6 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'meta' => [
                     'relation' => [
                         'priority' => 1,
-                        'inv_priority' => 2,
                         'params' => [
                             'gustavo' => 'supporto',
                         ],

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -1370,6 +1370,7 @@ class ObjectsControllerTest extends IntegrationTestCase
                         'modified_by' => 1,
                         'relation' => [
                             'priority' => 1,
+                            'inv_priority' => 2,
                             'params' => null,
                         ],
                     ],
@@ -1458,6 +1459,7 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'meta' => [
                         'relation' => [
                             'priority' => 1,
+                            'inv_priority' => 2,
                             'params' => null,
                         ],
                     ],
@@ -1497,6 +1499,7 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'meta' => [
                         'relation' => [
                             'priority' => 2,
+                            'inv_priority' => 1,
                             'params' => null,
                         ],
                     ],
@@ -1662,6 +1665,7 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'meta' => [
                         'relation' => [
                             'priority' => 1,
+                            'inv_priority' => 2,
                             'params' => [
                                 'gustavo' => 'supporto',
                             ],
@@ -1682,6 +1686,7 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'meta' => [
                     'relation' => [
                         'priority' => 1,
+                        'inv_priority' => 2,
                         'params' => [
                             'gustavo' => 'supporto',
                         ],
@@ -1741,6 +1746,7 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'meta' => [
                         'relation' => [
                             'priority' => 1,
+                            'inv_priority' => 2,
                             'params' => [
                                 'gustavo' => 'supporto',
                             ],
@@ -1761,6 +1767,7 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'meta' => [
                     'relation' => [
                         'priority' => 1,
+                        'inv_priority' => 2,
                         'params' => [
                             'gustavo' => 'supporto',
                         ],
@@ -1773,6 +1780,7 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'meta' => [
                     'relation' => [
                         'priority' => 1,
+                        'inv_priority' => 2,
                         'params' => [
                             'gustavo' => 'supporto',
                         ],
@@ -1931,6 +1939,7 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'meta' => [
                         'relation' => [
                             'priority' => 1,
+                            'inv_priority' => 2,
                             'params' => [
                                 'gustavo' => 'supporto',
                             ],
@@ -1951,6 +1960,7 @@ class ObjectsControllerTest extends IntegrationTestCase
                 'meta' => [
                     'relation' => [
                         'priority' => 1,
+                        'inv_priority' => 2,
                         'params' => [
                             'gustavo' => 'supporto',
                         ],

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -1741,7 +1741,6 @@ class ObjectsControllerTest extends IntegrationTestCase
                     'meta' => [
                         'relation' => [
                             'priority' => 1,
-                            'inv_priority' => 2,
                             'params' => [
                                 'gustavo' => 'supporto',
                             ],

--- a/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
@@ -229,7 +229,7 @@ class ListAssociatedAction extends BaseAction
                     $entity->setHidden([$inverseAssociation->getProperty()], true);
 
                     if (!empty($joinData)) {
-                        $this->setupPriority($joinData);
+                        $this->prepareJoinEntity($joinData);
                         $entity->set('_joinData', $joinData);
                     }
 
@@ -239,22 +239,14 @@ class ListAssociatedAction extends BaseAction
     }
 
     /**
-     * Setup `priority` on `joinData` on ObjectRelation associations:
-     *   - if relation is direct unset `inv_priority`
-     *   - if relation is inverse display `inv_priority` as `priority` and don't display `inv_priority`
+     * Prepare `joinData` entity.
      *
      * @param \Cake\Datasource\EntityInterface $joinData Join data entity.
      * @return void
+     * @codeCoverageIgnore
      */
-    protected function setupPriority(EntityInterface $joinData): void
+    protected function prepareJoinEntity(EntityInterface $joinData): void
     {
-        if (!$joinData instanceof ObjectRelation) {
-            return;
-        }
-        if ($this->Association->getForeignKey() === 'right_id') {
-            $joinData->set('priority', $joinData->get('inv_priority'));
-        }
-        $joinData->unsetProperty('inv_priority');
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
@@ -95,7 +95,10 @@ class ListRelatedObjectsAction extends ListAssociatedAction
      */
     protected function prepareJoinEntity(EntityInterface $joinData): void
     {
-        if (!$joinData instanceof ObjectRelation || $this->Association->getForeignKey() !== 'right_id') {
+        if (
+            !$joinData instanceof ObjectRelation ||
+            ($this->Association instanceof RelatedTo && !$this->Association->isInverse())
+        ) {
             return;
         }
 

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
@@ -13,10 +13,12 @@
 
 namespace BEdita\Core\Model\Action;
 
+use BEdita\Core\Model\Entity\ObjectRelation;
 use BEdita\Core\Model\Table\ObjectsTable;
 use BEdita\Core\ORM\Association\RelatedTo;
 use BEdita\Core\ORM\Inheritance\Table;
 use Cake\Core\Configure;
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\Association;
 use Cake\ORM\TableRegistry;
 
@@ -82,5 +84,24 @@ class ListRelatedObjectsAction extends ListAssociatedAction
         }
 
         return $query;
+    }
+
+    /**
+     * Prepare `joinData` entity on ObjectRelation associations.
+     * If relation is inverse switch between `priority`/`inv_priority`.
+     *
+     * @param \Cake\Datasource\EntityInterface $joinData Join data entity.
+     * @return void
+     */
+    protected function prepareJoinEntity(EntityInterface $joinData): void
+    {
+        if (!$joinData instanceof ObjectRelation || $this->Association->getForeignKey() !== 'right_id') {
+            return;
+        }
+
+        $invPriority = $joinData->get('priority');
+        $priority = $joinData->get('inv_priority');
+        $joinData->set('priority', $priority);
+        $joinData->set('inv_priority', $invPriority);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Model\Action;
 
 use BEdita\Core\Model\Entity\Folder;
+use Cake\Utility\Hash;
 
 /**
  * Abstract class for updating relations between BEdita objects.
@@ -48,6 +49,8 @@ abstract class UpdateRelatedObjectsAction extends UpdateAssociatedAction
     protected function prepareData(array $data)
     {
         if (empty($data['entity']) || !($data['entity'] instanceof Folder) || $this->Association->getName() !== 'Parents') {
+            $this->setupPriority($data);
+
             return $data;
         }
 
@@ -64,5 +67,28 @@ abstract class UpdateRelatedObjectsAction extends UpdateAssociatedAction
         $this->setConfig('association', $this->Association);
 
         return compact('entity', 'relatedEntities') + $data;
+    }
+
+    /**
+     * Setup `priority` on `_joinData`.
+     * If relation is inverse switch `priority` and `inv_priority`.
+     *
+     * @param array $data Action data.
+     * @return void
+     */
+    protected function setupPriority(array &$data): void
+    {
+        if ($this->Association->getForeignKey() !== 'right_id') {
+            return;
+        }
+
+        foreach ($data['relatedEntities'] as $related) {
+            $join = (array)$related->get('_joinData');
+            $priorities = [
+                'inv_priority' => Hash::get($join, 'priority'),
+                'priority' => Hash::get($join, 'inv_priority'),
+            ];
+            $related->set('_joinData', array_filter(array_merge($join, $priorities)));
+        }
     }
 }

--- a/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Model\Action;
 
 use BEdita\Core\Model\Entity\Folder;
+use BEdita\Core\ORM\Association\RelatedTo;
 use Cake\Utility\Hash;
 
 /**
@@ -78,7 +79,7 @@ abstract class UpdateRelatedObjectsAction extends UpdateAssociatedAction
      */
     protected function setupPriority(array &$data): void
     {
-        if ($this->Association->getForeignKey() !== 'right_id') {
+        if (!$this->Association instanceof RelatedTo || !$this->Association->isInverse()) {
             return;
         }
 

--- a/plugins/BEdita/Core/src/ORM/Association/RelatedTo.php
+++ b/plugins/BEdita/Core/src/ORM/Association/RelatedTo.php
@@ -23,6 +23,50 @@ use Cake\ORM\Table;
  */
 class RelatedTo extends BelongsToMany
 {
+    /**
+     * The name of the field that describe an inverse relation.
+     * This key is compared to `self::_foreignKey` to know the direction of the relation.
+     * Default is `right_id`.
+     *
+     * @var string|string[]
+     */
+    protected $inverseKey = 'right_id';
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function _options(array $options)
+    {
+        parent::_options($options);
+
+        if (!empty($options['inverseKey'])) {
+            $this->setInverseKey($options['inverseKey']);
+        }
+    }
+
+    /**
+     * Set the name of the field used to check if the association represents
+     * an inverse relation.
+     *
+     * @param string|string[] $key The key or keys used for inverse relation check.
+     * @return $this
+     */
+    public function setInverseKey($key): self
+    {
+        $this->inverseKey = $key;
+
+        return $this;
+    }
+
+    /**
+     * Return the inverse key.
+     *
+     * @return string|string[]
+     */
+    public function getInverseKey()
+    {
+        return $this->inverseKey;
+    }
 
     /**
      * Get sub-query for matching.
@@ -90,5 +134,16 @@ class RelatedTo extends BelongsToMany
         }
 
         return $table->objectType()->is_abstract;
+    }
+
+    /**
+     * Say if the association describe an inverse relation.
+     * The association is inverse if foreign key and inverse key are the same.
+     *
+     * @return bool
+     */
+    public function isInverse(): bool
+    {
+        return $this->getForeignKey() === $this->getInverseKey();
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
@@ -95,12 +95,12 @@ class AddRelatedObjectsActionTest extends TestCase
                 ],
             ],
             'update' => [
-                [4],
-                'Documents',
-                'test',
-                3,
+                [3],
+                'Profiles',
+                'inverse_test',
+                4,
                 [
-                    4 => [
+                    3 => [
                         'priority' => 1,
                         'inv_priority' => 1,
                         'params' => [

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsActionTest.php
@@ -61,6 +61,7 @@ class ListRelatedObjectsActionTest extends TestCase
                         'type' => 'profiles',
                         '_joinData' => [
                             'priority' => 1,
+                            'inv_priority' => 2,
                             'params' => null,
                         ],
                     ],
@@ -69,6 +70,7 @@ class ListRelatedObjectsActionTest extends TestCase
                         'type' => 'documents',
                         '_joinData' => [
                             'priority' => 2,
+                            'inv_priority' => 1,
                             'params' => null,
                         ],
                     ],
@@ -84,6 +86,7 @@ class ListRelatedObjectsActionTest extends TestCase
                         'type' => 'profiles',
                         '_joinData' => [
                             'priority' => 1,
+                            'inv_priority' => 1,
                             'params' => null,
                         ],
                     ],
@@ -99,6 +102,7 @@ class ListRelatedObjectsActionTest extends TestCase
                         'type' => 'documents',
                         '_joinData' => [
                             'priority' => 1,
+                            'inv_priority' => 1,
                             'params' => null,
                         ],
                         'categories' => [],
@@ -108,6 +112,7 @@ class ListRelatedObjectsActionTest extends TestCase
                         'type' => 'documents',
                         '_joinData' => [
                             'priority' => 2,
+                            'inv_priority' => 1,
                             'params' => null,
                         ],
                         'categories' => [
@@ -156,6 +161,7 @@ class ListRelatedObjectsActionTest extends TestCase
                         'publish_end' => null,
                         '_joinData' => [
                             'priority' => 1,
+                            'inv_priority' => 1,
                             'params' => null,
                         ],
                     ],
@@ -172,6 +178,7 @@ class ListRelatedObjectsActionTest extends TestCase
                         'type' => 'documents',
                         '_joinData' => [
                             'priority' => 2,
+                            'inv_priority' => 1,
                             'params' => null,
                         ],
                         'categories' => [
@@ -207,6 +214,7 @@ class ListRelatedObjectsActionTest extends TestCase
                         'type' => 'profiles',
                         '_joinData' => [
                             'priority' => 1,
+                            'inv_priority' => 2,
                             'params' => null,
                         ],
                     ],

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsActionTest.php
@@ -61,7 +61,6 @@ class ListRelatedObjectsActionTest extends TestCase
                         'type' => 'profiles',
                         '_joinData' => [
                             'priority' => 1,
-                            'inv_priority' => 2,
                             'params' => null,
                         ],
                     ],
@@ -70,7 +69,6 @@ class ListRelatedObjectsActionTest extends TestCase
                         'type' => 'documents',
                         '_joinData' => [
                             'priority' => 2,
-                            'inv_priority' => 1,
                             'params' => null,
                         ],
                     ],
@@ -86,7 +84,6 @@ class ListRelatedObjectsActionTest extends TestCase
                         'type' => 'profiles',
                         '_joinData' => [
                             'priority' => 1,
-                            'inv_priority' => 1,
                             'params' => null,
                         ],
                     ],
@@ -102,7 +99,6 @@ class ListRelatedObjectsActionTest extends TestCase
                         'type' => 'documents',
                         '_joinData' => [
                             'priority' => 1,
-                            'inv_priority' => 1,
                             'params' => null,
                         ],
                         'categories' => [],
@@ -111,8 +107,7 @@ class ListRelatedObjectsActionTest extends TestCase
                         'id' => 2,
                         'type' => 'documents',
                         '_joinData' => [
-                            'priority' => 1,
-                            'inv_priority' => 2,
+                            'priority' => 2,
                             'params' => null,
                         ],
                         'categories' => [
@@ -161,7 +156,6 @@ class ListRelatedObjectsActionTest extends TestCase
                         'publish_end' => null,
                         '_joinData' => [
                             'priority' => 1,
-                            'inv_priority' => 1,
                             'params' => null,
                         ],
                     ],
@@ -177,8 +171,7 @@ class ListRelatedObjectsActionTest extends TestCase
                         'id' => 2,
                         'type' => 'documents',
                         '_joinData' => [
-                            'priority' => 1,
-                            'inv_priority' => 2,
+                            'priority' => 2,
                             'params' => null,
                         ],
                         'categories' => [
@@ -214,7 +207,6 @@ class ListRelatedObjectsActionTest extends TestCase
                         'type' => 'profiles',
                         '_joinData' => [
                             'priority' => 1,
-                            'inv_priority' => 2,
                             'params' => null,
                         ],
                     ],

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
@@ -36,6 +36,7 @@ class SetRelatedObjectsActionTest extends TestCase
      * @var array
      */
     public $fixtures = [
+        'plugin.BEdita/Core.PropertyTypes',
         'plugin.BEdita/Core.Properties',
         'plugin.BEdita/Core.ObjectTypes',
         'plugin.BEdita/Core.Relations',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
@@ -36,6 +36,7 @@ class SetRelatedObjectsActionTest extends TestCase
      * @var array
      */
     public $fixtures = [
+        'plugin.BEdita/Core.Properties',
         'plugin.BEdita/Core.ObjectTypes',
         'plugin.BEdita/Core.Relations',
         'plugin.BEdita/Core.RelationTypes',
@@ -132,12 +133,12 @@ class SetRelatedObjectsActionTest extends TestCase
                 ],
             ],
             'update' => [
-                [4],
-                'Documents',
-                'test',
-                3,
+                [2, 3],
+                'Profiles',
+                'inverse_test',
+                4,
                 [
-                    4 => [
+                    3 => [
                         'priority' => 1,
                         'inv_priority' => 1,
                         'params' => [

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Association/RelatedToTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Association/RelatedToTest.php
@@ -185,4 +185,60 @@ class RelatedToTest extends TestCase
         $relatedTo->setTarget(TableRegistry::getTableLocator()->get($table));
         static::assertSame($expected, $relatedTo->isTargetAbstract());
     }
+
+    /**
+     * Data provider for testIsInverse()
+     *
+     * @return array
+     */
+    public function isInverseProvider(): array
+    {
+        return [
+            'direct' => [
+                false,
+                [
+                    'foreignKey' => 'left_id',
+                ],
+            ],
+            'inverse' => [
+                true,
+                [
+                    'foreignKey' => 'right_id',
+                ],
+            ],
+            'inverseCustom' => [
+                true,
+                [
+                    'foreignKey' => 'left_id',
+                    'inverseKey' => 'left_id',
+                ],
+            ],
+            'inverseMultiCustom' => [
+                true,
+                [
+                    'foreignKey' => ['left_id', 'custom_key'],
+                    'inverseKey' => ['left_id', 'custom_key'],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test if related association is inverse.
+     *
+     * @param bool $expected The value expected.
+     * @param array $options The options for the association.
+     * @return void
+     *
+     * @dataProvider isInverseProvider()
+     * @covers ::isInverse()
+     * @covers ::_options()
+     * @covers ::setInverseKey()
+     * @covers ::getInverseKey()
+     */
+    public function testIsInverse($expected, $options): void
+    {
+        $relatedTo = new RelatedTo('Alias', $options);
+        static::assertEquals($expected, $relatedTo->isInverse());
+    }
 }


### PR DESCRIPTION
This PR introduces a more transparent `priority` handling when dealing with inverse relations.

### Problem

When we see related objects or add new ones and we are using an inverse relation we should use `inv_priority` instead of `priority` as desired order.

With an API call like `GET /images/123/media_of` where `media_of` is an inverse relation we see a list objects having in `meta.relation` properties like

```json
 "priority": 2,
 "inv_priority": 1,
 "params": null
```

But we don't know that the real priority used is `inv_priority` and not `priority`.
We should check if this relation name is direct or not.

### Proposed solution

When we list related objects or we set new relations on the API we can always use `priority` to see and set the relation order. 
Internally (via simple switch) we decide to use `inv_priority` in case of inverse relation.