### PR TITLE
Invalidate destination on first save

### DIFF
--- a/bedita-app/models/behaviors/cacheable.php
+++ b/bedita-app/models/behaviors/cacheable.php
@@ -112,6 +112,10 @@ class CacheableBehavior extends ModelBehavior {
             'fields' => array('parent_id'),
             'conditions' => $treeConditions
         ));
+        // handle first save in tree (object still not in tree, but parent is in destination data)
+        if (!empty($model->data['BEObject']['destination']) && !in_array($model->data['BEObject']['destination'], $excludeIds)) {
+            $parents = array_merge($parents, $model->data['BEObject']['destination']);
+        }
 
         // get related object to clean
         $objectRelation = ClassRegistry::init('ObjectRelation');

--- a/bedita-app/models/search_text.php
+++ b/bedita-app/models/search_text.php
@@ -67,8 +67,12 @@ class SearchText extends BEAppModel
 		}
 		
 		$this->checkIndexModel();
-		if($this->indexModel) {
-			$res = $this->indexModel->indexObject($searchFields, $data);
+		if ($this->indexModel) {
+			$parents = array();
+			if (!empty($model->data[$model->alias]['destination'])) {
+				$parents = $model->data[$model->alias]['destination'];
+			}	
+			$res = $this->indexModel->indexObject($searchFields, $data, $parents);
 			if(!empty($res["error"])) {
 			    throw new BeditaException("crete object index error: " . 
 			            $res["error"]);

--- a/bedita-app/models/search_text.php
+++ b/bedita-app/models/search_text.php
@@ -49,7 +49,7 @@ class SearchText extends BEAppModel
 	 * @return boolean
 	 */
 	public function createSearchText($model) {
-		
+
 		$bviorCompactResults = null;
 		if (isset($model->bviorCompactResults)) {
 			$bviorCompactResults = $model->bviorCompactResults ;
@@ -71,7 +71,7 @@ class SearchText extends BEAppModel
 			$parents = array();
 			if (!empty($model->data[$model->alias]['destination'])) {
 				$parents = $model->data[$model->alias]['destination'];
-			}	
+			}
 			$res = $this->indexModel->indexObject($searchFields, $data, $parents);
 			if(!empty($res["error"])) {
 			    throw new BeditaException("crete object index error: " . 

--- a/bedita-app/models/search_text.php
+++ b/bedita-app/models/search_text.php
@@ -67,6 +67,7 @@ class SearchText extends BEAppModel
 		
 		$this->checkIndexModel();
 		if($this->indexModel) {
+
 			$res = $this->indexModel->indexObject($searchFields, $data);
 			if(!empty($res["error"])) {
 			    throw new BeditaException("crete object index error: " . 

--- a/bedita-app/models/search_text.php
+++ b/bedita-app/models/search_text.php
@@ -67,7 +67,6 @@ class SearchText extends BEAppModel
 		
 		$this->checkIndexModel();
 		if($this->indexModel) {
-			if ($this->indexModel) {
 			$res = $this->indexModel->indexObject($searchFields, $data);
 			if(!empty($res["error"])) {
 			    throw new BeditaException("crete object index error: " . 

--- a/bedita-app/models/search_text.php
+++ b/bedita-app/models/search_text.php
@@ -66,13 +66,9 @@ class SearchText extends BEAppModel
 		}
 		
 		$this->checkIndexModel();
-		if ($this->indexModel) {
-			$parents = array();
-			if (!empty($model->data[$model->alias]['destination'])) {
-				$excludeIds = (array)Configure::read('excludeFromTreeIds');
-				$parents = array_unique(array_diff((array)$model->data[$model->alias]['destination'], $excludeIds));
-			}
-			$res = $this->indexModel->indexObject($searchFields, $data, $parents);
+		if($this->indexModel) {
+			if ($this->indexModel) {
+			$res = $this->indexModel->indexObject($searchFields, $data);
 			if(!empty($res["error"])) {
 			    throw new BeditaException("crete object index error: " . 
 			            $res["error"]);

--- a/bedita-app/models/search_text.php
+++ b/bedita-app/models/search_text.php
@@ -49,6 +49,7 @@ class SearchText extends BEAppModel
 	 * @return boolean
 	 */
 	public function createSearchText($model) {
+		
 		$bviorCompactResults = null;
 		if (isset($model->bviorCompactResults)) {
 			$bviorCompactResults = $model->bviorCompactResults ;
@@ -67,7 +68,6 @@ class SearchText extends BEAppModel
 		
 		$this->checkIndexModel();
 		if($this->indexModel) {
-
 			$res = $this->indexModel->indexObject($searchFields, $data);
 			if(!empty($res["error"])) {
 			    throw new BeditaException("crete object index error: " . 

--- a/bedita-app/models/search_text.php
+++ b/bedita-app/models/search_text.php
@@ -49,7 +49,6 @@ class SearchText extends BEAppModel
 	 * @return boolean
 	 */
 	public function createSearchText($model) {
-
 		$bviorCompactResults = null;
 		if (isset($model->bviorCompactResults)) {
 			$bviorCompactResults = $model->bviorCompactResults ;
@@ -70,7 +69,8 @@ class SearchText extends BEAppModel
 		if ($this->indexModel) {
 			$parents = array();
 			if (!empty($model->data[$model->alias]['destination'])) {
-				$parents = $model->data[$model->alias]['destination'];
+				$excludeIds = (array)Configure::read('excludeFromTreeIds');
+				$parents = array_unique(array_diff((array)$model->data[$model->alias]['destination'], $excludeIds));
 			}
 			$res = $this->indexModel->indexObject($searchFields, $data, $parents);
 			if(!empty($res["error"])) {


### PR DESCRIPTION
This PR fixes #1676 

Cacheable behavior, via beforeSave and afterSave, clears object cache, including parents. The first time an object is saved in a destination, tree data is still not available, so parent cache is not invalidated properly. This provides a fix in `getObjectsToCleanById`: the parent id from model data is handled as well, so that cache clear on parent is performed also on first save

Bonus: handle object indexing, considering parents explicitely, before trees data is saved