### PR TITLE
Fix signup when user has no roles but conf require roles

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -426,7 +426,8 @@ return [
      * - `requireActivation` - boolean (default: true) - Are new users required to verify their contact method
      *      before being "activated"? If true upon creation user will have a `draft` status, otherwise `on`
      * - 'roles' - allowed role names on user signup (this config should be set normally at application level),
-     *      requested user roles MUST be included in this array
+     *      requested user roles MUST be included in this array.
+     *      Leave empty to allow signup only for users without roles.
      * - 'requireEmail' - require email upon signup (default: true)
      * - 'activationUrl' => default activation URL to use if not set by application
      * - 'requirePassword' - require password upon signup (default: true), can be false in some AUTH schemas like One Time Password

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -230,10 +230,7 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
             return __d('bedita', 'Roles are not allowed on signup');
         }
 
-        $adminRoleName = TableRegistry::getTableLocator()
-            ->get('Roles')
-            ->get(RolesTable::ADMIN_ROLE)
-            ->get('name');
+        $adminRoleName = $this->Roles->get(RolesTable::ADMIN_ROLE)->get('name');
 
         $roles = (array)$roles;
         $message = '{0} not allowed on signup';

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -241,7 +241,6 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
             return __d('bedita', $message, [$adminRoleName]);
         }
 
-
         $valid = array_intersect($roles, $allowedRoles);
         if (empty(array_diff($roles, $valid))) {
             return true;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -23,7 +23,6 @@ use Cake\Event\EventManager;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\InternalErrorException;
 use Cake\Http\Exception\UnauthorizedException;
-use Cake\Mailer\Email;
 use Cake\Mailer\TransportFactory;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -56,6 +55,7 @@ class SignupUserActionTest extends TestCase
         'plugin.BEdita/Core.RelationTypes',
         'plugin.BEdita/Core.ObjectRelations',
         'plugin.BEdita/Core.History',
+        'plugin.BEdita/Core.ObjectCategories',
     ];
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -56,6 +56,7 @@ class SignupUserActionTest extends TestCase
         'plugin.BEdita/Core.ObjectRelations',
         'plugin.BEdita/Core.History',
         'plugin.BEdita/Core.ObjectCategories',
+        'plugin.BEdita/Core.Categories',
     ];
 
     /**


### PR DESCRIPTION
This PR fixes some issues when `Signup.roles` is configured.

All logic that checks roles is now in a custom validation method.
Now when:
* `Signup.roles` is empty => signup is allowed for users without roles
* `Signup.roles` not empty => signup requires `roles` and all those passed must be present in conf 

A little refactor was done to set config `Signup` as configuration of the action.