### PR TITLE
test: empty response and no content type on 204

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/AdminResourcesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/AdminResourcesTest.php
@@ -132,6 +132,6 @@ class AdminResourcesTest extends IntegrationTestCase
         $this->configRequestHeaders('DELETE', $authHeader);
         $this->delete("$endpoint/$resourceId");
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
     }
 }

--- a/plugins/BEdita/API/tests/IntegrationTest/AssociatedEntitiesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/AssociatedEntitiesTest.php
@@ -148,13 +148,13 @@ class AssociatedEntitiesTest extends IntegrationTestCase
         $this->configRequestHeaders('DELETE', $authHeader);
         $this->delete("/$type/$lastId");
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
 
         // EMPTY TRASH
         $this->configRequestHeaders('DELETE', $authHeader);
         $this->delete("/trash/$lastId");
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
     }
 
     /**

--- a/plugins/BEdita/API/tests/IntegrationTest/DeleteFolderTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/DeleteFolderTest.php
@@ -47,7 +47,7 @@ class DeleteFolderTest extends IntegrationTestCase
         $this->delete(sprintf('/folders/%s', $folderId));
 
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
 
         foreach ($expectedChildren['data'] as $child) {
             $id = $child['id'];
@@ -86,7 +86,7 @@ class DeleteFolderTest extends IntegrationTestCase
         $this->configRequestHeaders('PATCH', $authHeader);
         $this->patch(sprintf('/trash/%s', $folderId), json_encode(compact('data')));
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
         $trash = TableRegistry::getTableLocator()->get('Objects')->get($folderId);
         $this->assertFalse($trash['deleted']);
 

--- a/plugins/BEdita/API/tests/IntegrationTest/NewObjectTypesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/NewObjectTypesTest.php
@@ -126,21 +126,20 @@ class NewObjectTypesTest extends IntegrationTestCase
         $this->configRequestHeaders('DELETE', $this->getUserAuthHeader());
         $this->delete("/$type/$lastId");
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
 
         // EMPTY TRASH
         TableRegistry::clear();
         $this->configRequestHeaders('DELETE', $this->getUserAuthHeader());
         $this->delete("/trash/$lastId");
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
-        $result = json_decode((string)$this->_response->getBody(), true);
+        $this->assertResponseEmpty();
 
         // REMOVE TYPE
         TableRegistry::clear();
         $this->configRequestHeaders('DELETE', $this->getUserAuthHeader());
         $this->delete("/model/object_types/$type");
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/ApplicationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/ApplicationsControllerTest.php
@@ -368,7 +368,7 @@ class ApplicationsControllerTest extends IntegrationTestCase
         $this->delete('/admin/applications/2');
 
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
         static::assertFalse(TableRegistry::getTableLocator()->get('Applications')->exists(['id' => 2]));
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/AsyncJobsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/AsyncJobsControllerTest.php
@@ -518,7 +518,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
         $this->delete('/admin/async_jobs/d6bb8c84-6b29-432e-bb84-c3c4b2c1b99c');
 
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
         static::assertFalse(TableRegistry::getTableLocator()->get('AsyncJobs')->exists(['uuid' => 'd6bb8c84-6b29-432e-bb84-c3c4b2c1b99c']));
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/ConfigControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/ConfigControllerTest.php
@@ -142,7 +142,7 @@ class ConfigControllerTest extends IntegrationTestCase
         $this->delete('/admin/config/Name2');
 
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
         static::assertFalse(TableRegistry::getTableLocator()->get('Config')->exists(['name' => 'Name2']));
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/EndpointsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/EndpointsControllerTest.php
@@ -368,7 +368,7 @@ class EndpointsControllerTest extends IntegrationTestCase
         $this->delete('/admin/endpoints/2');
 
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
         static::assertFalse(TableRegistry::getTableLocator()->get('Endpoints')->exists(['id' => 2]));
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/AnnotationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AnnotationsControllerTest.php
@@ -231,7 +231,7 @@ class AnnotationsControllerTest extends IntegrationTestCase
         $this->configRequestHeaders('DELETE', $this->getUserAuthHeader());
         $this->delete('/annotations/1');
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
         $this->assertFalse(TableRegistry::getTableLocator()->get('Annotations')->exists(['id' => 1]));
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -472,7 +472,7 @@ class FoldersControllerTest extends IntegrationTestCase
         $this->delete($endpoint);
 
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
 
         $this->configRequestHeaders();
         $this->get($endpoint);

--- a/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
@@ -402,10 +402,9 @@ class LoginControllerTest extends IntegrationTestCase
         ];
 
         $this->post('/auth/change', json_encode($data));
-        $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->assertResponseCode(204);
-        $this->assertEmpty($result);
+        $this->assertResponseEmpty();
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
@@ -919,7 +919,7 @@ class ObjectTypesControllerTest extends IntegrationTestCase
         $this->delete('/model/object_types/5');
 
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
         $this->assertFalse(TableRegistry::getTableLocator()->get('ObjectTypes')->exists(['id' => 5]));
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertiesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertiesControllerTest.php
@@ -500,7 +500,7 @@ class PropertiesControllerTest extends IntegrationTestCase
         $this->delete('/model/properties/1');
 
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
         static::assertFalse(TableRegistry::getTableLocator()->get('Properties')->exists(['id' => 1]));
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
@@ -684,7 +684,7 @@ class PropertyTypesControllerTest extends IntegrationTestCase
         $this->delete('/model/property_types/12');
 
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
         static::assertFalse(TableRegistry::getTableLocator()->get('PropertyTypes')->exists(['id' => 12]));
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
@@ -434,7 +434,7 @@ class RelationsControllerTest extends IntegrationTestCase
         $this->delete('/model/relations/1');
 
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
         $this->assertFalse(TableRegistry::getTableLocator()->get('Relations')->exists(['id' => 1]));
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -1254,7 +1254,7 @@ class ObjectsControllerTest extends IntegrationTestCase
         $this->delete('/documents/3');
 
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
 
         $this->configRequestHeaders();
         $this->get('/documents/3');
@@ -1827,7 +1827,6 @@ class ObjectsControllerTest extends IntegrationTestCase
         $this->post('/documents/2/relationships/test', json_encode(compact('data')));
 
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
         $this->assertResponseEmpty();
     }
 
@@ -1893,7 +1892,6 @@ class ObjectsControllerTest extends IntegrationTestCase
         $this->_sendRequest('/documents/2/relationships/test', 'DELETE', json_encode(compact('data')));
 
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
         $this->assertResponseEmpty();
     }
 
@@ -2048,7 +2046,6 @@ class ObjectsControllerTest extends IntegrationTestCase
         $this->patch('/documents/2/relationships/test', json_encode(compact('data')));
 
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
         $this->assertResponseEmpty();
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
@@ -216,7 +216,6 @@ class ResourcesControllerTest extends IntegrationTestCase
         $this->post('/roles/1/relationships/users', json_encode(compact('data')));
 
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
         $this->assertResponseEmpty();
     }
 
@@ -320,7 +319,6 @@ class ResourcesControllerTest extends IntegrationTestCase
         $this->_sendRequest('/roles/1/relationships/users', 'DELETE', json_encode(compact('data')));
 
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
         $this->assertResponseEmpty();
     }
 
@@ -423,7 +421,7 @@ class ResourcesControllerTest extends IntegrationTestCase
         $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
         $this->patch('/roles/3/relationships/users', json_encode(compact('data')));
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
     }
 
     /**
@@ -469,7 +467,6 @@ class ResourcesControllerTest extends IntegrationTestCase
         $this->patch('/roles/1/relationships/users', json_encode(compact('data')));
 
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
         $this->assertResponseEmpty();
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
@@ -405,7 +405,7 @@ class RolesControllerTest extends IntegrationTestCase
         $this->configRequestHeaders('DELETE', $this->getUserAuthHeader());
         $this->delete('/roles/2');
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
         $this->assertFalse(TableRegistry::getTableLocator()->get('Roles')->exists(['id' => 2]));
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
@@ -396,10 +396,8 @@ class SignupControllerTest extends IntegrationTestCase
         ]);
         $this->post('/signup/activation', json_encode($activationData));
 
-        $result = json_decode((string)$this->_response->getBody(), true);
-
         $this->assertResponseCode(204);
-        static::assertNull($result);
+        $this->assertResponseEmpty();
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/TranslationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TranslationsControllerTest.php
@@ -255,7 +255,7 @@ class TranslationsControllerTest extends IntegrationTestCase
         $this->configRequestHeaders('DELETE', $this->getUserAuthHeader());
         $this->delete('/translations/2');
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
         $this->assertFalse(TableRegistry::getTableLocator()->get('Translations')->exists(['id' => 2]));
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/TrashControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TrashControllerTest.php
@@ -295,12 +295,14 @@ class TrashControllerTest extends IntegrationTestCase
         $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
         $this->patch("/trash/$id", json_encode(compact('data')));
         $this->assertResponseCode($expected);
-        $this->assertContentType('application/vnd.api+json');
 
         // if restored
         if ($this->_response->getStatusCode() === 204) {
+            $this->assertResponseEmpty();
             $trash = $this->Objects->get($id);
             $this->assertFalse($trash['deleted']);
+        } else {
+            $this->assertContentType('application/vnd.api+json');
         }
     }
 
@@ -320,7 +322,7 @@ class TrashControllerTest extends IntegrationTestCase
         $this->configRequestHeaders('DELETE', $authHeader);
         $this->delete('/trash/7');
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
         $notFound = false;
         try {
             $this->Objects->get(7);

--- a/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
@@ -575,7 +575,7 @@ class UsersControllerTest extends IntegrationTestCase
         $this->delete('/users/5');
 
         $this->assertResponseCode(204);
-        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseEmpty();
 
         $this->configRequestHeaders();
         $this->get('/users/5');


### PR DESCRIPTION
Cake 3.8.10 release introduces a fix in `Response::withStatus()` method: on 204 and 304 status codes no body is returned and no content-type header should be set => header is cleared

We have some tests with 204 response where we check content-type header (via copy-paste probably) => tests are fixed here: empty body check instead of content-type header 