### PR TITLE
fix: avoid Table reconfigure error

### DIFF
--- a/plugins/BEdita/Core/src/Utility/Resources.php
+++ b/plugins/BEdita/Core/src/Utility/Resources.php
@@ -276,6 +276,7 @@ class Resources
                 __d('bedita', 'Resource type not allowed "{0}"', $type)
             );
         }
+        TableRegistry::getTableLocator()->clear();
 
         return TableRegistry::getTableLocator()
             ->get(Inflector::camelize($type), $options);


### PR DESCRIPTION
This PR avoids an error in migrations when table connection is changed (although only formally) and we may get an error like

```
RuntimeException: You cannot configure "ObjectTypes", it already exists in the registry. in vendor/cakephp/cakephp/src/ORM/Locator/TableLocator.php:202
```
