### PR TITLE
Custom Signup action

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -530,6 +530,15 @@ return [
     ],
 
     /**
+     * Uncomment to define Custom actions to load
+     * This way some action beahavior can be overridden
+     */
+    // 'Actions' => [
+    //     'signupUserAction' => '\MyPlugin\Model\Action\SignupUserAction',
+    //     'signupUserActivationAction' => '\MyPlugin\Model\Action\SignupUserActivationAction',
+    // ],
+
+    /**
      * Default values per object type
      * object type names as keys (lower case), default property names and values as value
      */

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -534,8 +534,8 @@ return [
      * This way some action beahavior can be overridden
      */
     // 'Actions' => [
-    //     'signupUserAction' => '\MyPlugin\Model\Action\SignupUserAction',
-    //     'signupUserActivationAction' => '\MyPlugin\Model\Action\SignupUserActivationAction',
+    //     'SignupUserAction' => '\MyPlugin\Model\Action\SignupUserAction',
+    //     'SignupUserActivationAction' => '\MyPlugin\Model\Action\SignupUserActivationAction',
     // ],
 
     /**

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -530,7 +530,7 @@ return [
     ],
 
     /**
-     * Uncomment to define Custom actions to load
+     * Uncomment to define custom actions to load
      * This way some action beahavior can be overridden
      */
     // 'Actions' => [

--- a/plugins/BEdita/API/src/Controller/SignupController.php
+++ b/plugins/BEdita/API/src/Controller/SignupController.php
@@ -13,8 +13,6 @@
 namespace BEdita\API\Controller;
 
 use BEdita\Core\Model\Action\ActionTrait;
-use BEdita\Core\Model\Action\SignupUserAction;
-use BEdita\Core\Model\Action\SignupUserActivationAction;
 
 /**
  * Controller for `/signup` endpoint.
@@ -52,7 +50,7 @@ class SignupController extends AppController
 
         $data = $this->request->getData();
 
-        $action = $this->createAction(SignupUserAction::class);
+        $action = $this->createAction('SignupUserAction');
         $user = $action(compact('data'));
 
         $this->response = $this->response->withStatus(202);
@@ -70,7 +68,7 @@ class SignupController extends AppController
     {
         $this->request->allowMethod('post');
 
-        $action = $this->createAction(SignupUserActivationAction::class);
+        $action = $this->createAction('SignupUserActivationAction');
         $action(['uuid' => $this->request->getData('uuid')]);
 
         return $this->response->withStatus(204);

--- a/plugins/BEdita/API/src/Controller/SignupController.php
+++ b/plugins/BEdita/API/src/Controller/SignupController.php
@@ -12,11 +12,9 @@
  */
 namespace BEdita\API\Controller;
 
-use BEdita\Core\Model\Action\BaseAction;
+use BEdita\Core\Model\Action\ActionTrait;
 use BEdita\Core\Model\Action\SignupUserAction;
 use BEdita\Core\Model\Action\SignupUserActivationAction;
-use Cake\Core\Configure;
-use Cake\Utility\Inflector;
 
 /**
  * Controller for `/signup` endpoint.
@@ -26,6 +24,8 @@ use Cake\Utility\Inflector;
  */
 class SignupController extends AppController
 {
+    use ActionTrait;
+
     /**
      * {@inheritDoc}
      *
@@ -52,37 +52,13 @@ class SignupController extends AppController
 
         $data = $this->request->getData();
 
-        $action = $this->createAction('SignupUserAction', SignupUserAction::class);
+        $action = $this->createAction(SignupUserAction::class);
         $user = $action(compact('data'));
 
         $this->response = $this->response->withStatus(202);
 
         $this->set('data', $user);
         $this->set('_serialize', ['data']);
-    }
-
-    /**
-     * Create action class, looking in configuration for custom class.
-     *
-     * You can set a custom class in configuration like this:
-     *
-     * ```
-     * Configure::write('Signup.signupUserAction', '\MyPlugin\Model\Action\MySignupAction')
-     * ```
-     *
-     * Or same setting in `config/app.php` (recommended)
-     * Custom class must extend BaseAction.
-     *
-     * @param string $name Configuration name to look for
-     * @param string $default Default action class to use
-     * @return \BEdita\Core\Model\Action\BaseAction
-     */
-    protected function createAction(string $name, string $default): BaseAction
-    {
-        $config = sprintf('Signup.%s', Inflector::variable($name));
-        $actionName = Configure::read($config, $default);
-
-        return new $actionName();
     }
 
     /**
@@ -94,10 +70,7 @@ class SignupController extends AppController
     {
         $this->request->allowMethod('post');
 
-        $action = $this->createAction(
-            'SignupUserActivationAction',
-            SignupUserActivationAction::class
-        );
+        $action = $this->createAction(SignupUserActivationAction::class);
         $action(['uuid' => $this->request->getData('uuid')]);
 
         return $this->response->withStatus(204);

--- a/plugins/BEdita/API/src/Controller/SignupController.php
+++ b/plugins/BEdita/API/src/Controller/SignupController.php
@@ -62,12 +62,15 @@ class SignupController extends AppController
     }
 
     /**
-     * Create requested action class, looking in configuration for custom class.
-     * You can set a custom class in configuration like:
+     * Create action class, looking in configuration for custom class.
+     *
+     * You can set a custom class in configuration like this:
      *
      * ```
      * Configure::write('Signup.signupUserAction', '\MyPlugin\Model\Action\MySignupAction')
      * ```
+     *
+     * Or same setting in `config/app.php` (recommended)
      * Custom class must extend BaseAction.
      *
      * @param string $name Configuration name to look for

--- a/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
@@ -458,4 +458,56 @@ class SignupControllerTest extends IntegrationTestCase
         $this->assertResponseCode(409);
         static::assertEquals($expected, $result);
     }
+
+    /**
+     * Test `createAction` method
+     *
+     * @return void
+     *
+     * @covers ::createAction()
+     */
+    public function testCreateAction()
+    {
+        Configure::write('Signup.signupUserAction', '\BEdita\Core\Model\Action\SignupUserAction');
+        $this->testActivationOk();
+    }
+
+    /**
+     * Test `createAction` failure
+     *
+     * @return void
+     *
+     * @covers ::createAction()
+     */
+    public function testCreateActionFail()
+    {
+        Configure::write('Signup.signupUserAction', '\Some\Class');
+
+        $this->configRequestHeaders('POST', [
+            'Content-Type' => 'application/json'
+        ]);
+        $data = [
+            'username' => 'gustavo',
+            'password' => 'password',
+            'email' => 'gus.sup@channelweb.it',
+            'activation_url' => 'http://example.com',
+        ];
+        $this->post('/signup', json_encode($data));
+        $result = json_decode((string)$this->_response->getBody(), true);
+        unset($result['error']['meta']);
+
+        $expected = [
+            'error' => [
+                'status' => '500',
+                'title' => "Class '\Some\Class' not found",
+            ],
+            'links' => [
+                'self' => 'http://api.example.com/signup',
+                'home' => 'http://api.example.com/home',
+            ],
+        ];
+
+        $this->assertResponseCode(500);
+        static::assertEquals($expected, $result);
+    }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
@@ -15,7 +15,6 @@ namespace BEdita\API\Test\TestCase\Controller;
 use BEdita\API\TestSuite\IntegrationTestCase;
 use Cake\Core\Configure;
 use Cake\I18n\Time;
-use Cake\Mailer\Email;
 use Cake\Mailer\TransportFactory;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
@@ -456,58 +455,6 @@ class SignupControllerTest extends IntegrationTestCase
         ];
 
         $this->assertResponseCode(409);
-        static::assertEquals($expected, $result);
-    }
-
-    /**
-     * Test `createAction` method
-     *
-     * @return void
-     *
-     * @covers ::createAction()
-     */
-    public function testCreateAction()
-    {
-        Configure::write('Signup.signupUserAction', '\BEdita\Core\Model\Action\SignupUserAction');
-        $this->testActivationOk();
-    }
-
-    /**
-     * Test `createAction` failure
-     *
-     * @return void
-     *
-     * @covers ::createAction()
-     */
-    public function testCreateActionFail()
-    {
-        Configure::write('Signup.signupUserAction', '\Some\Class');
-
-        $this->configRequestHeaders('POST', [
-            'Content-Type' => 'application/json'
-        ]);
-        $data = [
-            'username' => 'gustavo',
-            'password' => 'password',
-            'email' => 'gus.sup@channelweb.it',
-            'activation_url' => 'http://example.com',
-        ];
-        $this->post('/signup', json_encode($data));
-        $result = json_decode((string)$this->_response->getBody(), true);
-        unset($result['error']['meta']);
-
-        $expected = [
-            'error' => [
-                'status' => '500',
-                'title' => "Class '\Some\Class' not found",
-            ],
-            'links' => [
-                'self' => 'http://api.example.com/signup',
-                'home' => 'http://api.example.com/home',
-            ],
-        ];
-
-        $this->assertResponseCode(500);
         static::assertEquals($expected, $result);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Action/ActionTrait.php
+++ b/plugins/BEdita/Core/src/Model/Action/ActionTrait.php
@@ -15,10 +15,9 @@ namespace BEdita\Core\Model\Action;
 
 use Cake\Core\App;
 use Cake\Core\Configure;
-use Cake\Utility\Inflector;
 
 /**
- * Trait to create actions with possible
+ * Trait to create actions allowing custom actions load svia configuration.
  *
  * @since 4.2.0
  */
@@ -40,7 +39,7 @@ trait ActionTrait
      *  $this->createAction('\BEdita\Core\Model\Action\SignupUserAction');
      *
      *  // First we look in `Actions.ListObjectsAction` config for a custom class,
-     *  // if nothing is found `BEdita/Core.ListObjectsAction` is used, looking om `Model\Action` namespace
+     *  // if nothing is found `BEdita/Core.ListObjectsAction` is used, looking in `Model\Action` namespace
      *  // ['table' => $this->Table] is passed to constructor
      *  $this->createAction('ListObjectsAction', ['table' => $this->Table]);
      *

--- a/plugins/BEdita/Core/src/Model/Action/ActionTrait.php
+++ b/plugins/BEdita/Core/src/Model/Action/ActionTrait.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Model\Action;
+
+use Cake\Core\Configure;
+use Cake\Utility\Inflector;
+
+/**
+ * Trait to create actions with possible
+ *
+ * @since 4.2.0
+ */
+trait ActionTrait
+{
+    /**
+     * Create action class with options, load custom actions via configuration.
+     *
+     * You can override an action via configuration like this:
+     *
+     *  - if `$config` is set a custom class is searched in `$config` key
+     *  - otherwise a custom class is searched in in `Actions.{actionName}` where `{actionName}`
+     *      is the variable inflected class name, after namespace removal
+     *  - if no custom class is found `$action` class is created
+     *
+     * Examples:
+     * ```
+     *  // `SignupUserAction` loaded looking in `Actions.signupUserAction' for a custom class
+     *  $this->createAction(SignupUserAction::class);
+     *
+     *  // `ListObjectsAction` loaded looking in `Actions.sistObjectsAction' for a custom class,
+     *  // ['table' => $this->Table] passed to constructor
+     *  $this->createAction(ListObjectsAction::class, ['table' => $this->Table]);
+     *
+     *  // `SignupUserAction` loaded looking in `Signup.signupUserAction' for a custom class
+     *  $this->createAction(SignupUserAction::class, [], 'Signup.signupUserAction');
+     * ```
+     *
+     * Configuration example of default action override
+     *
+     * ```
+     *  'Actions ' => [
+     *   'signupUserAction', '\MyPlugin\Model\Action\MySignupAction',
+     *  ],
+     * ```
+     *
+     * Custom class must extend BaseAction.
+     *
+     * @param string $action Action class to create
+     * @param array $options Action options
+     * @param string $config Configuration key to use
+     * @return \BEdita\Core\Model\Action\BaseAction
+     */
+    protected function createAction(string $action, array $options = [], ?string $config = null): BaseAction
+    {
+        if (empty($config)) {
+            $path = explode('\\', $action);
+            $name = (string)end($path);
+            $config = sprintf('Actions.%s', Inflector::variable($name));
+        }
+        $action = (string)Configure::read($config, $action);
+
+        return new $action($options);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ActionTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ActionTraitTest.php
@@ -35,20 +35,9 @@ class ActionTraitTest extends TestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.ObjectTypes',
-        // 'plugin.BEdita/Core.Properties',
         'plugin.BEdita/Core.Objects',
-        // 'plugin.BEdita/Core.Profiles',
-        // 'plugin.BEdita/Core.Users',
-        // 'plugin.BEdita/Core.AsyncJobs',
-        // 'plugin.BEdita/Core.Roles',
-        // 'plugin.BEdita/Core.Trees',
-        // 'plugin.BEdita/Core.RolesUsers',
-        // 'plugin.BEdita/Core.ExternalAuth',
-        // 'plugin.BEdita/Core.AuthProviders',
         'plugin.BEdita/Core.Relations',
         'plugin.BEdita/Core.RelationTypes',
-        // 'plugin.BEdita/Core.ObjectRelations',
-        // 'plugin.BEdita/Core.History',
     ];
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ActionTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ActionTraitTest.php
@@ -29,6 +29,26 @@ class ActionTraitTest extends TestCase
     use ActionTrait;
 
     /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        Configure::write('Actions.ListObjectsAction', 'MyPlugin.MyListAction');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        Configure::delete('Actions');
+    }
+
+    /**
      * Fixtures
      *
      * @var array
@@ -52,40 +72,48 @@ class ActionTraitTest extends TestCase
                 'BEdita\Core\Model\Action\SignupUserAction',
                 SignupUserAction::class,
             ],
-            'override' => [
+            'syntax' => [
                 'BEdita\Core\Model\Action\SignupUserAction',
-                SignupUserAction::class,
+                'SignupUserAction',
             ],
-            'fail' => [
-                new \Error("Class '\My\Class' not found"),
-                SignupUserAction::class,
+            'prefix' => [
+                'BEdita\Core\Model\Action\GetObjectAction',
+                'GetObjectAction',
                 [],
-                ['Signup.myAction' => '\My\Class'],
+                'BEdita/Core',
+            ],
+            'fail with config' => [
+                new \RuntimeException('Unable to find class "MyPlugin.MyListAction"'),
+                'ListObjectsAction',
+            ],
+            'direct fail' => [
+                new \Error("Class '\My\Class' not found"),
+                '\My\Class',
             ],
         ];
     }
 
     /**
-     * Test getter for meta.
+     * Test `createAction` method
      *
      * @return void
+     *
+     * @param string|\Exception $expected Expected result
+     * @param string $class Class name
+     * @param array $options Class options
+     * @param string $prefix Class prefix
      *
      * @dataProvider createActionProvider
      * @covers ::createAction()
      */
-    public function testCreateAction($expected, string $action, array $options = [], ?array $config = null)
+    public function testCreateAction($expected, string $class, array $options = [], string $prefix = 'BEdita/Core')
     {
-        if (!empty($config)) {
-            Configure::write($config);
-            $config = key($config);
-        }
-
         if ($expected instanceof \Throwable) {
             $this->expectException(get_class($expected));
             $this->expectExceptionMessage($expected->getMessage());
         }
 
-        $action = $this->createAction($action, $options, $config);
-        static::assertEquals($expected, get_class($action));
+        $class = $this->createAction($class, $options, $prefix);
+        static::assertEquals($expected, get_class($class));
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ActionTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ActionTraitTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Action;
+
+use BEdita\Core\Model\Action\ActionTrait;
+use BEdita\Core\Model\Action\SignupUserAction;
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+use Exception;
+
+/**
+ *  {@see \BEdita\Core\Model\Action\ActionTrait} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Model\Action\ActionTrait
+ */
+class ActionTraitTest extends TestCase
+{
+    use ActionTrait;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.ObjectTypes',
+        // 'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.Objects',
+        // 'plugin.BEdita/Core.Profiles',
+        // 'plugin.BEdita/Core.Users',
+        // 'plugin.BEdita/Core.AsyncJobs',
+        // 'plugin.BEdita/Core.Roles',
+        // 'plugin.BEdita/Core.Trees',
+        // 'plugin.BEdita/Core.RolesUsers',
+        // 'plugin.BEdita/Core.ExternalAuth',
+        // 'plugin.BEdita/Core.AuthProviders',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.RelationTypes',
+        // 'plugin.BEdita/Core.ObjectRelations',
+        // 'plugin.BEdita/Core.History',
+    ];
+
+    /**
+     * Data provider for `testCreateAction`
+     *
+     * @return void
+     */
+    public function createActionProvider()
+    {
+        return [
+            'simple' => [
+                'BEdita\Core\Model\Action\SignupUserAction',
+                SignupUserAction::class,
+            ],
+            'override' => [
+                'BEdita\Core\Model\Action\SignupUserAction',
+                SignupUserAction::class,
+            ],
+            'fail' => [
+                new \Error("Class '\My\Class' not found"),
+                SignupUserAction::class,
+                [],
+                ['Signup.myAction' => '\My\Class'],
+            ],
+        ];
+    }
+
+    /**
+     * Test getter for meta.
+     *
+     * @return void
+     *
+     * @dataProvider createActionProvider
+     * @covers ::createAction()
+     */
+    public function testCreateAction($expected, string $action, array $options = [], ?array $config = null)
+    {
+        if (!empty($config)) {
+            Configure::write($config);
+            $config = key($config);
+        }
+
+        if ($expected instanceof \Throwable) {
+            $this->expectException(get_class($expected));
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+
+        $action = $this->createAction($action, $options, $config);
+        static::assertEquals($expected, get_class($action));
+    }
+}


### PR DESCRIPTION
This PR introduces custom signup actions.

You can now set a custom class in configuration like this:

```php
   Configure::write('Actions.signupUserAction', '\MyPlugin\Model\Action\MySignupAction')
 ```
Or with same setting in `config/app.php` (recommended)
Custom class **must** extend  `BaseAction`.

A new trait `ActionTrait` with a `createAction` method was introduced to dynamically load actions, see method annotations for its usage.


