### PR TITLE
Block anonymous apps as default

### DIFF
--- a/plugins/BEdita/API/src/Controller/AppController.php
+++ b/plugins/BEdita/API/src/Controller/AppController.php
@@ -130,7 +130,7 @@ class AppController extends Controller
             if (empty($apiKey)) {
                 $apiKey = (string)$this->request->getQuery('api_key');
             }
-            if (empty($apiKey) && empty(Configure::read('Security.blockAnonymousApps'))) {
+            if (empty($apiKey) && empty(Configure::read('Security.blockAnonymousApps', true))) {
                 return;
             }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/AppControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AppControllerTest.php
@@ -177,6 +177,25 @@ class AppControllerTest extends IntegrationTestCase
     }
 
     /**
+     * Test default behavior on missing 'Security.blockAnonymousApps' key
+     *
+     * @return void
+     * @coversNothing
+     */
+    public function testGetApplicationDefault()
+    {
+        static::expectException(ForbiddenException::class);
+        static::expectExceptionMessage('Missing API key');
+
+        Configure::delete('Security.blockAnonymousApps');
+        CurrentApplication::getInstance()->set(null);
+        $environment = ['HTTP_ACCEPT' => 'application/json'];
+        $request = new ServerRequest(compact('environment'));
+        $controller = new AppController($request);
+        $controller->dispatchEvent('Controller.initialize');
+    }
+
+    /**
      * Test included resources.
      *
      * @return void


### PR DESCRIPTION
Security PR: assume `Security.blockAnonymousApps` defaults to `true`.
To allow anonymous apps access you have to set `Security.blockAnonymousApps` to `false` explicitly.
