### PR TITLE
New Resources utility

### DIFF
--- a/plugins/BEdita/Core/src/Utility/Relations.php
+++ b/plugins/BEdita/Core/src/Utility/Relations.php
@@ -60,6 +60,23 @@ class Relations
     }
 
     /**
+     * Add relation type to relation
+     *
+     * @param string $relation Relation name or ID
+     * @param string $type Object type name
+     * @param string $side Relation side, 'left' or 'right'
+     * @param array $options Table locator options
+     * @return void
+     */
+    public static function addRelationType(string $relation, string $type, string $side, array $options = []): void
+    {
+        $relation = TableRegistry::getTableLocator()
+            ->get('Relations', $options)
+            ->get($relation);
+        static::addTypes($relation->get('id'), [$type], $side, $options);
+    }
+
+    /**
      * Add relation types to relation
      *
      * @param string|int $relationId Relation id
@@ -135,6 +152,23 @@ class Relations
 
             $RelationTypes->deleteOrFail($relationType);
         }
+    }
+
+    /**
+     * Remove relation type from relation
+     *
+     * @param string $relation Relation name or ID
+     * @param string $type Object type name
+     * @param string $side Relation side, 'left' or 'right'
+     * @param array $options Table locator options
+     * @return void
+     */
+    public static function removeRelationType(string $relation, string $type, string $side, array $options = []): void
+    {
+        $relation = TableRegistry::getTableLocator()
+            ->get('Relations', $options)
+            ->get($relation);
+        static::removeTypes($relation->get('id'), [$type], $side, $options);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Utility/Resources.php
+++ b/plugins/BEdita/Core/src/Utility/Resources.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Utility;
+
+use Cake\Http\Exception\BadRequestException;
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+use Cake\Utility\Hash;
+use Cake\Utility\Inflector;
+
+/**
+ * Utility class to resources creation/update/removal in migrations, shell scripts and similar scenarios
+ *
+ * Provides static methods to create and remove resources like applications, object_types, roles....
+ * using an array format
+ *
+ * Example:
+ *   [
+ *     [
+ *       'name' => 'custom_objects',
+ *       'singular' => 'custom_object',
+ *       'parent' => 'objects', // optional
+ *       'description' => 'my custom description', // optional
+ *     ],
+ *   ]
+ */
+class Resources
+{
+    /**
+     * Resource defaults in creation
+     *
+     * @var array
+     */
+    protected static $defaults = [
+        'object_types' => [
+            'plugin' => 'BEdita/Core',
+            'model' => 'Objects',
+            'parent' => 'objects',
+            'enabled' => 1,
+        ],
+    ];
+
+    /**
+     * Allowed resource types
+     *
+     * @var array
+     */
+    protected static $allowed = [
+        'applications',
+        'object_types',
+        'roles',
+    ];
+
+    /**
+     * Create new resources using data array.
+     *
+     * @param string $type Resource type name
+     * @param array $data Resource data
+     * @param array $options Table locator options
+     * @return void
+     */
+    public static function create(string $type, array $data, array $options = []): void
+    {
+        $Table = static::getTable($type, $options);
+
+        foreach ($data as $item) {
+            $resource = $Table->newEntity();
+            $defaults = (array)Hash::get(static::$defaults, $type);
+            $item = array_merge($defaults, $item);
+            $resource = $Table->patchEntity($resource, $item);
+            $Table->saveOrFail($resource);
+        }
+    }
+
+    /**
+     * Remove resources using data array.
+     *
+     * @param string $type Resource type name
+     * @param array $data Resource data
+     * @param array $options Table locator options
+     * @return void
+     */
+    public static function remove(string $type, array $data, array $options = []): void
+    {
+        $Table = static::getTable($type, $options);
+
+        foreach ($data as $item) {
+            $condition = static::findCondition($item);
+            $entity = $Table->find()
+                ->where($condition)
+                ->firstOrFail();
+
+            $Table->deleteOrFail($entity);
+        }
+    }
+
+    /**
+     * Update resources using data array.
+     *
+     * @param string $type Resource type name
+     * @param array $data Resource data
+     * @param array $options Table locator options
+     * @return void
+     */
+    public static function update(string $type, array $data, array $options = []): void
+    {
+        $Table = static::getTable($type, $options);
+
+        foreach ($data as $item) {
+            $condition = static::findCondition($item);
+            $entity = $Table->find()
+                ->where($condition)
+                ->firstOrFail();
+            $entity = $Table->patchEntity($entity, $item);
+
+            $Table->saveOrFail($entity);
+        }
+    }
+
+    /**
+     * Get resource table with type validation
+     *
+     * @param string $type Resource type name
+     * @param array $options Table locator options
+     * @return \Cake\ORM\Table
+     * @throws BadRequestException
+     */
+    protected static function getTable(string $type, array $options = []): Table
+    {
+        if (!in_array($type, static::$allowed)) {
+            throw new BadRequestException(
+                __d('bedita', 'Resource type not allowed "{0}"', $type)
+            );
+        }
+
+        return TableRegistry::getTableLocator()
+            ->get(Inflector::camelize($type), $options);
+    }
+
+    /**
+     * Extract find condition from input array
+     *
+     * @param array $item Single resource data
+     * @return array
+     * @throws BadRequestException
+     */
+    protected static function findCondition(array $item): array
+    {
+        // use `name` or `id` as condition
+        $keys = array_flip(['id', 'name']);
+        $condition = array_filter(array_intersect_key($item, $keys));
+        if (empty($condition)) {
+            throw new BadRequestException(
+                __d('bedita', 'Missing mandatory fields "id" or "name"')
+            );
+        }
+
+        return $condition;
+    }
+}

--- a/plugins/BEdita/Core/src/Utility/Resources.php
+++ b/plugins/BEdita/Core/src/Utility/Resources.php
@@ -82,19 +82,24 @@ class Resources
      * @param string $type Resource type name
      * @param array $data Resource data
      * @param array $options Table locator options
-     * @return void
+     * @return array
      */
-    public static function create(string $type, array $data, array $options = []): void
+    public static function create(string $type, array $data, array $options = []): array
     {
         $Table = static::getTable($type, $options);
+        $result = [];
 
         foreach ($data as $item) {
             $resource = $Table->newEntity();
             $defaults = (array)Hash::get(static::$defaults, $type);
             $item = array_merge($defaults, $item);
-            $resource = $Table->patchEntity($resource, $item);
-            $Table->saveOrFail($resource);
+            foreach ($item as $k => $v) {
+                $resource->set($k, $v);
+            }
+            $result[] = $Table->saveOrFail($resource);
         }
+
+        return $result;
     }
 
     /**
@@ -125,21 +130,26 @@ class Resources
      * @param string $type Resource type name
      * @param array $data Resource data
      * @param array $options Table locator options
-     * @return void
+     * @return array
      */
-    public static function update(string $type, array $data, array $options = []): void
+    public static function update(string $type, array $data, array $options = []): array
     {
         $Table = static::getTable($type, $options);
+        $result = [];
 
         foreach ($data as $item) {
             $condition = static::findCondition($item);
             $entity = $Table->find()
                 ->where($condition)
                 ->firstOrFail();
-            $entity = $Table->patchEntity($entity, $item);
-
-            $Table->saveOrFail($entity);
+            // $entity = $Table->patchEntity($entity, $item);
+            foreach ($item as $k => $v) {
+                $entity->set($k, $v);
+            }
+            $result[] = $Table->saveOrFail($entity);
         }
+
+        return $result;
     }
 
     /**

--- a/plugins/BEdita/Core/src/Utility/Resources.php
+++ b/plugins/BEdita/Core/src/Utility/Resources.php
@@ -22,10 +22,14 @@ use Cake\Utility\Inflector;
 /**
  * Utility class to resources creation/update/removal in migrations, shell scripts and similar scenarios
  *
- * Provides static methods to create and remove resources like applications, object_types, roles....
- * using an array format
+ * Provides static methods to create and remove resources like applications, object_types, property_types, roles
+ * and potentially many other using an array format.
  *
- * Example:
+ * Every resource must have a unique field like `name` to be used as index in environment agnostic way:
+ * in different environments same resources will have a different `id` (or other primary key) but should have a unique
+ * `name`.
+ *
+ * Array example for object_types:
  *   [
  *     [
  *       'name' => 'custom_objects',
@@ -33,7 +37,7 @@ use Cake\Utility\Inflector;
  *       'parent' => 'objects', // optional
  *       'description' => 'my custom description', // optional
  *     ],
- *   ]
+ *   ],
  */
 class Resources
 {
@@ -152,16 +156,34 @@ class Resources
     }
 
     /**
-     * Save resources
+     * Generic save on resources grouped by `action` with possible values: `create`, `update` and `remove`.
      *
+     * Supported resources: resources in static::$allowed + `relations` and `properties`.
      *
-     *  'create' => [
+     * Array example where a role is created, an object type is updated and an application is removed.
+     *
+     * 'create' => [
      *      'roles' => [
      *          [
      *              'name' => 'new-role',
-     *          ]
-     *      ]
-     *  ]
+     *          ],
+     *      ],
+     *  ],
+     * 'update' => [
+     *      'object_types' => [
+     *          [
+     *              'name' => 'news',
+     *              'hidden' => '["description"]',
+     *          ],
+     *      ],
+     *  ],
+     * 'remove' => [
+     *      'applications' => [
+     *          [
+     *              'name' => 'frontend-app',
+     *          ],
+     *      ],
+     *  ],
      *
      * @param array $resources Resources array.
      * @param array $options Table locator options.

--- a/plugins/BEdita/Core/tests/TestCase/Utility/RelationsTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/RelationsTest.php
@@ -85,6 +85,42 @@ class RelationsTest extends TestCase
     }
 
     /**
+     * Test `addRelationType` method.
+     *
+     * @covers ::addRelationType()
+     */
+    public function testAddRelationType()
+    {
+        Relations::create($this->relations);
+
+        Relations::addRelationType('poster', 'profiles', 'left');
+        $leftTypes = TableRegistry::getTableLocator()
+            ->get('RelationTypes')
+            ->find()
+            ->where(['relation_id' => 4, 'side' => 'left'])
+            ->toArray();
+        static::assertEquals(3, count($leftTypes));
+    }
+
+    /**
+     * Test `removeRelationType` method.
+     *
+     * @covers ::removeRelationType()
+     */
+    public function testRemoveRelationType()
+    {
+        Relations::create($this->relations);
+
+        Relations::removeRelationType('poster', 'documents', 'left');
+        $leftTypes = TableRegistry::getTableLocator()
+            ->get('RelationTypes')
+            ->find()
+            ->where(['relation_id' => 4, 'side' => 'left'])
+            ->toArray();
+        static::assertEquals(1, count($leftTypes));
+    }
+
+    /**
      * Test `validate` failure.
      *
      * @covers ::validate()

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
@@ -345,6 +345,7 @@ class ResourcesTest extends TestCase
      * @return void
      *
      * @covers ::save()
+     * @covers ::saveType()
      * @dataProvider saveProvider
      */
     public function testSave(array $resources, ?\Exception $exception = null): void

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Utility;
+
+use BEdita\Core\Utility\Resources;
+use Cake\Http\Exception\BadRequestException;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
+use Cake\Utility\Inflector;
+
+/**
+ * {@see \BEdita\Core\Utility\Resources} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Utility\Resources
+ */
+class ResourcesTest extends TestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.Applications',
+        'plugin.BEdita/Core.Endpoints',
+        'plugin.BEdita/Core.EndpointPermissions',
+        'plugin.BEdita/Core.Roles',
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.RelationTypes',
+        'plugin.BEdita/Core.RolesUsers',
+    ];
+
+    /**
+     * Data provider for `testCreate`
+     *
+     * @return array
+     */
+    public function createProvider(): array
+    {
+        return [
+            'roles' => [
+                'roles',
+                [
+                    [
+                        'name' => 'new role',
+                    ],
+                ],
+            ],
+            'apps' => [
+                'applications',
+                [
+                    [
+                        'name' => 'new app',
+                    ],
+                ],
+            ],
+            'objects' => [
+                'object_types',
+                [
+                    [
+                        'name' => 'cats',
+                        'singular' => 'cat',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `create` method.
+     *
+     * @param string $type Resource type.
+     * @param array $data Resource data.
+     * @return void
+     *
+     * @covers ::create()
+     * @covers ::getTable()
+     * @dataProvider createProvider
+     */
+    public function testCreate(string $type, array $data): void
+    {
+        Resources::create($type, $data);
+
+        $newResources = TableRegistry::getTableLocator()
+            ->get(Inflector::camelize($type))
+            ->find()
+            ->where(['name IN' => Hash::extract($data, '{n}.name')])
+            ->toArray();
+
+        static::assertEquals(count($data), count($newResources));
+    }
+
+    /**
+     * Data provider for `testRemove`
+     *
+     * @return array
+     */
+    public function removeProvider(): array
+    {
+        return [
+            'roles' => [
+                'roles',
+                [
+                    [
+                        'name' => 'second role',
+                    ],
+                ],
+            ],
+            'apps' => [
+                'applications',
+                [
+                    [
+                        'name' => 'Disabled app',
+                    ],
+                ],
+            ],
+            'objects' => [
+                'object_types',
+                [
+                    [
+                        'name' => 'news',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `remove` method.
+     *
+     * @param string $type Resource type.
+     * @param array $data Resource data.
+     * @return void
+     *
+     * @covers ::remove()
+     * @dataProvider removeProvider
+     */
+    public function testRemove(string $type, array $data): void
+    {
+        Resources::remove($type, $data);
+
+        $resources = TableRegistry::getTableLocator()
+            ->get(Inflector::camelize($type))
+            ->find()
+            ->where(['name IN' => Hash::extract($data, '{n}.name')])
+            ->toArray();
+
+        static::assertEmpty($resources);
+    }
+
+    /**
+     * Data provider for `testUpdate`
+     *
+     * @return array
+     */
+    public function updateProvider(): array
+    {
+        return [
+            'roles' => [
+                'roles',
+                [
+                    [
+                        'name' => 'second role',
+                        'description' => 'new role desc',
+                    ],
+                ],
+            ],
+            'apps' => [
+                'applications',
+                [
+                    [
+                        'name' => 'Disabled app',
+                        'description' => 'A new description',
+                    ],
+                ],
+            ],
+            'objects' => [
+                'object_types',
+                [
+                    [
+                        'name' => 'news',
+                        'hidden' => '["description"]',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `update` method.
+     *
+     * @param string $type Resource type.
+     * @param array $data Resource data.
+     * @return void
+     *
+     * @covers ::update()
+     * @covers ::findCondition()
+     * @dataProvider updateProvider
+     */
+    public function testUpdate(string $type, array $data): void
+    {
+        Resources::update($type, $data);
+
+        $resources = TableRegistry::getTableLocator()
+            ->get(Inflector::camelize($type))
+            ->find()
+            ->where(['name IN' => Hash::extract($data, '{n}.name')])
+            ->toArray();
+
+        static::assertEquals(count($data), count($resources));
+        $entity = $resources[0];
+        foreach ($data[0] as $name => $val) {
+            static::assertEquals($val, $entity->get($name));
+        }
+    }
+
+    /**
+     * Test `getTable` method failure.
+     *
+     * @covers ::getTable()
+     */
+    public function testGetTableFail()
+    {
+        static::expectException(BadRequestException::class);
+        static::expectExceptionMessage('Resource type not allowed "cats"');
+
+        Resources::create('cats', []);
+    }
+
+    /**
+     * Test `findCondition` method failure.
+     *
+     * @covers ::findCondition()
+     */
+    public function testFindConditionFail()
+    {
+        static::expectException(BadRequestException::class);
+        static::expectExceptionMessage('Missing mandatory fields "id" or "name"');
+
+        Resources::remove('applications', [['key' => 'value']]);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
@@ -41,6 +41,9 @@ class ResourcesTest extends TestCase
         'plugin.BEdita/Core.PropertyTypes',
         'plugin.BEdita/Core.Properties',
         'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.Locations',
+        'plugin.BEdita/Core.Media',
+        'plugin.BEdita/Core.Profiles',
         'plugin.BEdita/Core.Users',
         'plugin.BEdita/Core.Relations',
         'plugin.BEdita/Core.RelationTypes',
@@ -80,6 +83,18 @@ class ResourcesTest extends TestCase
                     ],
                 ],
             ],
+            'prop types' => [
+                'property_types',
+                [
+                    [
+                        'name' => 'my_type',
+                        'params' => [
+                            'type' => 'string',
+                            'enum' => ['A', 'B'],
+                        ],
+                    ],
+                ],
+            ],
         ];
     }
 
@@ -96,15 +111,8 @@ class ResourcesTest extends TestCase
      */
     public function testCreate(string $type, array $data): void
     {
-        Resources::create($type, $data);
-
-        $newResources = TableRegistry::getTableLocator()
-            ->get(Inflector::camelize($type))
-            ->find()
-            ->where(['name IN' => Hash::extract($data, '{n}.name')])
-            ->toArray();
-
-        static::assertEquals(count($data), count($newResources));
+        $result = Resources::create($type, $data);
+        static::assertEquals(count($data), count($result));
     }
 
     /**
@@ -136,6 +144,14 @@ class ResourcesTest extends TestCase
                 [
                     [
                         'name' => 'news',
+                    ],
+                ],
+            ],
+            'prop types' => [
+                'property_types',
+                [
+                    [
+                        'name' => 'unused property type',
                     ],
                 ],
             ],
@@ -200,6 +216,15 @@ class ResourcesTest extends TestCase
                     ],
                 ],
             ],
+            'prop types' => [
+                'property_types',
+                [
+                    [
+                        'name' => 'unused property type',
+                        'params' => ['type' => 'object'],
+                    ],
+                ],
+            ],
         ];
     }
 
@@ -216,7 +241,8 @@ class ResourcesTest extends TestCase
      */
     public function testUpdate(string $type, array $data): void
     {
-        Resources::update($type, $data);
+        $result = Resources::update($type, $data);
+        static::assertEquals(count($data), count($result));
 
         $resources = TableRegistry::getTableLocator()
             ->get(Inflector::camelize($type))


### PR DESCRIPTION
A new `Resources` utility class was created to in be used for resources creation/update/removal in migrations, shell scripts and similar scenarios

Provides static methods to create and remove resources like `applications`, `object_types`, `property_types` and `roles` and potentially many other using an array format.

Every resource must have a unique field like `name` to be used as index in environment agnostic way: in different environments same resources will have a different `id` (or other primary key) but should have a unique `name`.

Array example for object_types:
```php
   [
      [
        'name' => 'cats',
        'singular' => 'cat',
        'parent' => 'objects', // optional
        'description' => 'my custom description', // optional
      ],
   ],
```

A generic `save()` method is available on resources grouped by `action` with possible values: `create`, `update` and `remove`.

Supported resources: resources in static::$allowed + `relations` and `properties`.
   
Array example where a role is created, an object type is updated and an application is removed.

```php
[
    'create' => [
         'roles' => [
             [
                 'name' => 'new-role',
              ],
          ],
     ],
     'update' => [
          'object_types' => [
              [
                  'name' => 'news',
                  'hidden' => '["description"]',
             ],
         ],
     ],
     'remove' => [
          'applications' => [
               [
                  'name' => 'frontend-app',
               ],
           ],
      ],
]
```