### PR TITLE
Remove useless inline docblock, fix phpstan weirdness

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: 'Run tests'
 
 on:
+  pull_request:
+    paths:
+      - '**/*.php'
   push:
     paths:
       - '**/*.php'

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -115,7 +115,6 @@ class ObjectsController extends ResourcesController
     {
         $type = $this->request->getParam('object_type', Inflector::underscore($this->request->getParam('controller')));
         try {
-            /** @var \BEdita\Core\Model\Entity\ObjectType $this->objectType */
             $this->objectType = TableRegistry::getTableLocator()->get('ObjectTypes')->get($type);
             if ($type !== $this->objectType->name) {
                 $this->log(


### PR DESCRIPTION
This PR fixes a PHPStan reported problem, which was caused by a redundant inline docblock.

The docblock was redundant because the type of that attribute was already documented at the member declaration, plus it caused confusion around `$this`'s type to PHPStan.
