### PR TITLE
Move to GitHub Actions

### DIFF
--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -32,5 +32,5 @@ jobs:
 
       - name: 'Push to component repository'
         env:
-          REMOTE: "${{ format('https://{2}@github.com/{0}/{1}.git', github.repository_owner, matrix.repo, secrets.PERSONAL_ACCESS_TOKEN) }}"
+          REMOTE: "${{ format('https://{2}:x-oauth-basic@github.com/{0}/{1}.git', github.repository_owner, matrix.repo, secrets.PERSONAL_ACCESS_TOKEN) }}"
         run: 'git push --force --tags "${REMOTE}" HEAD'

--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -30,6 +30,6 @@ jobs:
 
       - name: 'Push to component repository'
         env:
-          REMOTE: "${{ format('https://github.com/{0}/{1}.git', github.repository_owner, matrix.repo) }}"
+          REMOTE: "${{ format('https://{2}@github.com/{0}/{1}.git', github.repository_owner, matrix.repo, secrets.PERSONAL_ACCESS_TOKEN) }}"
         run: |
-          git push --force --tags ${REMOTE} HEAD
+          git push --force --tags "${REMOTE}" HEAD

--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -1,0 +1,65 @@
+name: 'Publish components'
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - 'plugins/BEdita/**'
+
+jobs:
+  filter-tree:
+    name: 'Filter components tree and push'
+    runs-on: 'ubuntu-latest'
+
+    continue-on-error: yes
+    strategy:
+      matrix:
+        include:
+          - repo: 'api'
+            path: 'plugins/BEdita/API'
+          - repo: 'core'
+            path: 'plugins/BEdita/Core'
+
+    steps:
+      - name: 'Checkout current revision'
+        uses: 'actions/checkout@v2'
+
+      - name: 'Filter tree'
+        run: |
+          git filter-branch --prune-empty --subdirectory-filter ${{ matrix.path }} --tag-name-filter cat HEAD
+
+      - name: 'Push to component repository'
+        env:
+          REMOTE: "${{ format('https://github.com/{0}/{1}.git', github.repository_owner, matrix.repo) }}"
+        run: |
+          git push --force --tags ${REMOTE} HEAD
+
+
+  build-test-push:
+    name: Build, test and push
+    runs-on: ubuntu-20.04
+    if: "!contains(github.event.commits[0].message, 'skip ci')"
+    strategy:
+      matrix:
+        version: [ '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4' ]
+        flavor: [ '', '-apache', '-fpm' ]
+        include:
+          - version: 'latest'
+            flavor: ''
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build images
+        run: |
+          make build VERSION=${VERSION}
+          make -C dev build VERSION=${VERSION}
+        env:
+          VERSION: ${{ format('{0}{1}', matrix.version, matrix.flavor) }}
+
+      - name: Test images
+        run: |
+          make test VERSION=${VERSION}
+          make -C dev test VERSION=${VERSION}
+        env:
+          VERSION: ${{ format('{0}{1}', matrix.version, matrix.flavor) }}

--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: 'ubuntu-latest'
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - repo: 'api'

--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -33,4 +33,4 @@ jobs:
       - name: 'Push to component repository'
         env:
           REMOTE: "${{ format('https://{2}@github.com/{0}/{1}.git', github.repository_owner, matrix.repo, secrets.PERSONAL_ACCESS_TOKEN) }}"
-        run: 'echo "${REMOTE}" | head -c18; git push --force --tags "${REMOTE}" HEAD'
+        run: 'git push --force --tags "${REMOTE}" HEAD'

--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -12,7 +12,6 @@ jobs:
     name: 'Filter components tree and push'
     runs-on: 'ubuntu-latest'
 
-    continue-on-error: true
     strategy:
       matrix:
         include:

--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
       - name: 'Checkout current revision'
         uses: 'actions/checkout@v2'
+        with:
+          token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
+          fetch-depth: '0'
 
       - name: 'Filter tree'
         run: 'git filter-branch --prune-empty --subdirectory-filter "${{ matrix.path }}" --tag-name-filter cat HEAD'
@@ -32,5 +35,5 @@ jobs:
 
       - name: 'Push to component repository'
         env:
-          REMOTE: "${{ format('https://{2}:x-oauth-basic@github.com/{0}/{1}.git', github.repository_owner, matrix.repo, secrets.PERSONAL_ACCESS_TOKEN) }}"
+          REMOTE: "${{ format('https://github.com/{0}/{1}.git', github.repository_owner, matrix.repo) }}"
         run: 'git push --force --tags "${REMOTE}" HEAD'

--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -12,7 +12,7 @@ jobs:
     name: 'Filter components tree and push'
     runs-on: 'ubuntu-latest'
 
-    continue-on-error: yes
+    continue-on-error: true
     strategy:
       matrix:
         include:
@@ -34,32 +34,3 @@ jobs:
           REMOTE: "${{ format('https://github.com/{0}/{1}.git', github.repository_owner, matrix.repo) }}"
         run: |
           git push --force --tags ${REMOTE} HEAD
-
-
-  build-test-push:
-    name: Build, test and push
-    runs-on: ubuntu-20.04
-    if: "!contains(github.event.commits[0].message, 'skip ci')"
-    strategy:
-      matrix:
-        version: [ '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4' ]
-        flavor: [ '', '-apache', '-fpm' ]
-        include:
-          - version: 'latest'
-            flavor: ''
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Build images
-        run: |
-          make build VERSION=${VERSION}
-          make -C dev build VERSION=${VERSION}
-        env:
-          VERSION: ${{ format('{0}{1}', matrix.version, matrix.flavor) }}
-
-      - name: Test images
-        run: |
-          make test VERSION=${VERSION}
-          make -C dev test VERSION=${VERSION}
-        env:
-          VERSION: ${{ format('{0}{1}', matrix.version, matrix.flavor) }}

--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -25,11 +25,12 @@ jobs:
         uses: 'actions/checkout@v2'
 
       - name: 'Filter tree'
-        run: |
-          git filter-branch --prune-empty --subdirectory-filter ${{ matrix.path }} --tag-name-filter cat HEAD
+        run: 'git filter-branch --prune-empty --subdirectory-filter "${{ matrix.path }}" --tag-name-filter cat HEAD'
+
+      - name: 'Output last 10 commits'
+        run: 'git log -n 10'
 
       - name: 'Push to component repository'
         env:
           REMOTE: "${{ format('https://{2}@github.com/{0}/{1}.git', github.repository_owner, matrix.repo, secrets.PERSONAL_ACCESS_TOKEN) }}"
-        run: |
-          git push --force --tags "${REMOTE}" HEAD
+        run: 'echo "${REMOTE}" | head -c18; git push --force --tags "${REMOTE}" HEAD'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,11 +24,28 @@ jobs:
             --standard=vendor/cakephp/cakephp-codesniffer/CakePHP --ignore=/Migrations/,/Seeds/ \
             ./config ./src ./tests ./plugins/*/*/config ./plugins/*/*/src ./plugins/*/*/tests
 
+  stan:
+    name: 'Static code analyzer'
+    runs-on: 'ubuntu-latest'
+    container: 'chialab/php:7.4'
+    continue-on-error: true
+
+    steps:
+      - name: 'Checkout current revision'
+        uses: 'actions/checkout@v2'
+
+      - name: 'Install dependencies with Composer'
+        run: 'composer1 install --prefer-dist --no-interaction && composer1 require --dev phpstan/phpstan'
+
+      - name: 'Run PHP STAN'
+        run: |
+          vendor/bin/phpstan analyse --no-progress src plugins/BEdita/API/src plugins/BEdita/Core/src
+
   unit:
     name: 'Run unit tests'
     if: "!contains(github.event.commits[0].message, 'skip ci')"
     runs-on: 'ubuntu-latest'
-    container: 'chialab/php:${{ matrix.php }}'
+    container: 'chialab/php-dev:${{ matrix.php }}'
 
     strategy:
       fail-fast: false
@@ -37,12 +54,12 @@ jobs:
           - '7.3'
           - '7.4'
         db:
-          - '{"vendor": "SQLite", "dsn": "sqlite://tmp/test.sql", "image": "busybox"}'
-          - '{"vendor": "MySQL 5.6", "dsn": "mysql://bedita:bedita@db/bedita", "image": "mysql:5.6"}'
-          - '{"vendor": "MySQL 5.7", "dsn": "mysql://bedita:bedita@db/bedita", "image": "mysql:5.7"}'
-          # - '{"vendor": "MySQL 8.0", "dsn": "mysql://bedita:bedita@db/bedita?realVendor=mysql8", "image": "mysql:8.0"}'
-          - '{"vendor": "MariaDB", "dsn": "mysql://bedita:bedita@db/bedita?realVendor=mariadb", "image": "mariadb:10"}'
-          - '{"vendor": "PostgreSQL", "dsn": "postgres://bedita:bedita@db/bedita", "image": "postgres:13"}'
+          - '{"vendor": "SQLite", "dsn": "sqlite://tmp/test.sql", "image": "busybox", "options": ""}'
+          - '{"vendor": "MySQL 5.6", "dsn": "mysql://bedita:bedita@db/bedita", "image": "mysql:5.6", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "MySQL 5.7", "dsn": "mysql://bedita:bedita@db/bedita", "image": "mysql:5.7", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          # - '{"vendor": "MySQL 8.0", "dsn": "mysql://bedita:bedita@db/bedita?realVendor=mysql8", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "MariaDB", "dsn": "mysql://bedita:bedita@db/bedita?realVendor=mariadb", "image": "mariadb:10", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "PostgreSQL", "dsn": "postgres://bedita:bedita@db/bedita", "image": "postgres:13", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
     env:
       PHP_VERSION: '${{ matrix.php }}'
       DB_VENDOR: '${{ fromJson(matrix.db).vendor }}'
@@ -60,6 +77,7 @@ jobs:
           POSTGRES_USER: 'bedita'
           POSTGRES_PASSWORD: 'bedita'
           POSTGRES_DB: 'bedita'
+        options: '${{ fromJson(matrix.db).options }}'
 
     steps:
       - name: 'Checkout current revision'
@@ -69,7 +87,7 @@ jobs:
         run: 'composer1 install --prefer-dist --no-interaction'
 
       - name: 'Run PHPUnit'
-        run: 'vendor/bin/phpunit' # --coverage-clover=clover.xml'
+        run: 'vendor/bin/phpunit --coverage-clover=clover.xml'
 
       # - name: 'Export coverage results'
       #   uses: 'codecov/codecov-action@v1'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
           php-version: '7.4'
           tools: 'composer:v1'
           extensions: 'mbstring, intl'
-          coverage: 'pcov'
+          coverage: 'none'
 
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
@@ -59,7 +59,7 @@ jobs:
           php-version: '7.4'
           tools: 'composer:v1, phpstan'
           extensions: 'mbstring, intl'
-          coverage: 'pcov'
+          coverage: 'none'
 
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
@@ -91,7 +91,6 @@ jobs:
       matrix:
         php:
           - '7.4'
-          - '7.3'
         db:
           - '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
           - '{"vendor": "MySQL 5.7", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:5.7", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
@@ -99,6 +98,10 @@ jobs:
           - '{"vendor": "MariaDB", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mariadb", "image": "mariadb:10", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
           - '{"vendor": "PostgreSQL", "pdo": "pgsql", "dsn": "postgres://bedita:bedita@127.0.0.1:5432/bedita", "image": "postgres:13", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
         include:
+          - php: '7.3'
+            db: '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
+          - php: '7.3'
+            db: '{"vendor": "MySQL 5.7", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:5.7", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
           - php: '7.2'
             db: '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
           - php: '7.2'
@@ -156,6 +159,9 @@ jobs:
 
       - name: 'Install dependencies with Composer'
         run: 'composer install --prefer-dist --no-interaction'
+
+      - name: 'Setup PCOV clobber'
+        run: 'composer require pcov/clobber && vendor/bin/pcov clobber'
 
       - name: 'Run PHPUnit with coverage'
         run: 'vendor/bin/phpunit --coverage-clover=clover.xml'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,12 +94,12 @@ jobs:
           - '7.3'
           - '7.4'
         db:
-          - '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "busybox", "options": "--no-healthcheck"}'
-          - '{"vendor": "MySQL 5.6", "pdo": "mysql", "dsn": "mysql://bedita:bedita@db/bedita", "image": "mysql:5.6", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-          - '{"vendor": "MySQL 5.7", "pdo": "mysql", "dsn": "mysql://bedita:bedita@db/bedita", "image": "mysql:5.7", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-          # - '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@db/bedita?realVendor=mysql8", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-          - '{"vendor": "MariaDB", "pdo": "mysql", "dsn": "mysql://bedita:bedita@db/bedita?realVendor=mariadb", "image": "mariadb:10", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-          - '{"vendor": "PostgreSQL", "pdo": "pgsql", "dsn": "postgres://bedita:bedita@db/bedita", "image": "postgres:13", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "busybox", "options": "--health-cmd \"/bin/true\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "MySQL 5.6", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:5.6", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "MySQL 5.7", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:5.7", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          # - '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mysql8", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "MariaDB", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mariadb", "image": "mariadb:10", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "PostgreSQL", "pdo": "pgsql", "dsn": "postgres://bedita:bedita@127.0.0.1:5432/bedita", "image": "postgres:13", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
     env:
       PHP_VERSION: '${{ matrix.php }}'
       DB_VENDOR: '${{ fromJson(matrix.db).vendor }}'
@@ -117,6 +117,9 @@ jobs:
           POSTGRES_USER: 'bedita'
           POSTGRES_PASSWORD: 'bedita'
           POSTGRES_DB: 'bedita'
+        ports:
+          - '3306:3306'
+          - '5432:5432'
         options: '${{ fromJson(matrix.db).options }}'
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,16 +8,23 @@ on:
 jobs:
   cs:
     name: 'Check coding style'
-    runs-on: 'ubuntu-latest'
-    container: 'chialab/php:7.4'
+    runs-on: 'ubuntu-18.04'
 
     steps:
       - name: 'Checkout current revision'
         uses: 'actions/checkout@v2'
 
+      - name: 'Setup PHP'
+        uses: 'shivammathur/setup-php@v2'
+        with:
+          php-version: '7.4'
+          tools: 'composer:v1'
+          extensions: 'mbstring, intl'
+          coverage: 'pcov'
+
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
-        run: 'echo "::set-output name=path::$(composer1 global config cache-dir)"'
+        run: 'echo "::set-output name=path::$(composer global config cache-dir)"'
 
       - name: 'Share Composer cache across runs'
         uses: 'actions/cache@v2'
@@ -29,7 +36,7 @@ jobs:
             composer-
 
       - name: 'Install dependencies with Composer'
-        run: 'composer1 install --prefer-dist --no-interaction'
+        run: 'composer install --prefer-dist --no-interaction'
 
       - name: 'Run PHP CodeSniffer'
         run: |
@@ -39,17 +46,24 @@ jobs:
 
   stan:
     name: 'Static code analyzer'
-    runs-on: 'ubuntu-latest'
-    container: 'chialab/php:7.4'
+    runs-on: 'ubuntu-18.04'
     continue-on-error: true
 
     steps:
       - name: 'Checkout current revision'
         uses: 'actions/checkout@v2'
 
+      - name: 'Setup PHP'
+        uses: 'shivammathur/setup-php@v2'
+        with:
+          php-version: '7.4'
+          tools: 'composer:v1, phpstan'
+          extensions: 'mbstring, intl'
+          coverage: 'pcov'
+
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
-        run: 'echo "::set-output name=path::$(composer1 global config cache-dir)"'
+        run: 'echo "::set-output name=path::$(composer global config cache-dir)"'
 
       - name: 'Share Composer cache across runs'
         uses: 'actions/cache@v2'
@@ -61,7 +75,7 @@ jobs:
             composer-
 
       - name: 'Install dependencies with Composer'
-        run: 'composer1 install --prefer-dist --no-interaction && composer1 require --dev phpstan/phpstan'
+        run: 'composer install --prefer-dist --no-interaction'
 
       - name: 'Run PHP STAN'
         run: |
@@ -70,25 +84,24 @@ jobs:
   unit:
     name: 'Run unit tests'
     if: "!contains(github.event.commits[0].message, 'skip ci')"
-    runs-on: 'ubuntu-latest'
-    container: '${{ fromJson(matrix.php).image }}'
+    runs-on: 'ubuntu-18.04'
 
     strategy:
       fail-fast: false
       matrix:
         php:
-          - '{"version": "7.2", "image": "chialab/php-dev:7.2", "coverage": true}'
-          - '{"version": "7.3", "image": "chialab/php:7.3", "coverage": false}'
-          - '{"version": "7.4", "image": "chialab/php:7.4", "coverage": false}'
+          - '7.2'
+          - '7.3'
+          - '7.4'
         db:
-          - '{"vendor": "SQLite", "dsn": "sqlite://tmp/test.sql", "image": "busybox", "options": ""}'
-          - '{"vendor": "MySQL 5.6", "dsn": "mysql://bedita:bedita@db/bedita", "image": "mysql:5.6", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-          - '{"vendor": "MySQL 5.7", "dsn": "mysql://bedita:bedita@db/bedita", "image": "mysql:5.7", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-          # - '{"vendor": "MySQL 8.0", "dsn": "mysql://bedita:bedita@db/bedita?realVendor=mysql8", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-          - '{"vendor": "MariaDB", "dsn": "mysql://bedita:bedita@db/bedita?realVendor=mariadb", "image": "mariadb:10", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-          - '{"vendor": "PostgreSQL", "dsn": "postgres://bedita:bedita@db/bedita", "image": "postgres:13", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "busybox", "options": "--no-healthcheck"}'
+          - '{"vendor": "MySQL 5.6", "pdo": "mysql", "dsn": "mysql://bedita:bedita@db/bedita", "image": "mysql:5.6", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "MySQL 5.7", "pdo": "mysql", "dsn": "mysql://bedita:bedita@db/bedita", "image": "mysql:5.7", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          # - '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@db/bedita?realVendor=mysql8", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "MariaDB", "pdo": "mysql", "dsn": "mysql://bedita:bedita@db/bedita?realVendor=mariadb", "image": "mariadb:10", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "PostgreSQL", "pdo": "pgsql", "dsn": "postgres://bedita:bedita@db/bedita", "image": "postgres:13", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
     env:
-      PHP_VERSION: '${{ fromJson(matrix.php).version }}'
+      PHP_VERSION: '${{ matrix.php }}'
       DB_VENDOR: '${{ fromJson(matrix.db).vendor }}'
       db_dsn: '${{ fromJson(matrix.db).dsn }}'
 
@@ -110,32 +123,34 @@ jobs:
       - name: 'Checkout current revision'
         uses: 'actions/checkout@v2'
 
+      - name: 'Setup PHP'
+        uses: 'shivammathur/setup-php@v2'
+        with:
+          php-version: '${{ matrix.php }}'
+          tools: 'composer:v1, phpstan'
+          extensions: 'mbstring, intl, pdo_${{ fromJson(matrix.db).pdo }}'
+          coverage: 'pcov'
+
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
-        run: 'echo "::set-output name=path::$(composer1 global config cache-dir)"'
+        run: 'echo "::set-output name=path::$(composer global config cache-dir)"'
 
       - name: 'Share Composer cache across runs'
         uses: 'actions/cache@v2'
         with:
           path: '${{ steps.cachedir.outputs.path }}'
-          key: "composer-${{ fromJson(matrix.php).version }}-${{ hashFiles('**/composer.json') }}"
+          key: "composer-${{ matrix.php }}-${{ hashFiles('**/composer.json') }}"
           restore-keys: |
-            composer-${{ fromJson(matrix.php).version }}-
+            composer-${{ matrix.php }}-
             composer-
 
       - name: 'Install dependencies with Composer'
-        run: 'composer1 install --prefer-dist --no-interaction'
-
-      - name: 'Run PHPUnit'
-        if: '!fromJson(matrix.php).coverage'
-        run: 'vendor/bin/phpunit'
+        run: 'composer install --prefer-dist --no-interaction'
 
       - name: 'Run PHPUnit with coverage'
-        if: 'fromJson(matrix.php).coverage'
         run: 'vendor/bin/phpunit --coverage-clover=clover.xml'
 
       - name: 'Export coverage results'
-        if: 'fromJson(matrix.php).coverage'
         uses: 'codecov/codecov-action@v1'
         with:
           file: './clover.xml'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
     container: 'chialab/php:${{ matrix.php }}'
 
     strategy:
+      fail-fast: false
       matrix:
         php:
           - '7.3'
@@ -39,7 +40,7 @@ jobs:
           - 'sqlite://tmp/test.sql'
           - 'mysql://bedita:bedita@mysql56/bedita'
           - 'mysql://bedita:bedita@mysql57/bedita'
-          - 'mysql://bedita:bedita@mysql80/bedita?realVendor=mysql8'
+          # - 'mysql://bedita:bedita@mysql80/bedita?realVendor=mysql8'
           - 'mysql://bedita:bedita@mariadb/bedita?realVendor=mariadb'
           - 'postgres://bedita:bedita@postgres/bedita'
     env:
@@ -65,15 +66,15 @@ jobs:
           MYSQL_DATABASE: 'bedita'
         ports:
           - '3307:3306'
-      mysql80:
-        image: 'mysql:8.0'
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-          MYSQL_USER: 'bedita'
-          MYSQL_PASSWORD: 'bedita'
-          MYSQL_DATABASE: 'bedita'
-        ports:
-          - '3308:3306'
+      # mysql80:
+      #   image: 'mysql:8.0'
+      #   env:
+      #     MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+      #     MYSQL_USER: 'bedita'
+      #     MYSQL_PASSWORD: 'bedita'
+      #     MYSQL_DATABASE: 'bedita'
+      #   ports:
+      #     - '3308:3306'
       mariadb:
         image: 'mariadb:10'
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,14 @@ jobs:
     name: 'Check coding style'
     runs-on: 'ubuntu-latest'
     container: 'chialab/php:7.4'
+
     steps:
+      - name: 'Checkout current revision'
+        uses: 'actions/checkout@v2'
+
       - name: 'Install dependencies with Composer'
         run: 'composer1 install --prefer-dist --no-interaction'
+
       - name: 'Run PHP CodeSniffer'
         run: |
           vendor/bin/phpcs -n -p --extensions=php \
@@ -24,6 +29,7 @@ jobs:
     if: "!contains(github.event.commits[0].message, 'skip ci')"
     runs-on: 'ubuntu-latest'
     container: 'chialab/php-dev:${{ matrix.php }}'
+
     strategy:
       matrix:
         php:
@@ -39,6 +45,7 @@ jobs:
     env:
       PHP_VERSION: '${{ matrix.php }}'
       DB_DSN: '${{ matrix.db_dsn }}'
+
     services:
       mysql56:
         image: 'mysql:5.6'
@@ -84,11 +91,17 @@ jobs:
           POSTGRES_DB: 'bedita'
         ports:
           - '5432:5432'
+
     steps:
+      - name: 'Checkout current revision'
+        uses: 'actions/checkout@v2'
+
       - name: 'Install dependencies with Composer'
         run: 'composer1 install --prefer-dist --no-interaction'
+
       - name: 'Run PHPUnit'
         run: 'vendor/bin/phpunit --coverage-clover=clover.xml'
+
       - name: 'Export coverage results'
         uses: 'codecov/codecov-action@v1'
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         uses: 'actions/cache@v2'
         with:
           path: '${{ steps.cachedir.outputs.path }}'
-          key: 'composer-${{ github.job }}-${{ hashFiles("**/composer.json") }}'
+          key: "composer-${{ github.job }}-${{ hashFiles('**/composer.json') }}"
           restore-keys: |
             composer-${{ github.job }}-
             composer-
@@ -55,7 +55,7 @@ jobs:
         uses: 'actions/cache@v2'
         with:
           path: '${{ steps.cachedir.outputs.path }}'
-          key: 'composer-${{ github.job }}-${{ hashFiles("**/composer.json") }}'
+          key: "composer-${{ github.job }}-${{ hashFiles('**/composer.json') }}"
           restore-keys: |
             composer-${{ github.job }}-
             composer-
@@ -117,7 +117,7 @@ jobs:
         uses: 'actions/cache@v2'
         with:
           path: '${{ steps.cachedir.outputs.path }}'
-          key: 'composer-${{ matrix.php }}-${{ hashFiles("**/composer.json") }}'
+          key: "composer-${{ matrix.php }}-${{ hashFiles('**/composer.json') }}"
           restore-keys: |
             composer-${{ matrix.php }}-
             composer-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     name: 'Run unit tests'
     if: "!contains(github.event.commits[0].message, 'skip ci')"
     runs-on: 'ubuntu-latest'
-    container: 'chialab/php-dev:${{ matrix.php }}'
+    container: 'chialab/php:${{ matrix.php }}'
 
     strategy:
       matrix:
@@ -100,10 +100,10 @@ jobs:
         run: 'composer1 install --prefer-dist --no-interaction'
 
       - name: 'Run PHPUnit'
-        run: 'vendor/bin/phpunit --coverage-clover=clover.xml'
+        run: 'vendor/bin/phpunit' # --coverage-clover=clover.xml'
 
-      - name: 'Export coverage results'
-        uses: 'codecov/codecov-action@v1'
-        with:
-          file: './clover.xml'
-          env_vars: PHP,DB_DSN
+      # - name: 'Export coverage results'
+      #   uses: 'codecov/codecov-action@v1'
+      #   with:
+      #     file: './clover.xml'
+      #     env_vars: PHP,DB_DSN

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,96 @@
+name: 'Run tests'
+
+on:
+  push:
+    paths:
+      - '**/*.php'
+
+jobs:
+  cs:
+    name: 'Check coding style'
+    runs-on: 'ubuntu-latest'
+    container: 'chialab/php:7.4'
+    steps:
+      - name: 'Install dependencies with Composer'
+        run: 'composer1 install --prefer-dist --no-interaction'
+      - name: 'Run PHP CodeSniffer'
+        run: |
+          vendor/bin/phpcs -n -p --extensions=php \
+            --standard=vendor/cakephp/cakephp-codesniffer/CakePHP --ignore=/Migrations/,/Seeds/ \
+            ./config ./src ./tests ./plugins/*/*/config ./plugins/*/*/src ./plugins/*/*/tests
+
+  unit:
+    name: 'Run unit tests'
+    if: "!contains(github.event.commits[0].message, 'skip ci')"
+    runs-on: 'ubuntu-latest'
+    container: 'chialab/php-dev:${{ matrix.php }}'
+    strategy:
+      matrix:
+        php:
+          - '7.3'
+          - '7.4'
+        db_dsn:
+          - 'sqlite:///tmp/test.sql'
+          - 'mysql://bedita:bedita@127.0.0.1:3306/bedita'
+          - 'mysql://bedita:bedita@127.0.0.1:3307/bedita'
+          - 'mysql://bedita:bedita@127.0.0.1:3308/bedita?realVendor=mysql8'
+          - 'mysql://bedita:bedita@127.0.0.1:3310/bedita?realVendor=mariadb'
+          - 'postgres://bedita:bedita@127.0.0.1:5432/bedita'
+    env:
+      PHP_VERSION: '${{ matrix.php }}'
+      DB_DSN: '${{ matrix.db_dsn }}'
+    services:
+      mysql56:
+        image: 'mysql:5.6'
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+          MYSQL_USER: 'bedita'
+          MYSQL_PASSWORD: 'bedita'
+          MYSQL_DATABASE: 'bedita'
+        ports:
+          - '3306:3306'
+      mysql57:
+        image: 'mysql:5.7'
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+          MYSQL_USER: 'bedita'
+          MYSQL_PASSWORD: 'bedita'
+          MYSQL_DATABASE: 'bedita'
+        ports:
+          - '3307:3306'
+      mysql80:
+        image: 'mysql:8.0'
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+          MYSQL_USER: 'bedita'
+          MYSQL_PASSWORD: 'bedita'
+          MYSQL_DATABASE: 'bedita'
+        ports:
+          - '3308:3306'
+      mariadb:
+        image: 'mariadb:10'
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+          MYSQL_USER: 'bedita'
+          MYSQL_PASSWORD: 'bedita'
+          MYSQL_DATABASE: 'bedita'
+        ports:
+          - '3310:3306'
+      postgres:
+        image: 'postgres:13'
+        env:
+          POSTGRES_USER: 'bedita'
+          POSTGRES_PASSWORD: 'bedita'
+          POSTGRES_DB: 'bedita'
+        ports:
+          - '5432:5432'
+    steps:
+      - name: 'Install dependencies with Composer'
+        run: 'composer1 install --prefer-dist --no-interaction'
+      - name: 'Run PHPUnit'
+        run: 'vendor/bin/phpunit --coverage-clover=clover.xml'
+      - name: 'Export coverage results'
+        uses: 'codecov/codecov-action@v1'
+        with:
+          file: './clover.xml'
+          env_vars: PHP,DB_DSN

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,14 +37,14 @@ jobs:
           - '7.4'
         db_dsn:
           - 'sqlite://tmp/test.sql'
-          # - 'mysql://bedita:bedita@mysql56/bedita'
-          # - 'mysql://bedita:bedita@mysql57/bedita'
-          # - 'mysql://bedita:bedita@mysql80/bedita?realVendor=mysql8'
-          # - 'mysql://bedita:bedita@mariadb/bedita?realVendor=mariadb'
-          # - 'postgres://bedita:bedita@postgres/bedita'
+          - 'mysql://bedita:bedita@mysql56/bedita'
+          - 'mysql://bedita:bedita@mysql57/bedita'
+          - 'mysql://bedita:bedita@mysql80/bedita?realVendor=mysql8'
+          - 'mysql://bedita:bedita@mariadb/bedita?realVendor=mariadb'
+          - 'postgres://bedita:bedita@postgres/bedita'
     env:
       PHP_VERSION: '${{ matrix.php }}'
-      DB_DSN: '${{ matrix.db_dsn }}'
+      db_dsn: '${{ matrix.db_dsn }}'
 
     services:
       mysql56:
@@ -106,4 +106,4 @@ jobs:
       #   uses: 'codecov/codecov-action@v1'
       #   with:
       #     file: './clover.xml'
-      #     env_vars: PHP,DB_DSN
+      #     env_vars: PHP,db_dsn

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -175,5 +175,5 @@ jobs:
       - name: 'Archive code coverage results'
         uses: 'actions/upload-artifact@v2'
         with:
-          name: 'PHP ${{ matrix.php }} / ${{ fromJson(matrix.db).vendor }}'
+          name: 'PHP ${{ matrix.php }} with ${{ fromJson(matrix.db).vendor }}'
           path: 'clover.xml'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -170,4 +170,4 @@ jobs:
         uses: 'codecov/codecov-action@v1'
         with:
           file: './clover.xml'
-          env_vars: PHP,db_dsn
+          env_vars: PHP_VERSION,DB_VENDOR

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,14 +71,15 @@ jobs:
     name: 'Run unit tests'
     if: "!contains(github.event.commits[0].message, 'skip ci')"
     runs-on: 'ubuntu-latest'
-    container: 'chialab/php-dev:${{ matrix.php }}'
+    container: '${{ fromJson(matrix.php).image }}'
 
     strategy:
       fail-fast: false
       matrix:
         php:
-          - '7.3'
-          - '7.4'
+          - '{"version": "7.2", "image": "chialab/php-dev:7.2", "coverage": true}'
+          - '{"version": "7.3", "image": "chialab/php:7.3", "coverage": false}'
+          - '{"version": "7.4", "image": "chialab/php:7.4", "coverage": false}'
         db:
           - '{"vendor": "SQLite", "dsn": "sqlite://tmp/test.sql", "image": "busybox", "options": ""}'
           - '{"vendor": "MySQL 5.6", "dsn": "mysql://bedita:bedita@db/bedita", "image": "mysql:5.6", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
@@ -87,7 +88,7 @@ jobs:
           - '{"vendor": "MariaDB", "dsn": "mysql://bedita:bedita@db/bedita?realVendor=mariadb", "image": "mariadb:10", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
           - '{"vendor": "PostgreSQL", "dsn": "postgres://bedita:bedita@db/bedita", "image": "postgres:13", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
     env:
-      PHP_VERSION: '${{ matrix.php }}'
+      PHP_VERSION: '${{ fromJson(matrix.php).version }}'
       DB_VENDOR: '${{ fromJson(matrix.db).vendor }}'
       db_dsn: '${{ fromJson(matrix.db).dsn }}'
 
@@ -117,19 +118,25 @@ jobs:
         uses: 'actions/cache@v2'
         with:
           path: '${{ steps.cachedir.outputs.path }}'
-          key: "composer-${{ matrix.php }}-${{ hashFiles('**/composer.json') }}"
+          key: "composer-${{ fromJson(matrix.php).version }}-${{ hashFiles('**/composer.json') }}"
           restore-keys: |
-            composer-${{ matrix.php }}-
+            composer-${{ fromJson(matrix.php).version }}-
             composer-
 
       - name: 'Install dependencies with Composer'
         run: 'composer1 install --prefer-dist --no-interaction'
 
       - name: 'Run PHPUnit'
+        if: '!fromJson(matrix.php).coverage'
+        run: 'vendor/bin/phpunit'
+
+      - name: 'Run PHPUnit with coverage'
+        if: 'fromJson(matrix.php).coverage'
         run: 'vendor/bin/phpunit --coverage-clover=clover.xml'
 
-      # - name: 'Export coverage results'
-      #   uses: 'codecov/codecov-action@v1'
-      #   with:
-      #     file: './clover.xml'
-      #     env_vars: PHP,db_dsn
+      - name: 'Export coverage results'
+        if: 'fromJson(matrix.php).coverage'
+        uses: 'codecov/codecov-action@v1'
+        with:
+          file: './clover.xml'
+          env_vars: PHP,db_dsn

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,19 @@ jobs:
       - name: 'Checkout current revision'
         uses: 'actions/checkout@v2'
 
+      - name: 'Discover Composer cache directory'
+        id: 'cachedir'
+        run: 'echo "::set-output name=path::$(composer1 global config cache-dir)"'
+
+      - name: 'Share Composer cache across runs'
+        uses: 'actions/cache@v2'
+        with:
+          path: '${{ steps.cachedir.outputs.path }}'
+          key: 'composer-${{ github.job }}-${{ hashFiles("**/composer.json") }}'
+          restore-keys: |
+            composer-${{ github.job }}-
+            composer-
+
       - name: 'Install dependencies with Composer'
         run: 'composer1 install --prefer-dist --no-interaction'
 
@@ -33,6 +46,19 @@ jobs:
     steps:
       - name: 'Checkout current revision'
         uses: 'actions/checkout@v2'
+
+      - name: 'Discover Composer cache directory'
+        id: 'cachedir'
+        run: 'echo "::set-output name=path::$(composer1 global config cache-dir)"'
+
+      - name: 'Share Composer cache across runs'
+        uses: 'actions/cache@v2'
+        with:
+          path: '${{ steps.cachedir.outputs.path }}'
+          key: 'composer-${{ github.job }}-${{ hashFiles("**/composer.json") }}'
+          restore-keys: |
+            composer-${{ github.job }}-
+            composer-
 
       - name: 'Install dependencies with Composer'
         run: 'composer1 install --prefer-dist --no-interaction && composer1 require --dev phpstan/phpstan'
@@ -82,6 +108,19 @@ jobs:
     steps:
       - name: 'Checkout current revision'
         uses: 'actions/checkout@v2'
+
+      - name: 'Discover Composer cache directory'
+        id: 'cachedir'
+        run: 'echo "::set-output name=path::$(composer1 global config cache-dir)"'
+
+      - name: 'Share Composer cache across runs'
+        uses: 'actions/cache@v2'
+        with:
+          path: '${{ steps.cachedir.outputs.path }}'
+          key: 'composer-${{ matrix.php }}-${{ hashFiles("**/composer.json") }}'
+          restore-keys: |
+            composer-${{ matrix.php }}-
+            composer-
 
       - name: 'Install dependencies with Composer'
         run: 'composer1 install --prefer-dist --no-interaction'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -171,3 +171,9 @@ jobs:
         with:
           file: './clover.xml'
           env_vars: PHP_VERSION,DB_VENDOR
+
+      - name: 'Archive code coverage results'
+        uses: 'actions/upload-artifact@v2'
+        with:
+          name: 'PHP ${{ matrix.php }} / ${{ fromJson(matrix.db).vendor }}'
+          path: 'clover.xml'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,9 +140,10 @@ jobs:
         uses: 'shivammathur/setup-php@v2'
         with:
           php-version: '${{ matrix.php }}'
-          tools: 'composer:v1, phpstan'
+          tools: 'composer:v1'
           extensions: 'mbstring, intl, pdo_${{ fromJson(matrix.db).pdo }}'
           coverage: 'pcov'
+          ini-values: 'pcov.directory=., pcov.exclude="~vendor~"'
 
       - name: 'Discover Composer cache directory'
         id: 'cachedir'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,12 +36,12 @@ jobs:
           - '7.3'
           - '7.4'
         db_dsn:
-          - 'sqlite:///tmp/test.sql'
-          - 'mysql://bedita:bedita@127.0.0.1:3306/bedita'
-          - 'mysql://bedita:bedita@127.0.0.1:3307/bedita'
-          - 'mysql://bedita:bedita@127.0.0.1:3308/bedita?realVendor=mysql8'
-          - 'mysql://bedita:bedita@127.0.0.1:3310/bedita?realVendor=mariadb'
-          - 'postgres://bedita:bedita@127.0.0.1:5432/bedita'
+          - 'sqlite://${{ runner.temp }}/test.sql'
+          - 'mysql://bedita:bedita@mysql56/bedita'
+          - 'mysql://bedita:bedita@mysql57/bedita'
+          - 'mysql://bedita:bedita@mysql80/bedita?realVendor=mysql8'
+          - 'mysql://bedita:bedita@mariadb/bedita?realVendor=mariadb'
+          - 'postgres://bedita:bedita@postgres/bedita'
     env:
       PHP_VERSION: '${{ matrix.php }}'
       DB_DSN: '${{ matrix.db_dsn }}'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
           - '7.3'
           - '7.4'
         db_dsn:
-          - 'sqlite://${{ runner.temp }}/test.sql'
+          - 'sqlite://tmp/test.sql'
           - 'mysql://bedita:bedita@mysql56/bedita'
           - 'mysql://bedita:bedita@mysql57/bedita'
           - 'mysql://bedita:bedita@mysql80/bedita?realVendor=mysql8'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,11 +37,11 @@ jobs:
           - '7.4'
         db_dsn:
           - 'sqlite://tmp/test.sql'
-          - 'mysql://bedita:bedita@mysql56/bedita'
-          - 'mysql://bedita:bedita@mysql57/bedita'
-          - 'mysql://bedita:bedita@mysql80/bedita?realVendor=mysql8'
-          - 'mysql://bedita:bedita@mariadb/bedita?realVendor=mariadb'
-          - 'postgres://bedita:bedita@postgres/bedita'
+          # - 'mysql://bedita:bedita@mysql56/bedita'
+          # - 'mysql://bedita:bedita@mysql57/bedita'
+          # - 'mysql://bedita:bedita@mysql80/bedita?realVendor=mysql8'
+          # - 'mysql://bedita:bedita@mariadb/bedita?realVendor=mariadb'
+          # - 'postgres://bedita:bedita@postgres/bedita'
     env:
       PHP_VERSION: '${{ matrix.php }}'
       DB_DSN: '${{ matrix.db_dsn }}'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,16 +90,23 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '7.2'
-          - '7.3'
           - '7.4'
+          - '7.3'
         db:
-          - '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "busybox", "options": "--entrypoint tail --health-cmd \"/bin/true\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-          - '{"vendor": "MySQL 5.6", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:5.6", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
           - '{"vendor": "MySQL 5.7", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:5.7", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-          # - '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mysql8", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mysql8", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
           - '{"vendor": "MariaDB", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mariadb", "image": "mariadb:10", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
           - '{"vendor": "PostgreSQL", "pdo": "pgsql", "dsn": "postgres://bedita:bedita@127.0.0.1:5432/bedita", "image": "postgres:13", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+        include:
+          - php: '7.2'
+            db: '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
+          - php: '7.2'
+            db: '{"vendor": "MySQL 5.7", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:5.7", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - php: '7.1'
+            db: '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
+          - php: '7.1'
+            db: '{"vendor": "MySQL 5.7", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:5.7", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
     env:
       PHP_VERSION: '${{ matrix.php }}'
       DB_VENDOR: '${{ fromJson(matrix.db).vendor }}'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,62 +36,30 @@ jobs:
         php:
           - '7.3'
           - '7.4'
-        db_dsn:
-          - 'sqlite://tmp/test.sql'
-          - 'mysql://bedita:bedita@mysql56/bedita'
-          - 'mysql://bedita:bedita@mysql57/bedita'
-          # - 'mysql://bedita:bedita@mysql80/bedita?realVendor=mysql8'
-          - 'mysql://bedita:bedita@mariadb/bedita?realVendor=mariadb'
-          - 'postgres://bedita:bedita@postgres/bedita'
+        db:
+          - '{"vendor": "SQLite", "dsn": "sqlite://tmp/test.sql", "image": "busybox"}'
+          - '{"vendor": "MySQL 5.6", "dsn": "mysql://bedita:bedita@db/bedita", "image": "mysql:5.6"}'
+          - '{"vendor": "MySQL 5.7", "dsn": "mysql://bedita:bedita@db/bedita", "image": "mysql:5.7"}'
+          # - '{"vendor": "MySQL 8.0", "dsn": "mysql://bedita:bedita@db/bedita?realVendor=mysql8", "image": "mysql:8.0"}'
+          - '{"vendor": "MariaDB", "dsn": "mysql://bedita:bedita@db/bedita?realVendor=mariadb", "image": "mariadb:10"}'
+          - '{"vendor": "PostgreSQL", "dsn": "postgres://bedita:bedita@db/bedita", "image": "postgres:13"}'
     env:
       PHP_VERSION: '${{ matrix.php }}'
-      db_dsn: '${{ matrix.db_dsn }}'
+      DB_VENDOR: '${{ fromJson(matrix.db).vendor }}'
+      db_dsn: '${{ fromJson(matrix.db).dsn }}'
 
     services:
-      mysql56:
-        image: 'mysql:5.6'
+      db:
+        image: '${{ fromJson(matrix.db).image }}'
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
           MYSQL_USER: 'bedita'
           MYSQL_PASSWORD: 'bedita'
           MYSQL_DATABASE: 'bedita'
-        ports:
-          - '3306:3306'
-      mysql57:
-        image: 'mysql:5.7'
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-          MYSQL_USER: 'bedita'
-          MYSQL_PASSWORD: 'bedita'
-          MYSQL_DATABASE: 'bedita'
-        ports:
-          - '3307:3306'
-      # mysql80:
-      #   image: 'mysql:8.0'
-      #   env:
-      #     MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-      #     MYSQL_USER: 'bedita'
-      #     MYSQL_PASSWORD: 'bedita'
-      #     MYSQL_DATABASE: 'bedita'
-      #   ports:
-      #     - '3308:3306'
-      mariadb:
-        image: 'mariadb:10'
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-          MYSQL_USER: 'bedita'
-          MYSQL_PASSWORD: 'bedita'
-          MYSQL_DATABASE: 'bedita'
-        ports:
-          - '3310:3306'
-      postgres:
-        image: 'postgres:13'
-        env:
+
           POSTGRES_USER: 'bedita'
           POSTGRES_PASSWORD: 'bedita'
           POSTGRES_DB: 'bedita'
-        ports:
-          - '5432:5432'
 
     steps:
       - name: 'Checkout current revision'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,7 +83,7 @@ jobs:
 
   unit:
     name: 'Run unit tests'
-    if: "!contains(github.event.commits[0].message, 'skip ci')"
+    if: "!contains(github.event.commits[0].message, '[skip ci]') && !contains(github.event.commits[0].message, '[ci skip]')"
     runs-on: 'ubuntu-18.04'
 
     strategy:
@@ -178,3 +178,41 @@ jobs:
         with:
           name: 'PHP ${{ matrix.php }} with ${{ fromJson(matrix.db).vendor }}'
           path: 'clover.xml'
+
+  unit-lowest:
+    name: 'Run unit tests with lowest-matching dependencies versions'
+    if: "!contains(github.event.commits[0].message, '[skip ci]') && !contains(github.event.commits[0].message, '[ci skip]')"
+    runs-on: 'ubuntu-18.04'
+
+    env:
+      db_dsn: 'sqlite://tmp/test.sql'
+
+    steps:
+      - name: 'Checkout current revision'
+        uses: 'actions/checkout@v2'
+
+      - name: 'Setup PHP'
+        uses: 'shivammathur/setup-php@v2'
+        with:
+          php-version: '7.1'
+          tools: 'composer:v1'
+          extensions: 'mbstring, intl, pdo_sqlite'
+
+      - name: 'Discover Composer cache directory'
+        id: 'cachedir'
+        run: 'echo "::set-output name=path::$(composer global config cache-dir)"'
+
+      - name: 'Share Composer cache across runs'
+        uses: 'actions/cache@v2'
+        with:
+          path: '${{ steps.cachedir.outputs.path }}'
+          key: "composer-lowest-${{ hashFiles('**/composer.json') }}"
+          restore-keys: |
+            composer-lowest-
+            composer-
+
+      - name: 'Install dependencies with Composer'
+        run: 'composer update --prefer-lowest --prefer-dist --no-interaction'
+
+      - name: 'Run PHPUnit'
+        run: 'vendor/bin/phpunit'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: 'Run PHP STAN'
         run: |
-          vendor/bin/phpstan analyse --no-progress src plugins/BEdita/API/src plugins/BEdita/Core/src
+          phpstan analyse --no-progress src plugins/BEdita/API/src plugins/BEdita/Core/src
 
   unit:
     name: 'Run unit tests'
@@ -94,7 +94,7 @@ jobs:
           - '7.3'
           - '7.4'
         db:
-          - '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "busybox", "options": "--health-cmd \"/bin/true\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "busybox", "options": "--entrypoint tail --health-cmd \"/bin/true\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
           - '{"vendor": "MySQL 5.6", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:5.6", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
           - '{"vendor": "MySQL 5.7", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:5.7", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
           # - '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mysql8", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'

--- a/plugins/BEdita/Core/src/Model/Entity/StaticProperty.php
+++ b/plugins/BEdita/Core/src/Model/Entity/StaticProperty.php
@@ -35,12 +35,12 @@ class StaticProperty extends Property
      * This method is used to hydrate entities correctly.
      *
      * @param \BEdita\Core\Model\Entity\Property $property Property to convert.
-     * @return static
+     * @return self
      * @internal
      */
-    public static function fromProperty(Property $property)
+    public static function fromProperty(Property $property): self
     {
-        return new static(
+        return new self(
             $property->_properties,
             [
                 'markNew' => $property->isNew(),

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello token my old friend' ?>
+<?= 'hello world without undesired interruptions' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world with local temp dir' ?>
+<?= 'hello world with just sqlite' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world with swapped single and double quotes' ?>
+<?= 'hello world with PHP 7.2 and XDebug' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world with cache' ?>
+<?= 'hello world with swapped single and double quotes' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world with personal access token finally set' ?>
+<?= 'hello world with dangerous echo' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world with lowercase' ?>
+<?= 'hello world without mysql8 and fail-fast' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world with fixed phpstan path and busybox entrypoint' ?>
+<?= 'hello world with clobber' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world with ugly JSON in matrix' ?>
+<?= 'hello world with cache' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world with correct credentials' ?>
+<?= 'hello world with x-oauth-basic' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world with PHP 7.2 and XDebug' ?>
+<?= 'hello world without our docker images' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world with x-oauth-basic' ?>
+<?= 'hello token my old friend' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world' ?>
+<?= 'hello world without coverage' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world without coverage' ?>
+<?= 'hello world with fixed hosts and paths' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world without our docker images' ?>
+<?= 'hello world with updated db_dsn' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world with artifacts' ?>
+<?= 'hello world with sane artifact name' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world with updated db_dsn' ?>
+<?= 'hello world with fixed phpstan path and busybox entrypoint' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,0 @@
-<?= 'hello world with fixed pcov directory' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?="hello world" ?>
+<?= 'hello world' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world with just sqlite' ?>
+<?= 'hello world with lowercase' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,0 +1,1 @@
+<?="hello world" ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world with fixed hosts and paths' ?>
+<?= 'hello world with local temp dir' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world without undesired interruptions' ?>
+<?= 'hello world with artifacts' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world with clobber' ?>
+<?= 'hello world with personal access token finally set' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world with sane artifact name' ?>
+<?= 'hello world with fixed pcov directory' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world without mysql8 and fail-fast' ?>
+<?= 'hello world with ugly JSON in matrix' ?>

--- a/plugins/BEdita/helloworld.php
+++ b/plugins/BEdita/helloworld.php
@@ -1,1 +1,1 @@
-<?= 'hello world with dangerous echo' ?>
+<?= 'hello world with correct credentials' ?>


### PR DESCRIPTION
This PR gets rid of Travis CI in favour of GitHub Actions for unit tests and code linting. It also adds automatic repository splitting for components `bedita/core` and `bedita/api` on every push — non-default branches and tags included.

A secret `PERSONAL_ACCESS_TOKEN` needs to be set in GitHub in order for components' splitting actions to be authorized to push to `bedita/core` and `bedita/api` repositories — I'll take care of it as soon as the PR gets approved, before merging.

Example test run: https://github.com/fquffio/bedita/actions/runs/482387512
Example split run: https://github.com/fquffio/bedita/actions/runs/482387511

The latter is marked as failed because only one of the two repositories exists. Since it's a matrix build, the script is exactly the same, and I expect it to work seamlessly under `bedita`, where both `bedita/core` and `bedita/api` already exist.