### PR TITLE
Refactor tests on `default://` and `thumbnails://` filesystems

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/UploadComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/UploadComponentTest.php
@@ -46,7 +46,7 @@ class UploadComponentTest extends IntegrationTestCase
      */
     public function tearDown()
     {
-        $this->filesystemCleanup();
+        $this->filesystemRestore();
         parent::tearDown();
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/UploadControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/UploadControllerTest.php
@@ -44,7 +44,7 @@ class UploadControllerTest extends IntegrationTestCase
      */
     public function tearDown()
     {
-        $this->filesystemCleanup();
+        $this->filesystemRestore();
         parent::tearDown();
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/StreamTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/StreamTest.php
@@ -14,7 +14,7 @@
 namespace BEdita\Core\Test\TestCase\Model\Entity;
 
 use BEdita\Core\Filesystem\FilesystemRegistry;
-use Cake\Core\Configure;
+use BEdita\Core\Test\Utility\TestFilesystemTrait;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Text;
@@ -26,6 +26,7 @@ use Zend\Diactoros\Stream;
  */
 class StreamTest extends TestCase
 {
+    use TestFilesystemTrait;
 
     /**
      * Test subject
@@ -48,33 +49,13 @@ class StreamTest extends TestCase
     ];
 
     /**
-     * List of files to keep in test filesystem, and their contents.
-     *
-     * @var \Cake\Collection\Collection
-     */
-    private $keep = [];
-
-    /**
      * {@inheritDoc}
      */
     public function setUp()
     {
         parent::setUp();
-
-        FilesystemRegistry::setConfig(Configure::read('Filesystem'));
+        $this->filesystemSetup();
         $this->Streams = TableRegistry::getTableLocator()->get('Streams');
-
-        $mountManager = FilesystemRegistry::getMountManager();
-        $this->keep = collection($mountManager->listContents('default://'))
-            ->map(function (array $object) use ($mountManager) {
-                $path = sprintf('%s://%s', $object['filesystem'], $object['path']);
-                $contents = fopen('php://memory', 'wb+');
-                fwrite($contents, $mountManager->read($path));
-                fseek($contents, 0);
-
-                return compact('contents', 'path');
-            })
-            ->compile();
     }
 
     /**
@@ -82,28 +63,8 @@ class StreamTest extends TestCase
      */
     public function tearDown()
     {
-        // Cleanup test filesystem.
-        $mountManager = FilesystemRegistry::getMountManager();
-        $keep = $this->keep
-            ->each(function (array $object) use ($mountManager) {
-                $mountManager->putStream($object['path'], $object['contents']);
-            })
-            ->map(function (array $object) {
-                return $object['path'];
-            })
-            ->toList();
-        collection($mountManager->listContents('default://'))
-            ->map(function (array $object) {
-                return sprintf('%s://%s', $object['filesystem'], $object['path']);
-            })
-            ->reject(function ($uri) use ($keep) {
-                return in_array($uri, $keep);
-            })
-            ->each([$mountManager, 'delete']);
-
+        $this->filesystemRestore();
         unset($this->Streams);
-        FilesystemRegistry::dropAll();
-
         parent::tearDown();
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/StreamsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/StreamsTableTest.php
@@ -13,9 +13,8 @@
 
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
-use BEdita\Core\Filesystem\FilesystemRegistry;
 use BEdita\Core\Model\Table\ObjectsTable;
-use Cake\Core\Configure;
+use BEdita\Core\Test\Utility\TestFilesystemTrait;
 use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -27,6 +26,7 @@ use Cake\Utility\Text;
  */
 class StreamsTableTest extends TestCase
 {
+    use TestFilesystemTrait;
 
     /**
      * Test subject
@@ -49,33 +49,13 @@ class StreamsTableTest extends TestCase
     ];
 
     /**
-     * List of files to keep in test filesystem, and their contents.
-     *
-     * @var \Cake\Collection\Collection
-     */
-    protected $keep;
-
-    /**
      * {@inheritDoc}
      */
     public function setUp()
     {
         parent::setUp();
-
-        FilesystemRegistry::setConfig(Configure::read('Filesystem'));
         $this->Streams = TableRegistry::getTableLocator()->get('Streams');
-
-        $mountManager = FilesystemRegistry::getMountManager();
-        $this->keep = collection($mountManager->listContents('default://'))
-            ->map(function (array $object) use ($mountManager) {
-                $path = sprintf('%s://%s', $object['filesystem'], $object['path']);
-                $contents = fopen('php://memory', 'wb+');
-                fwrite($contents, $mountManager->read($path));
-                fseek($contents, 0);
-
-                return compact('contents', 'path');
-            })
-            ->compile();
+        $this->filesystemSetup(true, true);
     }
 
     /**
@@ -83,28 +63,8 @@ class StreamsTableTest extends TestCase
      */
     public function tearDown()
     {
-        // Cleanup test filesystem.
-        $mountManager = FilesystemRegistry::getMountManager();
-        $keep = $this->keep
-            ->each(function (array $object) use ($mountManager) {
-                $mountManager->putStream($object['path'], $object['contents']);
-            })
-            ->map(function (array $object) {
-                return $object['path'];
-            })
-            ->toList();
-        collection($mountManager->listContents('default://'))
-            ->map(function (array $object) {
-                return sprintf('%s://%s', $object['filesystem'], $object['path']);
-            })
-            ->reject(function ($uri) use ($keep) {
-                return in_array($uri, $keep);
-            })
-            ->each([$mountManager, 'delete']);
-
+        $this->filesystemRestore();
         unset($this->Streams);
-        FilesystemRegistry::dropAll();
-
         parent::tearDown();
     }
 

--- a/plugins/BEdita/Core/tests/Utility/TestFilesystemTrait.php
+++ b/plugins/BEdita/Core/tests/Utility/TestFilesystemTrait.php
@@ -90,7 +90,7 @@ trait TestFilesystemTrait
     }
 
     /**
-     * Restore original filesystem content amd remove new files.
+     * Restore original filesystem content and remove new files.
      * Call this method in test `tearDown()`
      * or after tests involving filesystem.
      *

--- a/plugins/BEdita/Core/tests/Utility/TestFilesystemTrait.php
+++ b/plugins/BEdita/Core/tests/Utility/TestFilesystemTrait.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Test\Utility;
 
 use BEdita\Core\Filesystem\FilesystemRegistry;
+use Cake\Collection\CollectionInterface;
 use Cake\Core\Configure;
 
 /**
@@ -24,46 +25,100 @@ trait TestFilesystemTrait
     /**
      * List of files to keep in test filesystem, and their contents.
      *
-     * @var \Cake\Collection\Collection
+     * @var array
      */
-    protected $keep = [];
+    protected $keep = [
+        'default://' => [],
+        'thumbnails://' => [],
+    ];
+
+    /**
+     * Use recursion in directories.
+     *
+     * @var array
+     */
+    protected $recursive = [
+        'default://' => false,
+        'thumbnails://' => true,
+    ];
 
     /**
      * Setup test filesystem.
      * Call this method in test `setUp()`
      * or before tests involving filesystem.
      *
+     * @param bool $default Setup `default://`filesystem.
+     * @param bool $thumbnails Setup `thumbnails://`filesystem.
      * @return void
      */
-    protected function filesystemSetup(): void
+    protected function filesystemSetup(bool $default = true, bool $thumbnails = false): void
     {
         FilesystemRegistry::setConfig(Configure::read('Filesystem'));
 
-        $mountManager = FilesystemRegistry::getMountManager();
-        $this->keep = collection($mountManager->listContents('default://'))
-            ->map(function (array $object) use ($mountManager) {
-                $path = sprintf('%s://%s', $object['filesystem'], $object['path']);
-                $contents = fopen('php://memory', 'wb+');
-                fwrite($contents, $mountManager->read($path));
-                fseek($contents, 0);
-
-                return compact('contents', 'path');
-            })
-            ->compile();
+        if ($default) {
+            $this->keep['default://'] = $this->keepCollection('default://');
+        }
+        if ($thumbnails) {
+            $this->keep['thumbnails://'] = $this->keepCollection('thumbnails://');
+        }
     }
 
     /**
-     * Setup test filesystem.
+     * Retrieve collection of file contents and paths to keep after test execution
+     *
+     * @param string $directory Directory content to list.
+     * @return \Cake\Collection\CollectionInterface
+     */
+    protected function keepCollection(string $directory): CollectionInterface
+    {
+        $mountManager = FilesystemRegistry::getMountManager();
+        $recursive = $this->recursive[$directory];
+
+        return collection($mountManager->listContents($directory, $recursive))
+                ->reject(function (array $object) {
+                    return $object['type'] === 'dir';
+                })
+                ->map(function (array $object) use ($mountManager) {
+                    $path = sprintf('%s://%s', $object['filesystem'], $object['path']);
+                    $contents = fopen('php://memory', 'wb+');
+                    fwrite($contents, $mountManager->read($path));
+                    fseek($contents, 0);
+
+                    return compact('contents', 'path');
+                })
+                ->compile();
+    }
+
+    /**
+     * Restore original filesystem content amd remove new files.
      * Call this method in test `tearDown()`
      * or after tests involving filesystem.
      *
      * @return void
      */
-    protected function filesystemCleanup(): void
+    protected function filesystemRestore(): void
     {
-        // Cleanup test filesystem.
+        foreach ($this->keep as $directory => $items) {
+            if (!empty($items)) {
+                $keep = $this->restoreFiles($directory);
+                $this->removeFiles($directory, $keep);
+            }
+        }
+
+        FilesystemRegistry::dropAll();
+    }
+
+    /**
+     * Restore file contents in a directory
+     *
+     * @param string $directory The Directory.
+     * @return array
+     */
+    protected function restoreFiles(string $directory): array
+    {
         $mountManager = FilesystemRegistry::getMountManager();
-        $keep = $this->keep
+
+        return $this->keep[$directory]
             ->each(function (array $object) use ($mountManager) {
                 $mountManager->putStream($object['path'], $object['contents']);
             })
@@ -71,7 +126,21 @@ trait TestFilesystemTrait
                 return $object['path'];
             })
             ->toList();
-        collection($mountManager->listContents('default://'))
+    }
+
+    /**
+     * Remove new files from directory not listed in $keep.
+     *
+     * @param string $directory Directory content to list.
+     * @param array $keep Files to keep.
+     * @return void
+     */
+    protected function removeFiles(string $directory, array $keep): void
+    {
+        $mountManager = FilesystemRegistry::getMountManager();
+        $recursive = $this->recursive[$directory];
+
+        collection($mountManager->listContents($directory, $recursive))
             ->map(function (array $object) {
                 return sprintf('%s://%s', $object['filesystem'], $object['path']);
             })
@@ -79,7 +148,5 @@ trait TestFilesystemTrait
                 return in_array($uri, $keep);
             })
             ->each([$mountManager, 'delete']);
-
-        FilesystemRegistry::dropAll();
     }
 }


### PR DESCRIPTION
In this PR:

* `TestFilesystemTrait` improved to handle both `default://` and `thumbnails://` filesystems
* trait used in all test cases using local files
* fixed a problem in `StreamsTableTest::testAfterDelete`  where a file was missing from `test/thumbnails` folder after test exectuion