### PR TITLE
Add endpoint_permissions to resource utility

### DIFF
--- a/plugins/BEdita/Core/src/Model/Entity/EndpointPermission.php
+++ b/plugins/BEdita/Core/src/Model/Entity/EndpointPermission.php
@@ -275,7 +275,7 @@ class EndpointPermission extends Entity
     /**
      * Setter for `application` virtual property.
      *
-     * @param string $name The role name
+     * @param string $name The application name
      * @return string|null
      */
     protected function _setApplication(?string $name): ?string

--- a/plugins/BEdita/Core/src/Model/Entity/EndpointPermission.php
+++ b/plugins/BEdita/Core/src/Model/Entity/EndpointPermission.php
@@ -15,6 +15,7 @@ namespace BEdita\Core\Model\Entity;
 
 use Cake\Log\Log;
 use Cake\ORM\Entity;
+use Cake\ORM\TableRegistry;
 
 /**
  * EndpointPermission Entity
@@ -225,5 +226,71 @@ class EndpointPermission extends Entity
         $this->permission = compact('write');
 
         return $this->write;
+    }
+
+    /**
+     * Setter for `endpoint` virtual property.
+     *
+     * @param string $name The endpoint name
+     * @return string|null
+     */
+    protected function _setEndpoint(?string $name): ?string
+    {
+        if ($name === null) {
+            $this->endpoint_id = null;
+
+            return null;
+        }
+
+        $this->endpoint_id = TableRegistry::getTableLocator()->get('Endpoints')
+            ->find('list', ['valueField' => 'id'])
+            ->where(['name' => $name])
+            ->firstOrFail();
+
+        return $name;
+    }
+
+    /**
+     * Setter for `role` virtual property.
+     *
+     * @param string $name The role name
+     * @return string|null
+     */
+    protected function _setRole(?string $name): ?string
+    {
+        if ($name === null) {
+            $this->role_id = null;
+
+            return null;
+        }
+
+        $this->role_id = TableRegistry::getTableLocator()->get('Roles')
+            ->find('list', ['valueField' => 'id'])
+            ->where(['name' => $name])
+            ->firstOrFail();
+
+        return $name;
+    }
+
+    /**
+     * Setter for `application` virtual property.
+     *
+     * @param string $name The role name
+     * @return string|null
+     */
+    protected function _setApplication(?string $name): ?string
+    {
+        if ($name === null) {
+            $this->application_id = null;
+
+            return null;
+        }
+
+        $this->application_id = TableRegistry::getTableLocator()->get('Applications')
+            ->find('list', ['valueField' => 'id'])
+            ->where(['name' => $name])
+            ->firstOrFail();
+
+        return $name;
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/ConfigTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ConfigTable.php
@@ -149,4 +149,18 @@ class ConfigTable extends Table
             return $query->where($conditions);
         });
     }
+
+    /**
+     * Alias for `name` finder.
+     * Used to load entity in `BEdita\Core\Utility\Resources`
+     *
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @param array $options Options array.
+     * @return \Cake\ORM\Query
+     * @codeCoverageIgnore
+     */
+    protected function findResource(Query $query, array $options): Query
+    {
+        return $query->find('name', $options);
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Table/EndpointPermissionsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/EndpointPermissionsTable.php
@@ -193,4 +193,49 @@ class EndpointPermissionsTable extends Table
             });
         });
     }
+
+    /**
+     * Find permissions by role, application and endpoint name.
+     *
+     * This finder accepts three options:
+     * - `endpoint``: the endpoint name
+     * - `role`: the role name
+     * - `application`: the application name
+     *
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @param array $options Additional options.
+     * @return \Cake\ORM\Query
+     */
+    protected function findResource(Query $query, array $options): Query
+    {
+        $endpoint = Hash::get($options, 'endpoint');
+        $role = Hash::get($options, 'role');
+        $application = Hash::get($options, 'application');
+
+        if ($endpoint === null) {
+            $query = $query->whereNull('endpoint_id');
+        } else {
+            $query = $query->innerJoinWith('Endpoints', function (Query $query) use ($endpoint) {
+                return $query->where(['Endpoints.name' => $endpoint]);
+            });
+        }
+
+        if ($role === null) {
+            $query = $query->whereNull('role_id');
+        } else {
+            $query = $query->innerJoinWith('Roles', function (Query $query) use ($role) {
+                return $query->where(['Roles.name' => $role]);
+            });
+        }
+
+        if ($application === null) {
+            $query = $query->whereNull('application_id');
+        } else {
+            $query = $query->innerJoinWith('Applications', function (Query $query) use ($application) {
+                return $query->where(['Applications.name' => $application]);
+            });
+        }
+
+        return $query;
+    }
 }

--- a/plugins/BEdita/Core/src/Utility/Resources.php
+++ b/plugins/BEdita/Core/src/Utility/Resources.php
@@ -72,6 +72,7 @@ class Resources
         'object_types',
         'roles',
         'endpoints',
+        'endpoint_permissions',
     ];
 
     /**
@@ -153,7 +154,7 @@ class Resources
     }
 
     /**
-     * Load single resource entity using `name` or `id` fields condition or `name` finder if set
+     * Load single resource entity using `name` or `id` fields condition or `resource` finder if set
      *
      * @param array $item Single resource data
      * @param Table $Table Resource table class
@@ -161,17 +162,13 @@ class Resources
      */
     protected static function loadEntity(array $item, Table $Table): EntityInterface
     {
-        if ($Table->hasFinder('name')) {
-            /** @var EntityInterface $entity */
-            $entity = $Table->find('name', $item)->firstOrFail();
-        } else {
-            /** @var EntityInterface $entity */
-            $entity = $Table->find()
-                ->where(static::findCondition($item))
-                ->firstOrFail();
+        if ($Table->hasFinder('resource')) {
+            return $Table->find('resource', $item)->firstOrFail();
         }
 
-        return $entity;
+        return $Table->find()
+            ->where(static::findCondition($item))
+            ->firstOrFail();
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointPermissionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointPermissionTest.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Test\TestCase\Model\Entity;
 
 use BEdita\Core\Model\Entity\EndpointPermission;
+use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -362,5 +363,140 @@ class EndpointPermissionTest extends TestCase
         $write = $entity->get('write');
 
         static::assertSame($expected, $write);
+    }
+
+    /**
+     * Data provder for `testSetEndpoint()`
+     *
+     * @return array
+     */
+    public function setEndpointProvider(): array
+    {
+        return [
+            'null' => [
+                null,
+                null,
+            ],
+            'valid name' => [
+                2,
+                'home',
+            ],
+            'not valid name' => [
+                new RecordNotFoundException('Record not found in table "endpoints"'),
+                'dontfindme',
+            ],
+        ];
+    }
+
+    /**
+     * Test magic setter for endpoint.
+     *
+     * @param mixed $expected The expected data
+     * @param string $name The endpoint name
+     * @return void
+     *
+     * @covers ::_setEndpoint()
+     * @dataProvider setEndpointProvider()
+     */
+    public function testSetEndpoint($expected, ?string $name): void
+    {
+        if ($expected instanceof \Exception) {
+            $this->expectException(RecordNotFoundException::class);
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+
+        $entity = new EndpointPermission();
+        $entity->set('endpoint', $name);
+        static::assertEquals($expected, $entity->get('endpoint_id'));
+    }
+
+    /**
+     * Data provder for `testSetRole()`
+     *
+     * @return array
+     */
+    public function setRoleProvider(): array
+    {
+        return [
+            'null' => [
+                null,
+                null,
+            ],
+            'valid name' => [
+                2,
+                'second role',
+            ],
+            'not valid name' => [
+                new RecordNotFoundException('Record not found in table "roles"'),
+                'dontfindme',
+            ],
+        ];
+    }
+
+    /**
+     * Test magic setter for role.
+     *
+     * @param mixed $expected The expected data
+     * @param string $name The role name
+     * @return void
+     *
+     * @covers ::_setRole()
+     * @dataProvider setRoleProvider()
+     */
+    public function testSetRole($expected, ?string $name): void
+    {
+        if ($expected instanceof \Exception) {
+            $this->expectException(RecordNotFoundException::class);
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+
+        $entity = new EndpointPermission();
+        $entity->set('role', $name);
+        static::assertEquals($expected, $entity->get('role_id'));
+    }
+
+    /**
+     * Data provder for `testSetApplication()`
+     *
+     * @return array
+     */
+    public function setApplicationProvider(): array
+    {
+        return [
+            'null' => [
+                null,
+                null,
+            ],
+            'valid name' => [
+                1,
+                'First app',
+            ],
+            'not valid name' => [
+                new RecordNotFoundException('Record not found in table "applications"'),
+                'dontfindme',
+            ],
+        ];
+    }
+
+    /**
+     * Test magic setter for application.
+     *
+     * @param mixed $expected The expected data
+     * @param string $name The application name
+     * @return void
+     *
+     * @covers ::_setApplication()
+     * @dataProvider setApplicationProvider()
+     */
+    public function testSetApplication($expected, ?string $name): void
+    {
+        if ($expected instanceof \Exception) {
+            $this->expectException(RecordNotFoundException::class);
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+
+        $entity = new EndpointPermission();
+        $entity->set('application', $name);
+        static::assertEquals($expected, $entity->get('application_id'));
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointPermissionsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointPermissionsTableTest.php
@@ -354,4 +354,58 @@ class EndpointPermissionsTableTest extends TestCase
 
         static::assertSame($expected, $count);
     }
+
+    /**
+     * Data provider for `testFindResource()`.
+     *
+     * @return array
+     */
+    public function findResourceProvider(): array
+    {
+        return [
+            'application, endpoint, role' => [
+                0b1001,
+                [
+                    'application' => 'Disabled app',
+                    'endpoint' => 'home',
+                    'role' => 'first role',
+                ],
+            ],
+            'application=null, endpoint=null, role=null' => [
+                0,
+                [
+                    'application' => null,
+                    'endpoint' => null,
+                    'role' => null,
+                ],
+            ],
+            'application, endpoint=null, role=null' => [
+                0b1111,
+                [
+                    'application' => 'First app',
+                    'endpoint' => null,
+                    'role' => null,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test custom finder `findResource()`.
+     *
+     * @param int $expected The value expected
+     * @param array $options The options for the finder
+     * @return void
+     *
+     * @covers ::findResource()
+     * @dataProvider findResourceProvider()
+     */
+    public function testFindResource($expected, $options)
+    {
+        $query = $this->EndpointPermissions->find('resource', $options);
+        $entity = $query->first();
+
+        static::assertEquals(1, $query->count());
+        static::assertEquals($expected, $entity->permission);
+    }
 }


### PR DESCRIPTION
This PR add the feature to handle `endpoint_permissions` used for migrations and yaml migrations.
We can now handle `endpoint_permissions` creation, deleting and updating too via yaml:

```
endpoint_permissions:
  - endpoint: pets
    application: app
    role: boss
    permission: 12
```

It contains a slight refactor to `Resources::loadEntity()` to use a more general `resource` finder instead of `name` finder.
