### PR TITLE
Layered cache

### DIFF
--- a/plugins/BEdita/Core/src/Cache/Engine/LayeredEngine.php
+++ b/plugins/BEdita/Core/src/Cache/Engine/LayeredEngine.php
@@ -44,7 +44,14 @@ class LayeredEngine extends CacheEngine
      * @var array
      */
     protected $_defaultConfig = [
-        'persistent' => ['className' => 'File'],
+        'duration' => 3600,
+        'groups' => [],
+        'prefix' => 'cake_',
+        'probability' => 100,
+        'warnOnWriteFailures' => true,
+        'persistent' => [
+            'className' => 'File',
+        ],
     ];
 
     /**
@@ -57,6 +64,7 @@ class LayeredEngine extends CacheEngine
 
         $this->persistent = $this->getEngineInstance($this->getConfig('persistent'));
         $this->memory = new ArrayEngine();
+        $this->memory->setConfig($this->getConfig());
 
         return true;
     }

--- a/plugins/BEdita/Core/src/Cache/Engine/LayeredEngine.php
+++ b/plugins/BEdita/Core/src/Cache/Engine/LayeredEngine.php
@@ -109,7 +109,7 @@ class LayeredEngine extends CacheEngine
 
             if ($instance !== null) {
                 if (!($instance instanceof CacheEngine)) {
-                    throw new Exception("Another object is already registered with name '{$name}', and is not an implementation of CacheEngine");
+                    throw new Exception("Another object is already registered with alias '{$name}', and is not an implementation of CacheEngine");
                 }
 
                 return $instance;

--- a/plugins/BEdita/Core/src/Cache/Engine/LayeredEngine.php
+++ b/plugins/BEdita/Core/src/Cache/Engine/LayeredEngine.php
@@ -82,7 +82,7 @@ class LayeredEngine extends CacheEngine
 
         if (is_string($config)) {
             if (!$registry->has($config)) {
-                throw new Exception("Cache engine alias {$config} is not defined");
+                throw new Exception("Cache engine alias '{$config}' is not defined");
             }
 
             $instance = $registry->get($config);
@@ -92,7 +92,7 @@ class LayeredEngine extends CacheEngine
             }
 
             if (!($instance instanceof CacheEngine)) {
-                throw new Exception("Cache engine alias {$config} is not an implementation of CacheEngine");
+                throw new Exception("Cache engine alias '{$config}' is not an implementation of CacheEngine");
             }
 
             return $instance;
@@ -103,16 +103,6 @@ class LayeredEngine extends CacheEngine
 
             if (!empty($config['prefix'])) {
                 $name = $config['prefix'] . $name;
-            }
-
-            $instance = $registry->get($name);
-
-            if ($instance !== null) {
-                if (!($instance instanceof CacheEngine)) {
-                    throw new Exception("Another object is already registered with alias '{$name}', and is not an implementation of CacheEngine");
-                }
-
-                return $instance;
             }
 
             return $registry->load($name, $config);

--- a/plugins/BEdita/Core/src/Cache/Engine/LayeredEngine.php
+++ b/plugins/BEdita/Core/src/Cache/Engine/LayeredEngine.php
@@ -10,7 +10,7 @@
  *
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
-namespace BEdita\Core;
+namespace BEdita\Core\Cache\Engine;
 
 use Cake\Cache\Cache;
 use Cake\Cache\CacheEngine;

--- a/plugins/BEdita/Core/src/Cache/Engine/LayeredEngine.php
+++ b/plugins/BEdita/Core/src/Cache/Engine/LayeredEngine.php
@@ -91,7 +91,7 @@ class LayeredEngine extends CacheEngine
                 throw new Exception('Recursion detected, Layered cache engine is configured as persistent engine of itself');
             }
 
-            if (!$instance instanceof CacheEngine) {
+            if (!($instance instanceof CacheEngine)) {
                 throw new Exception("Cache engine alias {$config} is not an implementation of CacheEngine");
             }
 
@@ -103,6 +103,16 @@ class LayeredEngine extends CacheEngine
 
             if (!empty($config['prefix'])) {
                 $name = $config['prefix'] . $name;
+            }
+
+            $instance = $registry->get($name);
+
+            if ($instance !== null) {
+                if (!($instance instanceof CacheEngine)) {
+                    throw new Exception("Another object is already registered with name '{$name}', and is not an implementation of CacheEngine");
+                }
+
+                return $instance;
             }
 
             return $registry->load($name, $config);

--- a/plugins/BEdita/Core/src/Cache/LayeredEngine.php
+++ b/plugins/BEdita/Core/src/Cache/LayeredEngine.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published

--- a/plugins/BEdita/Core/src/Cache/LayeredEngine.php
+++ b/plugins/BEdita/Core/src/Cache/LayeredEngine.php
@@ -17,8 +17,7 @@ use Cake\Cache\CacheEngine;
 use Exception;
 
 /**
- * This engine uses two layers of cache, one persistent and one in-memory for
- * faster lookup times.
+ * This engine uses two layers of cache, one persistent and one in-memory for faster lookup times.
  */
 class LayeredEngine extends CacheEngine
 {
@@ -40,13 +39,11 @@ class LayeredEngine extends CacheEngine
      * The default config used unless overridden by runtime configuration
      *
      * - `persistent` A cache configuration or an alias, to use as persistent cache
-     * - `memory` A cache configuration or an alias, to use as in-memory cache for faster lookups
      *
      * @var array
      */
     protected $_defaultConfig = [
         'persistent' => ['className' => 'File'],
-        'memory' => ['className' => 'Array'],
     ];
 
 
@@ -59,7 +56,7 @@ class LayeredEngine extends CacheEngine
         parent::init($config);
 
         $this->_persistent = $this->getEngineInstance($this->getConfig('persistent'));
-        $this->_memory = $this->getEngineInstance($this->getConfig('memory'));
+        $this->_memory = $this->getEngineInstance(['className' => 'Array']);
 
         return true;
     }
@@ -77,13 +74,13 @@ class LayeredEngine extends CacheEngine
 
         if (is_string($config)) {
             if (!$registry->has($config)) {
-                throw new Exception("Cache alias {$config} is not defined");
+                throw new Exception("Cache engine alias {$config} is not defined");
             }
 
             $instance = $registry->get($config);
 
             if (!$instance instanceof CacheEngine) {
-                throw new Exception("Cache alias {$config} is not an implementation of CacheEngine");
+                throw new Exception("Cache engine alias {$config} is not an implementation of CacheEngine");
             }
 
             return $instance;
@@ -127,8 +124,6 @@ class LayeredEngine extends CacheEngine
 
     /**
      * {@inheritDoc}
-     *
-     * @return int|false New incremented value, false otherwise
      */
     public function increment($key, $offset = 1)
     {

--- a/plugins/BEdita/Core/src/Cache/LayeredEngine.php
+++ b/plugins/BEdita/Core/src/Cache/LayeredEngine.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Core;
+
+use Cake\Cache\Cache;
+use Cake\Cache\CacheEngine;
+use Exception;
+
+/**
+ * This engine uses two layers of cache, one persistent and one in-memory for
+ * faster lookup times.
+ */
+class LayeredEngine extends CacheEngine
+{
+    /**
+     * Persistent cache instance.
+     *
+     * @var CacheEngine
+     */
+    protected $_persistent = null;
+
+    /**
+     * In-memory cache instance.
+     *
+     * @var CacheEngine
+     */
+    protected $_memory = null;
+
+    /**
+     * The default config used unless overridden by runtime configuration
+     *
+     * - `persistent` A cache configuration or an alias, to use as persistent cache
+     * - `memory` A cache configuration or an alias, to use as in-memory cache for faster lookups
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'persistent' => ['className' => 'File'],
+        'memory' => ['className' => 'Array'],
+    ];
+
+
+    /**
+     * {@inheritDoc}
+     * @throws Exception If the configuration is wrong
+     */
+    public function init(array $config = []): bool
+    {
+        parent::init($config);
+
+        $this->_persistent = $this->getEngineInstance($this->getConfig('persistent'));
+        $this->_memory = $this->getEngineInstance($this->getConfig('memory'));
+
+        return true;
+    }
+
+    /**
+     * Get the engine instance from a configuration or an alias.
+     *
+     * @param array|string $config Engine configuration or an alias
+     * @return CacheEngine The engine instance
+     * @throws Exception If the configuration is wrong
+     */
+    protected function getEngineInstance($config): CacheEngine
+    {
+        $registry = Cache::getRegistry();
+
+        if (is_string($config)) {
+            if (!$registry->has($config)) {
+                throw new Exception("Cache alias {$config} is not defined");
+            }
+
+            $instance = $registry->get($config);
+
+            if (!$instance instanceof CacheEngine) {
+                throw new Exception("Cache alias {$config} is not an implementation of CacheEngine");
+            }
+
+            return $instance;
+        }
+
+        if (is_array($config)) {
+            $name = ($config['prefix'] ?? '') . $config['className'];
+
+            return $registry->load($name, $config);
+        }
+
+        throw new Exception("Unknown cache configuration");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function write($key, $value): bool
+    {
+        $this->_memory->write($key, $value);
+
+        return $this->_persistent->write($key, $value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function read($key)
+    {
+        $value = $this->_memory->read($key);
+
+        if ($value !== false) {
+            return $value;
+        }
+
+        $value = $this->_persistent->read($key);
+        $this->_memory->write($key, $value);
+
+        return $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return int|false New incremented value, false otherwise
+     */
+    public function increment($key, $offset = 1)
+    {
+        if ($this->_memory->read($key) === false) {
+            $value = $this->_persistent->read($key);
+            $this->_memory->write($key, $value);
+        }
+
+        $this->_memory->increment($key, $offset);
+
+        return $this->_persistent->increment($key, $offset);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function decrement($key, $offset = 1)
+    {
+        if ($this->_memory->read($key) === false) {
+            $value = $this->_persistent->read($key);
+            $this->_memory->write($key, $value);
+        }
+
+        $this->_memory->increment($key, $offset);
+
+        return $this->_persistent->increment($key, $offset);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function delete($key): bool
+    {
+        $this->_memory->delete($key);
+
+        return $this->_persistent->delete($key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clear($check): bool
+    {
+        $this->_memory->clear($check);
+
+        return $this->_persistent->clear($check);
+    }
+}

--- a/plugins/BEdita/Core/src/Cache/LayeredEngine.php
+++ b/plugins/BEdita/Core/src/Cache/LayeredEngine.php
@@ -14,6 +14,7 @@ namespace BEdita\Core;
 
 use Cake\Cache\Cache;
 use Cake\Cache\CacheEngine;
+use Cake\Cache\Engine\ArrayEngine;
 use Exception;
 
 /**
@@ -55,7 +56,7 @@ class LayeredEngine extends CacheEngine
         parent::init($config);
 
         $this->_persistent = $this->getEngineInstance($this->getConfig('persistent'));
-        $this->_memory = $this->getEngineInstance(['className' => 'Array']);
+        $this->_memory = new ArrayEngine();
 
         return true;
     }

--- a/plugins/BEdita/Core/src/Cache/LayeredEngine.php
+++ b/plugins/BEdita/Core/src/Cache/LayeredEngine.php
@@ -46,7 +46,6 @@ class LayeredEngine extends CacheEngine
         'persistent' => ['className' => 'File'],
     ];
 
-
     /**
      * {@inheritDoc}
      * @throws Exception If the configuration is wrong

--- a/plugins/BEdita/Core/src/Cache/LayeredEngine.php
+++ b/plugins/BEdita/Core/src/Cache/LayeredEngine.php
@@ -86,12 +86,16 @@ class LayeredEngine extends CacheEngine
         }
 
         if (is_array($config)) {
-            $name = ($config['prefix'] ?? '') . $config['className'];
+            $name = $config['className'];
+
+            if (!empty($config['prefix'])) {
+                $name = $config['prefix'] . $name;
+            }
 
             return $registry->load($name, $config);
         }
 
-        throw new Exception("Unknown cache configuration");
+        throw new Exception('Unknown cache configuration');
     }
 
     /**
@@ -126,14 +130,10 @@ class LayeredEngine extends CacheEngine
      */
     public function increment($key, $offset = 1)
     {
-        if ($this->_memory->read($key) === false) {
-            $value = $this->_persistent->read($key);
-            $this->_memory->write($key, $value);
-        }
+        $value = $this->_persistent->increment($key, $offset);
+        $this->_memory->write($key, $value);
 
-        $this->_memory->increment($key, $offset);
-
-        return $this->_persistent->increment($key, $offset);
+        return $value;
     }
 
     /**
@@ -141,14 +141,10 @@ class LayeredEngine extends CacheEngine
      */
     public function decrement($key, $offset = 1)
     {
-        if ($this->_memory->read($key) === false) {
-            $value = $this->_persistent->read($key);
-            $this->_memory->write($key, $value);
-        }
+        $value = $this->_persistent->decrement($key, $offset);
+        $this->_memory->write($key, $value);
 
-        $this->_memory->increment($key, $offset);
-
-        return $this->_persistent->increment($key, $offset);
+        return $value;
     }
 
     /**

--- a/plugins/BEdita/Core/src/Cache/LayeredEngine.php
+++ b/plugins/BEdita/Core/src/Cache/LayeredEngine.php
@@ -79,6 +79,10 @@ class LayeredEngine extends CacheEngine
 
             $instance = $registry->get($config);
 
+            if ($instance === $this) {
+                throw new Exception('Recursion detected, Layered cache engine is configured as persistent engine of itself');
+            }
+
             if (!$instance instanceof CacheEngine) {
                 throw new Exception("Cache engine alias {$config} is not an implementation of CacheEngine");
             }

--- a/plugins/BEdita/Core/src/Cache/LayeredEngine.php
+++ b/plugins/BEdita/Core/src/Cache/LayeredEngine.php
@@ -25,16 +25,16 @@ class LayeredEngine extends CacheEngine
     /**
      * Persistent cache instance.
      *
-     * @var CacheEngine
+     * @var \Cake\Cache\CacheEngine
      */
-    protected $_persistent = null;
+    protected $persistent = null;
 
     /**
      * In-memory cache instance.
      *
-     * @var CacheEngine
+     * @var \Cake\Cache\Engine\ArrayEngine
      */
-    protected $_memory = null;
+    protected $memory = null;
 
     /**
      * The default config used unless overridden by runtime configuration
@@ -55,8 +55,8 @@ class LayeredEngine extends CacheEngine
     {
         parent::init($config);
 
-        $this->_persistent = $this->getEngineInstance($this->getConfig('persistent'));
-        $this->_memory = new ArrayEngine();
+        $this->persistent = $this->getEngineInstance($this->getConfig('persistent'));
+        $this->memory = new ArrayEngine();
 
         return true;
     }
@@ -104,9 +104,9 @@ class LayeredEngine extends CacheEngine
      */
     public function write($key, $value): bool
     {
-        $this->_memory->write($key, $value);
+        $this->memory->write($key, $value);
 
-        return $this->_persistent->write($key, $value);
+        return $this->persistent->write($key, $value);
     }
 
     /**
@@ -114,14 +114,14 @@ class LayeredEngine extends CacheEngine
      */
     public function read($key)
     {
-        $value = $this->_memory->read($key);
+        $value = $this->memory->read($key);
 
         if ($value !== false) {
             return $value;
         }
 
-        $value = $this->_persistent->read($key);
-        $this->_memory->write($key, $value);
+        $value = $this->persistent->read($key);
+        $this->memory->write($key, $value);
 
         return $value;
     }
@@ -131,8 +131,8 @@ class LayeredEngine extends CacheEngine
      */
     public function increment($key, $offset = 1)
     {
-        $value = $this->_persistent->increment($key, $offset);
-        $this->_memory->write($key, $value);
+        $value = $this->persistent->increment($key, $offset);
+        $this->memory->write($key, $value);
 
         return $value;
     }
@@ -142,8 +142,8 @@ class LayeredEngine extends CacheEngine
      */
     public function decrement($key, $offset = 1)
     {
-        $value = $this->_persistent->decrement($key, $offset);
-        $this->_memory->write($key, $value);
+        $value = $this->persistent->decrement($key, $offset);
+        $this->memory->write($key, $value);
 
         return $value;
     }
@@ -153,9 +153,9 @@ class LayeredEngine extends CacheEngine
      */
     public function delete($key): bool
     {
-        $this->_memory->delete($key);
+        $this->memory->delete($key);
 
-        return $this->_persistent->delete($key);
+        return $this->persistent->delete($key);
     }
 
     /**
@@ -163,8 +163,8 @@ class LayeredEngine extends CacheEngine
      */
     public function clear($check): bool
     {
-        $this->_memory->clear($check);
+        $this->memory->clear($check);
 
-        return $this->_persistent->clear($check);
+        return $this->persistent->clear($check);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Cache/Engine/LayeredEngineTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Cache/Engine/LayeredEngineTest.php
@@ -14,6 +14,8 @@
 namespace BEdita\Core\Test\TestCase\Cache\Engine;
 
 use Cake\Cache\Cache;
+use Cake\Cache\Engine\ArrayEngine;
+use Exception;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -55,7 +57,111 @@ class LayeredEngineTest extends TestCase
     protected function tearDown()
     {
         parent::tearDown();
-        Cache::drop('layered');
+
+        foreach (Cache::configured() as $name) {
+            Cache::drop($name);
+        }
+
+        foreach (Cache::getRegistry()->loaded() as $name) {
+            Cache::getRegistry()->unload($name);
+        }
+    }
+
+    /**
+     * Test cache init.
+     *
+     * @throws Exception
+     * @covers ::init()
+     */
+    public function testInit()
+    {
+        $layered = Cache::getRegistry()->get('layered');
+        static::assertAttributeInstanceOf(ArrayEngine::class, 'memory', $layered);
+        static::assertAttributeInstanceOf(ArrayEngine::class, 'persistent', $layered);
+    }
+
+    /**
+     * Test using an alias for persistent cache.
+     *
+     * @covers ::getEngineInstance()
+     */
+    public function testPersistentAlias()
+    {
+        Cache::setConfig('array-alias', ['className' => 'Array']);
+        Cache::setConfig('layered-alias', array_merge(
+            $this->defaultConfig,
+            ['persistent' => 'array-alias']
+        ));
+
+        $result = Cache::write('secret', 42, 'array-alias');
+        static::assertTrue($result);
+
+        $result = Cache::read('secret', 'layered-alias');
+        static::assertSame(42, $result);
+    }
+
+    /**
+     * Test using a bad persistent config.
+     *
+     * @covers ::getEngineInstance()
+     */
+    public function testPersistentBadConfig()
+    {
+        static::expectException(Exception::class);
+        static::expectExceptionMessage('Unknown cache configuration');
+        Cache::setConfig('layered-bad-persistent', array_merge(
+            $this->defaultConfig,
+            ['persistent' => 1]
+        ));
+        Cache::write('secret', 42, 'layered-bad-persistent');
+    }
+
+    /**
+     * Test using an nonexistent alias for persistent cache.
+     *
+     * @covers ::getEngineInstance()
+     */
+    public function testPersistentMissingAlias()
+    {
+        static::expectException(Exception::class);
+        static::expectExceptionMessage("Cache engine alias 'this-does-not-exist' is not defined");
+        Cache::setConfig('layered-missing-alias', array_merge(
+            $this->defaultConfig,
+            ['persistent' => 'this-does-not-exist']
+        ));
+        Cache::write('secret', 42, 'layered-missing-alias');
+    }
+
+    /**
+     * Test using the engine as persistent engine of itself.
+     *
+     * @covers ::getEngineInstance()
+     */
+    public function testPersistentRecursive()
+    {
+        static::expectException(Exception::class);
+        Cache::setConfig('layered-recursive', array_merge(
+            $this->defaultConfig,
+            ['persistent' => 'layered-recursive']
+        ));
+        Cache::write('secret', 42, 'layered-recursive');
+    }
+
+    /**
+     * Test using an alias to wrong object type as persistent engine.
+     *
+     * @covers ::getEngineInstance()
+     */
+    public function testPersistentWrongObject()
+    {
+        static::expectException(Exception::class);
+        static::expectExceptionMessage("Cache engine alias 'another-object' is not an implementation of CacheEngine");
+        Cache::getRegistry()->set('another-object', new \stdClass());
+        Cache::setConfig('layered-wrong-object', array_merge(
+            $this->defaultConfig,
+            ['persistent' => 'another-object']
+        ));;
+        Cache::write('secret', 42, 'layered-wrong-object');
     }
 
     /**
@@ -67,10 +173,30 @@ class LayeredEngineTest extends TestCase
     public function testWriteAndRead()
     {
         $result = Cache::write('secret', 42, 'layered');
-        $this->assertTrue($result);
+        static::assertTrue($result);
 
         $result = Cache::read('secret', 'layered');
-        $this->assertSame(42, $result);
+        static::assertSame(42, $result);
+    }
+
+    /**
+     * Test cache read, with miss in memory engine.
+     *
+     * @covers ::read()
+     */
+    public function testMemoryCacheMiss()
+    {
+        Cache::setConfig('array-miss', ['className' => 'Array']);
+        Cache::setConfig('layered-miss', array_merge(
+            $this->defaultConfig,
+            ['persistent' => 'array-miss']
+        ));
+
+        $result = Cache::write('secret', 42, 'array-miss');
+        static::assertTrue($result);
+
+        $result = Cache::read('secret', 'layered-miss');
+        static::assertSame(42, $result);
     }
 
     /**
@@ -81,19 +207,19 @@ class LayeredEngineTest extends TestCase
     public function testIncrement()
     {
         $result = Cache::write('increment', 42, 'layered');
-        $this->assertTrue($result);
+        static::assertTrue($result);
 
         $result = Cache::increment('increment', 1, 'layered');
-        $this->assertSame(43, $result);
+        static::assertSame(43, $result);
 
         $result = Cache::read('increment', 'layered');
-        $this->assertSame(43, $result);
+        static::assertSame(43, $result);
 
         $result = Cache::increment('increment', 2, 'layered');
-        $this->assertSame(45, $result);
+        static::assertSame(45, $result);
 
         $result = Cache::read('increment', 'layered');
-        $this->assertSame(45, $result);
+        static::assertSame(45, $result);
     }
 
     /**
@@ -104,19 +230,19 @@ class LayeredEngineTest extends TestCase
     public function testDecrement()
     {
         $result = Cache::write('decrement', 42, 'layered');
-        $this->assertTrue($result);
+        static::assertTrue($result);
 
         $result = Cache::decrement('decrement', 1, 'layered');
-        $this->assertSame(41, $result);
+        static::assertSame(41, $result);
 
         $result = Cache::read('decrement', 'layered');
-        $this->assertSame(41, $result);
+        static::assertSame(41, $result);
 
         $result = Cache::decrement('decrement', 2, 'layered');
-        $this->assertSame(39, $result);
+        static::assertSame(39, $result);
 
         $result = Cache::read('decrement', 'layered');
-        $this->assertSame(39, $result);
+        static::assertSame(39, $result);
     }
 
     /**
@@ -127,13 +253,13 @@ class LayeredEngineTest extends TestCase
     public function testDelete()
     {
         $result = Cache::write('delete', 42, 'layered');
-        $this->assertTrue($result);
+        static::assertTrue($result);
 
         $result = Cache::delete('delete', 'layered');
-        $this->assertTrue($result);
+        static::assertTrue($result);
 
         $result = Cache::read('delete', 'layered');
-        $this->assertFalse($result);
+        static::assertFalse($result);
     }
 
     /**
@@ -144,12 +270,12 @@ class LayeredEngineTest extends TestCase
     public function testClear()
     {
         $result = Cache::write('clear', 42, 'layered');
-        $this->assertTrue($result);
+        static::assertTrue($result);
 
         $result = Cache::clear(false, 'layered');
-        $this->assertTrue($result);
+        static::assertTrue($result);
 
         $result = Cache::read('clear', 'layered');
-        $this->assertFalse($result);
+        static::assertFalse($result);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Cache/Engine/LayeredEngineTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Cache/Engine/LayeredEngineTest.php
@@ -32,7 +32,11 @@ class LayeredEngineTest extends TestCase
      */
     public $defaultConfig = [
         'className' => 'BEdita/Core.Layered',
-        'persistent' => ['className' => 'Array'],
+        'prefix' => 'test-layered-',
+        'persistent' => [
+            'className' => 'Array',
+            'prefix' => 'test-layered-persistent-',
+        ],
     ];
 
     /**
@@ -72,9 +76,11 @@ class LayeredEngineTest extends TestCase
 
     /**
      * Test cache init.
+     * Covers persistent engine config with prefix.
      *
      * @throws Exception
      * @covers ::init()
+     * @covers ::getEngineInstance()
      */
     public function testInit()
     {

--- a/plugins/BEdita/Core/tests/TestCase/Cache/Engine/LayeredEngineTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Cache/Engine/LayeredEngineTest.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Cache\Engine;
+
+use Cake\Cache\Cache;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * {@see \BEdita\Core\Cache\Engine\LayeredEngine} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Cache\Engine\LayeredEngine
+ */
+class LayeredEngineTest extends TestCase
+{
+    /**
+     * Default cache engine config
+     *
+     * @var array
+     */
+    public $defaultConfig = [
+        'className' => 'BEdita/Core.Layered',
+        'prefix' => 'test-layered-',
+        'persistent' => [
+            'className' => 'Array',
+            'prefix' => 'test-layered-persistent-',
+        ],
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        Cache::enable();
+        Cache::drop('layered');
+        Cache::setConfig('layered', $this->defaultConfig);
+        Cache::clearAll();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        Cache::drop('layered');
+    }
+
+    /**
+     * Test cache write and read.
+     *
+     * @covers ::write()
+     * @covers ::read()
+     */
+    public function testWriteAndRead()
+    {
+        $result = Cache::write('secret', 42, 'layered');
+        $this->assertTrue($result);
+
+        $result = Cache::read('secret', 'layered');
+        $this->assertSame(42, $result);
+    }
+
+    /**
+     * Test cache increment.
+     *
+     * @covers ::increment()
+     */
+    public function testIncrement()
+    {
+        $result = Cache::write('increment', 42, 'layered');
+        $this->assertTrue($result);
+
+        $result = Cache::increment('increment', 1, 'layered');
+        $this->assertSame(43, $result);
+
+        $result = Cache::read('increment', 'layered');
+        $this->assertSame(43, $result);
+
+        $result = Cache::increment('increment', 2, 'layered');
+        $this->assertSame(45, $result);
+
+        $result = Cache::read('increment', 'layered');
+        $this->assertSame(45, $result);
+    }
+
+    /**
+     * Test cache decrement.
+     *
+     * @covers ::decrement()
+     */
+    public function testDecrement()
+    {
+        $result = Cache::write('decrement', 42, 'layered');
+        $this->assertTrue($result);
+
+        $result = Cache::decrement('decrement', 1, 'layered');
+        $this->assertSame(41, $result);
+
+        $result = Cache::read('decrement', 'layered');
+        $this->assertSame(41, $result);
+
+        $result = Cache::decrement('decrement', 2, 'layered');
+        $this->assertSame(39, $result);
+
+        $result = Cache::read('decrement', 'layered');
+        $this->assertSame(39, $result);
+    }
+
+    /**
+     * Test cache delete.
+     *
+     * @covers ::delete()
+     */
+    public function testDelete()
+    {
+        $result = Cache::write('delete', 42, 'layered');
+        $this->assertTrue($result);
+
+        $result = Cache::delete('delete', 'layered');
+        $this->assertTrue($result);
+
+        $result = Cache::read('delete', 'layered');
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test cache clear.
+     *
+     * @covers ::clear()
+     */
+    public function testClear()
+    {
+        $result = Cache::write('clear', 42, 'layered');
+        $this->assertTrue($result);
+
+        $result = Cache::clear(false, 'layered');
+        $this->assertTrue($result);
+
+        $result = Cache::read('clear', 'layered');
+        $this->assertFalse($result);
+    }
+}


### PR DESCRIPTION
This PR adds a cache engine with two layers, one persistent and one in-memory, for faster lookup times.

Example config:
```
'fast_cache' => [
    'className' => 'Layered',
    'persistent' => [
        'className' => 'File',
        'path' => CACHE,
        'url' => env('CACHE_DEFAULT_URL', null),
    ],
],
```
Example using a cache already configured:
```
'default' => [
    'className' => 'File',
    'path' => CACHE,
    'url' => env('CACHE_DEFAULT_URL', null),
],
'fast_cache' => [
    'className' => 'Layered',
    'persistent' => 'default',
],
```