### PR TITLE
Save relation metadata in `PATCH /folders/{id}/parent` (#1726)

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -593,6 +593,20 @@ class FoldersControllerTest extends IntegrationTestCase
                     'id' => 11,
                 ],
             ],
+            'patch + meta' => [
+                200,
+                'PATCH',
+                [
+                    'type' => 'folders',
+                    'id' => 11,
+                    'meta' => [
+                        'relation' => [
+                            'menu' => 'false',
+                            'canonical' => 'false',
+                        ],
+                    ],
+                ],
+            ],
             'patch conflict' => [
                 409,
                 'PATCH',
@@ -675,6 +689,65 @@ class FoldersControllerTest extends IntegrationTestCase
 
         $path = Hash::get($result, 'data.meta.path');
         static::assertEquals('/13/12', $path);
+    }
+
+    /**
+     * Test patch `parent` relationship with metadata
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testPatchParentMeta()
+    {
+        // create new folder and set parent
+        $data = [
+            'type' => 'folders',
+            'attributes' => [
+                'title' => 'New folder',
+            ],
+        ];
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $this->post('/folders', json_encode(compact('data')));
+        $folderId = $this->lastObjectId();
+
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $data = [
+            'type' => 'folders',
+            'id' => 12,
+            'meta' => [
+                'relation' => [
+                    'menu' => false,
+                ],
+            ],
+        ];
+        $this->patch(sprintf('/folders/%d/relationships/parent', $folderId), json_encode(compact('data')));
+        $this->assertResponseCode(200);
+        $result = json_decode((string)$this->_response->getBody(), true);
+        $expected = [
+            'links' => [
+                'self' => sprintf('http://api.example.com/folders/%d/relationships/parent', $folderId),
+                'home' => 'http://api.example.com/home',
+            ],
+        ];
+        static::assertEquals($expected, $result);
+
+        // Read `menu` from Trees
+        $Trees = TableRegistry::getTableLocator()->get('Trees');
+        $menu = $Trees->find('list', ['valueField' => 'menu'])
+            ->where(['object_id' => $folderId])
+            ->first();
+        static::assertFalse($menu);
+
+        // change flag with anoter `PATCH`
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $data['meta']['relation']['menu'] = true;
+        $this->patch(sprintf('/folders/%d/relationships/parent', $folderId), json_encode(compact('data')));
+        $this->assertResponseCode(200);
+        $menu = $Trees->find('list', ['valueField' => 'menu'])
+            ->where(['object_id' => $folderId])
+            ->first();
+        static::assertTrue($menu);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/SetAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SetAssociatedAction.php
@@ -123,6 +123,12 @@ class SetAssociatedAction extends UpdateAssociatedAction
 
         if ($existing === null && $relatedEntity === null) {
             return 0;
+        } elseif ($relatedEntity !== null && $this->Association->getName() !== 'ParentObjects') {
+            $bindingKey = (array)$this->Association->getBindingKey();
+
+            if ($existing !== null && $relatedEntity->extract($bindingKey) == $existing->extract($bindingKey)) {
+                return 0;
+            }
         }
 
         $entity->set($this->Association->getProperty(), $relatedEntity);

--- a/plugins/BEdita/Core/src/Model/Action/SetAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SetAssociatedAction.php
@@ -123,12 +123,6 @@ class SetAssociatedAction extends UpdateAssociatedAction
 
         if ($existing === null && $relatedEntity === null) {
             return 0;
-        } elseif ($relatedEntity !== null) {
-            $bindingKey = (array)$this->Association->getBindingKey();
-
-            if ($existing !== null && $relatedEntity->extract($bindingKey) == $existing->extract($bindingKey)) {
-                return 0;
-            }
         }
 
         $entity->set($this->Association->getProperty(), $relatedEntity);

--- a/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
@@ -63,6 +63,12 @@ abstract class UpdateRelatedObjectsAction extends UpdateAssociatedAction
         if (is_array($relatedEntities) && count($relatedEntities) === 1) {
             $relatedEntities = reset($relatedEntities);
         }
+        if (!empty($relatedEntities)) {
+            /** @var EntityInterface $relatedEntities */
+            $joinData = (array)$relatedEntities->get('_joinData');
+            // set join data properties in Tree entity, on empty array no properties are set
+            $entity->set($joinData);
+        }
 
         $this->Association = $table->getAssociation('ParentObjects');
         $this->setConfig('association', $this->Association);

--- a/plugins/BEdita/Core/src/Model/Entity/Tree.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Tree.php
@@ -112,6 +112,8 @@ class Tree extends Entity
             $parentId = $folder->id;
         }
         $this->parent_id = $parentId;
+        // set join data if present (`menu` and `canonical`)
+        $this->set((array)$folder->get('_joinData'));
 
         return $folder;
     }

--- a/plugins/BEdita/Core/src/Model/Entity/Tree.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Tree.php
@@ -110,8 +110,6 @@ class Tree extends Entity
         $parentId = null;
         if ($folder !== null) {
             $parentId = $folder->id;
-            // set join data if present (`menu` and `canonical`)
-            $this->set((array)$folder->get('_joinData'));
         }
         $this->parent_id = $parentId;
 

--- a/plugins/BEdita/Core/src/Model/Entity/Tree.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Tree.php
@@ -110,10 +110,10 @@ class Tree extends Entity
         $parentId = null;
         if ($folder !== null) {
             $parentId = $folder->id;
+            // set join data if present (`menu` and `canonical`)
+            $this->set((array)$folder->get('_joinData'));
         }
         $this->parent_id = $parentId;
-        // set join data if present (`menu` and `canonical`)
-        $this->set((array)$folder->get('_joinData'));
 
         return $folder;
     }


### PR DESCRIPTION
This PR fixes #1726 

when performing a `PATCH /folder/{id}/parent`

* parent relation metadata is now set via parent folder `_joinData` 
* `belongsTo` association is saved if target has changed (different folder ID or NULL) or if relation metadata have changed

A new `FoldersControllerTest::testPatchParentMeta()` was added.
