### PR TITLE
Resources migrations via YAML

### DIFF
--- a/plugins/BEdita/Core/src/Migration/ResourcesMigration.php
+++ b/plugins/BEdita/Core/src/Migration/ResourcesMigration.php
@@ -13,9 +13,11 @@
 namespace BEdita\Core\Migration;
 
 use BEdita\Core\Utility\Resources;
+use Cake\Database\Connection;
 use Cake\Utility\Hash;
 use Migrations\AbstractMigration;
 use ReflectionClass;
+use RuntimeException;
 use Symfony\Component\Yaml\Yaml;
 
 abstract class ResourcesMigration extends AbstractMigration
@@ -31,7 +33,7 @@ abstract class ResourcesMigration extends AbstractMigration
         $path = (new ReflectionClass($this))->getFileName();
         $file = str_replace('.php', '.yml', $path);
         if (!file_exists($file)) {
-            return [];
+            throw new RuntimeException(__d('bedita', 'YAML file not found'));
         }
 
         $data = (array)Yaml::parse(file_get_contents($file));
@@ -48,22 +50,34 @@ abstract class ResourcesMigration extends AbstractMigration
     /**
      * {@inheritDoc}
      */
-    public function up()
+    public function up(): void
     {
         Resources::save(
             $this->readData(),
-            ['connection' => $this->getAdapter()->getCakeConnection()]
+            ['connection' => $this->getConnection()]
         );
     }
 
     /**
      * {@inheritDoc}
      */
-    public function down()
+    public function down(): void
     {
         Resources::save(
             $this->readData(false),
-            ['connection' => $this->getAdapter()->getCakeConnection()]
+            ['connection' => $this->getConnection()]
         );
+    }
+
+    /**
+     * Retrieve Db Connection
+     *
+     * @return Connection
+     *
+     * @codeCoverageIgnore
+     */
+    protected function getConnection(): Connection
+    {
+        return $this->getAdapter()->getCakeConnection();
     }
 }

--- a/plugins/BEdita/Core/src/Migration/ResourcesMigration.php
+++ b/plugins/BEdita/Core/src/Migration/ResourcesMigration.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Core\Migration;
+
+use BEdita\Core\Utility\Resources;
+use Cake\Utility\Hash;
+use Migrations\AbstractMigration;
+use ReflectionClass;
+use Symfony\Component\Yaml\Yaml;
+
+abstract class ResourcesMigration extends AbstractMigration
+{
+    /**
+     * Read YAML migration data
+     *
+     * @param bool $up Up direction
+     * @return array
+     */
+    protected function readData(bool $up = true): array
+    {
+        $path = (new ReflectionClass($this))->getFileName();
+        $file = str_replace('.php', '.yml', $path);
+        if (!file_exists($file)) {
+            return [];
+        }
+
+        $data = (array)Yaml::parse(file_get_contents($file));
+        if ($up) {
+            return $data;
+        }
+
+        return array_filter([
+            'remove' => array_reverse(Hash::get($data, 'create')),
+            'update' => (array)Hash::get($data, 'restore'),
+        ]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function up()
+    {
+        Resources::save(
+            $this->readData(),
+            ['connection' => $this->getAdapter()->getCakeConnection()]
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function down()
+    {
+        Resources::save(
+            $this->readData(false),
+            ['connection' => $this->getAdapter()->getCakeConnection()]
+        );
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Migration/ResourcesMigrationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Migration/ResourcesMigrationTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Migration;
+
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use RuntimeException;
+
+/**
+ * {@see BEdita\Core\State\ResourcesMigration} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Migration\ResourcesMigration
+ */
+class ResourcesMigrationTest extends TestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.RelationTypes',
+        'plugin.BEdita/Core.Objects',
+    ];
+
+    /**
+     * Test `up` method.
+     *
+     * @covers ::up()
+     * @covers ::readData()
+     */
+    public function testUp()
+    {
+        $migration = new TestAdd('test', 1);
+
+        $migration->up();
+
+        $objectType = TableRegistry::getTableLocator()->get('ObjectTypes')->get('foos');
+        static::assertNotEmpty($objectType);
+    }
+
+    /**
+     * Test `down` method.
+     *
+     * @covers ::down()
+     * @covers ::readData()
+     */
+    public function testDown()
+    {
+        $ObjectTypes = TableRegistry::getTableLocator()->get('ObjectTypes');
+        $objectType = $ObjectTypes->newEntity(['name' => 'foos', 'singular' => 'foo']);
+        $ObjectTypes->saveOrFail($objectType);
+
+        $migration = new TestAdd('test', 1);
+
+        $migration->down();
+
+        $found = TableRegistry::getTableLocator()->get('ObjectTypes')->exists(['name' => 'foos']);
+        static::assertFalse($found);
+    }
+
+    /**
+     * Test missing data file.
+     *
+     * @covers ::readData()
+     */
+    public function testMissing()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('YAML file not found');
+
+        $migration = new TestMissing('test', 1);
+        $migration->up();
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Migration/TestAdd.php
+++ b/plugins/BEdita/Core/tests/TestCase/Migration/TestAdd.php
@@ -1,0 +1,14 @@
+<?php
+namespace BEdita\Core\Test\TestCase\Migration;
+
+use BEdita\Core\Migration\ResourcesMigration;
+use Cake\Database\Connection;
+use Cake\Datasource\ConnectionManager;
+
+class TestAdd extends ResourcesMigration
+{
+    protected function getConnection(): Connection
+    {
+        return ConnectionManager::get('default');
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Migration/TestAdd.yml
+++ b/plugins/BEdita/Core/tests/TestCase/Migration/TestAdd.yml
@@ -1,0 +1,11 @@
+
+create:
+
+  # Object Types
+  object_types:
+    - name: foos
+      singular: foo
+      description: Foo object
+      plugin: BEdita/Core
+      model: Objects
+      enabled: 1

--- a/plugins/BEdita/Core/tests/TestCase/Migration/TestMissing.php
+++ b/plugins/BEdita/Core/tests/TestCase/Migration/TestMissing.php
@@ -1,0 +1,8 @@
+<?php
+namespace BEdita\Core\Test\TestCase\Migration;
+
+use BEdita\Core\Migration\ResourcesMigration;
+
+class TestMissing extends ResourcesMigration
+{
+}


### PR DESCRIPTION
In this PR a new resources migrations YAML format to be easily used on BE4 model migrations.

A new abstract base class for `ResourcesMigration` was created, with this you can:

* create a migration class like: `<?php class MyMigration extends ResourcesMigration {}` 
* a YAML file is searched with same name and path of the migration file, say migration file is `/path/to/Migrations/20200909101955_MyMigration.php` a YAML file `/path/to/Migrations/20200909101955_MyMigration.yml` will be loaded
* YAML file must have at least a `create` and/or `update` keys and an optional `restore`: 
  - `create` and `update` actions are handled in migration (`up` method)
  - `remove` and `restore` are handled in migration rollback - `remove` action is automatically created by reversing `create` action, whereas `restore` action needs to be specified 

----

### YAML file example 

```yaml
create:

  # Object Types
  object_types:
    - name: foos
      singular: foo
      description: Foo object
  
  # Relations 
  relations:
     - name: poster
       label: Poster
       inverse_name: poster_of
       inverse_label: Poster Of
       left:
         - documents
         - profiles
       right:
         - images

  # Property types 
  property_types:
    - name: coding_style
      params:
        type: string
        enum:
          - bad
          - very_bad
          - ugly

  # Properties
  properties:
    - name: custom_url
      object: profiles
      property: url
      description: Custom URL

```