### PR TITLE
Add `config` and `auth_providers` to Resources utility

### DIFF
--- a/plugins/BEdita/Core/src/Model/Entity/Config.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Config.php
@@ -15,6 +15,7 @@ namespace BEdita\Core\Model\Entity;
 
 use BEdita\Core\Utility\JsonApiSerializable;
 use Cake\ORM\Entity;
+use Cake\ORM\TableRegistry;
 
 /**
  * Config Entity.
@@ -42,4 +43,29 @@ class Config extends Entity implements JsonApiSerializable
         'created' => false,
         'modified' => false,
     ];
+
+    /**
+     * Setter for `application` virtual property.
+     *
+     * @param string|null $application The application to set
+     * @return string|null
+     */
+    protected function _setApplication(?string $application): ?string
+    {
+        if ($application === null) {
+            $this->application_id = null;
+
+            return null;
+        }
+
+        $table = TableRegistry::getTableLocator()->get('Applications');
+        $this->application_id = $table
+            ->find('list', ['valueField' => 'id'])
+            ->where([
+                $table->aliasField('name') => $application,
+            ])
+            ->firstOrFail();
+
+        return $application;
+    }
 }

--- a/plugins/BEdita/Core/src/Utility/Resources.php
+++ b/plugins/BEdita/Core/src/Utility/Resources.php
@@ -65,6 +65,8 @@ class Resources
      */
     protected static $allowed = [
         'applications',
+        'auth_providers',
+        'config',
         'property_types',
         'object_types',
         'roles',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ConfigTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ConfigTest.php
@@ -87,4 +87,20 @@ class ConfigTest extends TestCase
         $this->assertEquals('group2', $config->context);
         $this->assertEquals('14', $config->content);
     }
+
+    /**
+     * Test `_setApplication` method
+     *
+     * @return void
+     * @covers ::_setApplication()
+     */
+    public function testSetApplication()
+    {
+        $config = $this->Config->get('Name2');
+        $config->set('application', null);
+        static::assertNull($config->get('application_id'));
+
+        $config->set('application', 'First app');
+        static::assertEquals(1, $config->get('application_id'));
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
@@ -34,8 +34,10 @@ class ResourcesTest extends TestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.Applications',
+        'plugin.BEdita/Core.AuthProviders',
         'plugin.BEdita/Core.Endpoints',
         'plugin.BEdita/Core.EndpointPermissions',
+        'plugin.BEdita/Core.Config',
         'plugin.BEdita/Core.Roles',
         'plugin.BEdita/Core.ObjectTypes',
         'plugin.BEdita/Core.PropertyTypes',
@@ -45,6 +47,7 @@ class ResourcesTest extends TestCase
         'plugin.BEdita/Core.Media',
         'plugin.BEdita/Core.Profiles',
         'plugin.BEdita/Core.Users',
+        'plugin.BEdita/Core.ExternalAuth',
         'plugin.BEdita/Core.Relations',
         'plugin.BEdita/Core.RelationTypes',
         'plugin.BEdita/Core.RolesUsers',
@@ -71,6 +74,31 @@ class ResourcesTest extends TestCase
                 [
                     [
                         'name' => 'new app',
+                    ],
+                ],
+            ],
+            'auth prov' => [
+                'auth_providers',
+                [
+                    [
+                        'name' => 'oauthsome',
+                        'auth_class' => 'BEdita/API.OAuth2',
+                        'url' => 'https://some.example.com/oauth2',
+                        'params' => [
+                            'provider_username_field' => 'owner_id',
+                        ],
+                        'enabled' => true,
+                    ],
+                ],
+            ],
+            'config' => [
+                'config',
+                [
+                    [
+                        'name' => 'Status',
+                        'context' => 'core',
+                        'content' => '{"level":"on"}',
+                        'application' => 'First app',
                     ],
                 ],
             ],
@@ -139,6 +167,22 @@ class ResourcesTest extends TestCase
                     ],
                 ],
             ],
+            'auth prov' => [
+                'auth_providers',
+                [
+                    [
+                        'name' => 'linkedout',
+                    ],
+                ],
+            ],
+            'config' => [
+                'config',
+                [
+                    [
+                        'name' => 'appVal',
+                    ],
+                ],
+            ],
             'objects' => [
                 'object_types',
                 [
@@ -204,6 +248,26 @@ class ResourcesTest extends TestCase
                     [
                         'name' => 'Disabled app',
                         'description' => 'A new description',
+                    ],
+                ],
+            ],
+            'auth prov' => [
+                'auth_providers',
+                [
+                    [
+                        'name' => 'linkedout',
+                        'params' => [
+                            'provider_username_field' => 'another_id',
+                        ],
+                    ],
+                ],
+            ],
+            'config' => [
+                'config',
+                [
+                    [
+                        'name' => 'appVal',
+                        'content' => '{"val": 50}',
                     ],
                 ],
             ],


### PR DESCRIPTION
This PR adds `config` and `auth_providers` as allowed resources handled by `Resources` utility class
