### PR TITLE
Add external_auth info in users meta

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/FieldsQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FieldsQueryStringTest.php
@@ -31,22 +31,22 @@ class FieldsQueryStringTest extends IntegrationTestCase
             'simple' => [
                 '/documents?fields=title',
                 ['title'],
-                []
+                [],
             ],
             'multi' => [
                 '/roles?fields=name,created',
                 ['name'],
-                ['created']
+                ['created'],
             ],
             'none' => [
                 '/users?fields[users]=gustavo',
                 [],
-                []
+                ['external_auth'],
             ],
             'single' => [
                 '/users/1?fields=username',
                 ['username'],
-                []
+                ['external_auth'],
             ],
             'meta' => [
                 '/roles/1?fields=unchangeable',
@@ -56,7 +56,7 @@ class FieldsQueryStringTest extends IntegrationTestCase
             'sparse' => [
                 '/roles?fields[roles]=name',
                 ['name'],
-                []
+                [],
             ],
         ];
     }

--- a/plugins/BEdita/API/tests/TestCase/Controller/AppControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AppControllerTest.php
@@ -285,6 +285,12 @@ class AppControllerTest extends IntegrationTestCase
                         'created_by' => 1,
                         'modified_by' => 1,
                         'verified' => '2017-05-29T11:36:00+00:00',
+                        'external_auth' => [
+                            [
+                                'provider' => 'example',
+                                'username' => 'first_user'
+                            ],
+                        ],
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/users/1',

--- a/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
@@ -495,6 +495,12 @@ class RolesControllerTest extends IntegrationTestCase
                         'last_login_err' => null,
                         'num_login_err' => 1,
                         'verified' => '2017-05-29T11:36:00+00:00',
+                        'external_auth' => [
+                            [
+                                'provider' => 'example',
+                                'username' => 'first_user'
+                            ],
+                        ],
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/users/1',

--- a/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
@@ -104,6 +104,12 @@ class UsersControllerTest extends IntegrationTestCase
                         'last_login_err' => null,
                         'num_login_err' => 1,
                         'verified' => '2017-05-29T11:36:00+00:00',
+                        'external_auth' => [
+                            [
+                                'provider' => 'example',
+                                'username' => 'first_user'
+                            ],
+                        ],
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/users/1',
@@ -183,6 +189,12 @@ class UsersControllerTest extends IntegrationTestCase
                         'last_login_err' => '2016-03-15T09:57:38+00:00',
                         'num_login_err' => 0,
                         'verified' => null,
+                        'external_auth' => [
+                            [
+                                'provider' => 'uuid',
+                                'username' => '17fec0fa-068a-4d7c-8283-da91d47cef7d',
+                            ],
+                        ],
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/users/5',
@@ -332,6 +344,12 @@ class UsersControllerTest extends IntegrationTestCase
                     'last_login_err' => null,
                     'num_login_err' => 1,
                     'verified' => '2017-05-29T11:36:00+00:00',
+                    'external_auth' => [
+                        [
+                            'provider' => 'example',
+                            'username' => 'first_user'
+                        ],
+                    ],
                 ],
                 'relationships' => [
                     'roles' => [

--- a/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
+++ b/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
@@ -51,6 +51,8 @@ class JsonApiViewTest extends TestCase
         'plugin.BEdita/Core.Users',
         'plugin.BEdita/Core.Roles',
         'plugin.BEdita/Core.RolesUsers',
+        'plugin.BEdita/Core.AuthProviders',
+        'plugin.BEdita/Core.ExternalAuth',
     ];
 
     /**
@@ -336,6 +338,14 @@ class JsonApiViewTest extends TestCase
                         [
                             'id' => '1',
                             'type' => 'users',
+                            'meta' => [
+                                'external_auth' => [
+                                    [
+                                        'provider' => 'example',
+                                        'username' => 'first_user',
+                                    ],
+                                ],
+                            ],
                             'links' => [
                                 'self' => '/users/1'
                             ],
@@ -369,6 +379,14 @@ class JsonApiViewTest extends TestCase
                         [
                             'id' => '5',
                             'type' => 'users',
+                            'meta' => [
+                                'external_auth' => [
+                                    [
+                                        'provider' => 'uuid',
+                                        'username' => '17fec0fa-068a-4d7c-8283-da91d47cef7d'
+                                    ],
+                                ],
+                            ],
                             'links' => [
                                 'self' => '/users/5'
                             ],

--- a/plugins/BEdita/Core/src/Model/Entity/User.php
+++ b/plugins/BEdita/Core/src/Model/Entity/User.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Model\Entity;
 
 use Cake\Auth\DefaultPasswordHasher;
+use Cake\ORM\Locator\LocatorAwareTrait;
 
 /**
  * User Entity.
@@ -33,6 +34,7 @@ use Cake\Auth\DefaultPasswordHasher;
  */
 class User extends Profile
 {
+    use LocatorAwareTrait;
 
     /**
      * {@inheritDoc}
@@ -43,6 +45,57 @@ class User extends Profile
 
         $this->setHidden(['password_hash', 'external_auth'], true);
         $this->setAccess(['blocked', 'last_login', 'last_login_err', 'num_login_err', 'verified'], false);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Add `external_auth` info to user meta.
+     */
+    protected function getMeta()
+    {
+        $meta = parent::getMeta();
+        $meta['external_auth'] = $this->getExternalAuthMeta();
+
+        return $meta;
+    }
+
+    /**
+     * Get external auth info as
+     *
+     * ```
+     * [
+     *     [
+     *         'provider' => 'the provider name',
+     *         'username' => 'username used for that provider',
+     *     ],
+     * ]
+     * ```
+     *
+     * @return array|null
+     */
+    protected function getExternalAuthMeta(): ?array
+    {
+        if (empty($this->id)) {
+            return null;
+        }
+
+        $result = $this->getTableLocator()
+            ->get('ExternalAuth')
+            ->find('user', ['user' => $this->id]);
+
+        if (!$result) {
+            return null;
+        }
+
+        $extAuth = $result->map(function (ExternalAuth $item) {
+            return [
+                'provider' => $item->auth_provider->name,
+                'username' => $item->provider_username,
+            ];
+        });
+
+        return $extAuth->toArray();
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Entity/User.php
+++ b/plugins/BEdita/Core/src/Model/Entity/User.php
@@ -80,22 +80,16 @@ class User extends Profile
             return null;
         }
 
-        $result = $this->getTableLocator()
+        return $this->getTableLocator()
             ->get('ExternalAuth')
-            ->find('user', ['user' => $this->id]);
-
-        if (!$result) {
-            return null;
-        }
-
-        $extAuth = $result->map(function (ExternalAuth $item) {
-            return [
-                'provider' => $item->auth_provider->name,
-                'username' => $item->provider_username,
-            ];
-        });
-
-        return $extAuth->toArray();
+            ->find('user', ['user' => $this->id])
+            ->map(function (ExternalAuth $item) {
+                return [
+                    'provider' => $item->auth_provider->name,
+                    'username' => $item->provider_username,
+                ];
+            })
+            ->toArray();
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/ExternalAuthTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ExternalAuthTable.php
@@ -185,4 +185,34 @@ class ExternalAuthTable extends Table
             $this->aliasField($this->AuthProviders->getForeignKey()) => $authProvider,
         ]);
     }
+
+    /**
+     * Find enabled external auth by user.
+     *
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @param array $options Additional options.
+     * @return \Cake\ORM\Query
+     * @throws \BEdita\Core\Exception\BadFilterException If missing `$options` data
+     */
+    protected function findUser(Query $query, array $options = []): Query
+    {
+        if (empty($options['user'])) {
+            throw new BadFilterException([
+                'title' => __d('bedita', 'Invalid data'),
+                'detail' => '"user" parameter missing',
+            ]);
+        }
+
+        $user = $options['user'];
+        if (!empty($user['id'])) {
+            $user = $user['id'];
+        }
+
+        return $query
+            ->contain('AuthProviders')
+            ->innerJoinWith('AuthProviders', function (Query $q) {
+                return $q->where(['AuthProviders.enabled' => true]);
+            })
+            ->where(['ExternalAuth.user_id' => $user]);
+    }
 }

--- a/plugins/BEdita/Core/tests/Fixture/AuthProvidersFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/AuthProvidersFixture.php
@@ -25,6 +25,7 @@ class AuthProvidersFixture extends TestFixture
      * {@inheritDoc}
      */
     public $records = [
+        // 1
         [
             'name' => 'example',
             'auth_class' => 'BEdita/API.OAuth2',
@@ -34,6 +35,7 @@ class AuthProvidersFixture extends TestFixture
             'created' => '2018-04-07 12:51:27',
             'modified' => '2018-04-07 12:51:27',
         ],
+        // 2
         [
             'name' => 'uuid',
             'auth_class' => 'BEdita/API.Uuid',
@@ -43,6 +45,7 @@ class AuthProvidersFixture extends TestFixture
             'created' => '2018-04-07 12:51:27',
             'modified' => '2018-04-07 12:51:27',
         ],
+        // 3
         [
             'name' => 'linkedout',
             'auth_class' => 'BEdita/API.OAuth2',
@@ -52,6 +55,7 @@ class AuthProvidersFixture extends TestFixture
             'created' => '2018-04-07 12:51:27',
             'modified' => '2018-04-07 12:51:27',
         ],
+        // 4
         [
             'name' => 'otp',
             'auth_class' => 'BEdita/API.OTP',

--- a/plugins/BEdita/Core/tests/Fixture/ExternalAuthFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ExternalAuthFixture.php
@@ -46,5 +46,13 @@ class ExternalAuthFixture extends TestFixture
             'created' => '2018-04-07 12:51:27',
             'modified' => '2018-04-07 12:51:27',
         ],
+        [
+            'user_id' => 5,
+            'auth_provider_id' => 3,
+            'params' => null,
+            'provider_username' => 'disabled_auth_provider',
+            'created' => '2020-10-26 17:16:27',
+            'modified' => '2020-10-26 17:16:27',
+        ],
     ];
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -57,6 +57,10 @@ class JsonApiTraitTest extends TestCase
         'plugin.BEdita/Core.RolesUsers',
         'plugin.BEdita/Core.Trees',
         'plugin.BEdita/Core.History',
+        'plugin.BEdita/Core.AuthProviders',
+        'plugin.BEdita/Core.ExternalAuth',
+        'plugin.BEdita/Core.Categories',
+        'plugin.BEdita/Core.ObjectCategories',
     ];
 
     /**
@@ -462,6 +466,7 @@ class JsonApiTraitTest extends TestCase
             'blocked',
             'created',
             'created_by',
+            'external_auth',
             'last_login',
             'last_login_err',
             'locked',
@@ -527,6 +532,7 @@ class JsonApiTraitTest extends TestCase
             'blocked',
             'created',
             'created_by',
+            'external_auth',
             'last_login',
             'last_login_err',
             'locked',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/UserTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/UserTest.php
@@ -14,9 +14,11 @@
 namespace BEdita\Core\Test\TestCase\Model\Entity;
 
 use BEdita\Core\Model\Entity\User;
+use BEdita\Core\Utility\JsonApiSerializable;
 use Cake\Auth\DefaultPasswordHasher;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 
 /**
  * {@see \BEdita\Core\Model\Entity\User} Test Case
@@ -47,6 +49,8 @@ class UserTest extends TestCase
         'plugin.BEdita/Core.Objects',
         'plugin.BEdita/Core.Profiles',
         'plugin.BEdita/Core.Users',
+        'plugin.BEdita/Core.AuthProviders',
+        'plugin.BEdita/Core.ExternalAuth',
     ];
 
     /**
@@ -156,5 +160,47 @@ class UserTest extends TestCase
 
         static::assertNotEquals('myPassword', $user->password_hash);
         static::assertTrue((new DefaultPasswordHasher())->check('myPassword', $user->password_hash));
+    }
+
+    /**
+     * Test getter for JSON API meta fields.
+     *
+     * @return void
+     *
+     * @covers ::getMeta()
+     * @covers ::getExternalAuthMeta()
+     */
+    public function testGetMeta(): void
+    {
+        $user = $this->Users->get(5);
+        $user = $user->jsonApiSerialize(
+            JsonApiSerializable::JSONAPIOPT_EXCLUDE_LINKS |
+            JsonApiSerializable::JSONAPIOPT_EXCLUDE_RELATIONSHIPS
+        );
+
+        static::assertArrayHasKey('external_auth', $user['meta']);
+        static::assertEquals('uuid', Hash::get($user, 'meta.external_auth.0.provider'));
+    }
+
+    /**
+     * Test that external_auth is null for entity withoud id.
+     *
+     * @return void
+     *
+     * @covers ::getMeta()
+     * @covers ::getExternalAuthMeta()
+     */
+    public function testGetMetaMissingUserId(): void
+    {
+        $user = new User();
+        $user->type = 'users';
+        $user->created_by = 1;
+        $user = $user->jsonApiSerialize(
+            JsonApiSerializable::JSONAPIOPT_EXCLUDE_LINKS |
+            JsonApiSerializable::JSONAPIOPT_EXCLUDE_RELATIONSHIPS
+        );
+
+        static::assertArrayHasKey('external_auth', $user['meta']);
+        static::assertEquals(null, Hash::get($user, 'meta.external_auth'));
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ExternalAuthTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ExternalAuthTableTest.php
@@ -327,4 +327,96 @@ class ExternalAuthTableTest extends TestCase
 
         static::assertEquals($expected, $result);
     }
+
+    /**
+     * Data provider for  `testFindUser()`
+     *
+     * @return array
+     */
+    public function findByUserProvider(): array
+    {
+        return [
+            'bad data' => [
+                new BadFilterException([
+                    'title' => 'Invalid data',
+                    'detail' => '"user" parameter missing',
+                ]),
+                null,
+            ],
+            'userId' => [
+                [
+                    [
+                        'id' => 2,
+                        'user_id' => 5,
+                        'auth_provider_id' => 2,
+                        'params' => null,
+                        'provider_username' => '17fec0fa-068a-4d7c-8283-da91d47cef7d',
+                        'created' => new Time('2018-04-07 12:51:27'),
+                        'modified' => new Time('2018-04-07 12:51:27'),
+                        'auth_provider' => [
+                            'id' => 2,
+                            'name' => 'uuid',
+                            'auth_class' => 'BEdita/API.Uuid',
+                            'url' => null,
+                            'params' => null,
+                            'enabled' => true,
+                            'created' => new Time('2018-04-07 12:51:27'),
+                            'modified' => new Time('2018-04-07 12:51:27'),
+                        ],
+                    ],
+                ],
+                5,
+            ],
+            'user as array' => [
+                [
+                    [
+                        'id' => 2,
+                        'user_id' => 5,
+                        'auth_provider_id' => 2,
+                        'params' => null,
+                        'provider_username' => '17fec0fa-068a-4d7c-8283-da91d47cef7d',
+                        'created' => new Time('2018-04-07 12:51:27'),
+                        'modified' => new Time('2018-04-07 12:51:27'),
+                        'auth_provider' => [
+                            'id' => 2,
+                            'name' => 'uuid',
+                            'auth_class' => 'BEdita/API.Uuid',
+                            'url' => null,
+                            'params' => null,
+                            'enabled' => true,
+                            'created' => new Time('2018-04-07 12:51:27'),
+                            'modified' => new Time('2018-04-07 12:51:27'),
+                        ],
+                    ],
+                ],
+                ['id' => 5],
+            ],
+        ];
+    }
+
+    /**
+     * Test finder by user.
+     *
+     * @param mixed $expected The expected result
+     * @param mixed $user The finder option
+     * @return void
+     *
+     * @covers ::findUser()
+     * @dataProvider findByUserProvider()
+     */
+    public function testFindByUser($expected, $user): void
+    {
+        if ($expected instanceof \Exception) {
+            $this->expectException(get_class($expected));
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+
+        $options = compact('user');
+        $result = $this->ExternalAuth
+            ->find('user', $options)
+            ->enableHydration(false)
+            ->toArray();
+
+        static::assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
This PR exposes in `meta` of `users` the external auth info as

```json
{
    "meta": {
        "external_auth": [
               {
                    "provider": "provider-name",
                    "username": "username-for-that-provider" 
               },
               {
                    "provider": "another-provider-name",
                    "username": "username-for-this-new-provider" 
               }
        ]
    }
}
```
