### PR TITLE
Feat/v4/filter related

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -754,4 +754,23 @@ class FilterQueryStringTest extends IntegrationTestCase
         $result = json_decode((string)$this->_response->getBody(), true);
         static::assertEquals(0, count($result['data']));
     }
+
+    /**
+     * Test `filter[related][{relation}]={id}`.
+     *
+     * @return void
+     * @coversNothing
+     */
+    public function testRelatedFilter(): void
+    {
+        $this->configRequestHeaders();
+        $this->get('/documents?filter[related][test]=4');
+        $result = json_decode((string)$this->_response->getBody(), true);
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertArrayHasKey('data', $result);
+        // assert documents id 2 and 3 are found
+        $found = Hash::extract($result, 'data.{n}.id');
+        static::assertEquals([2, 3], $found);
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
@@ -229,6 +229,8 @@ class RelationsBehavior extends Behavior
             if (empty($assoc) || !($assoc instanceof RelatedTo)) {
                 throw new BadFilterException(__d('bedita', 'Bad relation "{0}"', $relation));
             }
+            // Using default `available` finder in RelatedTo `through` class may cause an SQL error with this condition
+            // Example: if $objectId type is `Profiles` we may get => "no such column: {$alias}.deleted"
             $assoc->setFinder('all');
             $through = TableRegistry::getTableLocator()->get(
                 $alias . 'ObjectRelations',


### PR DESCRIPTION
This PR introduces a finder and a query string filter to retrieve objects related to one or more objects through an object relation.

A new `RelationsBehavior::findRelated()` finder method has been added.

Examples:

* `/documents?filter[related][has_media]=222` - documents having `has_media` relation with object id `222`
* `/documents?filter[related][has_media]=222,223,224` - documents having `has_media` relation with objects having id in `222,223,224` 
* `/documents?filter[related][has_media]=222&filter[related][part_of]=333`- documents having `has_media` relation with `222` and `part_of` with `333`

