### PR TITLE
fix: use `available` finder on `relatedTo` assoc

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/RelationshipsParamsTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/RelationshipsParamsTest.php
@@ -394,11 +394,13 @@ class RelationshipsParamsTest extends IntegrationTestCase
 
         $this->assertResponseCode(200);
 
-        $existing = $this->ObjectRelations->exists([
-            'left_id' => 5,
-            'right_id' => 8,
-            'relation_id' => 2,
-        ]);
-        static::assertTrue($existing);
+        $related = $this->ObjectRelations->find()
+            ->where([
+                'relation_id' => 2,
+                'right_id' => 8,
+            ])
+            ->toArray();
+        static::assertEquals(1, count($related));
+        static::assertEquals(5, $related[0]->get('left_id'));
     }
 }

--- a/plugins/BEdita/API/tests/IntegrationTest/RelationshipsParamsTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/RelationshipsParamsTest.php
@@ -364,4 +364,41 @@ class RelationshipsParamsTest extends IntegrationTestCase
         ]);
         static::assertTrue($existing);
     }
+
+    /**
+     * Test patch relationships.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testPatch()
+    {
+        $data = [
+            [
+                'id' => '5',
+                'type' => 'users',
+                'meta' => [
+                    'relation' => [
+                        'params' => [
+                            'name' => 'Gustavo',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $endpoint = sprintf('/locations/8/relationships/inverse_another_test');
+        $this->patch($endpoint, json_encode(compact('data')));
+
+        $this->assertResponseCode(200);
+
+        $existing = $this->ObjectRelations->exists([
+            'left_id' => 5,
+            'right_id' => 8,
+            'relation_id' => 2,
+        ]);
+        static::assertTrue($existing);
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
@@ -131,8 +131,8 @@ class RelationsBehavior extends Behavior
                 'targetForeignKey' => 'right_id',
                 'conditions' => [
                     $through->aliasField('relation_id') => $relation->id,
-                    sprintf('%s.deleted', $relation->alias) => false,
                 ],
+                'finder' => 'available',
                 'sort' => [
                     $through->aliasField('priority') => 'asc',
                 ],
@@ -166,8 +166,8 @@ class RelationsBehavior extends Behavior
                 'targetForeignKey' => 'left_id',
                 'conditions' => [
                     $through->aliasField('relation_id') => $relation->id,
-                    sprintf('%s.deleted', $relation->inverse_alias) => false,
                 ],
+                'finder' => 'available',
                 'sort' => [
                     $through->aliasField('inv_priority') => 'asc',
                 ],

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -411,7 +411,7 @@ class ObjectsTable extends Table
             $query = $query->find('statusLevel', [Configure::read('Status.level')]);
         }
 
-        return $query->where(['deleted' => 0]);
+        return $query->where([$this->aliasField('deleted') => 0]);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsActionTest.php
@@ -35,6 +35,8 @@ class ListRelatedObjectsActionTest extends TestCase
         'plugin.BEdita/Core.ObjectTypes',
         'plugin.BEdita/Core.Relations',
         'plugin.BEdita/Core.RelationTypes',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.PropertyTypes',
         'plugin.BEdita/Core.Objects',
         'plugin.BEdita/Core.ObjectRelations',
         'plugin.BEdita/Core.Profiles',
@@ -44,6 +46,7 @@ class ListRelatedObjectsActionTest extends TestCase
         'plugin.BEdita/Core.Users',
         'plugin.BEdita/Core.Categories',
         'plugin.BEdita/Core.ObjectCategories',
+        'plugin.BEdita/Core.History',
     ];
 
     /**
@@ -273,6 +276,42 @@ class ListRelatedObjectsActionTest extends TestCase
         $result = $action(['primaryKey' => $id] + compact('list', 'only'));
         $result = json_decode(json_encode($result->toArray()), true);
 
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test that deleted objects will not show as related
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testDeleted(): void
+    {
+        // set Document 3 `deleted`
+        // must not appear on right side of Document 2 `test` relation
+        $table = TableRegistry::getTableLocator()->get('Documents');
+        $entity = $table->get(3);
+        $entity->set('deleted', true);
+        $table->saveOrFail($entity);
+
+        $association = $table->getAssociation('test');
+        $action = new ListRelatedObjectsAction(compact('association'));
+
+        $result = $action(['primaryKey' => 2, 'list' => true]);
+        $result = json_decode(json_encode($result->toArray()), true);
+
+        $expected = [
+            [
+                'id' => 4,
+                'type' => 'profiles',
+                '_joinData' => [
+                    'priority' => 1,
+                    'inv_priority' => 2,
+                    'params' => null,
+                ],
+            ]
+        ];
         static::assertEquals($expected, $result);
     }
 }


### PR DESCRIPTION
This PR fixes an error invoking `PATCH` on object relationships involving object models using tables other than `objects`.

A new integration test `RelationshipsParamsTest::testpatch()` has been added that currently fails  