### PR TITLE
Email validation regex

### DIFF
--- a/bedita-app/app_model.php
+++ b/bedita-app/app_model.php
@@ -854,6 +854,20 @@ class BEAppModel extends AppModel {
         }
     }
 
+    /**
+     * Validate email with an up-to-date regex.
+     * 
+     * @param array $rule - An array with rule name as key (email) and value to validate
+     * @return bool
+     */
+    public function email(array $rule)
+    {
+        $Validation =& Validation::getInstance();
+        $hostnameRegex = "(?:[_\p{L}0-9][-_\p{L}0-9]*\.)*(?:[\p{L}0-9][-\p{L}0-9]{0,62})\.(?:(?:[a-z]{2}\.)?[a-z]{2,})";
+        $emailRegex = "/^[\p{L}0-9!#$%&\'*+\/=?^_`{|}~-]+(?:\.[\p{L}0-9!#$%&\'*+\/=?^_`{|}~-]+)*@" . $hostnameRegex . "$/i";
+
+        return $Validation->email($rule['email'], false, $emailRegex);
+    }
 }
 
 ///////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR fixes the regex used for email validation, now accepting all TLDs. The new regex is taken from CakePHP 3 validator.

The fix is made by creating `BEAppModel::email()` method that is automatically called on model validation. All BEdita models inherit the new regex without needing to update validation rules manually.

see [examples](https://regex101.com/r/INnusI/1)
