### PR TITLE
User roles filter/finder

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -250,17 +250,30 @@ class FilterQueryStringTest extends IntegrationTestCase
                     '5',
                 ],
             ],
-            'usersFilterRole' => [
+            'filter role id' => [
                 '/users?filter[roles]=1',
                 [
                     '1',
                 ],
             ],
-            'usersFilterRoles' => [
+            'filter roles ids' => [
                 '/users?filter[roles][]=1&filter[roles][]=2',
                 [
                     '1',
                     '5',
+                ],
+            ],
+            'role name' => [
+                '/users?filter[roles]=first role',
+                [
+                   '1',
+                ],
+            ],
+            'role name' => [
+                '/users?filter[roles]=first role,second role',
+                [
+                   '1',
+                   '5',
                 ],
             ],
             'here2' => [
@@ -449,13 +462,6 @@ class FilterQueryStringTest extends IntegrationTestCase
                 'filter[email]=second.user@example.com',
                 [
                    '5',
-                ],
-            ],
-            'user roles' => [
-                '/users',
-                'filter[roles]=first role',
-                [
-                   '1',
                 ],
             ],
             'status' => [

--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -451,6 +451,13 @@ class FilterQueryStringTest extends IntegrationTestCase
                    '5',
                 ],
             ],
+            'user roles' => [
+                '/users',
+                'filter[roles]=first role',
+                [
+                   '1',
+                ],
+            ],
             'status' => [
                 '/documents',
                 'filter[status]=off',

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -287,7 +287,7 @@ class UsersTable extends Table
     }
 
     /**
-     * Create assoc aarray separating `names` and `ids`
+     * Create assoc array separating `names` and `ids`
      *
      * @param array $options Options array
      * @return array

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Model\Table;
 
+use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Exception\ImmutableResourceException;
 use BEdita\Core\Model\Table\ObjectsBaseTable as Table;
 use BEdita\Core\Model\Validation\UsersValidator;
@@ -251,6 +252,27 @@ class UsersTable extends Table
             }
 
             return $query;
+        });
+    }
+
+    /**
+     * Find users by role name.
+     *
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @param array $options Comma separated list of role names as first element
+     * @return \Cake\ORM\Query
+     */
+    protected function findRoles(Query $query, array $options)
+    {
+        if (empty($options)) {
+            throw new BadFilterException(__d('bedita', 'Missing required parameter "{0}"', 'roles'));
+        }
+        $names = (array)explode(',', $options[0]);
+
+        return $query->innerJoinWith('Roles', function (Query $query) use ($names) {
+            return $query->where([
+                $this->Roles->aliasField('name') . ' IN' => $names,
+            ]);
         });
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -536,14 +536,16 @@ class UsersTableTest extends TestCase
      * @return void
      *
      * @covers ::findRoles()
+     * @covers ::rolesNamesIds()
      */
     public function testFindRoles()
     {
         $expected = [
+            1 => 1,
             5 => 5,
         ];
 
-        $result = $this->Users->find('roles', ['second role'])
+        $result = $this->Users->find('roles', [1, 'second role'])
             ->find('list', ['keyField' => 'id', 'valueField' => 'id'])
             ->toArray();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -531,6 +531,41 @@ class UsersTableTest extends TestCase
     }
 
     /**
+     * Test `findRoles` method.
+     *
+     * @return void
+     *
+     * @covers ::findRoles()
+     */
+    public function testFindRoles()
+    {
+        $expected = [
+            5 => 5,
+        ];
+
+        $result = $this->Users->find('roles', ['second role'])
+            ->find('list', ['keyField' => 'id', 'valueField' => 'id'])
+            ->toArray();
+
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test `findRoles` failure method.
+     *
+     * @return void
+     *
+     * @expectedException \BEdita\Core\Exception\BadFilterException
+     * @expectedExceptionMessage Missing required parameter "roles"
+     * @covers ::findRoles()
+     */
+    public function testFindRolesFail()
+    {
+        $this->Users->find('roles', [])
+            ->toArray();
+    }
+
+    /**
      * Data provider for `beforeMarshal`
      *
      * @return array


### PR DESCRIPTION
This PR adds a finder and `filter[roles]` filter to `Users`

With this finder these requests are now possible:

* `GET /users?filter[roles]=5,6,7`
* `GET /users?filter[roles][]=8&filter[roles][]=9`
* `GET /users?filter[roles]=manager,guest`
* `GET /users?filter[roles][]=admin&filter[roles][]=people`
* `GET /users?filter[roles]=admin`
