### PR TITLE
Limit uname max length

### DIFF
--- a/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -40,14 +40,21 @@ class UniqueNameBehavior extends Behavior
     const UNAME_MAX_REGENERATE = 10;
 
     /**
+     * Max regenerate iterations to avoid duplicates.
+     *
+     * @var int
+     */
+    const UNAME_MAX_LENGTH = 255;
+
+    /**
      * Default configuration.
      *
      * Possible keys are:
      *  - 'sourceField' field value to use for unique name creation
      *  - 'prefix' constant prefix to use
      *  - 'replacement' character replacement for space
-     *  - 'separator' seaparator of `hash` suffix
-     *  - 'hashlength' `hash` suffix length
+     *  - 'separator' hash suffix separator
+     *  - 'hashlength' hash suffix length
      *  - 'generator' callable function for unique name generation, if set all other keys are ignored
      *
      * @var array
@@ -56,7 +63,7 @@ class UniqueNameBehavior extends Behavior
         'sourceField' => 'title',
         'prefix' => '',
         'replacement' => '-',
-        'separator' => '_',
+        'separator' => '-',
         'hashlength' => 6,
         'generator' => null,
     ];
@@ -83,7 +90,7 @@ class UniqueNameBehavior extends Behavior
             $uname = $this->generateUniqueName($entity, true);
         }
 
-        $entity->set('uname', $uname);
+        $entity->set('uname', Text::truncate($uname, self::UNAME_MAX_LENGTH));
     }
 
     /**
@@ -131,7 +138,8 @@ class UniqueNameBehavior extends Behavior
             if (!empty($config['hashlength'])) {
                 $hash = substr($hash, 0, $config['hashlength']);
             }
-            $uname .= $config['separator'] . $hash;
+            $maxLen = self::UNAME_MAX_LENGTH - strlen($hash) - 1;
+            $uname = Text::truncate($uname, $maxLen) . $config['separator'] . $hash;
         }
 
         return strtolower($uname);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Test\TestCase\Model\Behavior;
 
+use BEdita\Core\Model\Behavior\UniqueNameBehavior;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
@@ -41,6 +42,7 @@ class UniqueNameBehaviorTest extends TestCase
         'plugin.BEdita/Core.Objects',
         'plugin.BEdita/Core.Profiles',
         'plugin.BEdita/Core.Users',
+        'plugin.BEdita/Core.History',
     ];
 
     /**
@@ -317,7 +319,7 @@ class UniqueNameBehaviorTest extends TestCase
         $document->set('uname', '');
         $document->set('title', '');
         $behavior->uniqueName($document);
-        static::assertContains('documents_', $document->get('uname'));
+        static::assertContains('documents-', $document->get('uname'));
     }
 
     /**
@@ -342,5 +344,29 @@ class UniqueNameBehaviorTest extends TestCase
         });
 
         $Documents->save($entity);
+    }
+
+    /**
+     * Test unique name max lenght
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testUniqueNameMaxLen()
+    {
+        $Documents = TableRegistry::getTableLocator()->get('Documents');
+        $behavior = $Documents->behaviors()->get('UniqueName');
+
+        // check internal uname generation lenght
+        $data = ['title' => str_repeat('new title', 100)];
+        $document = $Documents->newEntity($data);
+        $behavior->uniqueName($document);
+        $this->assertEquals(strlen($document->get('uname')), UniqueNameBehavior::UNAME_MAX_LENGTH);
+
+        // limit explicit uname set lenght
+        $document->set('uname', str_repeat('new-uname', 100));
+        $behavior->uniqueName($document);
+        $this->assertEquals(strlen($document->get('uname')), UniqueNameBehavior::UNAME_MAX_LENGTH);
     }
 }


### PR DESCRIPTION
This PR limits uname max length in order to avoid insert/update errors on RDBMS where `uname` lenght is usually limited to `255`.

Bonus track: default hash separator changed to `-` to be more URL-friendly