### PR TITLE
feat: relation params setter

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
@@ -330,7 +330,14 @@ class RelationsControllerTest extends IntegrationTestCase
 
         $this->assertHeader('Location', 'http://api.example.com/model/relations/' . $relation->id);
 
-        $expected = array_merge(['id' => $relation->id], $data['attributes']);
+        $expected = array_merge(['id' => $relation->id], $data['attributes'], [
+            'params' => [
+                'definitions' => [],
+                '$schema' => 'http://json-schema.org/draft-06/schema#',
+                'type' => 'object',
+                'test' => 'ok',
+            ],
+        ]);
         static::assertJsonStringEqualsJsonString(json_encode($expected), json_encode($relation->toArray()));
     }
 

--- a/plugins/BEdita/Core/src/Model/Entity/Relation.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Relation.php
@@ -99,4 +99,24 @@ class Relation extends Entity implements JsonApiSerializable
     {
         return Inflector::camelize($this->inverse_name);
     }
+
+    /**
+     * Magic setter for params.
+     *
+     * @param array $params Relation params.
+     * @return array
+     */
+    protected function _setParams($params)
+    {
+        if (is_array($params) && !empty($params)) {
+            $params = array_merge(
+                [
+                    'definitions' => new \stdClass(),
+                    '$schema' => 'http://json-schema.org/draft-06/schema#',
+                    'type' => 'object',
+                ], $params);
+        }
+
+        return $params;
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Entity/Relation.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Relation.php
@@ -59,6 +59,13 @@ class Relation extends Entity implements JsonApiSerializable
     ];
 
     /**
+     * Default JSON schema.
+     *
+     * @var string
+     */
+    const DEFAULT_SCHEMA = 'http://json-schema.org/draft-06/schema#';
+
+    /**
      * Magic setter for relation name.
      *
      * @param string $name Relation name.
@@ -109,12 +116,11 @@ class Relation extends Entity implements JsonApiSerializable
     protected function _setParams($params)
     {
         if (is_array($params) && !empty($params)) {
-            $params = array_merge(
-                [
-                    'definitions' => new \stdClass(),
-                    '$schema' => 'http://json-schema.org/draft-06/schema#',
-                    'type' => 'object',
-                ], $params);
+            $params = array_merge([
+                'definitions' => new \stdClass(),
+                '$schema' => self::DEFAULT_SCHEMA,
+                'type' => 'object',
+            ], $params);
         }
 
         return $params;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/RelationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/RelationTest.php
@@ -127,4 +127,37 @@ class RelationTest extends TestCase
         static::assertEquals('bar_foo', $relation->inverse_name);
         static::assertEquals('BarFoo', $relation->inverse_alias);
     }
+
+    /**
+     * Test setter method for `params`.
+     *
+     * @return void
+     *
+     * @covers ::_setParams()
+     */
+    public function testSetParams()
+    {
+        $properties = [
+            'dummy' => [
+                'type' => 'string',
+                'description' => 'a dummy property'
+            ],
+        ];
+        $data = [
+            'name' => 'FooBar',
+            'params' => [
+                'properties' => $properties,
+            ],
+        ];
+        $relation = $this->Relations->newEntity($data);
+        if (!($relation instanceof Relation)) {
+            static::fail(sprintf('Unexpected entity class "%s"', get_class($relation)));
+        }
+
+        static::assertEquals($properties, $relation->params['properties']);
+        static::assertEquals(Relation::DEFAULT_SCHEMA, $relation->params['$schema']);
+        static::assertArrayHasKey('definitions', (array)$relation->params);
+        static::assertArrayHasKey('$schema', (array)$relation->params);
+        static::assertArrayHasKey('type', (array)$relation->params);
+    }
 }


### PR DESCRIPTION
This provides `Relation` setter for field `params`, handling default json-schema fields:

```
'definitions' => new \stdClass(),
'$schema' => 'http://json-schema.org/draft-06/schema#',
'type' => 'object',
```