### PR TITLE
Dispatch JsonApi.beforeFormatData and JsonApi.afterFormatData events

### DIFF
--- a/plugins/BEdita/API/src/Utility/JsonApi.php
+++ b/plugins/BEdita/API/src/Utility/JsonApi.php
@@ -32,7 +32,7 @@ class JsonApi
     /**
      * Format single or multiple data items in JSON API format.
      *
-     * Two events will be dispacthed:
+     * Two events will be dispatched:
      * - `beforeFormatData` dispatched before the formatting of `$items`
      * - `afterFormatData` dispatched after the formatting of `$items`
      *

--- a/plugins/BEdita/API/src/Utility/JsonApi.php
+++ b/plugins/BEdita/API/src/Utility/JsonApi.php
@@ -65,7 +65,7 @@ class JsonApi
             $options |= JsonApiSerializable::JSONAPIOPT_EXCLUDE_LINKS;
         }
 
-        $items = static::dispatchEvent('JsonApi.beforeFormatData', $items);
+        $items = (array)static::dispatchEvent('JsonApi.beforeFormatData', $items);
 
         $data = $types = [];
         foreach ($items as $item) {
@@ -94,7 +94,7 @@ class JsonApi
             }
         }
 
-        $data = static::dispatchEvent('JsonApi.afterFormatData', $data);
+        $data = (array)static::dispatchEvent('JsonApi.afterFormatData', $data);
 
         $data = $single ? $data[0] : $data;
         $schema = static::metaSchema(array_filter(array_unique($types)));

--- a/plugins/BEdita/API/src/Utility/JsonApi.php
+++ b/plugins/BEdita/API/src/Utility/JsonApi.php
@@ -33,7 +33,7 @@ class JsonApi
      * Format single or multiple data items in JSON API format.
      *
      * Two events will be dispacthed:
-     * - `beforeFormatData` dispacthed before the formatting of `$items`
+     * - `beforeFormatData` dispatched before the formatting of `$items`
      * - `afterFormatData` dispatched after the formatting of `$items`
      *
      * @param \BEdita\Core\Utility\JsonApiSerializable|\BEdita\Core\Utility\JsonApiSerializable[]|null $items Items to be formatted.

--- a/plugins/BEdita/API/src/Utility/JsonApi.php
+++ b/plugins/BEdita/API/src/Utility/JsonApi.php
@@ -15,6 +15,8 @@ namespace BEdita\API\Utility;
 use BEdita\Core\Utility\JsonApiSerializable;
 use BEdita\Core\Utility\JsonSchema;
 use Cake\Collection\CollectionInterface;
+use Cake\Event\Event;
+use Cake\Event\EventManager;
 use Cake\Http\Exception\NotFoundException;
 use Cake\ORM\Query;
 use Cake\Routing\Router;
@@ -59,6 +61,12 @@ class JsonApi
             $options |= JsonApiSerializable::JSONAPIOPT_EXCLUDE_LINKS;
         }
 
+        $event = new Event('JsonApi.beforeFormat', null, compact('items'));
+        EventManager::instance()->dispatch($event);
+        if (is_array($event->getResult())) {
+            $items = $event->getResult();
+        }
+
         $data = $types = [];
         foreach ($items as $item) {
             if (!$item instanceof JsonApiSerializable) {
@@ -84,6 +92,12 @@ class JsonApi
             if (!empty($item['attributes']) && !empty($item['type'])) {
                 $types[] = $item['type'];
             }
+        }
+
+        $event = new Event('JsonApi.afterFormat', null, compact('data'));
+        EventManager::instance()->dispatch($event);
+        if (is_array($event->getResult())) {
+            $data = $event->getResult();
         }
 
         $data = $single ? $data[0] : $data;

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -799,13 +799,13 @@ class JsonApiTest extends TestCase
     }
 
     /**
-     * Test that ana exception was raised if the some item was not serializabile.
+     * Test that an exception was raised if some item was not serializable.
      *
      * @return void
      *
      * @covers ::formatData()
      */
-    public function testNotJsonSerializabile(): void
+    public function testNotJsonSerializable(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(sprintf('Objects must implement "%s", got "array" instead', JsonApiSerializable::class));

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -474,8 +474,9 @@ class JsonApiTest extends TestCase
      * @return void
      *
      * @dataProvider formatDataProvider
-     * @covers ::formatData
-     * @covers ::metaSchema
+     * @covers ::formatData()
+     * @covers ::metaSchema()
+     * @covers ::dispatchEvent()
      */
     public function testFormatData($expected, callable $items, $options = 0)
     {
@@ -732,15 +733,18 @@ class JsonApiTest extends TestCase
     }
 
     /**
-     * Test `JsonApi.beforeFormat` event.
+     * Test `JsonApi.beforeFormatData` event.
      *
      * @return void
+     *
+     * @covers ::formatData()
+     * @covers ::dispatchEvent()
      */
     public function testBeforeFormatEvent(): void
     {
         $dispatchedEvent = 0;
-        EventManager::instance()->on('JsonApi.beforeFormat', function (Event $event, $items) use (&$dispatchedEvent) {
-            EventManager::instance()->off('JsonApi.beforeFormat');
+        EventManager::instance()->on('JsonApi.beforeFormatData', function (Event $event, $items) use (&$dispatchedEvent) {
+            EventManager::instance()->off('JsonApi.beforeFormatData');
             $dispatchedEvent++;
             $item = $items[0];
 
@@ -760,15 +764,18 @@ class JsonApiTest extends TestCase
     }
 
     /**
-     * Test `afterFormat` event.
+     * Test `JsonApi.afterFormatData` event.
      *
      * @return void
+     *
+     * @covers ::formatData()
+     * @covers ::dispatchEvent()
      */
-    public function testAfterFormatEvent(): void
+    public function testAfterFormatDataEvent(): void
     {
         $dispatchedEvent = 0;
-        EventManager::instance()->on('JsonApi.afterFormat', function (Event $event, $data) use (&$dispatchedEvent) {
-            EventManager::instance()->off('JsonApi.afterFormat');
+        EventManager::instance()->on('JsonApi.afterFormatData', function (Event $event, $data) use (&$dispatchedEvent) {
+            EventManager::instance()->off('JsonApi.afterFormatData');
             $dispatchedEvent++;
 
             foreach ($data as $d) {

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -790,4 +790,19 @@ class JsonApiTest extends TestCase
         static::assertEquals(1, $dispatchedEvent);
         static::assertEquals($expected, Hash::extract($result, '{n}.meta.after_format'));
     }
+
+    /**
+     * Test that ana exception was raised if the some item was not serializabile.
+     *
+     * @return void
+     *
+     * @covers ::formatData()
+     */
+    public function testNotJsonSerializabile(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('Objects must implement "%s", got "array" instead', JsonApiSerializable::class));
+
+        JsonApi::formatData(['name' => 'Gustavo']);
+    }
 }


### PR DESCRIPTION
This PR add two events dispatched in `JsonApi::formatData`.

* `JsonApi.beforeFormatData` => the event dispatched contains the array of entities before are formatted.
* `JsonApi.afterFormatData` => the event dispatched contains the array of data formatted.