### PR TITLE
Fix entity virtual props recursion

### DIFF
--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -212,13 +212,11 @@ class CustomPropertiesBehavior extends Behavior
     {
         $allProperties = $entity;
         if ($entity instanceof EntityInterface) {
-            $hidden = $entity->getHidden();
-            try {
-                $entity->setHidden([]);
-                $allProperties = $entity->toArray();
-            } finally {
-                $entity->setHidden($hidden);
-            }
+            $allProperties = array_flip(array_merge(
+                $entity->getHidden(),
+                $entity->getVisible(),
+                $entity->getVirtual()
+            ));
         }
 
         return array_key_exists($field, $allProperties);

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Model\Behavior;
 
+use BEdita\Core\Model\Entity\ObjectEntity;
 use Cake\Collection\CollectionInterface;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\Exception\RecordNotFoundException;
@@ -177,7 +178,7 @@ class CustomPropertiesBehavior extends Behavior
      * @param \Cake\Datasource\EntityInterface $entity Entity being saved.
      * @return void
      */
-    protected function demoteProperties(EntityInterface $entity)
+    protected function demoteProperties(EntityInterface $entity): void
     {
         $field = $this->getConfig('field');
         $value = (array)$entity->get($field);
@@ -186,7 +187,7 @@ class CustomPropertiesBehavior extends Behavior
         $available = $this->getAvailable();
         foreach ($available as $property) {
             $propertyName = $property->name;
-            if (!$entity->isDirty($propertyName) || !$this->isFieldSet($entity, $propertyName)) {
+            if (!$this->isFieldSet($entity, $propertyName) || !$entity->isDirty($propertyName)) {
                 continue;
             }
 
@@ -208,16 +209,12 @@ class CustomPropertiesBehavior extends Behavior
      * @param string $field The field being looked for.
      * @return bool
      */
-    protected function isFieldSet($entity, $field)
+    protected function isFieldSet($entity, $field): bool
     {
-        $allProperties = $entity;
-        if ($entity instanceof EntityInterface) {
-            $allProperties = array_flip(array_merge(
-                $entity->getHidden(),
-                $entity->getVisible()
-            ));
+        if ($entity instanceof ObjectEntity) {
+            return $entity->hasProperty($field);
         }
 
-        return array_key_exists($field, (array)$allProperties);
+        return array_key_exists($field, (array)$entity);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -186,7 +186,7 @@ class CustomPropertiesBehavior extends Behavior
         $available = $this->getAvailable();
         foreach ($available as $property) {
             $propertyName = $property->name;
-            if (!$this->isFieldSet($entity, $propertyName) || !$entity->isDirty($propertyName)) {
+            if (!$entity->isDirty($propertyName) || !$this->isFieldSet($entity, $propertyName)) {
                 continue;
             }
 
@@ -214,11 +214,10 @@ class CustomPropertiesBehavior extends Behavior
         if ($entity instanceof EntityInterface) {
             $allProperties = array_flip(array_merge(
                 $entity->getHidden(),
-                $entity->getVisible(),
-                $entity->getVirtual()
+                $entity->getVisible()
             ));
         }
 
-        return array_key_exists($field, $allProperties);
+        return array_key_exists($field, (array)$allProperties);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
@@ -101,6 +101,33 @@ class ObjectEntity extends Entity implements JsonApiSerializable
     ];
 
     /**
+     * See if a property has been set in an entity.
+     * Could be set in `_properties` array or a virtual one.
+     * Options to exclude hidden properties and to include virtual properties.
+     *
+     * @param string $property Property name
+     * @param bool $hidden Include hidden (default false)
+     * @param bool $virtual Include virtual (default false)
+     * @return bool
+     */
+    public function hasProperty(string $property, bool $hidden = true, bool $virtual = false)
+    {
+        if ($hidden && !$virtual) {
+            return array_key_exists($property, $this->_properties);
+        }
+
+        $properties = array_keys($this->_properties);
+        if (!$hidden) {
+            $properties = array_diff($properties, $this->_hidden);
+        }
+        if ($virtual) {
+            $properties = array_merge($properties, $this->_virtual);
+        }
+
+        return in_array($property, $properties);
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getTable()

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
@@ -106,7 +106,7 @@ class ObjectEntity extends Entity implements JsonApiSerializable
      * Options to exclude hidden properties and to include virtual properties.
      *
      * @param string $property Property name
-     * @param bool $hidden Include hidden (default false)
+     * @param bool $hidden Include hidden (default true)
      * @param bool $virtual Include virtual (default false)
      * @return bool
      */

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
@@ -272,6 +272,6 @@ class FolderTest extends TestCase
         TableRegistry::getTableLocator()->get('Trees')->deleteAll(['object_id' => 12]);
         TableRegistry::getTableLocator()->get('Trees')->recover();
 
-        $this->Folders->get(12);
+        $this->Folders->get(12)->get('path');
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectEntityTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectEntityTest.php
@@ -559,4 +559,27 @@ class ObjectEntityTest extends TestCase
         static::assertArrayHasKey('included', $entity);
         static::assertEquals(1, count($entity['included']));
     }
+
+    /**
+     * Test `hasProperty` method
+     *
+     * @covers ::hasProperty()
+     * @return bool
+     */
+    public function testHasProperty()
+    {
+        $entity = TableRegistry::getTableLocator()->get('Documents')->get(2);
+
+        // core property
+        static::assertTrue($entity->hasProperty('title'));
+        // custom property
+        static::assertTrue($entity->hasProperty('another_title'));
+        // missing property
+        static::assertFalse($entity->hasProperty('some_property'));
+        // hidden property
+        static::assertTrue($entity->hasProperty('deleted'));
+        static::assertFalse($entity->hasProperty('deleted', false));
+        // virtual property
+        static::assertTrue($entity->hasProperty('type', false, true));
+    }
 }


### PR DESCRIPTION
This PR fixes #1602 a potential recursion problem in entities.

In a virtual getter or setter if you call for instance:

```
 $this->getTable()->loadInto($this, ['MyRelation']);
```

to retrieve related entities, will cause internally a new call on `$entity->toArray()` via `CustomPropertiesBehavior::isFieldSet()` that will call the above virtual method again...

