### PR TITLE
Message error for duplicate permissions on bulk edit

### DIFF
--- a/bedita-app/app_controller.php
+++ b/bedita-app/app_controller.php
@@ -1334,7 +1334,7 @@ abstract class ModulesController extends AppController {
                     return sprintf("object: %s, skipped: %s", $objectId, implode(', ', $permissionNames));
                 }, $duplicatePermissions, array_keys($duplicatePermissions));
                 
-                throw new BeditaException(__("Some permissions where already set and have been skipped", true),
+                throw new BeditaException(__("Some permissions were set already and have been skipped", true),
                     implode(" - ", $errorDetails));
             }
         }

--- a/bedita-app/app_controller.php
+++ b/bedita-app/app_controller.php
@@ -1320,15 +1320,15 @@ abstract class ModulesController extends AppController {
                         ),
                     ));
                     if ($countPermission > 0) {
-                        $errors[$objectId][] = sprintf(__("permission '%s' already set", true), $permissionData['name']);
+                        $errors[$objectId][] = sprintf(__("permission for '%s' already set", true), $permissionData['name']);
                         continue;
                     }
 
                     try {
                         $permission->add($objectId, array($permissionData));
                     } catch (Exception $e) {
-                        $errors[$objectId][] = sprintf(__("error adding permission '%s': %s", true), $e->getMessage());
-                        // TODO: write to log
+                        $errors[$objectId][] = sprintf(__("error adding permission for '%s': %s", true), $e->getMessage());
+                        $this->log(sprintf("Error adding permission '%s' to object %s: %s", $permissionData['name'], $objectId, $e->getMessage()), 'error');
                     }
                 }
             }

--- a/bedita-app/locale/deu/LC_MESSAGES/default.po
+++ b/bedita-app/locale/deu/LC_MESSAGES/default.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 3\n"
-"POT-Creation-Date: 2020-05-25 12:01:28\n"
+"POT-Creation-Date: 2020-05-26 09:30:51\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Nils-Christoph Fiedler <ncfiedler@fedoraproject.org>\n"
 "Language-Team: Bedita I18N & I10N Team\n"
@@ -1465,6 +1465,9 @@ msgstr ""
 msgid "Not Authorized"
 msgstr "Nicht autorisiert"
 
+msgid "Not all permissions have been added"
+msgstr ""
+
 msgid "Notes"
 msgstr "Notizen"
 
@@ -1778,9 +1781,6 @@ msgstr ""
 
 msgid "Software"
 msgstr "Software"
-
-msgid "Some permissions were set already and have been skipped"
-msgstr ""
 
 msgid "Something seems wrong. bedita_module_setup.php didn't found"
 msgstr ""
@@ -2562,6 +2562,9 @@ msgstr ""
 msgid "end"
 msgstr "Ende"
 
+msgid "error adding permission for '%s': %s"
+msgstr ""
+
 msgid "events"
 msgstr "Ereignisse"
 
@@ -3095,6 +3098,9 @@ msgstr "wartenden Emails"
 
 msgid "permission"
 msgstr "Erlaubnis"
+
+msgid "permission for '%s' already set"
+msgstr ""
 
 msgid "permission type"
 msgstr ""

--- a/bedita-app/locale/deu/LC_MESSAGES/default.po
+++ b/bedita-app/locale/deu/LC_MESSAGES/default.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 3\n"
-"POT-Creation-Date: 2020-05-12 17:00:12\n"
+"POT-Creation-Date: 2020-05-25 12:01:28\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Nils-Christoph Fiedler <ncfiedler@fedoraproject.org>\n"
 "Language-Team: Bedita I18N & I10N Team\n"
@@ -1778,6 +1778,9 @@ msgstr ""
 
 msgid "Software"
 msgstr "Software"
+
+msgid "Some permissions were set already and have been skipped"
+msgstr ""
 
 msgid "Something seems wrong. bedita_module_setup.php didn't found"
 msgstr ""

--- a/bedita-app/locale/eng/LC_MESSAGES/default.po
+++ b/bedita-app/locale/eng/LC_MESSAGES/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 3\n"
-"POT-Creation-Date: 2020-05-25 12:01:28\n"
+"POT-Creation-Date: 2020-05-26 09:30:51\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: Bedita I18N & I10N Team\n"
@@ -1433,6 +1433,9 @@ msgstr ""
 msgid "Not Authorized"
 msgstr ""
 
+msgid "Not all permissions have been added"
+msgstr ""
+
 msgid "Notes"
 msgstr ""
 
@@ -1745,9 +1748,6 @@ msgid "Smtp Options"
 msgstr ""
 
 msgid "Software"
-msgstr ""
-
-msgid "Some permissions were set already and have been skipped"
 msgstr ""
 
 msgid "Something seems wrong. bedita_module_setup.php didn't found"
@@ -2508,6 +2508,9 @@ msgstr ""
 msgid "end"
 msgstr ""
 
+msgid "error adding permission for '%s': %s"
+msgstr ""
+
 msgid "events"
 msgstr ""
 
@@ -3037,6 +3040,9 @@ msgid "pending"
 msgstr ""
 
 msgid "permission"
+msgstr ""
+
+msgid "permission for '%s' already set"
 msgstr ""
 
 msgid "permission type"

--- a/bedita-app/locale/eng/LC_MESSAGES/default.po
+++ b/bedita-app/locale/eng/LC_MESSAGES/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 3\n"
-"POT-Creation-Date: 2020-05-12 17:00:12\n"
+"POT-Creation-Date: 2020-05-25 12:01:28\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: Bedita I18N & I10N Team\n"
@@ -1745,6 +1745,9 @@ msgid "Smtp Options"
 msgstr ""
 
 msgid "Software"
+msgstr ""
+
+msgid "Some permissions were set already and have been skipped"
 msgstr ""
 
 msgid "Something seems wrong. bedita_module_setup.php didn't found"

--- a/bedita-app/locale/fra/LC_MESSAGES/default.po
+++ b/bedita-app/locale/fra/LC_MESSAGES/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 3\n"
-"POT-Creation-Date: 2020-05-25 12:01:28\n"
+"POT-Creation-Date: 2020-05-26 09:30:51\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: Bedita I18N & I10N Team\n"
@@ -1433,6 +1433,9 @@ msgstr ""
 msgid "Not Authorized"
 msgstr ""
 
+msgid "Not all permissions have been added"
+msgstr ""
+
 msgid "Notes"
 msgstr ""
 
@@ -1745,9 +1748,6 @@ msgid "Smtp Options"
 msgstr ""
 
 msgid "Software"
-msgstr ""
-
-msgid "Some permissions were set already and have been skipped"
 msgstr ""
 
 msgid "Something seems wrong. bedita_module_setup.php didn't found"
@@ -2508,6 +2508,9 @@ msgstr ""
 msgid "end"
 msgstr ""
 
+msgid "error adding permission for '%s': %s"
+msgstr ""
+
 msgid "events"
 msgstr ""
 
@@ -3037,6 +3040,9 @@ msgid "pending"
 msgstr ""
 
 msgid "permission"
+msgstr ""
+
+msgid "permission for '%s' already set"
 msgstr ""
 
 msgid "permission type"

--- a/bedita-app/locale/fra/LC_MESSAGES/default.po
+++ b/bedita-app/locale/fra/LC_MESSAGES/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 3\n"
-"POT-Creation-Date: 2020-05-12 17:00:12\n"
+"POT-Creation-Date: 2020-05-25 12:01:28\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: Bedita I18N & I10N Team\n"
@@ -1745,6 +1745,9 @@ msgid "Smtp Options"
 msgstr ""
 
 msgid "Software"
+msgstr ""
+
+msgid "Some permissions were set already and have been skipped"
 msgstr ""
 
 msgid "Something seems wrong. bedita_module_setup.php didn't found"

--- a/bedita-app/locale/ita/LC_MESSAGES/default.po
+++ b/bedita-app/locale/ita/LC_MESSAGES/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 3\n"
-"POT-Creation-Date: 2020-05-12 17:00:12\n"
+"POT-Creation-Date: 2020-05-25 12:01:28\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: Bedita I18N & I10N Team\n"
@@ -1778,6 +1778,9 @@ msgstr "Opzioni Smtp"
 
 msgid "Software"
 msgstr "Software"
+
+msgid "Some permissions were set already and have been skipped"
+msgstr "Alcuni permessi erano già presenti e sono stati ignorati"
 
 msgid "Something seems wrong. bedita_module_setup.php didn't found"
 msgstr "Errore. Impossibile trovare bedita_module_setup.php"

--- a/bedita-app/locale/ita/LC_MESSAGES/default.po
+++ b/bedita-app/locale/ita/LC_MESSAGES/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 3\n"
-"POT-Creation-Date: 2020-05-25 12:01:28\n"
+"POT-Creation-Date: 2020-05-26 09:30:51\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: Bedita I18N & I10N Team\n"
@@ -1460,6 +1460,9 @@ msgstr "Nessuno"
 msgid "Not Authorized"
 msgstr "Non Autorizzato"
 
+msgid "Not all permissions have been added"
+msgstr "Non tutti i permessi sono stati aggiunti"
+
 msgid "Notes"
 msgstr "Note"
 
@@ -1778,9 +1781,6 @@ msgstr "Opzioni Smtp"
 
 msgid "Software"
 msgstr "Software"
-
-msgid "Some permissions were set already and have been skipped"
-msgstr "Alcuni permessi erano già presenti e sono stati ignorati"
 
 msgid "Something seems wrong. bedita_module_setup.php didn't found"
 msgstr "Errore. Impossibile trovare bedita_module_setup.php"
@@ -2554,6 +2554,9 @@ msgstr "svuotare log"
 msgid "end"
 msgstr "fine"
 
+msgid "error adding permission for '%s': %s"
+msgstr "errore durante l'aggiunta dell'autorizzazione per '%s': %s"
+
 msgid "events"
 msgstr "eventi"
 
@@ -3087,6 +3090,9 @@ msgstr "in attesa"
 msgid "permission"
 msgstr "permesso"
 
+msgid "permission for '%s' already set"
+msgstr "autorizzazione per '%s' già impostata"
+
 msgid "permission type"
 msgstr "tipo di permesso"
 
@@ -3596,6 +3602,9 @@ msgstr "i tuoi 5 ultimi elementi"
 
 msgid "your message"
 msgstr "il tuo messaggio"
+
+#~ msgid "Some permissions were set already and have been skipped"
+#~ msgstr "Alcuni permessi erano già presenti e sono stati ignorati"
 
 #~ msgid "all areas"
 #~ msgstr "tutte le pubblicazioni"

--- a/bedita-app/locale/master.pot
+++ b/bedita-app/locale/master.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2020-05-12 17:00:12\n"
+"POT-Creation-Date: 2020-05-25 12:01:28\n"
 "MIME-Version: 1.0"
 "Content-Transfer-Encoding: 8bit\n"
 "Language-Team: BEdita I18N & I10N Team\n"
@@ -1723,6 +1723,9 @@ msgid "Smtp Options"
 msgstr ""
 
 msgid "Software"
+msgstr ""
+
+msgid "Some permissions were set already and have been skipped"
 msgstr ""
 
 msgid "Something seems wrong. bedita_module_setup.php didn't found"

--- a/bedita-app/locale/master.pot
+++ b/bedita-app/locale/master.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2020-05-25 12:01:28\n"
+"POT-Creation-Date: 2020-05-26 09:30:51\n"
 "MIME-Version: 1.0"
 "Content-Transfer-Encoding: 8bit\n"
 "Language-Team: BEdita I18N & I10N Team\n"
@@ -1413,6 +1413,9 @@ msgstr ""
 msgid "Not Authorized"
 msgstr ""
 
+msgid "Not all permissions have been added"
+msgstr ""
+
 msgid "Notes"
 msgstr ""
 
@@ -1723,9 +1726,6 @@ msgid "Smtp Options"
 msgstr ""
 
 msgid "Software"
-msgstr ""
-
-msgid "Some permissions were set already and have been skipped"
 msgstr ""
 
 msgid "Something seems wrong. bedita_module_setup.php didn't found"
@@ -2472,6 +2472,9 @@ msgstr ""
 msgid "end"
 msgstr ""
 
+msgid "error adding permission for '%s': %s"
+msgstr ""
+
 msgid "events"
 msgstr ""
 
@@ -3001,6 +3004,9 @@ msgid "pending"
 msgstr ""
 
 msgid "permission"
+msgstr ""
+
+msgid "permission for '%s' already set"
 msgstr ""
 
 msgid "permission type"

--- a/bedita-app/locale/por/LC_MESSAGES/default.po
+++ b/bedita-app/locale/por/LC_MESSAGES/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 3\n"
-"POT-Creation-Date: 2020-05-25 12:01:28\n"
+"POT-Creation-Date: 2020-05-26 09:30:51\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: Bedita I18N & I10N Team\n"
@@ -1433,6 +1433,9 @@ msgstr ""
 msgid "Not Authorized"
 msgstr ""
 
+msgid "Not all permissions have been added"
+msgstr ""
+
 msgid "Notes"
 msgstr ""
 
@@ -1745,9 +1748,6 @@ msgid "Smtp Options"
 msgstr ""
 
 msgid "Software"
-msgstr ""
-
-msgid "Some permissions were set already and have been skipped"
 msgstr ""
 
 msgid "Something seems wrong. bedita_module_setup.php didn't found"
@@ -2509,6 +2509,9 @@ msgstr ""
 msgid "end"
 msgstr ""
 
+msgid "error adding permission for '%s': %s"
+msgstr ""
+
 msgid "events"
 msgstr "eventos"
 
@@ -3038,6 +3041,9 @@ msgid "pending"
 msgstr ""
 
 msgid "permission"
+msgstr ""
+
+msgid "permission for '%s' already set"
 msgstr ""
 
 msgid "permission type"

--- a/bedita-app/locale/por/LC_MESSAGES/default.po
+++ b/bedita-app/locale/por/LC_MESSAGES/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 3\n"
-"POT-Creation-Date: 2020-05-12 17:00:12\n"
+"POT-Creation-Date: 2020-05-25 12:01:28\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: Bedita I18N & I10N Team\n"
@@ -1745,6 +1745,9 @@ msgid "Smtp Options"
 msgstr ""
 
 msgid "Software"
+msgstr ""
+
+msgid "Some permissions were set already and have been skipped"
 msgstr ""
 
 msgid "Something seems wrong. bedita_module_setup.php didn't found"

--- a/bedita-app/locale/spa/LC_MESSAGES/default.po
+++ b/bedita-app/locale/spa/LC_MESSAGES/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 3\n"
-"POT-Creation-Date: 2020-05-25 12:01:28\n"
+"POT-Creation-Date: 2020-05-26 09:30:51\n"
 "PO-Revision-Date: \n"
 "Last-Translator: taleo <supertaleo@libero.it>\n"
 "Language-Team: Bedita I18N & I10N Team\n"
@@ -1446,6 +1446,9 @@ msgstr ""
 msgid "Not Authorized"
 msgstr "No autorizado"
 
+msgid "Not all permissions have been added"
+msgstr ""
+
 msgid "Notes"
 msgstr "Notas"
 
@@ -1760,9 +1763,6 @@ msgstr "Opciones Smtp"
 
 msgid "Software"
 msgstr "Software"
-
-msgid "Some permissions were set already and have been skipped"
-msgstr ""
 
 msgid "Something seems wrong. bedita_module_setup.php didn't found"
 msgstr "Algo parece andar mal. No se encuentra bedita_module_setup.php"
@@ -2527,6 +2527,9 @@ msgstr "vacíar logs"
 msgid "end"
 msgstr "final"
 
+msgid "error adding permission for '%s': %s"
+msgstr ""
+
 msgid "events"
 msgstr "eventos"
 
@@ -3059,6 +3062,9 @@ msgstr "pendiente"
 
 msgid "permission"
 msgstr "permisos"
+
+msgid "permission for '%s' already set"
+msgstr ""
 
 msgid "permission type"
 msgstr ""

--- a/bedita-app/locale/spa/LC_MESSAGES/default.po
+++ b/bedita-app/locale/spa/LC_MESSAGES/default.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: BEdita 3\n"
-"POT-Creation-Date: 2020-05-12 17:00:12\n"
+"POT-Creation-Date: 2020-05-25 12:01:28\n"
 "PO-Revision-Date: \n"
 "Last-Translator: taleo <supertaleo@libero.it>\n"
 "Language-Team: Bedita I18N & I10N Team\n"
@@ -1760,6 +1760,9 @@ msgstr "Opciones Smtp"
 
 msgid "Software"
 msgstr "Software"
+
+msgid "Some permissions were set already and have been skipped"
+msgstr ""
 
 msgid "Something seems wrong. bedita_module_setup.php didn't found"
 msgstr "Algo parece andar mal. No se encuentra bedita_module_setup.php"

--- a/bedita-app/views/elements/message.tpl
+++ b/bedita-app/views/elements/message.tpl
@@ -24,7 +24,7 @@
 	
 {if !empty($detail)}
 <div class="messageDetail shadow" style="display:none">	
-	<p style="font-family:monospace;">{$detail|escape}</p>
+	<p style="font-family:monospace; white-space: pre-wrap;">{$detail|escape}</p>
 	<hr />
 	<a class="closemessage" href="javascript:void(0)">
 		{t}close{/t}</a>	

--- a/bedita-app/views/i18n.tpl
+++ b/bedita-app/views/i18n.tpl
@@ -100,4 +100,7 @@ Strings to translate not present in .tpl/.php files
 {t}recipient{/t}
 {t}mail body{/t}
 {t}log level{/t}
+
+// permissions bulk edit error message
+{t}Some permissions were set already and have been skipped{/t}
 *}

--- a/bedita-app/views/i18n.tpl
+++ b/bedita-app/views/i18n.tpl
@@ -102,5 +102,7 @@ Strings to translate not present in .tpl/.php files
 {t}log level{/t}
 
 // permissions bulk edit error message
-{t}Some permissions were set already and have been skipped{/t}
+{t}Not all permissions have been added{/t}
+{t}permission for '%s' already set{/t}
+{t}error adding permission for '%s': %s{/t}
 *}

--- a/bedita-app/webroot/css/bedita.css
+++ b/bedita-app/webroot/css/bedita.css
@@ -2009,14 +2009,14 @@ A.BEbutton.golink:before {
 
 .messageDetail {
 	width:340px; 
-	min-height:136px; 
+	min-height:140px; 
 	padding:10px;
 	background-color:#FFF;
 	color:#000;
 	position: absolute !important;
 	max-height: 100%;
 	overflow-y: auto;
-	left: 140px;
+	left: 300px;
 	top: 0px;
 }
 


### PR DESCRIPTION
This PR adds error details for bulk edit of permissions.

The new error message shows to the user which objects already had the permissions.