### PR TITLE
Improve objects handler

### DIFF
--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -415,6 +415,23 @@ class ObjectsTable extends Table
     }
 
     /**
+     * Finder to get an object by ID or 'uname'
+     *
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @param array $options Array with ID or uname as first element.
+     * @return \Cake\ORM\Query
+     */
+    protected function findUnameId(Query $query, array $options)
+    {
+        $id = (string)Hash::get($options, '0');
+        if (is_numeric($id)) {
+            return $query->where([$this->aliasField('id') => (int)$id]);
+        }
+
+        return $query->where([$this->aliasField('uname') => $id]);
+    }
+
+    /**
      * Finder for categories by name.
      *
      * @param \Cake\ORM\Query $query Query object instance.

--- a/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
+++ b/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
@@ -19,7 +19,7 @@ use Cake\ORM\TableRegistry;
 
 /**
  * Utility operations on objects mainly for seeding and shell commands.
- * These operations are only available on CLI with 'debug' activated.
+ * These operations are only available on CLI environment.
  * *DON'T* use these methods in an API response: various important checks on permissions,
  * users and applications are missing.
  *
@@ -48,7 +48,7 @@ class ObjectsHandler
      */
     protected static function isCli(): bool
     {
-       return (PHP_SAPI === 'cli');
+        return (PHP_SAPI === 'cli');
     }
 
     /**
@@ -98,6 +98,8 @@ class ObjectsHandler
      *
      * @param int|string $id Object to remove ID or uname
      * @return bool success
+     * @throws \Cake\Datasource\Exception\RecordNotFoundException
+     * @throws \Cake\ORM\Exception\PersistenceFailedException
      */
     public static function remove($id): bool
     {

--- a/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
+++ b/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -15,7 +15,6 @@ namespace BEdita\Core\Utility;
 
 use Cake\Console\Exception\StopException;
 use Cake\Datasource\EntityInterface;
-use Cake\Log\Log;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -37,12 +36,19 @@ class ObjectsHandler
      */
     protected static function checkEnvironment(): void
     {
-        if (PHP_SAPI !== 'cli') {
-            $detail = 'Operation avilable only in CLI environment';
-            Log::write('error', $detail);
-            throw new StopException(['title' => 'Not available',
-                'detail' => $detail]);
+        if (!static::isCli()) {
+            throw new StopException('Operation avilable only in CLI environment');
         }
+    }
+
+    /**
+     * Check if we are in CLI environment.
+     *
+     * @return bool
+     */
+    protected static function isCli(): bool
+    {
+       return (PHP_SAPI === 'cli');
     }
 
     /**
@@ -91,8 +97,7 @@ class ObjectsHandler
      * COMPLETELY and IRREVOCABLY remove an object from the database.
      *
      * @param int|string $id Object to remove ID or uname
-     * @throws \Cake\Console\Exception\StopException
-     * @return bool success or failure
+     * @return bool success
      */
     public static function remove($id): bool
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -700,4 +700,26 @@ class ObjectsTableTest extends TestCase
             ->toArray();
         static::assertSame(1, count($result));
     }
+
+    /**
+     * Test `findUnameId` method.
+     *
+     * @return void
+     *
+     * @covers ::findUnameId()
+     */
+    public function testFindUnameID()
+    {
+        $result = TableRegistry::getTableLocator()
+            ->get('Profiles')
+            ->find('unameId', ['gustavo-supporto'])
+            ->firstOrFail();
+        static::assertSame(4, $result->get('id'));
+
+        $result = TableRegistry::getTableLocator()
+            ->get('Profiles')
+            ->find('unameId', [4])
+            ->firstOrFail();
+        static::assertSame('gustavo-supporto', $result->get('uname'));
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHandlerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHandlerTest.php
@@ -82,13 +82,17 @@ class ObjectsHandlerTest extends TestCase
         $userId = $entity->id;
         $this->assertInternalType('integer', $userId);
 
-        $data = ['title' => 'a pragmatic title', 'description' => 'an agile descriptio'];
+        $data = [
+            'title' => 'a pragmatic title',
+            'description' => 'an agile description',
+            'uname' => 'agile-uname',
+        ];
         $entity = ObjectsHandler::save('documents', $data, ['id' => $userId]);
         $this->assertNotEmpty($entity);
         $docId = $entity->id;
         $this->assertInternalType('integer', $docId);
 
-        $result = ObjectsHandler::remove($docId);
+        $result = ObjectsHandler::remove('agile-uname');
         $this->assertTrue($result);
 
         $result = ObjectsHandler::remove($userId);
@@ -100,7 +104,7 @@ class ObjectsHandlerTest extends TestCase
      *
      * @return void
      * @covers ::save()
-     * @expectedException \Cake\Console\Exception\StopException
+     * @expectedException \Cake\ORM\Exception\PersistenceFailedException
      */
     public function testSaveException()
     {

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHandlerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -14,7 +14,6 @@ namespace BEdita\Core\Test\TestCase\Utility;
 
 use BEdita\Core\Utility\LoggedUser;
 use BEdita\Core\Utility\ObjectsHandler;
-use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -117,6 +116,7 @@ class ObjectsHandlerTest extends TestCase
      *
      * @return void
      * @covers ::save()
+     * @covers ::isCli()
      */
     public function testSaveExisting()
     {
@@ -144,11 +144,16 @@ class ObjectsHandlerTest extends TestCase
      * @return void
      * @covers ::checkEnvironment()
      * @expectedException \Cake\Console\Exception\StopException
+     * @expectedExceptionMessage Operation avilable only in CLI environment
      */
     public function testEnvironment()
     {
-        Configure::write('debug', false);
-        ObjectsHandler::save('documents', []);
-        Configure::write('debug', true);
+        $testClass = new class extends ObjectsHandler {
+            protected static function isCli(): bool
+            {
+               return false;
+            }
+        };
+        $testClass::save('documents', []);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHandlerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHandlerTest.php
@@ -151,7 +151,7 @@ class ObjectsHandlerTest extends TestCase
         $testClass = new class extends ObjectsHandler {
             protected static function isCli(): bool
             {
-               return false;
+                return false;
             }
         };
         $testClass::save('documents', []);


### PR DESCRIPTION
This PR adds some improvements/changes to `ObjectsHandler` utility class

* `ObjectsHandler::remove()` may be used with both ID or `uname`
* a `unameId` finder on `ObjectsTable` was introduced to find objects using both ID or `uname`
*  `ObjectsHandler` *debug* requirement removed, CLI requirement still valid
