### PR TITLE
Sanitize uname

### DIFF
--- a/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
@@ -85,10 +85,10 @@ class UniqueNameBehavior extends Behavior
         if (empty($uname)) {
             $uname = $this->generateUniqueName($entity);
         } else {
-            $uname = Text::slug($uname, [
+            $uname = strtolower(Text::slug($uname, [
                 'replacement' => $config['replacement'],
                 'preserve' => $config['preserve'],
-            ]);
+            ]));
         }
         $count = 0;
         while (

--- a/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
@@ -82,6 +82,9 @@ class UniqueNameBehavior extends Behavior
         if (empty($uname)) {
             $uname = $this->generateUniqueName($entity);
         }
+        else {
+            $uname = Text::slug($uname, $this->_defaultConfig['replacement']);
+        }
         $count = 0;
         while (
             $this->uniqueNameExists($uname, $entity->get('id'))

--- a/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
@@ -53,6 +53,7 @@ class UniqueNameBehavior extends Behavior
      *  - 'sourceField' field value to use for unique name creation
      *  - 'prefix' constant prefix to use
      *  - 'replacement' character replacement for space
+     *  - 'preserve' non-word character to preserve when creating slug
      *  - 'separator' hash suffix separator
      *  - 'hashlength' hash suffix length
      *  - 'generator' callable function for unique name generation, if set all other keys are ignored
@@ -63,6 +64,7 @@ class UniqueNameBehavior extends Behavior
         'sourceField' => 'title',
         'prefix' => '',
         'replacement' => '-',
+        'preserve' => '_',
         'separator' => '-',
         'hashlength' => 6,
         'generator' => null,
@@ -78,12 +80,15 @@ class UniqueNameBehavior extends Behavior
      */
     public function uniqueName(EntityInterface $entity)
     {
+        $config = $this->getConfig();
         $uname = $entity->get('uname');
         if (empty($uname)) {
             $uname = $this->generateUniqueName($entity);
-        }
-        else {
-            $uname = Text::slug($uname, $this->_defaultConfig['replacement']);
+        } else {
+            $uname = Text::slug($uname, [
+                'replacement' => $config['replacement'],
+                'preserve' => $config['preserve'],
+            ]);
         }
         $count = 0;
         while (
@@ -134,7 +139,11 @@ class UniqueNameBehavior extends Behavior
     public function uniqueNameFromValue($value, $regenerate = false, array $cfg = [])
     {
         $config = array_merge($this->getConfig(), $cfg);
-        $uname = $config['prefix'] . Text::slug($value, $config['replacement']);
+        $slug = Text::slug($value, [
+            'replacement' => $config['replacement'],
+            'preserve' => $config['preserve'],
+        ]);
+        $uname = $config['prefix'] . $slug;
         if ($regenerate) {
             $hash = Text::uuid();
             $hash = str_replace('-', '', $hash);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
@@ -83,6 +83,10 @@ class UniqueNameBehaviorTest extends TestCase
                 'Oèù yahìì',
                 'user-oeu-yahii',
             ],
+            'underscore' => [
+                'Guy_Dude',
+                'user-guy_dude',
+            ],
             'others' => [
                 '¬5654@-BIG STRING',
                 'user-5654-big-string',
@@ -265,6 +269,12 @@ class UniqueNameBehaviorTest extends TestCase
                     'hashlength' => 6,
                 ],
                 true
+            ],
+            'underscoreValue' => [
+                'test this_value',
+                'test-this_value',
+                [],
+                false,
             ],
         ];
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
@@ -17,6 +17,7 @@ use BEdita\Core\Model\Behavior\UniqueNameBehavior;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
+use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -83,7 +84,7 @@ class UniqueNameBehaviorTest extends TestCase
                 'Oèù yahìì',
                 'user-oeu-yahii',
             ],
-            'underscore' => [
+            'preserveUnderscore' => [
                 'Guy_Dude',
                 'user-guy_dude',
             ],
@@ -115,6 +116,48 @@ class UniqueNameBehaviorTest extends TestCase
         $Users->save($user);
 
         $this->assertEquals($user['uname'], $uname);
+    }
+
+    /**
+     * Data provider for `testUniqueName` test case.
+     *
+     * @return array
+     */
+    public function uniqueNameProvider()
+    {
+        return [
+            'mix' => [
+                'Amazing test! 100% gluten-free!',
+                'amazing-test-100-gluten-free',
+            ],
+            'preserveUnderscore' => [
+                '@Guy_Dude made this test',
+                'guy_dude-made-this-test',
+            ],
+            'accents' => [
+                'àéì òù',
+                'aei-ou',
+            ],
+        ];
+    }
+
+    /**
+     * testUniqueName method
+     *
+     * @param string $value Original uname.
+     * @param string $expected Expected sanitized uname.
+     * @return void
+     *
+     * @dataProvider uniqueNameProvider
+     * @covers ::uniqueName()
+     */
+    public function testUniqueName($value, $expected)
+    {
+        $behavior = TableRegistry::getTableLocator()->get('Objects')->behaviors()->get('UniqueName');
+        $entity = new Entity(['uname' => $value]);
+        $behavior->uniqueName($entity);
+
+        $this->assertEquals($expected, $entity->get('uname'));
     }
 
     /**


### PR DESCRIPTION
The current behavior is that when object's `uname` is empty, it gets generated as a slug of `title`.

This PR adds the "slugification" even when `uname` is manually inserted.