### PR TITLE
fix: rewind stream only if seekable

### DIFF
--- a/plugins/BEdita/Core/src/Model/Entity/Stream.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Stream.php
@@ -163,7 +163,10 @@ class Stream extends Entity implements JsonApiSerializable
      */
     protected function createStream($source)
     {
-        rewind($source);
+        $info = stream_get_meta_data($source);
+        if ($info['seekable'] === true) {
+            rewind($source);
+        }
 
         $resource = fopen('php://temp', 'wb+');
         stream_copy_to_stream($source, $resource);


### PR DESCRIPTION
This PR fixes a problem with not seekable resources used to create a stream entity.

When stream is an s3 resource, it can be not seekable, and in that case `rewind` fails with a warning.
To avoid this warning, this patch adds a control on resource (https://www.php.net/manual/en/function.stream-get-meta-data.php) to see if it's seekable, before rewinding it. (thanks to @le0m for the suggestion)