### PR TITLE
Feat: date from/to filters on `DateRanges` 

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -47,11 +47,23 @@ class FilterQueryStringTest extends IntegrationTestCase
                'filter[date_ranges][start_date][gt]=2017-01-01',
                1
             ],
-            'none' => [
+            'simple 2' => [
+                'filter[date_ranges][from_date]=2017-01-01T14:00:00',
+                1
+             ],
+             'simple 3' => [
+                'filter[date_ranges][from_date]=2017-03-08T21:41:00',
+                0
+             ],
+             'none' => [
                'filter[date_ranges][end_date][le]=2017-01-01',
                0
             ],
-            'combined' => [
+            'none 2' => [
+                'filter[date_ranges][to_date]=2017-01-01',
+                0
+             ],
+             'combined' => [
                'filter[date_ranges][start_date][gt]=2017-01-01&filter[date_ranges][end_date][lt]=2017-04-01',
                1
             ],

--- a/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
@@ -205,7 +205,7 @@ class DateRangesTable extends Table
                     $q->newExpr()
                         ->gte($this->aliasField('end_date'), $from),
                 ]);
-            });
+        });
     }
 
     /**
@@ -225,7 +225,7 @@ class DateRangesTable extends Table
                     $q->newExpr()
                         ->lte($this->aliasField('end_date'), $to),
                 ]);
-            });
+        });
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
@@ -17,6 +17,7 @@ use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Model\Validation\Validation;
 use BEdita\Core\ORM\QueryFilterTrait;
 use Cake\Database\Expression\QueryExpression;
+use Cake\I18n\Time;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
@@ -164,6 +165,29 @@ class DateRangesTable extends Table
     }
 
     /**
+     * Create Time object from $time string
+     *
+     * @param string $time Input time.
+     * @return null|\Cake\I18n\Time
+     */
+    protected function getTime(string $time): ?Time
+    {
+        if (empty($time)) {
+            return null;
+        }
+        try {
+            $res = new Time($time);
+        } catch (\Exception $e) {
+            throw new BadFilterException([
+                'title' => __d('bedita', 'Invalid data'),
+                'detail' => __d('bedita', 'Wrong date time format "{0}"', $time),
+            ]);
+        }
+
+        return $res;
+    }
+
+    /**
      * Modify query object with `from_date`and `to_date` params
      *
      * @param \Cake\ORM\Query $query Query object instance.
@@ -172,8 +196,8 @@ class DateRangesTable extends Table
      */
     protected function fromToDateFilter(Query $query, array $options): Query
     {
-        $from = (string)Hash::get($options, 'from_date');
-        $to = (string)Hash::get($options, 'to_date');
+        $from = $this->getTime((string)Hash::get($options, 'from_date'));
+        $to = $this->getTime((string)Hash::get($options, 'to_date'));
         if (empty($from) && empty($to)) {
             return $query;
         }
@@ -192,10 +216,10 @@ class DateRangesTable extends Table
      * Add `from_date` query condition
      *
      * @param \Cake\ORM\Query $query Query object instance.
-     * @param string $from From date.
+     * @param Time $from From date.
      * @return \Cake\ORM\Query
      */
-    protected function fromDateFilter(Query $query, string $from): Query
+    protected function fromDateFilter(Query $query, Time $from): Query
     {
         return $query->where(function (QueryExpression $exp, Query $q) use ($from) {
                 return $exp->or_([
@@ -212,10 +236,10 @@ class DateRangesTable extends Table
      * Add `to_date` query condition
      *
      * @param \Cake\ORM\Query $query Query object instance.
-     * @param string $to To date.
+     * @param Time $to To date.
      * @return \Cake\ORM\Query
      */
-    protected function toDateFilter(Query $query, string $to): Query
+    protected function toDateFilter(Query $query, Time $to): Query
     {
         return $query->where(function (QueryExpression $exp, Query $q) use ($to) {
                 return $exp->or_([
@@ -232,11 +256,11 @@ class DateRangesTable extends Table
      * Add `from_date`/`to_date` query condition
      *
      * @param \Cake\ORM\Query $query Query object instance.
-     * @param string $from From date.
-     * @param string $to To date.
+     * @param Time $from From date.
+     * @param Time $to To date.
      * @return \Cake\ORM\Query
      */
-    protected function betweenDatesFilter(Query $query, string $from, string $to): Query
+    protected function betweenDatesFilter(Query $query, Time $from, Time $to): Query
     {
         return $query->where(function (QueryExpression $exp, Query $q) use ($from, $to) {
             return $exp->or_([

--- a/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -16,6 +16,7 @@ namespace BEdita\Core\Model\Table;
 use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Model\Validation\Validation;
 use BEdita\Core\ORM\QueryFilterTrait;
+use Cake\Database\Expression\QueryExpression;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
@@ -108,17 +109,25 @@ class DateRangesTable extends Table
      *
      * Create a query to filter objects using start and end date conditions.
      * Accepted options are:
-     *   - 'start_date' or 'end_date'
-     *   - mandatory sub-option must be one of 'gt' (greather than), 'lt' (less than),
+     *   - 'start_date', 'end_date', 'from_date' and 'to_date'
+     *   - when using 'from_date' or 'to_date' dates must be provided
+     *   - when using 'start_date' or 'end_date' mandatory sub-option
+     *          must be one of 'gt' (greather than), 'lt' (less than),
      *          'ge' (greater or equal), 'le' (less or equal) with a date
      *
      * Examples
      * ```
-     * // find events with a start date after '2017-03-01'
+     * // find objects with a start date after '2017-03-01'
      * $table->find('dateRanges', ['start_date' => ['gt' => '2017-03-01']]);
      *
-     * // find events with an ending date before '2017-05-01 22:00:00'
+     * // find objects with an ending date before '2017-05-01 22:00:00'
      * $table->find('dateRanges', ['end_date' => ['lt' => '2017-05-01 22:00:00']]);
+     *
+     * // find objects with valid date ranges from '2018-05-01 22:00:00' onwards
+     * $table->find('dateRanges', ['from_date' => '2018-05-01 22:00:00']);
+     *
+     * // find objects with valid date ranges until '2018-05-01 22:00:00'
+     * $table->find('dateRanges', [to_date' => '2018-05-01 22:00:00']);
      * ```
      *
      * @param \Cake\ORM\Query $query Query object instance.
@@ -128,7 +137,13 @@ class DateRangesTable extends Table
      */
     protected function findDateRanges(Query $query, array $options)
     {
-        $options = array_intersect_key($options, array_flip(['start_date', 'end_date', 'date']));
+        $allowed = array_flip([
+            'start_date',
+            'end_date',
+            'from_date',
+            'to_date'
+        ]);
+        $options = array_intersect_key($options, $allowed);
         if (empty($options)) {
             throw new BadFilterException([
                 'title' => __d('bedita', 'Invalid data'),
@@ -136,10 +151,10 @@ class DateRangesTable extends Table
             ]);
         }
 
-        $query = $this->customDateFilter($query, $options);
-        unset($options['date']);
+        $query = $this->fromToDateFilter($query, $options);
+        unset($options['from_date'], $options['to_date']);
 
-        // create filter with `start_date` and `end_date` if present in options
+        // filter on `start_date` and `end_date` fields
         $options = array_combine(
             array_map([$this, 'aliasField'], array_keys($options)),
             array_values($options)
@@ -148,39 +163,90 @@ class DateRangesTable extends Table
         return $this->fieldsFilter($query, $options);
     }
 
-    protected function customDateFilter(Query $query, array $options): Query
+    /**
+     * Modify query object with `from_date`and `to_date` params
+     *
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @param array $options Array of date conditions.
+     * @return \Cake\ORM\Query
+     */
+    protected function fromToDateFilter(Query $query, array $options): Query
     {
-        $custom = (string)Hash::get($options, 'date');
-        if (empty($custom)) {
+        $from = (string)Hash::get($options, 'from_date');
+        $to = (string)Hash::get($options, 'to_date');
+        if (empty($from) && empty($to)) {
             return $query;
         }
-        $method = sprintf('%sCustomFilter', $custom);
-        if (!method_exists($this, $method)) {
-            throw new BadFilterException([
-                'title' => __d('bedita', 'Invalid data'),
-                'detail' => __d('bedita', 'Custom date filter "{0}" not available', $custom)
-            ]);
+
+        if (empty($to)) {
+            return $this->fromDateFilter($query, $from);
+        }
+        if (empty($from)) {
+            return $this->toDateFilter($query, $to);
         }
 
-        return $this->{$method}($query);
+        return $this->betweenDatesFilter($query, $from, $to);
     }
 
-    protected function todayCustomFilter(Query $query): Query
+    /**
+     * Add `from_date` query condition
+     *
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @param string $from From date.
+     * @return \Cake\ORM\Query
+     */
+    protected function fromDateFilter(Query $query, string $from): Query
     {
-        $today = date('Y-m-d');
+        return $query->where(function (QueryExpression $exp, Query $q) use ($from) {
+                return $exp->or_([
+                    $q->newExpr()
+                        ->gte($this->aliasField('start_date'), $from)
+                        ->isNull($this->aliasField('end_date')),
+                    $q->newExpr()
+                        ->gte($this->aliasField('end_date'), $from),
+                ]);
+            });
+    }
 
-        return $query->where([$this->aliasField('start_date') => $today])
-            ->orWhere([
-                $this->aliasField('start_date') . ' <' => $today,
-                $this->aliasField('end_date') . ' >=' => $today,
+    /**
+     * Add `to_date` query condition
+     *
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @param string $to To date.
+     * @return \Cake\ORM\Query
+     */
+    protected function toDateFilter(Query $query, string $to): Query
+    {
+        return $query->where(function (QueryExpression $exp, Query $q) use ($to) {
+                return $exp->or_([
+                    $q->newExpr()
+                        ->lte($this->aliasField('start_date'), $to)
+                        ->isNull($this->aliasField('end_date')),
+                    $q->newExpr()
+                        ->lte($this->aliasField('end_date'), $to),
+                ]);
+            });
+    }
+
+    /**
+     * Add `from_date`/`to_date` query condition
+     *
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @param string $from From date.
+     * @param string $to To date.
+     * @return \Cake\ORM\Query
+     */
+    protected function betweenDatesFilter(Query $query, string $from, string $to): Query
+    {
+        return $query->where(function (QueryExpression $exp, Query $q) use ($from, $to) {
+            return $exp->or_([
+                $q->newExpr()
+                    ->gte($this->aliasField('start_date'), $from)
+                    ->lte($this->aliasField('start_date'), $to),
+                $q->newExpr()
+                    ->lte($this->aliasField('start_date'), $to)
+                    ->gte($this->aliasField('end_date'), $from),
             ]);
-    }
-
-    protected function futureCustomFilter(Query $query): Query
-    {
-        $today = date('Y-m-d');
-
-        return $query->where([$this->aliasField('start_date') . ' >=' => $today])
-            ->orWhere([$this->aliasField('end_date') . ' >=' => $today]);
+        });
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
@@ -161,7 +161,7 @@ class DateRangesTable extends Table
             array_values($options)
         );
 
-        return $this->fieldsFilter($query, $options);
+        return $this->fieldsFilter($query, (array)$options);
     }
 
     /**
@@ -176,15 +176,13 @@ class DateRangesTable extends Table
             return null;
         }
         try {
-            $res = new Time($time);
+            return new Time($time);
         } catch (\Exception $e) {
             throw new BadFilterException([
                 'title' => __d('bedita', 'Invalid data'),
                 'detail' => __d('bedita', 'Wrong date time format "{0}"', $time),
             ]);
         }
-
-        return $res;
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/DateRangesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/DateRangesTableTest.php
@@ -238,6 +238,7 @@ class DateRangesTableTest extends TestCase
      *
      * @dataProvider fromToDateFilterProvider
      * @covers ::fromToDateFilter()
+     * @covers ::getTime()
      * @covers ::fromDateFilter()
      * @covers ::toDateFilter()
      * @covers ::betweenDatesFilter()
@@ -247,5 +248,17 @@ class DateRangesTableTest extends TestCase
         $result = $this->DateRanges->find('dateRanges', $conditions)->toArray();
 
         static::assertEquals($numExpected, count($result));
+    }
+
+    /**
+     * Test `getTime` failure.
+     *
+     * @covers ::getTime()
+     */
+    public function testGetTimeFailure()
+    {
+        $conditions = ['from_date' => 'gustavo'];
+        $this->expectException('BEdita\Core\Exception\BadFilterException');
+        $this->DateRanges->find('dateRanges', $conditions)->toArray();
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/DateRangesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/DateRangesTableTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -157,6 +157,7 @@ class DateRangesTableTest extends TestCase
      *
      * @dataProvider findDateProvider
      * @covers ::findDateRanges()
+     * @covers ::fromToDateFilter()
      */
     public function testFindDate($conditions, $numExpected)
     {
@@ -174,8 +175,77 @@ class DateRangesTableTest extends TestCase
     {
         $conditions = ['what_date' => ['lt' => '2017-01-01']];
 
-        static::expectException('BEdita\Core\Exception\BadFilterException');
+        $this->expectException('BEdita\Core\Exception\BadFilterException');
 
         $this->DateRanges->find('dateRanges', $conditions)->toArray();
+    }
+
+    /**
+     * Data provider for `testFromToDateFilter` test case.
+     *
+     * @return array
+     */
+    public function fromToDateFilterProvider()
+    {
+        return [
+            'from ok' => [
+                [
+                    'from_date' => '2017-01-01',
+                ],
+                1,
+            ],
+            'from not' => [
+                [
+                    'from_date' => '2017-08-01',
+                ],
+                0,
+            ],
+            'to ok' => [
+                [
+                    'to_date' => '2018-01-01',
+                ],
+                1,
+            ],
+            'to not' => [
+                [
+                    'to_date' => '2017-01-01',
+                ],
+                0,
+            ],
+            'between ok' => [
+                [
+                    'from_date' => '2017-03-07 08:00:00',
+                    'to_date' => '2017-03-07 12:40:20',
+                ],
+                1,
+            ],
+            'between not' => [
+                [
+                    'from_date' => '2018-01-01',
+                    'to_date' => '2018-12-31',
+                ],
+                0,
+            ],
+        ];
+    }
+
+    /**
+     * Test `dateRanges` finder with `from_date` and `to_date`
+     *
+     * @param array $conditions Date conditions.
+     * @param array|false $numExpected Number of expected results.
+     * @return void
+     *
+     * @dataProvider fromToDateFilterProvider
+     * @covers ::fromToDateFilter()
+     * @covers ::fromDateFilter()
+     * @covers ::toDateFilter()
+     * @covers ::betweenDatesFilter()
+     */
+    public function testFromToDateFilter($conditions, $numExpected)
+    {
+        $result = $this->DateRanges->find('dateRanges', $conditions)->toArray();
+
+        static::assertEquals($numExpected, count($result));
     }
 }


### PR DESCRIPTION
This PR introduces new finder options and related query string options on `DateRanges`: `from_date` and `to_date`. 
These options allow to filter date ranges that are *valid* from/to a specific date.

API example:

 * `GET /events?filter[date_ranges][from_date]=2020-03-01` - date ranges having a `start_date` >= '2020-03-01' and a NULL `end_time` or and `end_time` >= '2020-03-01' 
 * `GET /events?filter[date_ranges][to_date]=2020-03-01` - date ranges having a `start_date` <= '2020-03-01' and a NULL `end_time` or having `end_time`  <=  '2020-03-01' 
 * `GET /events?filter[date_ranges][from_date]=2020-03-01T00:00:00&filter[date_ranges][to_date]=2020-03-01T23:59:59` - date_ranges valid on a specific day (we can use dates or date time with ISO 8601 format)