### PR TITLE
Avoid to use real properties as virtual properties

### DIFF
--- a/plugins/BEdita/Core/src/Model/Entity/EndpointPermission.php
+++ b/plugins/BEdita/Core/src/Model/Entity/EndpointPermission.php
@@ -27,6 +27,9 @@ use Cake\ORM\TableRegistry;
  * @property int $permission
  * @property bool|string $read
  * @property bool|string $write
+ * @property string $endpoint_name (virtual prop)
+ * @property string $application_name (virtual prop)
+ * @property string $role_name (virtual prop)
  *
  * @property \BEdita\Core\Model\Entity\Endpoint|null $endpoint
  * @property \BEdita\Core\Model\Entity\Application|null $application
@@ -229,67 +232,73 @@ class EndpointPermission extends Entity
     }
 
     /**
-     * Setter for `endpoint` virtual property.
+     * Setter for `endpoint_name` virtual property.
      *
      * @param string $name The endpoint name
      * @return string|null
      */
-    protected function _setEndpoint(?string $name): ?string
+    protected function _setEndpointName(?string $name): ?string
     {
         if ($name === null) {
-            $this->endpoint_id = null;
+            $this->endpoint_id = $this->endpoint = null;
 
             return null;
         }
 
-        $this->endpoint_id = TableRegistry::getTableLocator()->get('Endpoints')
-            ->find('list', ['valueField' => 'id'])
+        $this->endpoint = TableRegistry::getTableLocator()->get('Endpoints')
+            ->find()
             ->where(['name' => $name])
             ->firstOrFail();
+
+        $this->endpoint_id = $this->endpoint->id;
 
         return $name;
     }
 
     /**
-     * Setter for `role` virtual property.
+     * Setter for `role_name` virtual property.
      *
      * @param string $name The role name
      * @return string|null
      */
-    protected function _setRole(?string $name): ?string
+    protected function _setRoleName(?string $name): ?string
     {
         if ($name === null) {
-            $this->role_id = null;
+            $this->role_id = $this->role = null;
 
             return null;
         }
 
-        $this->role_id = TableRegistry::getTableLocator()->get('Roles')
-            ->find('list', ['valueField' => 'id'])
+        $this->role = TableRegistry::getTableLocator()->get('Roles')
+            ->find()
             ->where(['name' => $name])
             ->firstOrFail();
+
+        $this->role_id = $this->role->id;
 
         return $name;
     }
 
     /**
-     * Setter for `application` virtual property.
+     * Setter for `application_name` virtual property.
      *
      * @param string $name The application name
      * @return string|null
      */
-    protected function _setApplication(?string $name): ?string
+    protected function _setApplicationName(?string $name): ?string
     {
         if ($name === null) {
-            $this->application_id = null;
+            $this->application_id = $this->application = null;
 
             return null;
         }
 
-        $this->application_id = TableRegistry::getTableLocator()->get('Applications')
-            ->find('list', ['valueField' => 'id'])
+        $this->application = TableRegistry::getTableLocator()->get('Applications')
+            ->find()
             ->where(['name' => $name])
             ->firstOrFail();
+
+        $this->application_id = $this->application->id;
 
         return $name;
     }

--- a/plugins/BEdita/Core/src/Model/Table/EndpointPermissionsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/EndpointPermissionsTable.php
@@ -198,9 +198,9 @@ class EndpointPermissionsTable extends Table
      * Find permissions by role, application and endpoint name.
      *
      * This finder accepts three options:
-     * - `endpoint``: the endpoint name
-     * - `role`: the role name
-     * - `application`: the application name
+     * - `endpoint_name``: the endpoint name
+     * - `role_name`: the role name
+     * - `application_name`: the application name
      *
      * @param \Cake\ORM\Query $query Query object instance.
      * @param array $options Additional options.
@@ -208,9 +208,9 @@ class EndpointPermissionsTable extends Table
      */
     protected function findResource(Query $query, array $options): Query
     {
-        $endpoint = Hash::get($options, 'endpoint');
-        $role = Hash::get($options, 'role');
-        $application = Hash::get($options, 'application');
+        $endpoint = Hash::get($options, 'endpoint_name');
+        $role = Hash::get($options, 'role_name');
+        $application = Hash::get($options, 'application_name');
 
         if ($endpoint === null) {
             $query = $query->whereNull('endpoint_id');

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointPermissionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointPermissionTest.php
@@ -13,7 +13,10 @@
 
 namespace BEdita\Core\Test\TestCase\Model\Entity;
 
+use BEdita\Core\Model\Entity\Application;
+use BEdita\Core\Model\Entity\Endpoint;
 use BEdita\Core\Model\Entity\EndpointPermission;
+use BEdita\Core\Model\Entity\Role;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -366,11 +369,11 @@ class EndpointPermissionTest extends TestCase
     }
 
     /**
-     * Data provder for `testSetEndpoint()`
+     * Data provder for `testSetEndpointName()`
      *
      * @return array
      */
-    public function setEndpointProvider(): array
+    public function setEndpointNameProvider(): array
     {
         return [
             'null' => [
@@ -389,16 +392,16 @@ class EndpointPermissionTest extends TestCase
     }
 
     /**
-     * Test magic setter for endpoint.
+     * Test magic setter for endpoint_name.
      *
      * @param mixed $expected The expected data
      * @param string $name The endpoint name
      * @return void
      *
-     * @covers ::_setEndpoint()
-     * @dataProvider setEndpointProvider()
+     * @covers ::_setEndpointName()
+     * @dataProvider setEndpointNameProvider()
      */
-    public function testSetEndpoint($expected, ?string $name): void
+    public function testSetEndpointName($expected, ?string $name): void
     {
         if ($expected instanceof \Exception) {
             $this->expectException(RecordNotFoundException::class);
@@ -406,16 +409,26 @@ class EndpointPermissionTest extends TestCase
         }
 
         $entity = new EndpointPermission();
-        $entity->set('endpoint', $name);
-        static::assertEquals($expected, $entity->get('endpoint_id'));
+        $entity->set('endpoint_name', $name);
+        $endpoint = $entity->endpoint;
+        if ($expected === null) {
+            static::assertNull($endpoint);
+            static::assertNull($entity->endpoint_id);
+
+            return;
+        }
+
+        static::assertInstanceOf(Endpoint::class, $endpoint);
+        static::assertEquals($expected, $endpoint->id);
+        static::assertEquals($expected, $entity->endpoint_id);
     }
 
     /**
-     * Data provder for `testSetRole()`
+     * Data provder for `testSetRoleName()`
      *
      * @return array
      */
-    public function setRoleProvider(): array
+    public function setRoleNameProvider(): array
     {
         return [
             'null' => [
@@ -434,16 +447,16 @@ class EndpointPermissionTest extends TestCase
     }
 
     /**
-     * Test magic setter for role.
+     * Test magic setter for role_name.
      *
      * @param mixed $expected The expected data
      * @param string $name The role name
      * @return void
      *
-     * @covers ::_setRole()
-     * @dataProvider setRoleProvider()
+     * @covers ::_setRoleName()
+     * @dataProvider setRoleNameProvider()
      */
-    public function testSetRole($expected, ?string $name): void
+    public function testSetRoleName($expected, ?string $name): void
     {
         if ($expected instanceof \Exception) {
             $this->expectException(RecordNotFoundException::class);
@@ -451,16 +464,26 @@ class EndpointPermissionTest extends TestCase
         }
 
         $entity = new EndpointPermission();
-        $entity->set('role', $name);
-        static::assertEquals($expected, $entity->get('role_id'));
+        $entity->set('role_name', $name);
+        $role = $entity->role;
+        if ($expected === null) {
+            static::assertNull($role);
+            static::assertNull($entity->role_id);
+
+            return;
+        }
+
+        static::assertInstanceOf(Role::class, $role);
+        static::assertEquals($expected, $role->id);
+        static::assertEquals($expected, $entity->role_id);
     }
 
     /**
-     * Data provder for `testSetApplication()`
+     * Data provder for `testSetApplicationName()`
      *
      * @return array
      */
-    public function setApplicationProvider(): array
+    public function setApplicationNameProvider(): array
     {
         return [
             'null' => [
@@ -479,16 +502,16 @@ class EndpointPermissionTest extends TestCase
     }
 
     /**
-     * Test magic setter for application.
+     * Test magic setter for application_name.
      *
      * @param mixed $expected The expected data
      * @param string $name The application name
      * @return void
      *
-     * @covers ::_setApplication()
-     * @dataProvider setApplicationProvider()
+     * @covers ::_setApplicationName()
+     * @dataProvider setApplicationNameProvider()
      */
-    public function testSetApplication($expected, ?string $name): void
+    public function testSetApplicationName($expected, ?string $name): void
     {
         if ($expected instanceof \Exception) {
             $this->expectException(RecordNotFoundException::class);
@@ -496,7 +519,17 @@ class EndpointPermissionTest extends TestCase
         }
 
         $entity = new EndpointPermission();
-        $entity->set('application', $name);
-        static::assertEquals($expected, $entity->get('application_id'));
+        $entity->set('application_name', $name);
+        $application = $entity->application;
+        if ($expected === null) {
+            static::assertNull($application);
+            static::assertNull($entity->application_id);
+
+            return;
+        }
+
+        static::assertInstanceOf(Application::class, $application);
+        static::assertEquals($expected, $application->id);
+        static::assertEquals($expected, $entity->application_id);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointPermissionsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointPermissionsTableTest.php
@@ -366,25 +366,25 @@ class EndpointPermissionsTableTest extends TestCase
             'application, endpoint, role' => [
                 0b1001,
                 [
-                    'application' => 'Disabled app',
-                    'endpoint' => 'home',
-                    'role' => 'first role',
+                    'application_name' => 'Disabled app',
+                    'endpoint_name' => 'home',
+                    'role_name' => 'first role',
                 ],
             ],
             'application=null, endpoint=null, role=null' => [
                 0,
                 [
-                    'application' => null,
-                    'endpoint' => null,
-                    'role' => null,
+                    'application_name' => null,
+                    'endpoint_name' => null,
+                    'role_name' => null,
                 ],
             ],
             'application, endpoint=null, role=null' => [
                 0b1111,
                 [
-                    'application' => 'First app',
-                    'endpoint' => null,
-                    'role' => null,
+                    'application_name' => 'First app',
+                    'endpoint_name' => null,
+                    'role_name' => null,
                 ],
             ],
         ];

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
@@ -264,14 +264,14 @@ class ResourcesTest extends TestCase
                 'endpoint_permissions',
                 [
                     [
-                        'application' => 'Disabled app',
-                        'endpoint' => 'home',
-                        'role' => 'second role',
+                        'application_name' => 'Disabled app',
+                        'endpoint_name' => 'home',
+                        'role_name' => 'second role',
                     ],
                     [
-                        'application' => 'First app',
-                        'endpoint' => null,
-                        'role' => null,
+                        'application_name' => 'First app',
+                        'endpoint_name' => null,
+                        'role_name' => null,
                     ],
                 ],
             ],
@@ -386,9 +386,9 @@ class ResourcesTest extends TestCase
                 'endpoint_permissions',
                 [
                     [
-                        'application' => 'Disabled app',
-                        'endpoint' => 'home',
-                        'role' => 'first role',
+                        'application_name' => 'Disabled app',
+                        'endpoint_name' => 'home',
+                        'role_name' => 'first role',
                         'permission' => 0b1111,
                     ],
                 ],


### PR DESCRIPTION
In `EndpointPermission` entity we were using magic setters for virtual properties that are real properties of the entity. To avoid confusion and errors this PR replaces `_setEndpoint()`, `_setApplication()` and `_setRole()` with `_setEndpointName()`, `_setApplicationName()` and `_setRoleName()` defining the virtual props `application_name`, `endpoint_name` and `role_name`.
