### PR TITLE
Categories type finder + filter

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -720,4 +720,26 @@ class FilterQueryStringTest extends IntegrationTestCase
         static::assertArrayHasKey('data', $result);
         static::assertEquals($expected, Hash::extract($result['data'], '{n}.id'));
     }
+
+    /**
+     * Test `/model/categories?filter[type]={type}`.
+     *
+     * @return void
+     * @coversNothing
+     */
+    public function testCategoriesTypeFilter(): void
+    {
+        $this->configRequestHeaders();
+        $this->get('/model/categories?filter[type]=documents');
+        $result = json_decode((string)$this->_response->getBody(), true);
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertArrayHasKey('data', $result);
+        static::assertEquals(3, count($result['data']));
+
+        $this->configRequestHeaders();
+        $this->get('/model/categories?filter[type]=locations');
+        $result = json_decode((string)$this->_response->getBody(), true);
+        static::assertEquals(0, count($result['data']));
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Model\Table;
 
+use BEdita\Core\Exception\BadFilterException;
 use Cake\Event\Event;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
@@ -145,5 +146,24 @@ class CategoriesTable extends CategoriesTagsBaseTable
             return;
         }
         $this->hideFields($query);
+    }
+
+    /**
+     * Find categories by object type name
+     *
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @param array $options Options array.
+     * @return \Cake\ORM\Query
+     * @throws BadFilterException
+     */
+    public function findType(Query $query, array $options): Query
+    {
+        if (empty($options[0])) {
+            throw new BadFilterException(__d('bedita', 'Missing required parameter "{0}"', 'type'));
+        }
+
+        return $query->innerJoinWith('ObjectTypes', function (Query $query) use ($options) {
+            return $query->where([$this->ObjectTypes->aliasField('name') => $options[0]]);
+        });
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/CategoriesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/CategoriesTableTest.php
@@ -135,10 +135,13 @@ class CategoriesTableTest extends TestCase
      */
     public function testFindCategoriesType()
     {
-        $categories = $this->Categories->find('type', ['documents'])->toArray();
+        $order = [
+            $this->Categories->aliasField('id') => 'ASC',
+        ];
+        $categories = $this->Categories->find('type', ['documents'])->order($order)->toArray();
         static::assertEquals([1, 2, 3], Hash::extract($categories, '{n}.id'));
 
-        $categories = $this->Categories->find('type', ['news'])->toArray();
+        $categories = $this->Categories->find('type', ['news'])->order($order)->toArray();
         static::assertEquals([], $categories);
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/CategoriesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/CategoriesTableTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2019 ChannelWeb Srl, Chialab Srl
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
+use BEdita\Core\Exception\BadFilterException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
@@ -124,5 +125,34 @@ class CategoriesTableTest extends TestCase
     {
         $categories = $this->Categories->find('enabled')->toArray();
         static::assertEquals([1, 2], Hash::extract($categories, '{n}.id'));
+    }
+
+    /**
+     * Test find categories by type
+     *
+     * @return void
+     * @covers ::findType()
+     */
+    public function testFindCategoriesType()
+    {
+        $categories = $this->Categories->find('type', ['documents'])->toArray();
+        static::assertEquals([1, 2, 3], Hash::extract($categories, '{n}.id'));
+
+        $categories = $this->Categories->find('type', ['news'])->toArray();
+        static::assertEquals([], $categories);
+    }
+
+    /**
+     * Test find categories by type failure
+     *
+     * @return void
+     * @covers ::findType()
+     */
+    public function testFindCategoriesTypeFail(): void
+    {
+        $this->expectException(BadFilterException::class);
+        $this->expectExceptionMessage('Missing required parameter "type"');
+
+        $this->Categories->find('type')->toArray();
     }
 }


### PR DESCRIPTION
This PR adds a finder to retrieve categories via type name.

Currently only an id base filter exists via `filter[object_type_id]={id}`

* `CategoriesTable::findType()` method was added
* unit tests on table class and integration tests on `filter[type]` have been added