### PR TITLE
Object creation on file upload #1551

### DIFF
--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -219,11 +219,11 @@ Router::plugin(
             ['_name' => 'history:index']
         );
 
-        // Direct media object upload
+        // Upload file and create object.
         $routes->connect(
             '/:object_type/upload/:fileName',
             ['controller' => 'Upload', 'action' => 'upload'],
-            ['_name' => 'upbjects:upload', 'pass' => ['fileName']]
+            ['_name' => 'objects:upload', 'pass' => ['fileName']]
         );
 
         // Objects.

--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -219,6 +219,13 @@ Router::plugin(
             ['_name' => 'history:index']
         );
 
+        // Direct media object upload
+        $routes->connect(
+            '/:object_type/upload/:fileName',
+            ['controller' => 'Upload', 'action' => 'upload'],
+            ['_name' => 'upbjects:upload', 'pass' => ['fileName']]
+        );
+
         // Objects.
         $routes->connect(
             '/:object_type',

--- a/plugins/BEdita/API/src/Controller/Component/UploadComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/UploadComponent.php
@@ -25,7 +25,6 @@ use Zend\Diactoros\Stream;
  *
  * @since 4.2.0
  *
- * @property \Cake\Controller\Component\RequestHandlerComponent $RequestHandler
  * @property \BEdita\Core\Model\Table\StreamsTable $Streams
  */
 class UploadComponent extends Component

--- a/plugins/BEdita/API/src/Controller/Component/UploadComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/UploadComponent.php
@@ -37,14 +37,10 @@ class UploadComponent extends Component
      */
     public function beforeFilter(Event $event): void
     {
-        $request = $this->getController()->getRequest();
-        if ($request->getParam('action') !== 'upload') {
-            return;
-        }
-
         // avoid that RequestHandler tries to parse body
         $this->getController()->RequestHandler->setConfig('inputTypeMap', [], false);
 
+        $request = $this->getController()->getRequest();
         // Decode base64-encoded body.
         if ($request->getHeaderLine('Content-Transfer-Encoding') === 'base64') {
             // Append filter to stream.

--- a/plugins/BEdita/API/src/Controller/Component/UploadComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/UploadComponent.php
@@ -57,9 +57,10 @@ class UploadComponent extends Component
      * Upload a new stream and return entity.
      *
      * @param string $fileName Original file name.
+     * @param int|null $objectId Object id.
      * @return \Cake\Datasource\EntityInterface
      */
-    public function upload($fileName): EntityInterface
+    public function upload($fileName, int $objectId = null): EntityInterface
     {
         $request = $this->getController()->getRequest();
         $request->allowMethod(['post']);
@@ -74,6 +75,7 @@ class UploadComponent extends Component
             'mime_type' => $request->contentType(),
             'contents' => $request->getBody(),
         ];
+        $entity->set('object_id', $objectId);
         $data = $action(compact('entity', 'data'));
         $action = new GetEntityAction(['table' => $this->Streams]);
 

--- a/plugins/BEdita/API/src/Controller/Component/UploadComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/UploadComponent.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Controller\Component;
+
+use BEdita\Core\Model\Action\GetEntityAction;
+use BEdita\Core\Model\Action\SaveEntityAction;
+use Cake\Controller\Component;
+use Cake\Datasource\EntityInterface;
+use Cake\Datasource\ModelAwareTrait;
+use Cake\Event\Event;
+use Zend\Diactoros\Stream;
+
+/**
+ * Handles file upload actions
+ *
+ * @since 4.2.0
+ *
+ * @property \Cake\Controller\Component\RequestHandlerComponent $RequestHandler
+ * @property \BEdita\Core\Model\Table\StreamsTable $Streams
+ */
+class UploadComponent extends Component
+{
+    use ModelAwareTrait;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function beforeFilter(Event $event): void
+    {
+        $request = $this->getController()->getRequest();
+        if ($request->getParam('action') !== 'upload') {
+            return;
+        }
+
+        // avoid that RequestHandler tries to parse body
+        $this->getController()->RequestHandler->setConfig('inputTypeMap', [], false);
+
+        // Decode base64-encoded body.
+        if ($request->getHeaderLine('Content-Transfer-Encoding') === 'base64') {
+            // Append filter to stream.
+            $body = $request->getBody();
+
+            $stream = $body->detach();
+            stream_filter_append($stream, 'convert.base64-decode', STREAM_FILTER_READ);
+
+            $body = new Stream($stream, 'r');
+            $this->getController()->setRequest($request->withBody($body));
+        }
+    }
+
+    /**
+     * Upload a new stream and return entity.
+     *
+     * @param string $fileName Original file name.
+     * @return \Cake\Datasource\EntityInterface
+     */
+    public function upload($fileName): EntityInterface
+    {
+        $request = $this->getController()->getRequest();
+        $request->allowMethod(['post']);
+
+        $this->loadModel('Streams');
+        // Add a new entity.
+        $entity = $this->Streams->newEntity();
+        $action = new SaveEntityAction(['table' => $this->Streams]);
+
+        $data = [
+            'file_name' => $fileName,
+            'mime_type' => $request->contentType(),
+            'contents' => $request->getBody(),
+        ];
+        $data = $action(compact('entity', 'data'));
+        $action = new GetEntityAction(['table' => $this->Streams]);
+
+        return $action(['primaryKey' => $data->get($this->Streams->getPrimaryKey())]);
+    }
+}

--- a/plugins/BEdita/API/src/Controller/StreamsController.php
+++ b/plugins/BEdita/API/src/Controller/StreamsController.php
@@ -82,7 +82,7 @@ class StreamsController extends ResourcesController
                     [
                         '_name' => 'api:resources:resource',
                         'controller' => $this->name,
-                        'id' => $data->uuid,
+                        'id' => $data->get('uuid'),
                     ],
                     true
                 )

--- a/plugins/BEdita/API/src/Controller/UploadController.php
+++ b/plugins/BEdita/API/src/Controller/UploadController.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -14,7 +14,6 @@
 namespace BEdita\API\Controller;
 
 use Cake\Http\Exception\ForbiddenException;
-use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 
@@ -53,13 +52,15 @@ class UploadController extends ObjectsController
             ));
         };
 
-        $this->request = $this->request
-            ->withData('title', $fileName)
-            ->withData('type', Inflector::underscore($this->Table->getAlias()));
-        // create media object from POST request
-        $this->index();
+        $this->Table->getConnection()->transactional(function () use ($fileName) {
+            $this->request = $this->request
+                ->withData('title', $fileName)
+                ->withData('type', Inflector::underscore($this->Table->getAlias()));
+            // create media object from POST request
+            $this->index();
 
-        $objectId = (int)Hash::get($this->viewVars, 'data.id');
-        $this->Upload->upload($fileName, $objectId);
+            $objectId = (int)Hash::get($this->viewVars, 'data.id');
+            $this->Upload->upload($fileName, $objectId);
+        });
     }
 }

--- a/plugins/BEdita/API/src/Controller/UploadController.php
+++ b/plugins/BEdita/API/src/Controller/UploadController.php
@@ -53,15 +53,13 @@ class UploadController extends ObjectsController
             ));
         };
 
-        $stream = $this->Upload->upload($fileName);
         $this->request = $this->request
             ->withData('title', $fileName)
             ->withData('type', Inflector::underscore($this->Table->getAlias()));
         // create media object from POST request
         $this->index();
 
-        // update object_id in stream resource
-        $stream->set('object_id', Hash::get($this->viewVars, 'data.id'));
-        TableRegistry::getTableLocator()->get('Streams')->saveOrFail($stream);
+        $objectId = (int)Hash::get($this->viewVars, 'data.id');
+        $this->Upload->upload($fileName, $objectId);
     }
 }

--- a/plugins/BEdita/API/src/Controller/UploadController.php
+++ b/plugins/BEdita/API/src/Controller/UploadController.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\API\Controller;
+
+use Cake\Http\Exception\ForbiddenException;
+use Cake\ORM\TableRegistry;
+use Cake\Utility\Hash;
+use Cake\Utility\Inflector;
+
+/**
+ * Controller to create objects via file upload.
+ *
+ * @since 4.2.0
+ *
+ * @property \BEdita\API\Controller\Component\UploadComponent $Upload
+ */
+class UploadController extends ObjectsController
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function initialize()
+    {
+        $this->loadComponent('BEdita/API.Upload');
+        parent::initialize();
+    }
+
+    /**
+     * Create new media uploading new stream.
+     *
+     * @param string $fileName Original file name.
+     * @return void
+     */
+    public function upload($fileName)
+    {
+        $stream = $this->Upload->upload($fileName);
+        $this->request = $this->request
+            ->withData('title', $fileName)
+            ->withData('type', Inflector::underscore($this->Table->getAlias()));
+        // create media object from POST request
+        $this->index();
+
+        $associations = (array)Hash::get($this->objectType, 'associations');
+        if (!in_array('Streams', $associations)) {
+            throw new ForbiddenException(__d(
+                'bedita',
+                'You are not allowed to upload streams on "{0}"',
+                $this->objectType->get('name')
+            ));
+        };
+        // update object_id in stream resource
+        $stream->set('object_id', Hash::get($this->viewVars, 'data.id'));
+        TableRegistry::getTableLocator()->get('Streams')->saveOrFail($stream);
+    }
+}

--- a/plugins/BEdita/API/src/Controller/UploadController.php
+++ b/plugins/BEdita/API/src/Controller/UploadController.php
@@ -44,13 +44,6 @@ class UploadController extends ObjectsController
      */
     public function upload($fileName)
     {
-        $stream = $this->Upload->upload($fileName);
-        $this->request = $this->request
-            ->withData('title', $fileName)
-            ->withData('type', Inflector::underscore($this->Table->getAlias()));
-        // create media object from POST request
-        $this->index();
-
         $associations = (array)Hash::get($this->objectType, 'associations');
         if (!in_array('Streams', $associations)) {
             throw new ForbiddenException(__d(
@@ -59,6 +52,14 @@ class UploadController extends ObjectsController
                 $this->objectType->get('name')
             ));
         };
+
+        $stream = $this->Upload->upload($fileName);
+        $this->request = $this->request
+            ->withData('title', $fileName)
+            ->withData('type', Inflector::underscore($this->Table->getAlias()));
+        // create media object from POST request
+        $this->index();
+
         // update object_id in stream resource
         $stream->set('object_id', Hash::get($this->viewVars, 'data.id'));
         TableRegistry::getTableLocator()->get('Streams')->saveOrFail($stream);

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/UploadComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/UploadComponentTest.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\API\Test\TestCase\Controller\Component;
+
+use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestFilesystemTrait;
+use Cake\Utility\Hash;
+use Cake\Validation\Validation;
+
+/**
+ * @coversDefaultClass \BEdita\API\Controller\Component\UploadComponent
+ */
+class UploadComponentTest extends IntegrationTestCase
+{
+    use TestFilesystemTrait;
+
+    /**
+     * {@inheritDoc}
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.Streams',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->filesystemSetup();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        $this->filesystemCleanup();
+        parent::tearDown();
+    }
+
+    /**
+     * Upload data provider for testUpload()
+     *
+     * @return array
+     */
+    public function uploadProvider()
+    {
+        return [
+            'javascript' => [
+                [
+                    'fileName' => 'synapse.js',
+                    'contents' => 'exports.synapse = Promise.resolve();',
+                    'contentType' => 'text/javascript',
+                ],
+            ],
+            'xml' => [
+                [
+                    'fileName' => 'gustavo.xml',
+                    'contents' => '<?xml version="1.0" encoding="utf-8"?><items><item>one</item><item>two</item></items>',
+                    'contentType' => 'text/xml',
+                ],
+            ],
+            'json' => [
+                [
+                    'fileName' => 'gustavo.json',
+                    'contents' => '{"name":"Gustavo","surname":"Supporto"}',
+                    'contentType' => 'application/json',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test upload method.
+     *
+     * @param array $data The file data.
+     * @return void
+     *
+     * @dataProvider uploadProvider
+     * @covers ::upload()
+     * @covers ::beforeFilter()
+     */
+    public function testUpload($data)
+    {
+        $fileName = Hash::get($data, 'fileName');
+        $contents = Hash::get($data, 'contents');
+        $contentType = Hash::get($data, 'contentType');
+
+        $attributes = [
+            'file_name' => $fileName,
+            'mime_type' => $contentType,
+        ];
+        $meta = [
+            'version' => 1,
+            'file_size' => strlen($contents),
+            'hash_md5' => md5($contents),
+            'hash_sha1' => sha1($contents),
+            'url' => null,
+        ];
+
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader() + ['Content-Type' => $contentType]);
+        $this->post(sprintf('/streams/upload/%s', $fileName), $contents);
+
+        $this->assertResponseCode(201);
+        $this->assertContentType('application/vnd.api+json');
+
+        $response = json_decode((string)$this->_response->getBody(), true);
+
+        static::assertArrayHasKey('data', $response);
+        static::assertArrayHasKey('id', $response['data']);
+        static::assertArrayHasKey('type', $response['data']);
+        static::assertArrayHasKey('attributes', $response['data']);
+        static::assertArrayHasKey('meta', $response['data']);
+        static::assertArrayHasKey('links', $response);
+
+        $id = $response['data']['id'];
+        $url = sprintf('http://api.example.com/streams/%s', $id);
+        $meta['url'] = sprintf('https://static.example.org/files/%s-%s', $id, $fileName);
+        static::assertTrue(Validation::uuid($id));
+        static::assertSame('streams', $response['data']['type']);
+        static::assertEquals($attributes, $response['data']['attributes']);
+        static::assertArraySubset($meta, $response['data']['meta']);
+
+        $this->assertHeader('Location', $url);
+    }
+
+    /**
+     * Test upload method.
+     *
+     * @return void
+     *
+     * @covers ::upload()
+     * @covers ::beforeFilter()
+     */
+    public function testUploadBase64()
+    {
+        $fileName = 'synapse.js';
+        $contents = 'exports.synapse = Promise.resolve();';
+        $contentType = 'text/javascript';
+
+        $attributes = [
+            'file_name' => $fileName,
+            'mime_type' => $contentType,
+        ];
+        $meta = [
+            'version' => 1,
+            'file_size' => strlen($contents),
+            'hash_md5' => md5($contents),
+            'hash_sha1' => sha1($contents),
+            'url' => null,
+        ];
+
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader() + ['Content-Type' => $contentType, 'Content-Transfer-Encoding' => 'base64']);
+        $this->post(sprintf('/streams/upload/%s', $fileName), base64_encode($contents));
+
+        $this->assertResponseCode(201);
+        $this->assertContentType('application/vnd.api+json');
+
+        $response = json_decode((string)$this->_response->getBody(), true);
+
+        static::assertArrayHasKey('data', $response);
+        static::assertArrayHasKey('id', $response['data']);
+        static::assertArrayHasKey('type', $response['data']);
+        static::assertArrayHasKey('attributes', $response['data']);
+        static::assertArrayHasKey('meta', $response['data']);
+        static::assertArrayHasKey('links', $response);
+
+        $id = $response['data']['id'];
+        $url = sprintf('http://api.example.com/streams/%s', $id);
+        $meta['url'] = sprintf('https://static.example.org/files/%s-synapse.js', $id);
+        static::assertTrue(Validation::uuid($id));
+        static::assertSame('streams', $response['data']['type']);
+        static::assertEquals($attributes, $response['data']['attributes']);
+        static::assertArraySubset($meta, $response['data']['meta']);
+
+        $this->assertHeader('Location', $url);
+    }
+}

--- a/plugins/BEdita/API/tests/TestCase/Controller/UploadControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/UploadControllerTest.php
@@ -49,9 +49,8 @@ class UploadControllerTest extends IntegrationTestCase
     }
 
     /**
-     * Test upload method.
+     * Test `upload` method.
      *
-     * @param array $data The file data.
      * @return void
      *
      * @covers ::upload()
@@ -62,18 +61,6 @@ class UploadControllerTest extends IntegrationTestCase
         $fileName = 'gustavo.json';
         $contents = '{"name":"Gustavo","surname":"Supporto"}';
         $contentType = 'application/json';
-
-        $attributes = [
-            'file_name' => $fileName,
-            'mime_type' => $contentType,
-        ];
-        $meta = [
-            'version' => 1,
-            'file_size' => strlen($contents),
-            'hash_md5' => md5($contents),
-            'hash_sha1' => sha1($contents),
-            'url' => null,
-        ];
 
         $this->configRequestHeaders('POST', $this->getUserAuthHeader() + ['Content-Type' => $contentType]);
         $this->post(sprintf('/files/upload/%s', $fileName), $contents);
@@ -90,5 +77,35 @@ class UploadControllerTest extends IntegrationTestCase
         static::assertEquals($fileName, $response['data']['attributes']['title']);
 
         $this->assertHeader('Location', $url);
+    }
+
+    /**
+     * Test `upload` failure.
+     *
+     * @return void
+     *
+     * @covers ::upload()
+     */
+    public function testUploadFail()
+    {
+        $fileName = 'gustavo.json';
+        $contents = '{"name":"Gustavo","surname":"Supporto"}';
+        $contentType = 'application/json';
+
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader() + ['Content-Type' => $contentType]);
+        $this->post(sprintf('/documents/upload/%s', $fileName), $contents);
+
+        $this->assertResponseCode(403);
+        $this->assertContentType('application/vnd.api+json');
+
+        $response = json_decode((string)$this->_response->getBody(), true);
+        $expected = [
+            'error' => [
+                'status' => '403',
+                'title' => 'You are not allowed to upload streams on "documents"',
+            ],
+        ];
+        unset($response['links'], $response['error']['meta']);
+        static::assertEquals($expected, $response);
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/UploadControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/UploadControllerTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\API\Test\TestCase\Controller;
+
+use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestFilesystemTrait;
+
+/**
+ * @coversDefaultClass \BEdita\API\Controller\UploadController
+ */
+class UploadControllerTest extends IntegrationTestCase
+{
+    use TestFilesystemTrait;
+
+    /**
+     * {@inheritDoc}
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.Streams',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->filesystemSetup();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        $this->filesystemCleanup();
+        parent::tearDown();
+    }
+
+    /**
+     * Test upload method.
+     *
+     * @param array $data The file data.
+     * @return void
+     *
+     * @covers ::upload()
+     * @covers ::initialize()
+     */
+    public function testUpload()
+    {
+        $fileName = 'gustavo.json';
+        $contents = '{"name":"Gustavo","surname":"Supporto"}';
+        $contentType = 'application/json';
+
+        $attributes = [
+            'file_name' => $fileName,
+            'mime_type' => $contentType,
+        ];
+        $meta = [
+            'version' => 1,
+            'file_size' => strlen($contents),
+            'hash_md5' => md5($contents),
+            'hash_sha1' => sha1($contents),
+            'url' => null,
+        ];
+
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader() + ['Content-Type' => $contentType]);
+        $this->post(sprintf('/files/upload/%s', $fileName), $contents);
+
+        $this->assertResponseCode(201);
+        $this->assertContentType('application/vnd.api+json');
+
+        $response = json_decode((string)$this->_response->getBody(), true);
+        static::assertArrayHasKey('data', $response);
+
+        $id = $response['data']['id'];
+        $url = sprintf('http://api.example.com/files/%s', $id);
+        static::assertSame('files', $response['data']['type']);
+        static::assertEquals($fileName, $response['data']['attributes']['title']);
+
+        $this->assertHeader('Location', $url);
+    }
+}

--- a/plugins/BEdita/Core/config/reserved.php
+++ b/plugins/BEdita/Core/config/reserved.php
@@ -57,4 +57,5 @@ return [
     'tree_parent_nodes',
     'type',
     'types',
+    'upload',
 ];

--- a/plugins/BEdita/Core/tests/Utility/TestFilesystemTrait.php
+++ b/plugins/BEdita/Core/tests/Utility/TestFilesystemTrait.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\Utility;
+
+use BEdita\Core\Filesystem\FilesystemRegistry;
+use Cake\Core\Configure;
+
+/**
+ * Trait with methods to setup and cleanup filesystem in test cases
+ */
+trait TestFilesystemTrait
+{
+    /**
+     * List of files to keep in test filesystem, and their contents.
+     *
+     * @var \Cake\Collection\Collection
+     */
+    protected $keep = [];
+
+    /**
+     * Setup test filesystem.
+     * Call this method in test `setUp()`
+     * or before tests involving filesystem.
+     *
+     * @return void
+     */
+    protected function filesystemSetup(): void
+    {
+        FilesystemRegistry::setConfig(Configure::read('Filesystem'));
+
+        $mountManager = FilesystemRegistry::getMountManager();
+        $this->keep = collection($mountManager->listContents('default://'))
+            ->map(function (array $object) use ($mountManager) {
+                $path = sprintf('%s://%s', $object['filesystem'], $object['path']);
+                $contents = fopen('php://memory', 'wb+');
+                fwrite($contents, $mountManager->read($path));
+                fseek($contents, 0);
+
+                return compact('contents', 'path');
+            })
+            ->compile();
+    }
+
+    /**
+     * Setup test filesystem.
+     * Call this method in test `tearDown()`
+     * or after tests involving filesystem.
+     */
+    protected function filesystemCleanup(): void
+    {
+        // Cleanup test filesystem.
+        $mountManager = FilesystemRegistry::getMountManager();
+        $keep = $this->keep
+            ->each(function (array $object) use ($mountManager) {
+                $mountManager->putStream($object['path'], $object['contents']);
+            })
+            ->map(function (array $object) {
+                return $object['path'];
+            })
+            ->toList();
+        collection($mountManager->listContents('default://'))
+            ->map(function (array $object) {
+                return sprintf('%s://%s', $object['filesystem'], $object['path']);
+            })
+            ->reject(function ($uri) use ($keep) {
+                return in_array($uri, $keep);
+            })
+            ->each([$mountManager, 'delete']);
+
+        FilesystemRegistry::dropAll();
+    }
+}

--- a/plugins/BEdita/Core/tests/Utility/TestFilesystemTrait.php
+++ b/plugins/BEdita/Core/tests/Utility/TestFilesystemTrait.php
@@ -56,6 +56,8 @@ trait TestFilesystemTrait
      * Setup test filesystem.
      * Call this method in test `tearDown()`
      * or after tests involving filesystem.
+     *
+     * @return void
      */
     protected function filesystemCleanup(): void
     {


### PR DESCRIPTION
This PR fixes #1551 

With a single request like `POST /images/upload/{filename.ext}`

A new object + related stream is created in one shot.

* every object type with a `Streams` association can be created this way, otherwise a `403` error is returned
* initial object `title` will be `{filename.ext}`

Code changes:

* new `UploadController` to handle `/:object_type/upload/:file` route
* new `UploadComponent` for common stream upload logic between `StreamsController` and `UploadController` 


