### PR TITLE
fix: disable autosave, on submit fail

### DIFF
--- a/bedita-app/views/elements/form_common_js.tpl
+++ b/bedita-app/views/elements/form_common_js.tpl
@@ -337,7 +337,7 @@ function autoSave() {
 
 	var optionsForm = {
 		target: '#messagesDiv',
-		error: function() { switchAutosave('enable', false) }
+		error: function() { switchAutosave('disable', false) }
 	};
 
 	var newStatus = $("input[name=data\\[status\\]]:checked").attr('value');

--- a/bedita-app/views/elements/form_common_js.tpl
+++ b/bedita-app/views/elements/form_common_js.tpl
@@ -410,7 +410,11 @@ function updateEditors() {
 	var submitUrl = "{$html->url('/pages/updateEditor/')}"+"{$object.id|default:''}";
 	
 	
-	$("#concurrenteditors").load(submitUrl);
+	$("#concurrenteditors").load(submitUrl, function(response, status, xhr) {
+		if (status === 'error') {
+			$("#concurrenteditors").html(response);
+		}
+	});
 	chatTimer=setTimeout(updateEditors,checkTime);	
 }
 

--- a/bedita-app/views/elements/form_common_js.tpl
+++ b/bedita-app/views/elements/form_common_js.tpl
@@ -337,7 +337,7 @@ function autoSave() {
 
 	var optionsForm = {
 		target: '#messagesDiv',
-		error: function() { switchAutosave('disable', false) }
+		error: function() { switchAutosave('off', false) }
 	};
 
 	var newStatus = $("input[name=data\\[status\\]]:checked").attr('value');

--- a/bedita-app/views/elements/form_common_js.tpl
+++ b/bedita-app/views/elements/form_common_js.tpl
@@ -335,7 +335,10 @@ function autoSave() {
 	var submitUrl = "{$html->url('/')}{$view->params.controller}/autosave/";
 	
 
-	var optionsForm = { target: '#messagesDiv' };
+	var optionsForm = {
+		target: '#messagesDiv',
+		error: function() { switchAutosave('enable', false) }
+	};
 
 	var newStatus = $("input[name=data\\[status\\]]:checked").attr('value');
 


### PR DESCRIPTION
When session expires, autosave in documents view doesn't stop and produces several error logs.

This fixes the issue, disabling the autosave, on first error.