### PR TITLE
Add virtual property object_type_name to Endpoint Entity

### DIFF
--- a/plugins/BEdita/Core/src/Model/Entity/Endpoint.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Endpoint.php
@@ -15,6 +15,7 @@ namespace BEdita\Core\Model\Entity;
 
 use BEdita\Core\Utility\JsonApiSerializable;
 use Cake\ORM\Entity;
+use Cake\ORM\TableRegistry;
 
 /**
  * Endpoint Entity
@@ -26,6 +27,7 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\Time $modified
  * @property bool $enabled
  * @property int $object_type_id
+ * @property string $object_type_name (virtual prop)
  *
  * @property \BEdita\Core\Model\Entity\ObjectType $object_type
  * @property \BEdita\Core\Model\Entity\EndpointPermission[] $endpoint_permissions
@@ -45,4 +47,23 @@ class Endpoint extends Entity implements JsonApiSerializable
         'created' => false,
         'modified' => false,
     ];
+
+    /**
+     * Setter for `object_type_name` virtual property.
+     *
+     * @param string $name The object type name
+     * @return string|null
+     */
+    protected function _setObjectTypeName(?string $name): ?string
+    {
+        if ($name === null) {
+            $this->object_type_id = $this->object_type = null;
+
+            return null;
+        }
+
+        $this->object_type = TableRegistry::getTableLocator()->get('ObjectTypes')->get($name);
+
+        return $name;
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointTest.php
@@ -43,6 +43,7 @@ class EndpointTest extends TestCase
         'plugin.BEdita/Core.ObjectTypes',
         'plugin.BEdita/Core.Relations',
         'plugin.BEdita/Core.ObjectRelations',
+        'plugin.BEdita/Core.Objects',
         'plugin.BEdita/Core.RelationTypes',
         'plugin.BEdita/Core.Endpoints',
     ];

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointTest.php
@@ -14,6 +14,8 @@
 namespace BEdita\Core\Test\TestCase\Model\Entity;
 
 use BEdita\Core\Model\Entity\Endpoint;
+use BEdita\Core\Model\Entity\ObjectType;
+use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -39,6 +41,9 @@ class EndpointTest extends TestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.ObjectRelations',
+        'plugin.BEdita/Core.RelationTypes',
         'plugin.BEdita/Core.Endpoints',
     ];
 
@@ -88,5 +93,63 @@ class EndpointTest extends TestCase
         $this->assertEquals(1, $endpoint->id);
         $this->assertEquals($created, $endpoint->created);
         $this->assertEquals($modified, $endpoint->modified);
+    }
+
+    /**
+     * Data provder for `testSetObjectTypeName()`
+     *
+     * @return array
+     */
+    public function setObjectTypeNameProvider(): array
+    {
+        return [
+            'null' => [
+                null,
+                null,
+            ],
+            'name' => [
+                2,
+                'documents',
+            ],
+            'singular name' => [
+                2,
+                'document',
+            ],
+            'not valid name' => [
+                new RecordNotFoundException('Record not found in table "object_types"'),
+                'dontfindme',
+            ],
+        ];
+    }
+
+    /**
+     * Test magic setter for object_type_name.
+     *
+     * @param mixed $expected The expected data
+     * @param string $name The object type name
+     * @return void
+     *
+     * @covers ::_setObjectTypeName()
+     * @dataProvider setObjectTypeNameProvider()
+     */
+    public function testSetObjectTypeName($expected, ?string $name): void
+    {
+        if ($expected instanceof \Exception) {
+            $this->expectException(RecordNotFoundException::class);
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+
+        $entity = new Endpoint();
+        $entity->set('object_type_name', $name);
+        $objectType = $entity->object_type;
+        if ($expected === null) {
+            static::assertNull($objectType);
+            static::assertNull($entity->object_type_id);
+
+            return;
+        }
+
+        static::assertInstanceOf(ObjectType::class, $objectType);
+        static::assertEquals($expected, $objectType->id);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
@@ -131,6 +131,14 @@ class ResourcesTest extends TestCase
                         'description' => 'handle pets with care',
                     ]
                 ],
+                'endpoints with object type',
+                [
+                    [
+                        'name' => 'pets',
+                        'description' => 'handle pets with care',
+                        'object_type_name' => 'documents',
+                    ]
+                ],
             ],
             'endpoint_permissions' => [
                 'endpoint_permissions',
@@ -379,6 +387,13 @@ class ResourcesTest extends TestCase
                     [
                         'name' => 'disabled',
                         'enabled' => 1,
+                    ]
+                ],
+                'endpoints with object type',
+                [
+                    [
+                        'name' => 'disabled',
+                        'object_type_name' => 'documents',
                     ]
                 ],
             ],


### PR DESCRIPTION
This PR adds a virtual property `object_type_name` on `Endpoint` entity to easily set an object type. Useful for yaml migrations.