### PR TITLE
Fix sort priority

### DIFF
--- a/plugins/BEdita/API/src/Datasource/JsonApiPaginator.php
+++ b/plugins/BEdita/API/src/Datasource/JsonApiPaginator.php
@@ -14,8 +14,11 @@
 namespace BEdita\API\Datasource;
 
 use Cake\Datasource\Paginator;
+use Cake\Datasource\QueryInterface;
 use Cake\Datasource\RepositoryInterface;
+use Cake\Datasource\ResultSetInterface;
 use Cake\Http\Exception\BadRequestException;
+use Cake\ORM\Query;
 
 /**
  * Handle model pagination using JSON API conventions.
@@ -41,6 +44,20 @@ class JsonApiPaginator extends Paginator
      * @var int
      */
     const MAX_LIMIT = 500;
+
+    /**
+     * Remove any other `order` clause if an explicit 'sort' is requested
+     *
+     * {@inheritDoc}
+     */
+    public function paginate($object, array $params = [], array $settings = []): ResultSetInterface
+    {
+        if ($object instanceof QueryInterface && !empty($params['sort'])) {
+            $object->order([], Query::OVERWRITE);
+        }
+
+        return parent::paginate($object, $params, $settings);
+    }
 
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/API/tests/TestCase/Datasource/JsonApiPaginatorTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Datasource/JsonApiPaginatorTest.php
@@ -17,6 +17,7 @@ use BEdita\API\Datasource\JsonApiPaginator;
 use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 
 /**
  * @coversDefaultClass \BEdita\API\Datasource\JsonApiPaginator
@@ -155,5 +156,24 @@ class JsonApiPaginatorTest extends TestCase
         $options = $paginator->validateSort($repository, compact('sort'));
 
         static::assertEquals($expected, $options['order']);
+    }
+
+    /**
+     * Test `paginate()` method.
+     *
+     * @covers ::paginate()
+     */
+    public function testPaginate()
+    {
+        $paginator = new JsonApiPaginator();
+
+        $query = TableRegistry::getTableLocator()->get('Roles')->find()->order('id');
+        $params = ['sort' => '-name'];
+        $res = $paginator->paginate($query, $params);
+
+        // using 'id' order we should have 'first role', 'second role'
+        // but '-name' order must prevail and invert above items
+        $names = Hash::extract($res->toArray(), '{n}.name');
+        static::assertEquals(['second role', 'first role'], $names);
     }
 }


### PR DESCRIPTION
This PR fixes a problem using `sort` query string.
In some scenarios, for example when ordering related objects, `sort` order must overwrite any other query order.

In cases like `GET /documents/{id}/{relation}?sort={field}` currently `{field}` order comes after the default order in related objects using `priority/inv_priority` field and can be as a result ineffective.

