### PR TITLE
filter by user_created session user

### DIFF
--- a/bedita-app/models/behaviors/build_filter.php
+++ b/bedita-app/models/behaviors/build_filter.php
@@ -992,6 +992,9 @@ class BuildFilterBehavior extends ModelBehavior {
         $this->fields .= $locFields;
         $this->from .= ", {$s}users{$e} AS {$s}User{$e}";
         $this->conditions[] = "{$s}User{$e}.{$s}id{$e}={$s}BEObject{$e}.{$s}user_created{$e}";
+        if (!empty($this->filter['user_created'])) {
+            $this->conditions[] = "{$s}BEObject{$e}.{$s}user_created{$e}={$this->filter['user_created']}";
+        }
         $this->group .= $locFields;
     }
 

--- a/bedita-app/models/behaviors/build_filter.php
+++ b/bedita-app/models/behaviors/build_filter.php
@@ -986,14 +986,15 @@ class BuildFilterBehavior extends ModelBehavior {
      *
      * @param string $s, start quote sql
      * @param string $e, end quote sql
+     * @param string|null $value The value of field
      */
-    protected function user_createdFilter($s, $e) {
+    protected function user_createdFilter($s, $e, $value) {
         $locFields = ", {$s}User{$e}.{$s}userid{$e}, {$s}User{$e}.{$s}realname{$e}";
         $this->fields .= $locFields;
         $this->from .= ", {$s}users{$e} AS {$s}User{$e}";
         $this->conditions[] = "{$s}User{$e}.{$s}id{$e}={$s}BEObject{$e}.{$s}user_created{$e}";
-        if (!empty($this->filter['user_created'])) {
-            $this->conditions[] = "{$s}BEObject{$e}.{$s}user_created{$e}={$this->filter['user_created']}";
+        if (!empty($value)) {
+            $this->conditions[] = "{$s}BEObject{$e}.{$s}user_created{$e}={$value}";
         }
         $this->group .= $locFields;
     }

--- a/bedita-app/models/behaviors/build_filter.php
+++ b/bedita-app/models/behaviors/build_filter.php
@@ -994,6 +994,7 @@ class BuildFilterBehavior extends ModelBehavior {
         $this->from .= ", {$s}users{$e} AS {$s}User{$e}";
         $this->conditions[] = "{$s}User{$e}.{$s}id{$e}={$s}BEObject{$e}.{$s}user_created{$e}";
         if (!empty($value)) {
+            $value = Sanitize::escape($value);
             $this->conditions[] = "{$s}BEObject{$e}.{$s}user_created{$e}={$value}";
         }
         $this->group .= $locFields;

--- a/bedita-app/views/elements/filters.tpl
+++ b/bedita-app/views/elements/filters.tpl
@@ -26,6 +26,7 @@
     'relations' => true,
     'type' => false,
     'language' => true,
+    'user' => true,
     'customProp' => ['showObjectTypes' => false],
     'categories' => true,
     'mediaTypes' => false,

--- a/bedita-app/views/elements/filters_form.tpl
+++ b/bedita-app/views/elements/filters_form.tpl
@@ -86,19 +86,19 @@ available options:
 
 		{if !empty($filters.user)}
 		{$createdbyme = $view->SessionFilter->read('user_created') == $BEAuthUser.id}
-		<div class="cell">
-			<label>{t}created by{/t}:</label>
-			<select name="filter[user_created]" id="user_created">
-				{strip}
-				<option value="" {if !$createdbyme}selected="selected"{/if}>
-					{t}anybody{/t}
-				</option>
-				<option value="{$BEAuthUser.id}" {if $createdbyme}selected="selected"{/if}>
-					{$BEAuthUser.userid} (you)
-				</option>
-				{/strip}
-			</select>
-		</div>
+			<div class="cell">
+				<label>{t}created by{/t}:</label>
+				<select name="filter[user_created]" id="user_created">
+					{strip}
+					<option value="" {if !$createdbyme}selected="selected"{/if}>
+						{t}anybody{/t}
+					</option>
+					<option value="{$BEAuthUser.id}" {if $createdbyme}selected="selected"{/if}>
+						{$BEAuthUser.userid} ({t}you{/t})
+					</option>
+					{/strip}
+				</select>
+			</div>
 		{/if}
 
 		{if !empty($filters.tree)}

--- a/bedita-app/views/elements/filters_form.tpl
+++ b/bedita-app/views/elements/filters_form.tpl
@@ -10,6 +10,7 @@ available options:
 	'treeDescendants' => true,
 	'type' => true,
 	'language' => true,
+	'user' => true,
 	'customProp' => false,
 	'categories' => true or array('label' => 'myLabel'),
 	'mediaType' => false,
@@ -81,6 +82,15 @@ available options:
 					{/foreach}
 				</select>
 			</div>
+		{/if}
+
+		{if !empty($filters.user)}
+		{$createdbyme = $view->SessionFilter->read('user_created') == $BEAuthUser.id}
+		<div class="cell">
+			<label>{t}created by{/t}:</label>
+			<input type="radio" name="filter[user_created]" value="{$BEAuthUser.id}" {if $createdbyme}checked="checked"{/if} />{$BEAuthUser.userid} (you)
+			<input type="radio" name="filter[user_created]" value="" {if !$createdbyme}checked="checked"{/if} />{t}anybody{/t}
+		</div>
 		{/if}
 
 		{if !empty($filters.tree)}
@@ -260,6 +270,7 @@ available options:
 		<div class="formbuttons">
 			<input type="submit" id="searchButton" value=" {t}find it{/t} ">
 			<input type="button" id="cleanFilters" value=" {t}reset filters{/t} ">
+			DEBUG
 		</div>
 
 	</div>

--- a/bedita-app/views/elements/filters_form.tpl
+++ b/bedita-app/views/elements/filters_form.tpl
@@ -88,8 +88,16 @@ available options:
 		{$createdbyme = $view->SessionFilter->read('user_created') == $BEAuthUser.id}
 		<div class="cell">
 			<label>{t}created by{/t}:</label>
-			<input type="radio" name="filter[user_created]" value="{$BEAuthUser.id}" {if $createdbyme}checked="checked"{/if} />{$BEAuthUser.userid} (you)
-			<input type="radio" name="filter[user_created]" value="" {if !$createdbyme}checked="checked"{/if} />{t}anybody{/t}
+			<select name="filter[user_created]" id="user_created">
+				{strip}
+				<option value="" {if !$createdbyme}selected="selected"{/if}>
+					{t}anybody{/t}
+				</option>
+				<option value="{$BEAuthUser.id}" {if $createdbyme}selected="selected"{/if}>
+					{$BEAuthUser.userid} (you)
+				</option>
+				{/strip}
+			</select>
 		</div>
 		{/if}
 

--- a/bedita-app/views/elements/filters_form.tpl
+++ b/bedita-app/views/elements/filters_form.tpl
@@ -270,7 +270,6 @@ available options:
 		<div class="formbuttons">
 			<input type="submit" id="searchButton" value=" {t}find it{/t} ">
 			<input type="button" id="cleanFilters" value=" {t}reset filters{/t} ">
-			DEBUG
 		</div>
 
 	</div>


### PR DESCRIPTION
This PR provides #1674 

If `$filter['user_created']` exists, objects search apply a filter by user_created = `$filter['user_created']`.
UI provides the possibility to choose "created by me", meaning: `$filter['user_created'] = $BEAuthUser.id`.