### PR TITLE
DateRanges sort 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,7 +128,7 @@ before_install:
   # Use GitHub OAuth token with Composer to increase API limits.
   - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi
   # upgrade to MySQL 8 if requested
-  - if [ "$DB" = 'mysql8' ]; then wget https://repo.mysql.com//mysql-apt-config_0.8.10-1_all.deb; sudo dpkg -i mysql-apt-config_0.8.10-1_all.deb; sudo apt-key adv --keyserver keys.gnupg.net --recv-keys 8C718D3B5072E1F5; sudo apt-get update -q; sudo apt-get install -q -y --allow-unauthenticated -o Dpkg::Options::=--force-confnew mysql-server; sudo systemctl restart mysql; sudo mysql_upgrade; mysql --version ; fi
+  - if [ "$DB" = 'mysql8' ]; then wget https://repo.mysql.com//mysql-apt-config_0.8.10-1_all.deb; sudo dpkg -i mysql-apt-config_0.8.10-1_all.deb; sudo apt-key adv --keyserver keys.gnupg.net --recv-keys 8C718D3B5072E1F5; sudo apt-get update -q; sudo apt-get install -q -y --allow-unauthenticated -o Dpkg::Options::=--force-confnew mysql-server; sudo systemctl restart mysql; sudo mysql_upgrade; fi
 
 install:
   # Install Composer dependencies.
@@ -139,7 +139,7 @@ before_script:
   - set +H
 
   # Set up and configure databases.
-  - if [ "$DB" = 'mysql' ] || [ "$DB" = 'mysql8' ]; then mysql -u root -e 'CREATE DATABASE bedita_test;'; mysql -u root -e 'SHOW DATABASES;'; fi
+  - if [ "$DB" = 'mysql' ] || [ "$DB" = 'mysql8' ]; then mysql -u root -e 'CREATE DATABASE bedita_test;'; mysql -u root -e 'SHOW DATABASES;'; mysql -u root -e "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''))"; mysql --version; fi
   - if [ "$DB" = 'mariadb' ]; then sudo mysql -e 'CREATE DATABASE bedita_test;'; sudo mysql -e "SET Password=PASSWORD('travis');"; sudo mysql -e 'SHOW DATABASES;'; fi
   - if [ "$DB" = 'pgsql' ]; then psql -c 'CREATE DATABASE bedita_test;' -U postgres; fi
   - if [ "$DB" = 'pgsql' ] && [ "$DB_POSTGIS" = '1' ]; then psql -c 'CREATE EXTENSION postgis;' -U postgres; fi

--- a/plugins/BEdita/API/postman/BE4-template.postman_environment.json
+++ b/plugins/BEdita/API/postman/BE4-template.postman_environment.json
@@ -141,6 +141,18 @@
       "type": "text"
     },
     {
+        "enabled": true,
+        "key": "startDate",
+        "value": "",
+        "type": "text"
+    },
+    {
+        "enabled": true,
+        "key": "endDate",
+        "value": "",
+        "type": "text"
+    },
+    {
       "key": "annotationId",
       "value": "",
       "description": "",

--- a/plugins/BEdita/API/postman/BE4.postman_collection.json
+++ b/plugins/BEdita/API/postman/BE4.postman_collection.json
@@ -2951,6 +2951,50 @@
 					"response": []
 				},
 				{
+					"name": "GET objects index",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "4899d210-8c96-4b14-928a-f12cbb66f456",
+								"exec": [
+									"tests[\"Status code is 200\"] = responseCode.code === 200;",
+									"tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.api+json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}"
+							},
+							{
+								"key": "X-Api-Key",
+								"value": "{{apiKey}}"
+							}
+						],
+						"url": {
+							"raw": "{{be4Url}}/{{objectTypeName}}",
+							"host": [
+								"{{be4Url}}"
+							],
+							"path": [
+								"{{objectTypeName}}"
+							]
+						},
+						"description": "Get objects list"
+					},
+					"response": []
+				},
+				{
 					"name": "Modify object",
 					"event": [
 						{
@@ -4369,59 +4413,6 @@
 			"name": "7. Folders",
 			"item": [
 				{
-					"name": "Trees",
-					"item": [
-						{
-							"name": "Get path on trees",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "d4ec4dc4-de0c-408b-be3f-1f2b72133891",
-										"exec": [
-											"tests[\"Status code is 200\"] = responseCode.code === 200;",
-											"tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "Accept",
-										"value": "application/vnd.api+json"
-									},
-									{
-										"key": "Authorization",
-										"value": "Bearer {{jwt}}"
-									},
-									{
-										"key": "X-Api-Key",
-										"value": "{{apiKey}}"
-									}
-								],
-								"url": {
-									"raw": "{{be4Url}}/trees/{{rootFolderId}}/{{subFolderId}}/{{objectId}}",
-									"host": [
-										"{{be4Url}}"
-									],
-									"path": [
-										"trees",
-										"{{rootFolderId}}",
-										"{{subFolderId}}",
-										"{{objectId}}"
-									]
-								}
-							},
-							"response": []
-						}
-					],
-					"protocolProfileBehavior": {},
-					"_postman_isSubFolder": true
-				},
-				{
 					"name": "Create root folder",
 					"event": [
 						{
@@ -4681,7 +4672,7 @@
 							"script": {
 								"type": "text/javascript",
 								"exec": [
-									"tests[\"Status code is 200\"] = responseCode.code === 200;",
+									"tests[\"Status code is 200 or 204\"] = (responseCode.code === 200 || responseCode.code === 204);",
 									"tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';"
 								]
 							}
@@ -4709,7 +4700,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"data\": {\n        \"type\": \"folders\",\n        \"id\": \"{{rootFolderId}}\"\n    }\n}",
+							"raw": "{\n    \"data\": {\n        \"type\": \"folders\",\n        \"id\": \"{{rootFolderId}}\",\n        \"meta\": {\n            \"relation\": {\n                \"menu\": false,\n                \"canonical\": false\n            }\n        }\n    }\n}",
 							"options": {}
 						},
 						"url": {
@@ -4968,10 +4959,10 @@
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"data\": [\n    \t{\n\t        \"type\": \"{{objectTypeName}}\",\n\t        \"id\": \"{{objectId}}\",\n\t        \"meta\": {\n\t        \t\"relation\": {\n\t        \t\t\"canonical\": true,\n\t\t\t\t\t\"menu\": false\n\t        \t}\n\t        }\n    \t}\n    ]\n}\n",
-							"options": {
-								"raw": {}
-							}
-						},
+                            "options": {
+                                "raw": {}
+                            }
+                        },
 						"url": {
 							"raw": "{{be4Url}}/folders/{{rootFolderId}}/relationships/children",
 							"host": [
@@ -4982,6 +4973,61 @@
 								"{{rootFolderId}}",
 								"relationships",
 								"children"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Set parents folders",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "330def70-e268-4d2b-abc4-9c1be8e50918",
+								"exec": [
+									"tests[\"Status code is 200\"] = responseCode.code === 200;",
+									"tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.api+json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}"
+							},
+							{
+								"key": "X-Api-Key",
+								"value": "{{apiKey}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"data\": [\n        {\n            \"type\": \"folders\",\n            \"id\": \"{{rootFolderId}}\",\n            \"meta\": {\n\t            \"relation\": {\n\t        \t\t\"canonical\": true,\n\t\t\t\t\t\"menu\": true\n\t        \t}\n\t        }\n        },\n        {\n            \"type\": \"folders\",\n            \"id\": \"{{subFolderId}}\"\n        }\n    ] \n}",
+							"options": {}
+						},
+						"url": {
+							"raw": "{{be4Url}}/{{objectTypeName}}/{{objectId}}/relationships/parents",
+							"host": [
+								"{{be4Url}}"
+							],
+							"path": [
+								"{{objectTypeName}}",
+								"{{objectId}}",
+								"relationships",
+								"parents"
 							]
 						}
 					},
@@ -7482,7 +7528,748 @@
 			"protocolProfileBehavior": {}
 		},
 		{
-			"name": "14. Remove All",
+			"name": "14. Trees",
+			"item": [
+				{
+					"name": "Get path on trees",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "d4ec4dc4-de0c-408b-be3f-1f2b72133891",
+								"exec": [
+									"tests[\"Status code is 200\"] = responseCode.code === 200;",
+									"tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.api+json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}"
+							},
+							{
+								"key": "X-Api-Key",
+								"value": "{{apiKey}}"
+							}
+						],
+						"url": {
+							"raw": "{{be4Url}}/trees/{{rootFolderId}}/{{subFolderId}}/{{objectId}}",
+							"host": [
+								"{{be4Url}}"
+							],
+							"path": [
+								"trees",
+								"{{rootFolderId}}",
+								"{{subFolderId}}",
+								"{{objectId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get path on subfolder",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "034ee11a-95e9-41a5-a408-8e8ae41e3729",
+								"exec": [
+									"tests[\"Status code is 200\"] = responseCode.code === 200;",
+									"tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.api+json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}"
+							},
+							{
+								"key": "X-Api-Key",
+								"value": "{{apiKey}}"
+							}
+						],
+						"url": {
+							"raw": "{{be4Url}}/trees/{{rootFolderId}}/{{subFolderId}}",
+							"host": [
+								"{{be4Url}}"
+							],
+							"path": [
+								"trees",
+								"{{rootFolderId}}",
+								"{{subFolderId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get trees (roots)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fc8e853a-9b30-478f-8733-73b8e9420322",
+								"exec": [
+									"tests[\"Status code is 200\"] = responseCode.code === 200;",
+									"tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.api+json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}"
+							},
+							{
+								"key": "X-Api-Key",
+								"value": "{{apiKey}}"
+							}
+						],
+						"url": {
+							"raw": "{{be4Url}}/trees",
+							"host": [
+								"{{be4Url}}"
+							],
+							"path": [
+								"trees"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "15. Filters",
+			"item": [
+				{
+					"name": "Date Ranges",
+					"item": [
+						{
+							"name": "GET events + start date filter",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "0acc0a0c-0a24-499b-bc58-d8547e97ba23",
+										"exec": [
+											"var schema = {",
+											"    \"type\": \"object\",",
+											"    \"properties\": {",
+											"        \"data\": {",
+											"            \"type\": \"array\",",
+											"            \"properties\": {",
+											"                \"id\": {\"type\": \"string\"},",
+											"                \"type\": {\"type\": \"string\"},",
+											"                \"attributes\": {\"type\": \"object\"},",
+											"            },",
+											"            \"required\": [\"id\", \"type\", \"attributes\"]",
+											"        },",
+											"        \"links\": {",
+											"            \"type\": \"object\",",
+											"            \"properties\": {",
+											"                \"self\": {\"type\": \"string\", \"format\": \"uri\"},",
+											"                \"home\": {\"type\": \"string\", \"format\": \"uri\"},",
+											"            },",
+											"            \"required\": [\"self\", \"home\"]",
+											"        },",
+											"        \"meta\": {",
+											"            \"type\": \"object\",",
+											"            \"properties\": {",
+											"                \"pagination\": {",
+											"                    \"type\": \"object\",",
+											"                    \"properties\": {",
+											"                        \"count\": {\"type\": \"number\"},",
+											"                        \"page\": {\"type\": \"number\"},",
+											"                        \"page_count\": {\"type\": \"number\"},",
+											"                        \"page_items\": {\"type\": \"number\"},",
+											"                        \"page_size\": {\"type\": \"number\"}",
+											"                    },",
+											"                    \"required\": [\"count\",\"page\",\"page_count\",\"page_items\",\"page_size\"]",
+											"                }",
+											"            },",
+											"            \"required\": [\"pagination\"]",
+											"        }",
+											"    },",
+											"    \"required\": [\"data\",\"links\",\"meta\"]",
+											"};",
+											"var responseJSON;",
+											"try {",
+											"    responseJSON = JSON.parse(responseBody); ",
+											"    tests[\"Status code is 200\"] = responseCode.code === 200;",
+											"    tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';",
+											"    tests[\"Valid data\"] = tv4.validate(responseJSON, schema);",
+											"} catch (e) {",
+											"    tests[\"Error in parsing response\"] = e;",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.api+json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{jwt}}"
+									},
+									{
+										"key": "X-Api-Key",
+										"value": "{{apiKey}}"
+									}
+								],
+								"url": {
+									"raw": "{{be4Url}}/events?filter[date_ranges][start_date][gt]={{startDate}}",
+									"host": [
+										"{{be4Url}}"
+									],
+									"path": [
+										"events"
+									],
+									"query": [
+										{
+											"key": "filter[date_ranges][start_date][gt]",
+											"value": "{{startDate}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "GET events + end date filter",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "0e47f94c-166b-48f2-bd11-fce4270a2626",
+										"exec": [
+											"var schema = {",
+											"    \"type\": \"object\",",
+											"    \"properties\": {",
+											"        \"data\": {",
+											"            \"type\": \"array\",",
+											"            \"properties\": {",
+											"                \"id\": {\"type\": \"string\"},",
+											"                \"type\": {\"type\": \"string\"},",
+											"                \"attributes\": {\"type\": \"object\"},",
+											"            },",
+											"            \"required\": [\"id\", \"type\", \"attributes\"]",
+											"        },",
+											"        \"links\": {",
+											"            \"type\": \"object\",",
+											"            \"properties\": {",
+											"                \"self\": {\"type\": \"string\", \"format\": \"uri\"},",
+											"                \"home\": {\"type\": \"string\", \"format\": \"uri\"},",
+											"            },",
+											"            \"required\": [\"self\", \"home\"]",
+											"        },",
+											"        \"meta\": {",
+											"            \"type\": \"object\",",
+											"            \"properties\": {",
+											"                \"pagination\": {",
+											"                    \"type\": \"object\",",
+											"                    \"properties\": {",
+											"                        \"count\": {\"type\": \"number\"},",
+											"                        \"page\": {\"type\": \"number\"},",
+											"                        \"page_count\": {\"type\": \"number\"},",
+											"                        \"page_items\": {\"type\": \"number\"},",
+											"                        \"page_size\": {\"type\": \"number\"}",
+											"                    },",
+											"                    \"required\": [\"count\",\"page\",\"page_count\",\"page_items\",\"page_size\"]",
+											"                }",
+											"            },",
+											"            \"required\": [\"pagination\"]",
+											"        }",
+											"    },",
+											"    \"required\": [\"data\",\"links\",\"meta\"]",
+											"};",
+											"var responseJSON;",
+											"try {",
+											"    responseJSON = JSON.parse(responseBody); ",
+											"    tests[\"Status code is 200\"] = responseCode.code === 200;",
+											"    tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';",
+											"    tests[\"Valid data\"] = tv4.validate(responseJSON, schema);",
+											"} catch (e) {",
+											"    tests[\"Error in parsing response\"] = e;",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.api+json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{jwt}}"
+									},
+									{
+										"key": "X-Api-Key",
+										"value": "{{apiKey}}"
+									}
+								],
+								"url": {
+									"raw": "{{be4Url}}/events?filter[date_ranges][end_date][le]={{endDate}}",
+									"host": [
+										"{{be4Url}}"
+									],
+									"path": [
+										"events"
+									],
+									"query": [
+										{
+											"key": "filter[date_ranges][end_date][le]",
+											"value": "{{endDate}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "GET events + from date filter",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c42e1e23-8962-4667-8624-f946f38b39b5",
+										"exec": [
+											"var schema = {",
+											"    \"type\": \"object\",",
+											"    \"properties\": {",
+											"        \"data\": {",
+											"            \"type\": \"array\",",
+											"            \"properties\": {",
+											"                \"id\": {\"type\": \"string\"},",
+											"                \"type\": {\"type\": \"string\"},",
+											"                \"attributes\": {\"type\": \"object\"},",
+											"            },",
+											"            \"required\": [\"id\", \"type\", \"attributes\"]",
+											"        },",
+											"        \"links\": {",
+											"            \"type\": \"object\",",
+											"            \"properties\": {",
+											"                \"self\": {\"type\": \"string\", \"format\": \"uri\"},",
+											"                \"home\": {\"type\": \"string\", \"format\": \"uri\"},",
+											"            },",
+											"            \"required\": [\"self\", \"home\"]",
+											"        },",
+											"        \"meta\": {",
+											"            \"type\": \"object\",",
+											"            \"properties\": {",
+											"                \"pagination\": {",
+											"                    \"type\": \"object\",",
+											"                    \"properties\": {",
+											"                        \"count\": {\"type\": \"number\"},",
+											"                        \"page\": {\"type\": \"number\"},",
+											"                        \"page_count\": {\"type\": \"number\"},",
+											"                        \"page_items\": {\"type\": \"number\"},",
+											"                        \"page_size\": {\"type\": \"number\"}",
+											"                    },",
+											"                    \"required\": [\"count\",\"page\",\"page_count\",\"page_items\",\"page_size\"]",
+											"                }",
+											"            },",
+											"            \"required\": [\"pagination\"]",
+											"        }",
+											"    },",
+											"    \"required\": [\"data\",\"links\",\"meta\"]",
+											"};",
+											"var responseJSON;",
+											"try {",
+											"    responseJSON = JSON.parse(responseBody); ",
+											"    tests[\"Status code is 200\"] = responseCode.code === 200;",
+											"    tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';",
+											"    tests[\"Valid data\"] = tv4.validate(responseJSON, schema);",
+											"} catch (e) {",
+											"    tests[\"Error in parsing response\"] = e;",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.api+json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{jwt}}"
+									},
+									{
+										"key": "X-Api-Key",
+										"value": "{{apiKey}}"
+									}
+								],
+								"url": {
+									"raw": "{{be4Url}}/events?filter[date_ranges][from_date]={{startDate}}",
+									"host": [
+										"{{be4Url}}"
+									],
+									"path": [
+										"events"
+									],
+									"query": [
+										{
+											"key": "filter[date_ranges][from_date]",
+											"value": "{{startDate}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "GET events + to date filter",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "70bf3cf8-773a-4607-8323-1ee00718c07b",
+										"exec": [
+											"var schema = {",
+											"    \"type\": \"object\",",
+											"    \"properties\": {",
+											"        \"data\": {",
+											"            \"type\": \"array\",",
+											"            \"properties\": {",
+											"                \"id\": {\"type\": \"string\"},",
+											"                \"type\": {\"type\": \"string\"},",
+											"                \"attributes\": {\"type\": \"object\"},",
+											"            },",
+											"            \"required\": [\"id\", \"type\", \"attributes\"]",
+											"        },",
+											"        \"links\": {",
+											"            \"type\": \"object\",",
+											"            \"properties\": {",
+											"                \"self\": {\"type\": \"string\", \"format\": \"uri\"},",
+											"                \"home\": {\"type\": \"string\", \"format\": \"uri\"},",
+											"            },",
+											"            \"required\": [\"self\", \"home\"]",
+											"        },",
+											"        \"meta\": {",
+											"            \"type\": \"object\",",
+											"            \"properties\": {",
+											"                \"pagination\": {",
+											"                    \"type\": \"object\",",
+											"                    \"properties\": {",
+											"                        \"count\": {\"type\": \"number\"},",
+											"                        \"page\": {\"type\": \"number\"},",
+											"                        \"page_count\": {\"type\": \"number\"},",
+											"                        \"page_items\": {\"type\": \"number\"},",
+											"                        \"page_size\": {\"type\": \"number\"}",
+											"                    },",
+											"                    \"required\": [\"count\",\"page\",\"page_count\",\"page_items\",\"page_size\"]",
+											"                }",
+											"            },",
+											"            \"required\": [\"pagination\"]",
+											"        }",
+											"    },",
+											"    \"required\": [\"data\",\"links\",\"meta\"]",
+											"};",
+											"var responseJSON;",
+											"try {",
+											"    responseJSON = JSON.parse(responseBody); ",
+											"    tests[\"Status code is 200\"] = responseCode.code === 200;",
+											"    tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';",
+											"    tests[\"Valid data\"] = tv4.validate(responseJSON, schema);",
+											"} catch (e) {",
+											"    tests[\"Error in parsing response\"] = e;",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.api+json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{jwt}}"
+									},
+									{
+										"key": "X-Api-Key",
+										"value": "{{apiKey}}"
+									}
+								],
+								"url": {
+									"raw": "{{be4Url}}/events?filter[date_ranges][to_date]={{endDate}}",
+									"host": [
+										"{{be4Url}}"
+									],
+									"path": [
+										"events"
+									],
+									"query": [
+										{
+											"key": "filter[date_ranges][to_date]",
+											"value": "{{endDate}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "GET events + from date/to date filters",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "93bd94be-7a7d-43b9-9a7e-a9310c24fd58",
+										"exec": [
+											"var schema = {",
+											"    \"type\": \"object\",",
+											"    \"properties\": {",
+											"        \"data\": {",
+											"            \"type\": \"array\",",
+											"            \"properties\": {",
+											"                \"id\": {\"type\": \"string\"},",
+											"                \"type\": {\"type\": \"string\"},",
+											"                \"attributes\": {\"type\": \"object\"},",
+											"            },",
+											"            \"required\": [\"id\", \"type\", \"attributes\"]",
+											"        },",
+											"        \"links\": {",
+											"            \"type\": \"object\",",
+											"            \"properties\": {",
+											"                \"self\": {\"type\": \"string\", \"format\": \"uri\"},",
+											"                \"home\": {\"type\": \"string\", \"format\": \"uri\"},",
+											"            },",
+											"            \"required\": [\"self\", \"home\"]",
+											"        },",
+											"        \"meta\": {",
+											"            \"type\": \"object\",",
+											"            \"properties\": {",
+											"                \"pagination\": {",
+											"                    \"type\": \"object\",",
+											"                    \"properties\": {",
+											"                        \"count\": {\"type\": \"number\"},",
+											"                        \"page\": {\"type\": \"number\"},",
+											"                        \"page_count\": {\"type\": \"number\"},",
+											"                        \"page_items\": {\"type\": \"number\"},",
+											"                        \"page_size\": {\"type\": \"number\"}",
+											"                    },",
+											"                    \"required\": [\"count\",\"page\",\"page_count\",\"page_items\",\"page_size\"]",
+											"                }",
+											"            },",
+											"            \"required\": [\"pagination\"]",
+											"        }",
+											"    },",
+											"    \"required\": [\"data\",\"links\",\"meta\"]",
+											"};",
+											"var responseJSON;",
+											"try {",
+											"    responseJSON = JSON.parse(responseBody); ",
+											"    tests[\"Status code is 200\"] = responseCode.code === 200;",
+											"    tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';",
+											"    tests[\"Valid data\"] = tv4.validate(responseJSON, schema);",
+											"} catch (e) {",
+											"    tests[\"Error in parsing response\"] = e;",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.api+json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{jwt}}"
+									},
+									{
+										"key": "X-Api-Key",
+										"value": "{{apiKey}}"
+									}
+								],
+								"url": {
+									"raw": "{{be4Url}}/events?filter[date_ranges][from_date]={{startDate}}&filter[date_ranges][to_date]={{endDate}}",
+									"host": [
+										"{{be4Url}}"
+									],
+									"path": [
+										"events"
+									],
+									"query": [
+										{
+											"key": "filter[date_ranges][from_date]",
+											"value": "{{startDate}}"
+										},
+										{
+											"key": "filter[date_ranges][to_date]",
+											"value": "{{endDate}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "GET events + from date filter + sort date_ranges.start_date",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "cace3779-474c-4207-977b-92a9e4e389b5",
+										"exec": [
+											"var schema = {",
+											"    \"type\": \"object\",",
+											"    \"properties\": {",
+											"        \"data\": {",
+											"            \"type\": \"array\",",
+											"            \"properties\": {",
+											"                \"id\": {\"type\": \"string\"},",
+											"                \"type\": {\"type\": \"string\"},",
+											"                \"attributes\": {\"type\": \"object\"},",
+											"            },",
+											"            \"required\": [\"id\", \"type\", \"attributes\"]",
+											"        },",
+											"        \"links\": {",
+											"            \"type\": \"object\",",
+											"            \"properties\": {",
+											"                \"self\": {\"type\": \"string\", \"format\": \"uri\"},",
+											"                \"home\": {\"type\": \"string\", \"format\": \"uri\"},",
+											"            },",
+											"            \"required\": [\"self\", \"home\"]",
+											"        },",
+											"        \"meta\": {",
+											"            \"type\": \"object\",",
+											"            \"properties\": {",
+											"                \"pagination\": {",
+											"                    \"type\": \"object\",",
+											"                    \"properties\": {",
+											"                        \"count\": {\"type\": \"number\"},",
+											"                        \"page\": {\"type\": \"number\"},",
+											"                        \"page_count\": {\"type\": \"number\"},",
+											"                        \"page_items\": {\"type\": \"number\"},",
+											"                        \"page_size\": {\"type\": \"number\"}",
+											"                    },",
+											"                    \"required\": [\"count\",\"page\",\"page_count\",\"page_items\",\"page_size\"]",
+											"                }",
+											"            },",
+											"            \"required\": [\"pagination\"]",
+											"        }",
+											"    },",
+											"    \"required\": [\"data\",\"links\",\"meta\"]",
+											"};",
+											"var responseJSON;",
+											"try {",
+											"    responseJSON = JSON.parse(responseBody); ",
+											"    tests[\"Status code is 200\"] = responseCode.code === 200;",
+											"    tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';",
+											"    tests[\"Valid data\"] = tv4.validate(responseJSON, schema);",
+											"} catch (e) {",
+											"    tests[\"Error in parsing response\"] = e;",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/vnd.api+json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{jwt}}"
+									},
+									{
+										"key": "X-Api-Key",
+										"value": "{{apiKey}}"
+									}
+								],
+								"url": {
+									"raw": "{{be4Url}}/events?filter[date_ranges][from_date]={{startDate}}&sort=date_ranges.start_date&fields=title,date_ranges",
+									"host": [
+										"{{be4Url}}"
+									],
+									"path": [
+										"events"
+									],
+									"query": [
+										{
+											"key": "filter[date_ranges][from_date]",
+											"value": "{{startDate}}"
+										},
+										{
+											"key": "sort",
+											"value": "date_ranges.start_date"
+										},
+										{
+											"key": "fields",
+											"value": "title,date_ranges"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "16. Remove All",
 			"item": [
 				{
 					"name": "Remove sub folder permanently",
@@ -8090,6 +8877,28 @@
 				}
 			],
 			"description": "Remove all objects and resources created",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "1a17a11e-cc7f-4eb7-b3ad-ceec1af735a1",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "3571ab85-2508-4393-8619-bb60deac624c",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			],
 			"protocolProfileBehavior": {}
 		}
 	],

--- a/plugins/BEdita/API/src/TestSuite/IntegrationTestCase.php
+++ b/plugins/BEdita/API/src/TestSuite/IntegrationTestCase.php
@@ -71,6 +71,7 @@ abstract class IntegrationTestCase extends CakeIntegrationTestCase
         'plugin.BEdita/Core.Categories',
         'plugin.BEdita/Core.ObjectCategories',
         'plugin.BEdita/Core.History',
+        'plugin.BEdita/Core.DateRanges',
     ];
 
     /**

--- a/plugins/BEdita/API/tests/IntegrationTest/SortQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/SortQueryStringTest.php
@@ -52,7 +52,7 @@ class SortQueryStringTest extends IntegrationTestCase
                 200,
                 '/roles',
                 'name'
-            ]
+            ],
         ];
     }
 
@@ -92,5 +92,49 @@ class SortQueryStringTest extends IntegrationTestCase
             $sortedFields = array_reverse($sortedFields);
             $this->assertEquals($fields, $sortedFields);
         }
+    }
+
+    /**
+     * Provider for testDateRangesSort()
+     *
+     * @return array
+     */
+    public function dateRangesSortProvider()
+    {
+        return [
+            'date ranges start' => [
+                200,
+                '/events?filter[date_ranges][from_date]=2016-12-01&sort=date_ranges.start_date',
+            ],
+            'date ranges end' => [
+                200,
+                '/events?filter[date_ranges][from_date]=2018-12-01&sort=-date_ranges.end_date',
+            ],
+            'date ranges fail' => [
+                400,
+                '/events?sort=date_ranges.end_date',
+            ],
+            'not applicable' => [
+                400,
+                '/profiles?sort=date_ranges.end_date',
+            ],
+        ];
+    }
+
+    /**
+     * Test sort on different endpoints
+     *
+     * @param mixed $expected Expected result
+     * @param string $url Request URL
+     * @return void
+     *
+     * @dataProvider dateRangesSortProvider
+     * @coversNothing
+     */
+    public function testDateRangesSort($expected, $url): void
+    {
+        $this->configRequestHeaders();
+        $this->get($url);
+        $this->assertResponseCode($expected);
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Datasource/JsonApiPaginatorTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Datasource/JsonApiPaginatorTest.php
@@ -141,6 +141,7 @@ class JsonApiPaginatorTest extends TestCase
      *
      * @dataProvider validateSortProvider()
      * @covers ::validateSort()
+     * @covers ::updateSortOptions()
      */
     public function testValidateSort($expected, $sort = null)
     {
@@ -155,6 +156,26 @@ class JsonApiPaginatorTest extends TestCase
 
         $options = $paginator->validateSort($repository, compact('sort'));
 
+        static::assertEquals($expected, $options['order']);
+    }
+
+    /**
+     * Undocumented function
+     *
+     * @return void
+     *
+     * @covers ::updateSortOptions()
+     */
+    public function testAssocSort(): void
+    {
+        $paginator = new JsonApiPaginator();
+        $repository = TableRegistry::getTableLocator()->get('Roles')->find()->getRepository();
+        $sort = 'date_ranges.start_date';
+        $paginator->setConfig('filter', ['date_ranges' => 1]);
+
+        $options = $paginator->validateSort($repository, compact('sort'));
+
+        $expected = ['DateRanges.start_date' => 'asc'];
         static::assertEquals($expected, $options['order']);
     }
 

--- a/plugins/BEdita/API/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/plugins/BEdita/API/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -61,6 +61,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
                     'plugin.BEdita/Core.Categories',
                     'plugin.BEdita/Core.ObjectCategories',
                     'plugin.BEdita/Core.History',
+                    'plugin.BEdita/Core.DateRanges',
                 ],
                 []
             ],
@@ -92,6 +93,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
                     'plugin.BEdita/Core.Categories',
                     'plugin.BEdita/Core.ObjectCategories',
                     'plugin.BEdita/Core.History',
+                    'plugin.BEdita/Core.DateRanges',
                 ],
                 [
                     'plugin.BEdita/Core.Users',

--- a/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
@@ -156,7 +156,6 @@ class DateRangesTable extends Table
             'end_date',
             'from_date',
             'to_date',
-            'order_date',
         ]);
         $options = array_intersect_key($options, $allowed);
         if (empty($options)) {
@@ -165,8 +164,6 @@ class DateRangesTable extends Table
                 'detail' => 'start_date or end_date or date parameter missing',
             ]);
         }
-        $query = $this->orderFilter($query, $options);
-        unset($options['order_date']);
 
         $query = $this->fromToDateFilter($query, $options);
         unset($options['from_date'], $options['to_date']);
@@ -264,23 +261,6 @@ class DateRangesTable extends Table
                         ->lte($this->aliasField('end_date'), $to),
                 ]);
         });
-    }
-
-    /**
-     * Add an order query condition
-     *
-     * @param \Cake\ORM\Query $query Query object instance.
-     * @param array $options Array of conditions.
-     * @return \Cake\ORM\Query
-     */
-    protected function orderFilter(Query $query, array $options): Query
-    {
-        $order = (string)Hash::get($options, 'order_date');
-        if (empty($order)) {
-            return $query;
-        }
-
-        return $query->order([$this->aliasField('start_date') => $order]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
@@ -155,7 +155,8 @@ class DateRangesTable extends Table
             'start_date',
             'end_date',
             'from_date',
-            'to_date'
+            'to_date',
+            'order_date',
         ]);
         $options = array_intersect_key($options, $allowed);
         if (empty($options)) {
@@ -164,6 +165,8 @@ class DateRangesTable extends Table
                 'detail' => 'start_date or end_date or date parameter missing',
             ]);
         }
+        $query = $this->orderFilter($query, $options);
+        unset($options['order_date']);
 
         $query = $this->fromToDateFilter($query, $options);
         unset($options['from_date'], $options['to_date']);
@@ -261,6 +264,23 @@ class DateRangesTable extends Table
                         ->lte($this->aliasField('end_date'), $to),
                 ]);
         });
+    }
+
+    /**
+     * Add an order query condition
+     *
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @param array $options Array of conditions.
+     * @return \Cake\ORM\Query
+     */
+    protected function orderFilter(Query $query, array $options): Query
+    {
+        $order = (string)Hash::get($options, 'order_date');
+        if (empty($order)) {
+            return $query;
+        }
+
+        return $query->order([$this->aliasField('start_date') => $order]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -363,7 +363,7 @@ class ObjectsTable extends Table
             throw new BadFilterException(__d('bedita', 'Invalid options for finder "{0}"', 'status'));
         }
 
-        $level = reset($options);
+        $level = $options[0];
         switch ($level) {
             case 'on':
                 return $query->where([

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -261,7 +261,8 @@ class ObjectsTable extends Table
             ->distinct([$this->aliasField($this->getPrimaryKey())])
             ->innerJoinWith('DateRanges', function (Query $query) use ($options) {
                 return $query->find('dateRanges', $options);
-            });
+            })
+            ->group($this->aliasField('id'));
     }
 
     /**
@@ -363,7 +364,7 @@ class ObjectsTable extends Table
             throw new BadFilterException(__d('bedita', 'Invalid options for finder "{0}"', 'status'));
         }
 
-        $level = reset($options);
+        $level = $options[0];
         switch ($level) {
             case 'on':
                 return $query->where([

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -261,8 +261,7 @@ class ObjectsTable extends Table
             ->distinct([$this->aliasField($this->getPrimaryKey())])
             ->innerJoinWith('DateRanges', function (Query $query) use ($options) {
                 return $query->find('dateRanges', $options);
-            })
-            ->group($this->aliasField('id'));
+            });
     }
 
     /**
@@ -364,7 +363,7 @@ class ObjectsTable extends Table
             throw new BadFilterException(__d('bedita', 'Invalid options for finder "{0}"', 'status'));
         }
 
-        $level = $options[0];
+        $level = reset($options);
         switch ($level) {
             case 'on':
                 return $query->where([


### PR DESCRIPTION
This PR enables sorting on `date_ranges.start_date` or `date_ranges.end_date` when a `date_ranges` filter is used.

Examples:

* `/events?filter[date_ranges][from_date]=2020-03-01&sort=date_ranges.start_date` - events scheduled/valid from a date ordered by start date

* `/events?filter[date_ranges][to_date]=2020-03-01&sort=-date_ranges.end_date` - events scheduled/valid until a date orderd by descending end date

Current issues: 
 * in MySQL `ONLY_FULL_GROUP_BY` must be disabled
 * on Postgres this strategy is not working => `ERROR:  SELECT DISTINCT ON expressions must match initial ORDER BY expressions` 

Bonus track:
 * postman reference updated with new `Filters` folder
