### PR TITLE
fix: search behavior update

### DIFF
--- a/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
@@ -131,8 +131,8 @@ class SearchableBehavior extends Behavior
         $words = array_unique(array_map( // Escape `%`, `_` and `\` characters in words.
             function ($word) {
                 return str_replace(
-                    ['%', '_', '\\'],
-                    ['\\%', '_', '\\\\'],
+                    ['%', '\\'],
+                    ['\\%', '\\\\'],
                     $word
                 );
             },

--- a/plugins/BEdita/Core/tests/Fixture/FakeSearchesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeSearchesFixture.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\Fixture;
+
+use BEdita\Core\TestSuite\Fixture\TestFixture;
+
+/**
+ * Fixture for `fake_search` table.
+ */
+class FakeSearchesFixture extends TestFixture
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public $fields = [
+        'id' => ['type' => 'integer', 'length' => 10, 'unsigned' => true, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => true],
+        'name' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'precision' => null],
+        'updated_at' => ['type' => 'datetime', 'null' => true, 'default' => null],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+        ],
+        '_options' => [
+            'engine' => 'InnoDB',
+            'collation' => 'utf8_general_ci'
+        ],
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public $records = [
+        ['name' => 'hippo-tiger'],
+        ['name' => 'lion_snake'],
+    ];
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
@@ -206,11 +206,13 @@ class SearchableBehaviorTest extends TestCase
                 'lion_snake',
                 'FakeSearches',
             ],
-            // 'search underscore 2' => [
-            //     [],
-            //     'li_n',
-            //     'FakeSearches',
-            // ],
+             'search underscore 2' => [
+                 [
+                     2 => 'lion_snake',
+                 ],
+                 'li_n',
+                 'FakeSearches',
+             ],
         ];
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
@@ -35,6 +35,7 @@ class SearchableBehaviorTest extends TestCase
         'plugin.BEdita/Core.FakeAnimals',
         'plugin.BEdita/Core.FakeMammals',
         'plugin.BEdita/Core.FakeFelines',
+        'plugin.BEdita/Core.FakeSearches',
     ];
 
     /**
@@ -191,6 +192,25 @@ class SearchableBehaviorTest extends TestCase
                 ]),
                 'this query string contains too many words thus will be rejected to avoid denial of service',
             ],
+            'search hyphen' => [
+                [
+                    1 => 'hippo-tiger',
+                ],
+                'hippo-tiger',
+                'FakeSearches',
+            ],
+            'search underscore' => [
+                [
+                    2 => 'lion_snake',
+                ],
+                'lion_snake',
+                'FakeSearches',
+            ],
+            // 'search underscore 2' => [
+            //     [],
+            //     'li_n',
+            //     'FakeSearches',
+            // ],
         ];
     }
 


### PR DESCRIPTION
This provides an update on `SearchableBehavior`, to provide search when text contain `_` or `-`.
