### PR TITLE
Feat add `Relations::update()`

### DIFF
--- a/plugins/BEdita/Core/src/Utility/Relations.php
+++ b/plugins/BEdita/Core/src/Utility/Relations.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Utility;
 
+use Cake\Datasource\EntityInterface;
 use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
@@ -169,6 +170,54 @@ class Relations
             ->get('Relations', $options)
             ->get($relation);
         static::removeTypes($relation->get('id'), [$type], $side, $options);
+    }
+
+    /**
+     * Update relation array.
+     *
+     * @param array $data Relation data
+     * @param array $options Table locator options
+     * @return array
+     */
+    public static function update(array $data, array $options = []): array
+    {
+        $Relations = TableRegistry::getTableLocator()->get('Relations', $options);
+
+        foreach ($data as $r) {
+            $relation = $Relations->find()
+                ->where(['name' => Hash::get($r, 'name')])
+                ->contain(['LeftObjectTypes', 'RightObjectTypes'])
+                ->firstOrFail();
+            static::updateTypes($relation, $r, $options);
+            foreach ($r as $k => $v) {
+                $relation->set($k, $v);
+            }
+            $result[] = $Relations->saveOrFail($relation);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Update relation types of relation
+     *
+     * @param EntityInterace $relation Relation entity
+     * @param array $data Relation data
+     * @param array $options Table locator options
+     * @return void
+     */
+    protected static function updateTypes(EntityInterface $relation, array $data, array $options): void
+    {
+        $id = $relation->get('id');
+        foreach (['left', 'right'] as $side) {
+            $newTypes = (array)Hash::get($data, $side);
+            if (!empty($newTypes)) {
+                $currTypes = (array)Hash::extract($relation, sprintf('%s_object_types.{n}.name', $side));
+                static::removeTypes($id, array_diff($currTypes, $newTypes), $side, $options);
+                static::addTypes($id, array_diff($newTypes, $currTypes), $side, $options);
+            }
+        }
+        $relation->unsetProperty(['left_object_types', 'right_object_types']);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Utility/Relations.php
+++ b/plugins/BEdita/Core/src/Utility/Relations.php
@@ -183,12 +183,13 @@ class Relations
     {
         $Relations = TableRegistry::getTableLocator()->get('Relations', $options);
 
+        $result = [];
         foreach ($data as $r) {
             $relation = $Relations->find()
                 ->where(['name' => Hash::get($r, 'name')])
                 ->contain(['LeftObjectTypes', 'RightObjectTypes'])
                 ->firstOrFail();
-            static::updateTypes($relation, $r, $options);
+            static::updateTypes($relation, (array)$r, $options);
             foreach ($r as $k => $v) {
                 $relation->set($k, $v);
             }
@@ -201,7 +202,7 @@ class Relations
     /**
      * Update relation types of relation
      *
-     * @param EntityInterace $relation Relation entity
+     * @param \Cake\Datasource\EntityInterface $relation Relation entity
      * @param array $data Relation data
      * @param array $options Table locator options
      * @return void

--- a/plugins/BEdita/Core/src/Utility/Relations.php
+++ b/plugins/BEdita/Core/src/Utility/Relations.php
@@ -173,7 +173,7 @@ class Relations
     }
 
     /**
-     * Update relation array.
+     * Update relations in `relations` and  related `relation_types` tables using an array
      *
      * @param array $data Relation data
      * @param array $options Table locator options

--- a/plugins/BEdita/Core/tests/TestCase/Utility/RelationsTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/RelationsTest.php
@@ -17,6 +17,7 @@ use BEdita\Core\Utility\Relations;
 use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 
 /**
  * {@see \BEdita\Core\Utility\Relations} Test Case
@@ -132,5 +133,32 @@ class RelationsTest extends TestCase
 
         unset($this->relations[0]['left']);
         Relations::create($this->relations);
+    }
+
+    /**
+     * Test `update` method.
+     *
+     * @covers ::update()
+     * @covers ::updateTypes()
+     */
+    public function testUpdate()
+    {
+        $update = [
+            [
+                'name' => 'test_abstract',
+                'description' => 'a new description',
+                'left' => ['events', 'documents'],
+            ],
+        ];
+
+        $res = Relations::update($update);
+        static::assertEquals('a new description', Hash::get($res, '0.description'));
+
+        $leftTypes = TableRegistry::getTableLocator()
+            ->get('RelationTypes')
+            ->find()
+            ->where(['relation_id' => 3, 'side' => 'left'])
+            ->toArray();
+        static::assertEquals(2, count($leftTypes));
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
@@ -316,6 +316,19 @@ class ResourcesTest extends TestCase
                     ],
                 ],
             ],
+            'update relation' => [
+                [
+                    'update' => [
+                        'relations' => [
+                            [
+                                'name' => 'test_abstract',
+                                'left' => ['documents'],
+                                'right' => ['files'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
             'bad action' => [
                 [
                     'assign' => [
@@ -370,7 +383,9 @@ class ResourcesTest extends TestCase
                 } else {
                     $entity = $entities[0];
                     foreach ($details[0] as $name => $val) {
-                        static::assertEquals($val, $entity->get($name));
+                        if ($type != 'relations' || !in_array($name, ['left', 'right'])) {
+                            static::assertEquals($val, $entity->get($name));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This PR adds a new `Relations::update()` method to update `relations` mainly on migrations and CLI scripts.
