### PR TITLE
Avoid `included` repetitions

### DIFF
--- a/plugins/BEdita/API/src/View/JsonApiView.php
+++ b/plugins/BEdita/API/src/View/JsonApiView.php
@@ -86,11 +86,32 @@ class JsonApiView extends JsonView
 
         if (!empty($included)) {
             $included = JsonApi::formatData($included, $options, $fields);
+            $this->includedUnique($included);
             unset($included['_schema']);
             $res += compact('included');
         }
 
         return $res;
+    }
+
+    /**
+     * Make sure included items are unique.
+     *
+     * @param array $included Included items.
+     * @return void
+     */
+    protected function includedUnique(array &$included): void
+    {
+        $idx = [];
+        foreach ($included as $k => $item) {
+            $id = Hash::get($item, 'id');
+            $type = Hash::get($item, 'type');
+            if (!empty($idx[$type][$id])) {
+                unset($included[$k]);
+            } else {
+                $idx[$type][$id] = 1;
+            }
+        }
     }
 
     /**

--- a/plugins/BEdita/API/src/View/JsonApiView.php
+++ b/plugins/BEdita/API/src/View/JsonApiView.php
@@ -85,8 +85,8 @@ class JsonApiView extends JsonView
         $res = compact('data') + array_filter(compact('links', 'meta'));
 
         if (!empty($included)) {
-            $included = $this->includedUnique($included);
             $included = JsonApi::formatData($included, $options, $fields);
+            $included = $this->includedUnique($included);
             unset($included['_schema']);
             $res += compact('included');
         }

--- a/plugins/BEdita/API/src/View/JsonApiView.php
+++ b/plugins/BEdita/API/src/View/JsonApiView.php
@@ -85,8 +85,8 @@ class JsonApiView extends JsonView
         $res = compact('data') + array_filter(compact('links', 'meta'));
 
         if (!empty($included)) {
+            $included = $this->includedUnique($included);
             $included = JsonApi::formatData($included, $options, $fields);
-            $this->includedUnique($included);
             unset($included['_schema']);
             $res += compact('included');
         }
@@ -98,20 +98,17 @@ class JsonApiView extends JsonView
      * Make sure included items are unique.
      *
      * @param array $included Included items.
-     * @return void
+     * @return array
      */
-    protected function includedUnique(array &$included): void
+    protected function includedUnique(array $included): array
     {
-        $idx = [];
-        foreach ($included as $k => $item) {
-            $id = Hash::get($item, 'id');
-            $type = Hash::get($item, 'type');
-            if (!empty($idx[$type][$id])) {
-                unset($included[$k]);
-            } else {
-                $idx[$type][$id] = 1;
-            }
+        $includedType = Hash::combine($included, '{n}.id', '{n}', '{n}.type');
+        $unique = [];
+        foreach ($includedType as $inc) {
+            $unique = array_merge($unique, array_values($inc));
         }
+
+        return $unique;
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
+++ b/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
@@ -260,21 +260,47 @@ class JsonApiViewTest extends TestCase
             'included' => [
                 json_encode([
                     'data' => [
-                        'id' => '1',
-                        'type' => 'roles',
-                        'relationships' => [
-                            'users' => [
-                                'data' => [
-                                   [
-                                        'id' => '1',
-                                        'type' => 'users'
-                                   ],
-                                ],
-                                'links' => [
-                                    'related' => '/roles/1/users',
-                                    'self' => '/roles/1/relationships/users'
-                                ]
-                             ],
+                        [
+                            'id' => '1',
+                            'type' => 'roles',
+                            'links' => [
+                                'self' => '/roles/1',
+                            ],
+                            'relationships' => [
+                                'users' => [
+                                    'data' => [
+                                       [
+                                            'id' => '1',
+                                            'type' => 'users'
+                                       ],
+                                    ],
+                                    'links' => [
+                                        'related' => '/roles/1/users',
+                                        'self' => '/roles/1/relationships/users'
+                                    ]
+                                 ],
+                            ],
+                        ],
+                        [
+                            'id' => '2',
+                            'type' => 'roles',
+                            'links' => [
+                                'self' => '/roles/2',
+                            ],
+                            'relationships' => [
+                                'users' => [
+                                    'data' => [
+                                       [
+                                            'id' => '1',
+                                            'type' => 'users'
+                                       ],
+                                    ],
+                                    'links' => [
+                                        'related' => '/roles/2/users',
+                                        'self' => '/roles/2/relationships/users'
+                                    ]
+                                 ],
+                            ],
                         ],
                     ],
                     'meta' => [
@@ -293,16 +319,16 @@ class JsonApiViewTest extends TestCase
                                 'self' => '/users/1'
                             ],
                             'relationships' => [
-                                'roles' => [
-                                    'links' => [
-                                        'related' => '/users/1/roles',
-                                        'self' => '/users/1/relationships/roles'
-                                    ]
-                                ],
                                 'another_test' => [
                                     'links' => [
                                         'related' => '/users/1/another_test',
                                         'self' => '/users/1/relationships/another_test'
+                                    ]
+                                ],
+                                'roles' => [
+                                    'links' => [
+                                        'related' => '/users/1/roles',
+                                        'self' => '/users/1/relationships/roles'
                                     ]
                                 ],
                                 'parents' => [
@@ -323,7 +349,10 @@ class JsonApiViewTest extends TestCase
                 ]),
                 function (Table $Table) {
                     return [
-                        'object' => $Table->get(1, ['contain' => 'Users']),
+                        'objects' => [
+                            $Table->get(1, ['contain' => 'Users']),
+                            $Table->get(1, ['contain' => 'Users'])->set('id', 2),
+                        ],
                         '_serialize' => true,
                         '_fields' => [
                             'roles' => '',

--- a/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
+++ b/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
@@ -291,13 +291,34 @@ class JsonApiViewTest extends TestCase
                                 'users' => [
                                     'data' => [
                                        [
-                                            'id' => '1',
+                                            'id' => '5',
                                             'type' => 'users'
                                        ],
                                     ],
                                     'links' => [
                                         'related' => '/roles/2/users',
                                         'self' => '/roles/2/relationships/users'
+                                    ]
+                                 ],
+                            ],
+                        ],
+                        [
+                            'id' => '3',
+                            'type' => 'roles',
+                            'links' => [
+                                'self' => '/roles/3',
+                            ],
+                            'relationships' => [
+                                'users' => [
+                                    'data' => [
+                                       [
+                                            'id' => '1',
+                                            'type' => 'users'
+                                       ],
+                                    ],
+                                    'links' => [
+                                        'related' => '/roles/3/users',
+                                        'self' => '/roles/3/relationships/users'
                                     ]
                                  ],
                             ],
@@ -341,6 +362,39 @@ class JsonApiViewTest extends TestCase
                                     'links' => [
                                         'related' => '/users/1/translations',
                                         'self' => '/users/1/relationships/translations'
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'id' => '5',
+                            'type' => 'users',
+                            'links' => [
+                                'self' => '/users/5'
+                            ],
+                            'relationships' => [
+                                'another_test' => [
+                                    'links' => [
+                                        'related' => '/users/5/another_test',
+                                        'self' => '/users/5/relationships/another_test'
+                                    ]
+                                ],
+                                'roles' => [
+                                    'links' => [
+                                        'related' => '/users/5/roles',
+                                        'self' => '/users/5/relationships/roles'
+                                    ]
+                                ],
+                                'parents' => [
+                                    'links' => [
+                                        'related' => '/users/5/parents',
+                                        'self' => '/users/5/relationships/parents'
+                                    ]
+                                ],
+                                'translations' => [
+                                    'links' => [
+                                        'related' => '/users/5/translations',
+                                        'self' => '/users/5/relationships/translations'
                                     ]
                                 ]
                             ]
@@ -351,7 +405,8 @@ class JsonApiViewTest extends TestCase
                     return [
                         'objects' => [
                             $Table->get(1, ['contain' => 'Users']),
-                            $Table->get(1, ['contain' => 'Users'])->set('id', 2),
+                            $Table->get(2, ['contain' => 'Users']),
+                            $Table->get(1, ['contain' => 'Users'])->set('id', 3),
                         ],
                         '_serialize' => true,
                         '_fields' => [


### PR DESCRIPTION
This PR removes duplicates in `included` response array: when same objects/resources are included in a GET list response those items are repeated in `included` array.
