### PR TITLE
DateRanges min/max sort

### DIFF
--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -22,7 +22,7 @@ use BEdita\Core\Model\Action\ListRelatedObjectsAction;
 use BEdita\Core\Model\Action\RemoveRelatedObjectsAction;
 use BEdita\Core\Model\Action\SaveEntityAction;
 use BEdita\Core\Model\Action\SetRelatedObjectsAction;
-use BEdita\Core\Model\Table\DateRangesTable;
+use BEdita\Core\Model\Table\ObjectsTable;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Event\Event;
@@ -479,7 +479,7 @@ class ObjectsController extends ResourcesController
         // Add date ranges special sort field to filter if found
         // It will be used in `ObjectsTable::findDateRanges`
         $sort = str_replace('-', '', $sort);
-        if (in_array($sort, DateRangesTable::SPECIAL_SORT_FIELDS)) {
+        if (in_array($sort, ObjectsTable::DATERANGES_SORT_FIELDS)) {
             $filter['date_ranges'][$sort] = true;
         }
 

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -22,6 +22,7 @@ use BEdita\Core\Model\Action\ListRelatedObjectsAction;
 use BEdita\Core\Model\Action\RemoveRelatedObjectsAction;
 use BEdita\Core\Model\Action\SaveEntityAction;
 use BEdita\Core\Model\Action\SetRelatedObjectsAction;
+use BEdita\Core\Model\Table\DateRangesTable;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Event\Event;
@@ -191,7 +192,7 @@ class ObjectsController extends ResourcesController
                 );
         } else {
             // List existing entities.
-            $filter = (array)$this->request->getQuery('filter') + array_filter(['query' => $this->request->getQuery('q')]);
+            $filter = $this->prepareFilter();
             $contain = $this->prepareInclude($this->request->getQuery('include'));
             $lang = $this->request->getQuery('lang');
 
@@ -293,7 +294,7 @@ class ObjectsController extends ResourcesController
         $relatedId = TableRegistry::getTableLocator()->get('Objects')->getId($this->request->getParam('related_id'));
 
         $association = $this->findAssociation($relationship);
-        $filter = (array)$this->request->getQuery('filter') + array_filter(['query' => $this->request->getQuery('q')]);
+        $filter = $this->prepareFilter();
         $contain = $this->prepareInclude($this->request->getQuery('include'));
         $lang = $this->request->getQuery('lang');
 
@@ -339,7 +340,7 @@ class ObjectsController extends ResourcesController
 
             case 'GET':
             default:
-                $filter = (array)$this->request->getQuery('filter') + array_filter(['query' => $this->request->getQuery('q')]);
+                $filter = $this->prepareFilter();
 
                 $action = $this->getAssociatedAction($association);
                 $data = $action(['primaryKey' => $id, 'list' => true, 'filter' => $filter]);
@@ -460,5 +461,28 @@ class ObjectsController extends ResourcesController
         /** @var \BEdita\Core\Model\Action\CountRelatedObjectsAction $action */
         $action = $this->createAction('CountRelatedObjectsAction');
         $action(compact('entities', 'count'));
+    }
+
+    /**
+     * Prepare filter array from request.
+     *
+     * @return array
+     */
+    protected function prepareFilter(): array
+    {
+        $filter = (array)$this->request->getQuery('filter') +
+            array_filter(['query' => $this->request->getQuery('q')]);
+        $sort = $this->request->getQuery('sort');
+        if (empty($sort)) {
+            return $filter;
+        }
+        // Add date ranges special sort field to filter if found
+        // It will be used in `ObjectsTable::findDateRanges`
+        $sort = str_replace('-', '', $sort);
+        if (in_array($sort, DateRangesTable::SPECIAL_SORT_FIELDS)) {
+            $filter['date_ranges'][$sort] = true;
+        }
+
+        return $filter;
     }
 }

--- a/plugins/BEdita/API/src/Datasource/JsonApiPaginator.php
+++ b/plugins/BEdita/API/src/Datasource/JsonApiPaginator.php
@@ -13,7 +13,7 @@
 
 namespace BEdita\API\Datasource;
 
-use BEdita\Core\Model\Table\DateRangesTable;
+use BEdita\Core\Model\Table\ObjectsTable;
 use Cake\Datasource\Paginator;
 use Cake\Datasource\QueryInterface;
 use Cake\Datasource\RepositoryInterface;
@@ -37,7 +37,7 @@ class JsonApiPaginator extends Paginator
         'limit' => 20,
         'maxLimit' => 100,
         'whitelist' => ['page', 'page_size', 'sort'],
-        'sortWhitelist' => DateRangesTable::SPECIAL_SORT_FIELDS,
+        'sortWhitelist' => ObjectsTable::DATERANGES_SORT_FIELDS,
     ];
 
     /**

--- a/plugins/BEdita/API/src/Datasource/JsonApiPaginator.php
+++ b/plugins/BEdita/API/src/Datasource/JsonApiPaginator.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\API\Datasource;
 
+use BEdita\Core\Model\Table\DateRangesTable;
 use Cake\Datasource\Paginator;
 use Cake\Datasource\QueryInterface;
 use Cake\Datasource\RepositoryInterface;
@@ -36,6 +37,7 @@ class JsonApiPaginator extends Paginator
         'limit' => 20,
         'maxLimit' => 100,
         'whitelist' => ['page', 'page_size', 'sort'],
+        'sortWhitelist' => DateRangesTable::SPECIAL_SORT_FIELDS,
     ];
 
     /**

--- a/plugins/BEdita/API/src/Datasource/JsonApiPaginator.php
+++ b/plugins/BEdita/API/src/Datasource/JsonApiPaginator.php
@@ -37,7 +37,6 @@ class JsonApiPaginator extends Paginator
         'limit' => 20,
         'maxLimit' => 100,
         'whitelist' => ['page', 'page_size', 'sort'],
-        'sortWhitelist' => ObjectsTable::DATERANGES_SORT_FIELDS,
     ];
 
     /**
@@ -89,6 +88,9 @@ class JsonApiPaginator extends Paginator
                 $options['direction'] = 'desc';
             }
             unset($options['order']);
+            if (in_array($options['sort'], ObjectsTable::DATERANGES_SORT_FIELDS)) {
+                $options['sortWhitelist'] = [$options['sort']];
+            }
         }
 
         $options = parent::validateSort($object, $options);

--- a/plugins/BEdita/API/tests/IntegrationTest/SortQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/SortQueryStringTest.php
@@ -21,6 +21,15 @@ use Cake\Utility\Hash;
 class SortQueryStringTest extends IntegrationTestCase
 {
     /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.DateRanges'
+    ];
+
+    /**
      * Provider for testSortObjects()
      *
      * @return array
@@ -52,7 +61,12 @@ class SortQueryStringTest extends IntegrationTestCase
                 200,
                 '/roles',
                 'name'
-            ]
+            ],
+            'eventsSpecialSort' => [
+                200,
+                '/events',
+                'date_ranges_max_end_date',
+            ],
         ];
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -33,6 +33,7 @@ class ObjectsControllerTest extends IntegrationTestCase
         'plugin.BEdita/Core.Locations',
         'plugin.BEdita/Core.ObjectRelations',
         'plugin.BEdita/Core.Streams',
+        'plugin.BEdita/Core.DateRanges',
         'plugin.BEdita/Core.Media',
     ];
 
@@ -44,6 +45,7 @@ class ObjectsControllerTest extends IntegrationTestCase
      * @covers ::index()
      * @covers ::initialize()
      * @covers ::addCount()
+     * @covers ::prepareFilter()
      */
     public function testIndex()
     {
@@ -2702,5 +2704,21 @@ class ObjectsControllerTest extends IntegrationTestCase
         $this->assertContentType('application/vnd.api+json');
 
         static::assertEquals(2, Hash::get($result, 'data.relationships.test.meta.count'));
+    }
+
+    /**
+     * Test prepareFilter()
+     *
+     * @return void
+     *
+     * @covers ::prepareFilter()
+     */
+    public function testPrepareFilter(): void
+    {
+        $this->configRequestHeaders();
+        $this->get('/events?sort=date_ranges_min_start_date');
+        $result = json_decode((string)$this->_response->getBody(), true);
+        $this->assertResponseCode(200);
+        static::assertEquals(9, Hash::get($result, 'data.0.id'));
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Datasource/JsonApiPaginatorTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Datasource/JsonApiPaginatorTest.php
@@ -117,6 +117,10 @@ class JsonApiPaginatorTest extends TestCase
                 ['Roles.name' => 'desc'],
                 '-name',
             ],
+            'special' => [
+                ['date_ranges_max_end_date' => 'desc'],
+                '-date_ranges_max_end_date',
+            ],
             'multipleFields' => [
                 new BadRequestException('Unsupported sorting field'),
                 'username,created',

--- a/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
@@ -43,18 +43,6 @@ class DateRangesTable extends Table
     use QueryFilterTrait;
 
     /**
-     * Special sort fields
-     *
-     * @var array
-     */
-    const SPECIAL_SORT_FIELDS = [
-        'date_ranges_min_start_date',
-        'date_ranges_max_start_date',
-        'date_ranges_min_end_date',
-        'date_ranges_max_end_date',
-    ];
-
-    /**
      * Initialize method
      *
      * @param array $config The configuration for the Table.

--- a/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
@@ -43,6 +43,18 @@ class DateRangesTable extends Table
     use QueryFilterTrait;
 
     /**
+     * Special sort fields
+     *
+     * @var array
+     */
+    const SPECIAL_SORT_FIELDS = [
+        'date_ranges_min_start_date',
+        'date_ranges_max_start_date',
+        'date_ranges_min_end_date',
+        'date_ranges_max_end_date',
+    ];
+
+    /**
      * Initialize method
      *
      * @param array $config The configuration for the Table.
@@ -155,7 +167,7 @@ class DateRangesTable extends Table
             'start_date',
             'end_date',
             'from_date',
-            'to_date'
+            'to_date',
         ]);
         $options = array_intersect_key($options, $allowed);
         if (empty($options)) {

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -299,11 +299,6 @@ class ObjectsTable extends Table
         if (empty($minMaxField)) {
             return null;
         }
-        if (strpos($minMaxField, 'date_ranges_min_') === 0) {
-            $func = $query->func()->min(substr($minMaxField, 16));
-        } else {
-            $func = $query->func()->max(substr($minMaxField, 16));
-        }
         unset($options[$minMaxField]);
         $finder = 'dateRanges';
         if (empty($options)) {
@@ -312,7 +307,10 @@ class ObjectsTable extends Table
         $subQuery = $this->DateRanges->find($finder, $options)
             ->select([
                 'date_ranges_object_id' => 'object_id',
-                $minMaxField => $func,
+                'date_ranges_min_start_date' => $query->func()->min('start_date'),
+                'date_ranges_max_start_date' => $query->func()->max('start_date'),
+                'date_ranges_min_end_date' => $query->func()->min('end_date'),
+                'date_ranges_max_end_date' => $query->func()->max('end_date'),
             ])
             ->group('object_id');
 

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -320,7 +320,7 @@ class ObjectsTable extends Table
             ])
             ->innerJoin(
                 ['DateBoundaries' => $subQuery],
-                ['DateBoundaries.date_ranges_object_id = ' . $this->aliasField('id')]
+                ['DateBoundaries.date_ranges_object_id = ' . $this->aliasField($this->getPrimaryKey())]
             );
     }
 

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -270,15 +270,15 @@ class ObjectsTable extends Table
      */
     protected function findDateRanges(Query $query, array $options)
     {
-        $query = $query->distinct([$this->aliasField($this->getPrimaryKey())]);
         $join = $this->dateRangesSubQueryJoin($query, $options);
         if (!empty($join)) {
             return $join;
         }
 
-        return $query->innerJoinWith('DateRanges', function (Query $query) use ($options) {
-            return $query->find('dateRanges', $options);
-        });
+        return $query->distinct([$this->aliasField($this->getPrimaryKey())])
+                ->innerJoinWith('DateRanges', function (Query $query) use ($options) {
+                    return $query->find('dateRanges', $options);
+                });
     }
 
     /**
@@ -314,10 +314,14 @@ class ObjectsTable extends Table
             ])
             ->group('object_id');
 
-        return $query->innerJoin(
-            ['DateBoundaries' => $subQuery],
-            ['DateBoundaries.date_ranges_object_id = ' . $this->aliasField('id')]
-        );
+        return $query->distinct([
+                $this->aliasField($this->getPrimaryKey()),
+                $minMaxField,
+            ])
+            ->innerJoin(
+                ['DateBoundaries' => $subQuery],
+                ['DateBoundaries.date_ranges_object_id = ' . $this->aliasField('id')]
+            );
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -261,17 +261,51 @@ class ObjectsTableTest extends TestCase
     }
 
     /**
+     * Data provider for `testFindDateRanges` test case.
+     *
+     * @return array
+     */
+    public function findDateRangesProvider()
+    {
+        return [
+            'simple' => [
+                [9],
+                [
+                    'start_date' => ['gt' => '2017-01-01'],
+                ],
+            ],
+            'sub1' => [
+                [],
+                [
+                    'date_ranges_min_start_date' => true,
+                    'from_date' => '2019-01-01',
+                ],
+            ],
+            'sub2' => [
+                [9],
+                [
+                    'date_ranges_max_start_date' => true,
+                ],
+            ],
+        ];
+    }
+
+    /**
      * Test object date ranges finder.
      * {@see \BEdita\Core\Model\Table\DateRangesTable} for a more detailed test case
      *
+     * @param array $expected Expected results.
+     * @param array $options Finder options.
      * @return void
      *
+     * @dataProvider findDateRangesProvider
      * @covers ::findDateRanges()
+     * @covers ::dateRangesSubQueryJoin()
      */
-    public function testFindDateRanges()
+    public function testFindDateRanges(array $expected, array $options)
     {
-        $result = $this->Objects->find('dateRanges', ['start_date' => ['gt' => '2017-01-01']])->toArray();
-        $this->assertNotEmpty($result);
+        $result = $this->Objects->find('dateRanges', $options)->toArray();
+        $this->assertEquals($expected, Hash::extract($result, '{n}.id'));
     }
 
     /**


### PR DESCRIPTION
This PR introduces some special sort fields on `DateRanges` namely:
``` date_ranges_min_start_date, date_ranges_max_start_date, date_ranges_min_end_date, date_ranges_max_end_date```

These sort fields will enable sorting `events` or other objects having `DateRanges` with `start_date` or `end_date` in ascending/descending order.

A few examples:

* ```GET /events?sort=date_ranges_min_start_date``` - sort all events with ascending min start_date
* ```GET /events?filter[date_ranges][from_date]=2020-11-14&sort=-date_ranges_max_end_date``` - all events with valid date ranges from `2020-11-14` sorted in reverse max end date

When one of the above special sort fields are used an `INNER JOIN` with a subquery having MAX/MIN on `date_ranges.start_date` or `date_ranges.end_date` is added that will be used as `sort` field in the final query.


