### PR TITLE
Fix some issue with BeToolbar

### DIFF
--- a/bedita-app/views/elements/toolbar.tpl
+++ b/bedita-app/views/elements/toolbar.tpl
@@ -1,7 +1,7 @@
 {strip}
 <div class="head">
 
-    {$beToolbar->show(['noitem' => $noitem|default:false, 'itemName' => $itemName|default:null])}
+    {$beToolbar->show('default', ['noitem' => $noitem|default:false, 'itemName' => $itemName|default:null])}
     <div id="loading">&nbsp;</div>
 
 </div>

--- a/bedita-app/views/helpers/be_toolbar.php
+++ b/bedita-app/views/helpers/be_toolbar.php
@@ -604,7 +604,7 @@ class BeToolbarHelper extends AppHelper {
     public function pagePagination() {
         $cells = '';
         $moduleModify = Set::classicExtract($this->_view, 'viewVars.module_modify', null);
-        if ($moduleModify === "1" && empty($_noitem)) {
+        if ($moduleModify === "1" && empty($this->_noitem)) {
             $title = __('Create new', true) . '&nbsp;';
             if (!empty($this->_itemName)) {
                 $title.= __($this->_itemName, true);


### PR DESCRIPTION
This PR fixes two issue with `BeToolbar` helper.

In `elements/toolbar.tpl`  the show method was called without passing the first `$type` argument.
Inside the helper the property `$_noitem` was used without `$this` context.
