### PR TITLE
Virtual methods to get/set parent by uname

### DIFF
--- a/plugins/BEdita/Core/src/Model/Entity/Folder.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Folder.php
@@ -95,7 +95,7 @@ class Folder extends ObjectEntity
      * @param int|null $parentId The parent id to set
      * @return int|null
      */
-    protected function _setParentId($parentId)
+    protected function _setParentId($parentId): ?int
     {
         if ($parentId === null) {
             $this->parent = null;
@@ -132,14 +132,14 @@ class Folder extends ObjectEntity
      * Setter for `parent_uname` virtual property.
      *
      * @param string|null $parentUname The parent uname to set
-     * @return void
+     * @return string|null
      */
-    protected function _setParentUname(?string $parentUname): void
+    protected function _setParentUname(?string $parentUname): ?string
     {
         if ($parentUname === null) {
             $this->parent = null;
 
-            return;
+            return null;
         }
 
         $table = TableRegistry::getTableLocator()->get($this->getSource());
@@ -149,6 +149,8 @@ class Folder extends ObjectEntity
                 $table->aliasField('uname') => $parentUname,
             ])
             ->firstOrFail();
+
+        return $parentUname;
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Entity/Folder.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Folder.php
@@ -111,6 +111,39 @@ class Folder extends ObjectEntity
     }
 
     /**
+     * Getter for `parent_uname` virtual property
+     *
+     * @return string|null
+     */
+    protected function _getParentUname(): ?string
+    {
+        return Hash::get((array)$this->parents, '0.uname');
+    }
+
+    /**
+     * Setter for `parent_uname` virtual property.
+     *
+     * @param string|null $parentUname The parent uname to set
+     * @return void
+     */
+    protected function _setParentUname(?string $parentUname): void
+    {
+        if ($parentUname === null) {
+            $this->parent = null;
+
+            return;
+        }
+
+        $table = TableRegistry::getTableLocator()->get($this->getSource());
+        $this->parent = $table
+            ->find()
+            ->where([
+                $table->aliasField('uname') => $parentUname,
+            ])
+            ->firstOrFail();
+    }
+
+    /**
      * Getter for `path` virtual property
      *
      * @return string|null

--- a/plugins/BEdita/Core/src/Model/Entity/Folder.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Folder.php
@@ -80,9 +80,13 @@ class Folder extends ObjectEntity
      *
      * @return int|null
      */
-    protected function _getParentId()
+    protected function _getParentId(): ?int
     {
-        return Hash::get((array)$this->parents, '0.id');
+        if (empty($this->parents)) {
+            return null;
+        }
+
+        return (int)Hash::get((array)$this->parents, '0.id');
     }
 
     /**
@@ -117,7 +121,11 @@ class Folder extends ObjectEntity
      */
     protected function _getParentUname(): ?string
     {
-        return Hash::get((array)$this->parents, '0.uname');
+        if (empty($this->parents)) {
+            return null;
+        }
+
+        return (string)Hash::get((array)$this->parents, '0.uname');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
@@ -172,10 +172,12 @@ class FolderTest extends TestCase
         $parent = $this->Folders->get(13);
         static::assertEquals($parent, $folder->parent);
         static::assertEquals([$parent], $folder->parents);
+        static::assertEquals('another-root-folder', $folder->get('parent_uname'));
 
         $folder->parent_uname = null;
         static::assertEquals(null, $folder->parent);
         static::assertEquals([], $folder->parents);
+        static::assertEquals(null, $folder->get('parent_uname'));
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
@@ -143,6 +143,42 @@ class FolderTest extends TestCase
     }
 
     /**
+     * Test getter for `parent_uname`
+     *
+     * @return void
+     *
+     * @covers ::_getParentUname()
+     */
+    public function testGetParentUname()
+    {
+        $folder = new Folder();
+        static::assertNull($folder->parent_uname);
+
+        $folder->parents = [$this->Folders->get(13)];
+        static::assertEquals('another-root-folder', $folder->parent_uname);
+    }
+
+    /**
+     * Test setter for `parent_uname`
+     *
+     * @return void
+     *
+     * @covers ::_setParentUname()
+     */
+    public function testSetParentUname()
+    {
+        $folder = new Folder([], ['source' => 'Folders']);
+        $folder->parent_uname = 'another-root-folder';
+        $parent = $this->Folders->get(13);
+        static::assertEquals($parent, $folder->parent);
+        static::assertEquals([$parent], $folder->parents);
+
+        $folder->parent_uname = null;
+        static::assertEquals(null, $folder->parent);
+        static::assertEquals([], $folder->parents);
+    }
+
+    /**
      * Test for isParentSet()
      *
      * @return void


### PR DESCRIPTION
This PR adds `_getParentUname()` and `_setParentUname()` virtual methods to `Folder` entity in order to get/set a parent via `uname` instead of ID
