### PR TITLE
DateRanges order

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/AssociatedEntitiesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/AssociatedEntitiesTest.php
@@ -16,6 +16,7 @@ use BEdita\API\TestSuite\IntegrationTestCase;
 use BEdita\Core\Filesystem\FilesystemRegistry;
 use Cake\Core\Configure;
 use Cake\ORM\TableRegistry;
+use Cake\Utility\Hash;
 
 /**
  * Test CRUD operations on objects with associated entities
@@ -43,11 +44,11 @@ class AssociatedEntitiesTest extends IntegrationTestCase
                     'title' => 'My Event',
                     'date_ranges' => [
                         [
-                            'start_date' => '2017-03-01 12:12:12',
-                            'end_date' => '2017-04-01 12:12:12',
+                            'start_date' => '2017-04-01T00:00:00+00:00',
                         ],
                         [
-                            'start_date' => '2017-04-01T00:00:00+00:00',
+                            'start_date' => '2017-03-01 12:12:12',
+                            'end_date' => '2017-04-01 12:12:12',
                         ],
                     ],
                 ],
@@ -121,7 +122,7 @@ class AssociatedEntitiesTest extends IntegrationTestCase
         $this->assertContentType('application/vnd.api+json');
 
         $resultDates = $result['data']['attributes']['date_ranges'];
-        $expectedDates = $attributes['date_ranges'];
+        $expectedDates = Hash::sort($attributes['date_ranges'], '{n}.start_date', 'asc');
         static::assertEquals(count($resultDates), count($expectedDates));
         $count = count($expectedDates);
         for ($i = 0; $i < $count; $i++) {

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -86,6 +86,7 @@ class ObjectsTable extends Table
         $this->hasMany('DateRanges', [
             'foreignKey' => 'object_id',
             'className' => 'BEdita/Core.DateRanges',
+            'sort' => ['start_date' => 'ASC'],
             'saveStrategy' => 'replace',
         ]);
         $this->belongsTo('CreatedByUsers', [


### PR DESCRIPTION
This PR introduces a sort order in `date_ranges` attributes: ranges array will be ordered from the oldest to the newest `start_date`

An intergation test has been modified in order to show this new order.

