### PR TITLE
Update composer to use plugin-installer ^1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.1.0",
         "cakephp/cakephp": "~3.8.1",
-        "cakephp/plugin-installer": "^1.1",
+        "cakephp/plugin-installer": "^1.3",
         "wikimedia/composer-merge-plugin": "^1.4"
     },
     "require-dev": {
@@ -53,7 +53,6 @@
         "post-install-cmd": "BEdita\\App\\Console\\Installer::postInstall",
         "post-update-cmd": "BEdita\\App\\Console\\Installer::postInstall",
         "post-create-project-cmd": "BEdita\\App\\Console\\Installer::postInstall",
-        "post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump",
         "check": [
             "@test",
             "@cs-setup",


### PR DESCRIPTION
Remove the deprecated `Cake\Composer\Installer\PluginInstaller::postAutoloadDump()`.

![image](https://user-images.githubusercontent.com/1306319/98105827-c2faa300-1e98-11eb-8a36-bfa809af1ed6.png)

Now the autoload dump action is handled by pugin-installer taking advantage of composer plugin https://getcomposer.org/doc/articles/plugins.md