### PR TITLE
fix: perform non atomic changes in `Resources`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /config/app.json
 /config/.env
 /config/environment.php
+/config/projects/*
 /coverage/*
 /docs/*
 /index.html

--- a/plugins/BEdita/Core/src/Utility/Properties.php
+++ b/plugins/BEdita/Core/src/Utility/Properties.php
@@ -101,6 +101,7 @@ class Properties
             static::validate($p);
             $objectType = $ObjectTypes->get(Inflector::camelize($p['object']));
 
+            /** @var \Cake\Datasource\EntityInterface $property */
             $property = $Properties->find()
                 ->where([
                     'name' => $p['name'],

--- a/plugins/BEdita/Core/src/Utility/Properties.php
+++ b/plugins/BEdita/Core/src/Utility/Properties.php
@@ -41,6 +41,25 @@ use Cake\Utility\Inflector;
 class Properties
 {
     /**
+     * Default options array with following keys:
+     *
+     *  - 'save': default options performing `Table::save()`
+     *  - 'delete': default options performing `Table::delete()`
+     *
+     * @var array
+     */
+    protected static $defaults = [
+        // since default usage is in migrations
+        // don't commit transactions but let migrations do it
+        'save' => [
+            'atomic' => false,
+        ],
+        'delete' => [
+            'atomic' => false,
+        ],
+    ];
+
+    /**
      * Create new properties in `properties` table using input `$properties` array
      *
      * @param array $properties Properties data
@@ -49,6 +68,7 @@ class Properties
      */
     public static function create(array $properties, array $options = []): void
     {
+        TableRegistry::getTableLocator()->clear();
         $Properties = TableRegistry::getTableLocator()->get('Properties', $options);
 
         foreach ($properties as $p) {
@@ -60,7 +80,7 @@ class Properties
                 'description' => Hash::get($p, 'description'),
             ]);
 
-            $Properties->saveOrFail($property);
+            $Properties->saveOrFail($property, static::$defaults['save']);
         }
     }
 
@@ -73,6 +93,7 @@ class Properties
      */
     public static function remove(array $properties, array $options = []): void
     {
+        TableRegistry::getTableLocator()->clear();
         $Properties = TableRegistry::getTableLocator()->get('Properties', $options);
         $ObjectTypes = TableRegistry::getTableLocator()->get('ObjectTypes', $options);
 
@@ -87,7 +108,7 @@ class Properties
                 ])
                 ->firstOrFail();
 
-            $Properties->deleteOrFail($property);
+            $Properties->deleteOrFail($property, static::$defaults['delete']);
         }
     }
 

--- a/plugins/BEdita/Core/src/Utility/Relations.php
+++ b/plugins/BEdita/Core/src/Utility/Relations.php
@@ -137,6 +137,7 @@ class Relations
         $Relations = TableRegistry::getTableLocator()->get('Relations', $options);
         foreach ($relations as $r) {
             static::validate($r);
+            /** @var \Cake\Datasource\EntityInterface $relation */
             $relation = $Relations->find()
                 ->where(['name' => Hash::get($r, 'name')])
                 ->firstOrFail();
@@ -166,6 +167,7 @@ class Relations
         foreach ($types as $name) {
             $objectType = $ObjectTypes->get(Inflector::camelize($name));
 
+            /** @var \Cake\Datasource\EntityInterface $relationType */
             $relationType = $RelationTypes->find()
                 ->where([
                     'relation_id' => $relationId,
@@ -208,6 +210,7 @@ class Relations
 
         $result = [];
         foreach ($data as $r) {
+            /** @var \Cake\Datasource\EntityInterface $relation */
             $relation = $Relations->find()
                 ->where(['name' => Hash::get($r, 'name')])
                 ->contain(['LeftObjectTypes', 'RightObjectTypes'])

--- a/plugins/BEdita/Core/src/Utility/Relations.php
+++ b/plugins/BEdita/Core/src/Utility/Relations.php
@@ -41,6 +41,25 @@ use Cake\Utility\Inflector;
 class Relations
 {
     /**
+     * Default options array with following keys:
+     *
+     *  - 'save': default options performing `Table::save()`
+     *  - 'delete': default options performing `Table::delete()`
+     *
+     * @var array
+     */
+    protected static $defaults = [
+        // since default usage is in migrations
+        // don't commit transactions but let migrations do it
+        'save' => [
+            'atomic' => false,
+        ],
+        'delete' => [
+            'atomic' => false,
+        ],
+    ];
+
+    /**
      * Create new relations in `relations` table using input `$relations` array
      *
      * @param array $relations Relation data
@@ -49,11 +68,12 @@ class Relations
      */
     public static function create(array $relations, array $options = []): void
     {
+        TableRegistry::getTableLocator()->clear();
         $Relations = TableRegistry::getTableLocator()->get('Relations', $options);
         foreach ($relations as $data) {
             static::validate($data);
             $relation = $Relations->newEntity($data);
-            $relation = $Relations->saveOrFail($relation);
+            $relation = $Relations->saveOrFail($relation, static::$defaults['save']);
 
             static::addTypes($relation->get('id'), $data['left'], 'left', $options);
             static::addTypes($relation->get('id'), $data['right'], 'right', $options);
@@ -100,7 +120,7 @@ class Relations
                 'object_type_id' => $objectType->get('id'),
                 'side' => $side,
             ]);
-            $RelationTypes->saveOrFail($entity);
+            $RelationTypes->saveOrFail($entity, static::$defaults['save']);
         }
     }
 
@@ -113,6 +133,7 @@ class Relations
      */
     public static function remove(array $relations, array $options = []): void
     {
+        TableRegistry::getTableLocator()->clear();
         $Relations = TableRegistry::getTableLocator()->get('Relations', $options);
         foreach ($relations as $r) {
             static::validate($r);
@@ -123,7 +144,7 @@ class Relations
             static::removeTypes($relation->get('id'), $r['left'], 'left', $options);
             static::removeTypes($relation->get('id'), $r['right'], 'right', $options);
 
-            $Relations->deleteOrFail($relation);
+            $Relations->deleteOrFail($relation, static::$defaults['delete']);
         }
     }
 
@@ -153,7 +174,7 @@ class Relations
                 ])
                 ->firstOrFail();
 
-            $RelationTypes->deleteOrFail($relationType);
+            $RelationTypes->deleteOrFail($relationType, static::$defaults['delete']);
         }
     }
 
@@ -195,7 +216,7 @@ class Relations
             foreach ($r as $k => $v) {
                 $relation->set($k, $v);
             }
-            $result[] = $Relations->saveOrFail($relation);
+            $result[] = $Relations->saveOrFail($relation, static::$defaults['save']);
         }
 
         return $result;

--- a/plugins/BEdita/Core/src/Utility/Resources.php
+++ b/plugins/BEdita/Core/src/Utility/Resources.php
@@ -43,11 +43,25 @@ use Cake\Utility\Inflector;
 class Resources
 {
     /**
-     * Resource defaults in creation
+     * Default options array with following keys:
+     *
+     *  - 'save': default options performing `Table::save()`
+     *  - 'delete': default options performing `Table::delete()`
+     *  - 'object_types': default options on object types
+     *  - 'property_types': default options on property types
      *
      * @var array
      */
     protected static $defaults = [
+        // since default usage is in migrations
+        // don't commit transactions but let migrations do it
+        'save' => [
+            'atomic' => false,
+        ],
+        'delete' => [
+            'atomic' => false,
+        ],
+
         'object_types' => [
             'plugin' => 'BEdita/Core',
             'model' => 'Objects',
@@ -104,7 +118,7 @@ class Resources
             foreach ($item as $k => $v) {
                 $resource->set($k, $v);
             }
-            $result[] = $Table->saveOrFail($resource);
+            $result[] = $Table->saveOrFail($resource, static::$defaults['save']);
         }
 
         return $result;
@@ -124,7 +138,7 @@ class Resources
 
         foreach ($data as $item) {
             $entity = static::loadEntity($item, $Table);
-            $Table->deleteOrFail($entity);
+            $Table->deleteOrFail($entity, static::$defaults['delete']);
         }
     }
 
@@ -146,7 +160,7 @@ class Resources
             foreach ($item as $k => $v) {
                 $entity->set($k, $v);
             }
-            $result[] = $Table->saveOrFail($entity);
+            $result[] = $Table->saveOrFail($entity, static::$defaults['save']);
         }
 
         return $result;


### PR DESCRIPTION
This PR fixes a transactional problem on `Resources`: since its main usage is in migrations and operations should be performed on same transaction => write operations like `save` or `delete` through table classes should not be atomic.

This fixes also a problem with the current `4.2.0` official docker image running with `Sqlite`