### PR TITLE
Search item count

### DIFF
--- a/bedita-app/app_model.php
+++ b/bedita-app/app_model.php
@@ -443,7 +443,6 @@ class BEAppModel extends AppModel {
 
                 // search all results
                 $options['searchOptions']['dim'] = 10000; // high number to get all results
-                $options['searchOptions']['all'] = true;
                 unset($options['searchOptions']['page']);
                 $searchEngineResult = $this->Behaviors->BuildFilter->searchEngineResult(
                     Configure::read('searchEngine'),
@@ -480,7 +479,7 @@ class BEAppModel extends AppModel {
         ));
 
         $query = $this->buildQueryStatement($clauses);
-
+debug($query);
         $tmp = $this->query($query);
         if ($tmp === false) {
             throw new BeditaException(__('Error finding objects', true));
@@ -555,7 +554,8 @@ class BEAppModel extends AppModel {
         if (!$executeQuery) {
             return $queryCount;
         }
-
+        debug($queryCount);
+        exit;
         $count = $this->query($queryCount);
         if ($count === false) {
             throw new BeditaException(__('Error counting objects', true));

--- a/bedita-app/app_model.php
+++ b/bedita-app/app_model.php
@@ -444,6 +444,7 @@ class BEAppModel extends AppModel {
                 // search all results
                 $options['searchOptions']['dim'] = 10000; // high number to get all results
                 $options['searchOptions']['all'] = true;
+                unset($options['searchOptions']['page']);
                 $searchEngineResult = $this->Behaviors->BuildFilter->searchEngineResult(
                     Configure::read('searchEngine'),
                     $options['searchOptions']

--- a/bedita-app/app_model.php
+++ b/bedita-app/app_model.php
@@ -479,7 +479,7 @@ class BEAppModel extends AppModel {
         ));
 
         $query = $this->buildQueryStatement($clauses);
-debug($query);
+
         $tmp = $this->query($query);
         if ($tmp === false) {
             throw new BeditaException(__('Error finding objects', true));
@@ -554,8 +554,7 @@ debug($query);
         if (!$executeQuery) {
             return $queryCount;
         }
-        debug($queryCount);
-        exit;
+
         $count = $this->query($queryCount);
         if ($count === false) {
             throw new BeditaException(__('Error counting objects', true));

--- a/bedita-app/app_model.php
+++ b/bedita-app/app_model.php
@@ -434,12 +434,14 @@ class BEAppModel extends AppModel {
         $afterFilter = $this->Behaviors->BuildFilter->prepareAfterFilter($filter, $order);
 
         $rankOrder = null;
+        $size = null;
 
-        // listen if search engine was used and eventually update $rankOrder
+        // listen if search engine was used and eventually update $rankOrder and $size
         BeLib::eventManager()->bind(
             'buildFindObjects.searchEngineResult',
-            function ($data) use (&$rankOrder) {
+            function ($data) use (&$rankOrder, &$size) {
                 $rankOrder = $data['order'];
+                $size = $data['count'];
                 return $data;
             }
         );
@@ -463,11 +465,6 @@ class BEAppModel extends AppModel {
         if ($tmp === false) {
             throw new BeditaException(__('Error finding objects', true));
         }
-
-        $size = $this->findObjectsCount(array(
-            'joins' => $clauses['joins'],
-            'conditions' => $clauses['conditions']
-        ));
 
         $recordset = array(
             'items'	=> array(),


### PR DESCRIPTION
This PR fixes an issue with item count in the pagination information.

It returned a count equal to the pagination size, because it used the same clauses as the previously run query which has results limited by pagination.

Instead, this PR uses the event `buildFindObjects.searchEngineResult` to get the correct total item count from the search engine.