### PR TITLE
Ensure entity not marked as dirty promoting empty custom prop

### DIFF
--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -152,11 +152,7 @@ class CustomPropertiesBehavior extends Behavior
         }
         $entity[$field] = $entity[$field] + $this->getDefaultValues();
 
-        if (empty($entity[$field])) {
-            return $entity;
-        }
-
-        $customProps = $entity[$field];
+        $customProps = $entity[$field] ?? [];
         if ($entity instanceof EntityInterface) {
             $entity->setHidden([$field], true);
         } else {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
@@ -13,6 +13,8 @@
 
 namespace BEdita\Core\Test\TestCase\Model\Behavior;
 
+use BEdita\Core\Filesystem\FilesystemRegistry;
+use Cake\Core\Configure;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -39,7 +41,27 @@ class CustomPropertiesBehaviorTest extends TestCase
         'plugin.BEdita/Core.Profiles',
         'plugin.BEdita/Core.Users',
         'plugin.BEdita/Core.Media',
+        'plugin.BEdita/Core.Streams',
     ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        FilesystemRegistry::setConfig(Configure::read('Filesystem'));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        FilesystemRegistry::dropAll();
+        parent::tearDown();
+    }
 
     /**
      * Test initialization.
@@ -226,6 +248,7 @@ class CustomPropertiesBehaviorTest extends TestCase
             ->enableHydration($hydrate)
             ->first();
         if ($hydrate) {
+            static::assertFalse($result->isDirty());
             $result = $result->toArray();
         }
 


### PR DESCRIPTION
This PR ensure that `custom_props` field and consequently the entity itself is not marked as dirty when `CustomPropertiesBehavior` tries to promote empty custom properties.
