### PR TITLE
Dispatch events when adding, removing, or replacing associations

### DIFF
--- a/plugins/BEdita/Core/src/Model/Action/AddRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/AddRelatedObjectsAction.php
@@ -35,6 +35,7 @@ class AddRelatedObjectsAction extends UpdateRelatedObjectsAction
     {
         if (!($this->Association instanceof RelatedTo)) {
             $action = new AddAssociatedAction($this->getConfig());
+            $action->setEventManager($this->getEventManager());
 
             return $action->execute(compact('entity', 'relatedEntities'));
         }

--- a/plugins/BEdita/Core/src/Model/Action/AddRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/AddRelatedObjectsAction.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Model\Action;
 
+use ArrayObject;
 use BEdita\Core\ORM\Association\RelatedTo;
 use Cake\Datasource\EntityInterface;
 
@@ -39,11 +40,14 @@ class AddRelatedObjectsAction extends UpdateRelatedObjectsAction
         }
 
         return $this->Association->getConnection()->transactional(function () use ($entity, $relatedEntities) {
-            $relatedEntities = $this->diff($entity, $relatedEntities, false);
+            $relatedEntities = new ArrayObject($relatedEntities);
+            $this->dispatchEvent('Associated.beforeSave', compact('entity', 'relatedEntities') + ['action' => 'add', 'association' => $this->Association]);
 
+            $relatedEntities = $this->diff($entity, $relatedEntities->getArrayCopy(), false);
             if (!$this->Association->link($entity, $relatedEntities)) {
                 return false;
             }
+            $this->dispatchEvent('Associated.afterSave', compact('entity', 'relatedEntities') + ['action' => 'add', 'association' => $this->Association]);
 
             return collection($relatedEntities)
                 ->extract($this->Association->getBindingKey())

--- a/plugins/BEdita/Core/src/Model/Action/AssociatedTrait.php
+++ b/plugins/BEdita/Core/src/Model/Action/AssociatedTrait.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Model\Action;
 
 use Cake\Datasource\EntityInterface;
+use Cake\Event\EventDispatcherTrait;
 use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\Association\BelongsToMany;
 
@@ -26,6 +27,8 @@ use Cake\ORM\Association\BelongsToMany;
  */
 trait AssociatedTrait
 {
+
+    use EventDispatcherTrait;
 
     /**
      * Find entity among list of entities.

--- a/plugins/BEdita/Core/src/Model/Action/AssociatedTrait.php
+++ b/plugins/BEdita/Core/src/Model/Action/AssociatedTrait.php
@@ -27,7 +27,6 @@ use Cake\ORM\Association\BelongsToMany;
  */
 trait AssociatedTrait
 {
-
     use EventDispatcherTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/RemoveAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/RemoveAssociatedAction.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Model\Action;
 
+use ArrayObject;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Association\HasMany;
@@ -46,9 +47,13 @@ class RemoveAssociatedAction extends UpdateAssociatedAction
             }
 
             return $this->Association->getConnection()->transactional(function () use ($entity, $relatedEntities) {
-                $relatedEntities = $this->intersection((array)$this->existing($entity), $relatedEntities);
+                $relatedEntities = new ArrayObject($relatedEntities);
+                $this->dispatchEvent('Associated.beforeSave', compact('entity', 'relatedEntities') + ['action' => 'remove', 'association' => $this->Association]);
+
+                $relatedEntities = $this->intersection((array)$this->existing($entity), $relatedEntities->getArrayCopy());
 
                 $this->Association->unlink($entity, $relatedEntities);
+                $this->dispatchEvent('Associated.afterSave', compact('entity', 'relatedEntities') + ['action' => 'remove', 'association' => $this->Association]);
 
                 return count($relatedEntities);
             });

--- a/plugins/BEdita/Core/src/Model/Action/RemoveRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/RemoveRelatedObjectsAction.php
@@ -25,7 +25,6 @@ use Cake\Event\EventDispatcherTrait;
  */
 class RemoveRelatedObjectsAction extends UpdateRelatedObjectsAction
 {
-
     use EventDispatcherTrait;
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/RemoveRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/RemoveRelatedObjectsAction.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Model\Action;
 
 use Cake\Datasource\EntityInterface;
+use Cake\Event\EventDispatcherTrait;
 
 /**
  * Command to remove links between related objects or objects and associated entities.
@@ -25,6 +26,8 @@ use Cake\Datasource\EntityInterface;
 class RemoveRelatedObjectsAction extends UpdateRelatedObjectsAction
 {
 
+    use EventDispatcherTrait;
+
     /**
      * Remove existing relations using `\BEdita\Core\Model\Action\RemoveAssociatedAction`.
      *
@@ -35,6 +38,7 @@ class RemoveRelatedObjectsAction extends UpdateRelatedObjectsAction
     protected function update(EntityInterface $entity, $relatedEntities)
     {
         $action = new RemoveAssociatedAction($this->getConfig());
+        $action->setEventManager($this->getEventManager());
 
         return $action->execute(compact('entity', 'relatedEntities'));
     }

--- a/plugins/BEdita/Core/src/Model/Action/SetAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SetAssociatedAction.php
@@ -13,12 +13,14 @@
 
 namespace BEdita\Core\Model\Action;
 
+use ArrayObject;
 use Cake\Datasource\EntityInterface;
 use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Association\HasMany;
 use Cake\ORM\Association\HasOne;
+use InvalidArgumentException;
 
 /**
  * Command to replace all entities associated to another entity.
@@ -68,7 +70,7 @@ class SetAssociatedAction extends UpdateAssociatedAction
         }
 
         if ($relatedEntities !== null && !($relatedEntities instanceof EntityInterface)) {
-            throw new \InvalidArgumentException(__d('bedita', 'Unable to link multiple entities'));
+            throw new InvalidArgumentException(__d('bedita', 'Unable to link multiple entities'));
         }
 
         if ($this->Association instanceof BelongsTo) {
@@ -95,16 +97,31 @@ class SetAssociatedAction extends UpdateAssociatedAction
      */
     protected function toMany(EntityInterface $entity, array $relatedEntities)
     {
+        $relatedEntities = new ArrayObject($relatedEntities);
+        $this->dispatchEvent('Associated.beforeSave', compact('entity', 'relatedEntities') + ['action' => 'set', 'association' => $this->Association]);
+
         // This doesn't need to be in a transaction.
-        $relatedEntities = $this->diff($entity, $relatedEntities, true, $affectedEntities);
+        $relatedEntities = $this->diff($entity, $relatedEntities->getArrayCopy(), true, $affectedEntities);
         $count = count($affectedEntities);
 
         if ($this->Association instanceof HasMany) {
-            return $this->Association->replace($entity, $relatedEntities, ['atomic' => false]) ? $count : false;
+            if ($this->Association->replace($entity, $relatedEntities, ['atomic' => false]) === false) {
+                return false;
+            }
+
+            $this->dispatchEvent('Associated.afterSave', compact('entity', 'relatedEntities') + ['action' => 'set', 'association' => $this->Association]);
+
+            return $count;
         }
 
         if ($this->Association instanceof BelongsToMany) {
-            return $this->Association->replaceLinks($entity, $relatedEntities, ['atomic' => false]) ? $count : false;
+            if ($this->Association->replaceLinks($entity, $relatedEntities, ['atomic' => false]) === false) {
+                return false;
+            }
+
+            $this->dispatchEvent('Associated.afterSave', compact('entity', 'relatedEntities') + ['action' => 'set', 'association' => $this->Association]);
+
+            return $count;
         }
 
         return false;
@@ -123,6 +140,10 @@ class SetAssociatedAction extends UpdateAssociatedAction
         $dirty = $entity->isDirty();
         $existing = $this->existing($entity);
 
+        $relatedEntities = new ArrayObject([$relatedEntity]);
+        $this->dispatchEvent('Associated.beforeSave', compact('entity', 'relatedEntities') + ['action' => 'set', 'association' => $this->Association]);
+        $relatedEntity = $relatedEntities[0];
+
         if ($existing === null && $relatedEntity === null) {
             return 0;
         } elseif (!$dirty && $relatedEntity !== null) {
@@ -132,10 +153,16 @@ class SetAssociatedAction extends UpdateAssociatedAction
                 return 0;
             }
         }
-
         $entity->set($this->Association->getProperty(), $relatedEntity);
 
-        return $this->Association->getSource()->save($entity) ? 1 : false;
+        if ($this->Association->getSource()->save($entity) === false) {
+            return false;
+        }
+
+        $relatedEntities = [$relatedEntity];
+        $this->dispatchEvent('Associated.afterSave', compact('entity', 'relatedEntities') + ['action' => 'set', 'association' => $this->Association]);
+
+        return 1;
     }
 
     /**
@@ -150,6 +177,10 @@ class SetAssociatedAction extends UpdateAssociatedAction
         $foreignKey = (array)$this->Association->getForeignKey();
         $bindingKeyValue = $entity->extract((array)$this->Association->getBindingKey());
         $existing = $this->existing($entity);
+
+        $relatedEntities = new ArrayObject([$relatedEntity]);
+        $this->dispatchEvent('Associated.beforeSave', compact('entity', 'relatedEntities') + ['action' => 'set', 'association' => $this->Association]);
+        $relatedEntity = $relatedEntities[0];
 
         if ($existing === null && $relatedEntity === null) {
             return 0;
@@ -183,6 +214,13 @@ class SetAssociatedAction extends UpdateAssociatedAction
             $bindingKeyValue
         ));
 
-        return $this->Association->getTarget()->save($relatedEntity) ? 1 : false;
+        if ($this->Association->getTarget()->save($relatedEntity) === false) {
+            return false;
+        }
+
+        $relatedEntities = [$relatedEntity];
+        $this->dispatchEvent('Associated.afterSave', compact('entity', 'relatedEntities') + ['action' => 'set', 'association' => $this->Association]);
+
+        return 1;
     }
 }

--- a/plugins/BEdita/Core/src/Model/Action/SetRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SetRelatedObjectsAction.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Model\Action;
 
+use ArrayObject;
 use BEdita\Core\ORM\Association\RelatedTo;
 use Cake\Datasource\EntityInterface;
 
@@ -38,11 +39,14 @@ class SetRelatedObjectsAction extends UpdateRelatedObjectsAction
             return $action->execute(compact('entity', 'relatedEntities'));
         }
 
-        $relatedEntities = $this->diff($entity, $relatedEntities, true, $affectedEntities);
+        $relatedEntities = new ArrayObject($relatedEntities);
+        $this->dispatchEvent('Associated.beforeSave', compact('entity', 'relatedEntities') + ['action' => 'set', 'association' => $this->Association]);
 
+        $relatedEntities = $this->diff($entity, $relatedEntities->getArrayCopy(), true, $affectedEntities);
         if (!$this->Association->replaceLinks($entity, $relatedEntities)) {
             return false;
         }
+        $this->dispatchEvent('Associated.afterSave', compact('entity', 'relatedEntities') + ['action' => 'set', 'association' => $this->Association]);
 
         return collection($affectedEntities)
             ->extract($this->Association->getBindingKey())

--- a/plugins/BEdita/Core/src/Model/Action/SetRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SetRelatedObjectsAction.php
@@ -35,6 +35,7 @@ class SetRelatedObjectsAction extends UpdateRelatedObjectsAction
     {
         if (!($this->Association instanceof RelatedTo)) {
             $action = new SetAssociatedAction($this->getConfig());
+            $action->setEventManager($this->getEventManager());
 
             return $action->execute(compact('entity', 'relatedEntities'));
         }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddAssociatedActionTest.php
@@ -15,6 +15,7 @@ namespace BEdita\Core\Test\TestCase\Model\Action;
 
 use BEdita\Core\Model\Action\AddAssociatedAction;
 use Cake\Core\Exception\Exception;
+use Cake\Event\Event;
 use Cake\ORM\Query;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -114,7 +115,7 @@ class AddAssociatedActionTest extends TestCase
     /**
      * Test invocation of command.
      *
-     * @param bool|\Exception Expected result.
+     * @param int|\Exception Expected result.
      * @param string $table Table to use.
      * @param string $association Association to use.
      * @param int $entity Entity to update relations for.
@@ -145,7 +146,32 @@ class AddAssociatedActionTest extends TestCase
                 ->toArray();
         }
 
+        $beforeSaveTriggered = $afterSaveTriggered = 0;
+        $action->getEventManager()->on('Associated.beforeSave', function (Event $event) use ($association, $entity, $relatedEntities, &$beforeSaveTriggered) {
+            $beforeSaveTriggered++;
+            static::assertSame('Associated.beforeSave', $event->getName());
+            static::assertSame('add', $event->getData('action'));
+            static::assertSame($association, $event->getData('association'));
+            static::assertSame($entity, $event->getData('entity'));
+            static::assertInstanceOf(\ArrayObject::class, $event->getData('relatedEntities'));
+            $rel = is_object($relatedEntities) ? [$relatedEntities] : (array)$relatedEntities;
+            static::assertSameSize($rel, $event->getData('relatedEntities'));
+            for ($i = 0; $i < count($rel); $i++) {
+                static::assertSame($rel[$i], $event->getData('relatedEntities')[$i]);
+            }
+        });
+        $action->getEventManager()->on('Associated.afterSave', function (Event $event) use ($association, $entity, $expected, &$afterSaveTriggered) {
+            $afterSaveTriggered++;
+            static::assertSame('Associated.afterSave', $event->getName());
+            static::assertSame('add', $event->getData('action'));
+            static::assertSame($association, $event->getData('association'));
+            static::assertSame($entity, $event->getData('entity'));
+            static::assertCount($expected, $event->getData('relatedEntities'));
+        });
+
         $result = $action(compact('entity', 'relatedEntities'));
+        static::assertSame(1, $beforeSaveTriggered);
+        static::assertSame(1, $afterSaveTriggered);
 
         $count = 0;
         if ($related !== null) {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddAssociatedActionTest.php
@@ -156,7 +156,8 @@ class AddAssociatedActionTest extends TestCase
             static::assertInstanceOf(\ArrayObject::class, $event->getData('relatedEntities'));
             $rel = is_object($relatedEntities) ? [$relatedEntities] : (array)$relatedEntities;
             static::assertSameSize($rel, $event->getData('relatedEntities'));
-            for ($i = 0; $i < count($rel); $i++) {
+            $n = count($rel);
+            for ($i = 0; $i < $n; $i++) {
                 static::assertSame($rel[$i], $event->getData('relatedEntities')[$i]);
             }
         });

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
@@ -17,6 +17,7 @@ use BEdita\Core\Model\Action\AddRelatedObjectsAction;
 use BEdita\Core\ORM\Association\RelatedTo;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
+use Cake\Event\Event;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Inflector;
@@ -124,7 +125,7 @@ class AddRelatedObjectsActionTest extends TestCase
     /**
      * Test invocation of command.
      *
-     * @param bool|\Exception Expected result.
+     * @param int[]|\Exception Expected result.
      * @param string $objectType Table to use.
      * @param string $relation Association to use.
      * @param int $id Entity to update relations for.
@@ -162,7 +163,32 @@ class AddRelatedObjectsActionTest extends TestCase
                 ->toArray();
         }
 
+        $beforeSaveTriggered = $afterSaveTriggered = 0;
+        $action->getEventManager()->on('Associated.beforeSave', function (Event $event) use ($association, $entity, $relatedEntities, &$beforeSaveTriggered) {
+            $beforeSaveTriggered++;
+            static::assertSame('Associated.beforeSave', $event->getName());
+            static::assertSame('add', $event->getData('action'));
+            static::assertSame($association, $event->getData('association'));
+            static::assertSame($entity, $event->getData('entity'));
+            static::assertInstanceOf(\ArrayObject::class, $event->getData('relatedEntities'));
+            $rel = is_object($relatedEntities) ? [$relatedEntities] : (array)$relatedEntities;
+            static::assertSameSize($rel, $event->getData('relatedEntities'));
+            for ($i = 0; $i < count($rel); $i++) {
+                static::assertSame($rel[$i], $event->getData('relatedEntities')[$i]);
+            }
+        });
+        $action->getEventManager()->on('Associated.afterSave', function (Event $event) use ($association, $entity, $expected, &$afterSaveTriggered) {
+            $afterSaveTriggered++;
+            static::assertSame('Associated.afterSave', $event->getName());
+            static::assertSame('add', $event->getData('action'));
+            static::assertSame($association, $event->getData('association'));
+            static::assertSame($entity, $event->getData('entity'));
+            static::assertSameSize($expected, $event->getData('relatedEntities'));
+        });
+
         $result = $action(compact('entity', 'relatedEntities'));
+        static::assertSame(1, $beforeSaveTriggered);
+        static::assertSame(1, $afterSaveTriggered);
 
         static::assertEquals($expected, $result, '', 0, 10, true);
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
@@ -173,7 +173,8 @@ class AddRelatedObjectsActionTest extends TestCase
             static::assertInstanceOf(\ArrayObject::class, $event->getData('relatedEntities'));
             $rel = is_object($relatedEntities) ? [$relatedEntities] : (array)$relatedEntities;
             static::assertSameSize($rel, $event->getData('relatedEntities'));
-            for ($i = 0; $i < count($rel); $i++) {
+            $n = count($rel);
+            for ($i = 0; $i < $n; $i++) {
                 static::assertSame($rel[$i], $event->getData('relatedEntities')[$i]);
             }
         });

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveAssociatedActionTest.php
@@ -155,7 +155,8 @@ class RemoveAssociatedActionTest extends TestCase
             static::assertInstanceOf(\ArrayObject::class, $event->getData('relatedEntities'));
             $rel = is_object($relatedEntities) ? [$relatedEntities] : (array)$relatedEntities;
             static::assertSameSize($rel, $event->getData('relatedEntities'));
-            for ($i = 0; $i < count($rel); $i++) {
+            $n = count($rel);
+            for ($i = 0; $i < $n; $i++) {
                 static::assertSame($rel[$i], $event->getData('relatedEntities')[$i]);
             }
         });

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
@@ -140,7 +140,8 @@ class RemoveRelatedObjectsActionTest extends TestCase
             static::assertInstanceOf(\ArrayObject::class, $event->getData('relatedEntities'));
             $rel = is_object($relatedEntities) ? [$relatedEntities] : (array)$relatedEntities;
             static::assertSameSize($rel, $event->getData('relatedEntities'));
-            for ($i = 0; $i < count($rel); $i++) {
+            $n = count($rel);
+            for ($i = 0; $i < $n; $i++) {
                 static::assertSame($rel[$i], $event->getData('relatedEntities')[$i]);
             }
         });

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Test\TestCase\Model\Action;
 
 use BEdita\Core\Model\Action\RemoveRelatedObjectsAction;
+use Cake\Event\Event;
 use Cake\ORM\Query;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -97,7 +98,7 @@ class RemoveRelatedObjectsActionTest extends TestCase
     /**
      * Test invocation of command.
      *
-     * @param bool|\Exception $expected Expected result.
+     * @param int|\Exception $expected Expected result.
      * @param string $table Table to use.
      * @param string $association Association to use.
      * @param int $entity Entity to update relations for.
@@ -129,7 +130,32 @@ class RemoveRelatedObjectsActionTest extends TestCase
                 ->toArray();
         }
 
+        $beforeSaveTriggered = $afterSaveTriggered = 0;
+        $action->getEventManager()->on('Associated.beforeSave', function (Event $event) use ($association, $entity, $relatedEntities, &$beforeSaveTriggered) {
+            $beforeSaveTriggered++;
+            static::assertSame('Associated.beforeSave', $event->getName());
+            static::assertSame('remove', $event->getData('action'));
+            static::assertSame($association, $event->getData('association'));
+            static::assertSame($entity, $event->getData('entity'));
+            static::assertInstanceOf(\ArrayObject::class, $event->getData('relatedEntities'));
+            $rel = is_object($relatedEntities) ? [$relatedEntities] : (array)$relatedEntities;
+            static::assertSameSize($rel, $event->getData('relatedEntities'));
+            for ($i = 0; $i < count($rel); $i++) {
+                static::assertSame($rel[$i], $event->getData('relatedEntities')[$i]);
+            }
+        });
+        $action->getEventManager()->on('Associated.afterSave', function (Event $event) use ($association, $entity, $expected, &$afterSaveTriggered) {
+            $afterSaveTriggered++;
+            static::assertSame('Associated.afterSave', $event->getName());
+            static::assertSame('remove', $event->getData('action'));
+            static::assertSame($association, $event->getData('association'));
+            static::assertSame($entity, $event->getData('entity'));
+            static::assertCount($expected, $event->getData('relatedEntities'));
+        });
+
         $result = $action(compact('entity', 'relatedEntities'));
+        static::assertSame(1, $beforeSaveTriggered);
+        static::assertSame(1, $afterSaveTriggered);
 
         $count = 0;
         if ($related !== null) {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SetAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SetAssociatedActionTest.php
@@ -226,7 +226,8 @@ class SetAssociatedActionTest extends TestCase
             static::assertInstanceOf(\ArrayObject::class, $event->getData('relatedEntities'));
             $rel = is_object($relatedEntities) || !$toMany ? [$relatedEntities] : (array)$relatedEntities;
             static::assertSameSize($rel, $event->getData('relatedEntities'));
-            for ($i = 0; $i < count($rel); $i++) {
+            $n = count($rel);
+            for ($i = 0; $i < $n; $i++) {
                 static::assertSame($rel[$i] ?: null, $event->getData('relatedEntities')[$i]);
             }
         });

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
@@ -217,7 +217,8 @@ class SetRelatedObjectsActionTest extends TestCase
             static::assertInstanceOf(\ArrayObject::class, $event->getData('relatedEntities'));
             $rel = is_object($relatedEntities) ? [$relatedEntities] : (array)$relatedEntities;
             static::assertSameSize($rel, $event->getData('relatedEntities'));
-            for ($i = 0; $i < count($rel); $i++) {
+            $n = count($rel);
+            for ($i = 0; $i < $n; $i++) {
                 static::assertSame($rel[$i], $event->getData('relatedEntities')[$i]);
             }
         });


### PR DESCRIPTION
This PR introduces new events `Associated.beforeSave` and `Associated.afterSave` to be dispatched before and after saving associated entities and relationships.

The events' data contains the following keys:
* `entity`: the source entity for which relationships are being managed
* `relatedEntities`: list of related entities being added, removed or replaced. This is an `ArrayObject` in `Associated.beforeSave` so that listeners may change the list of related entities to save by adding, removing, or replacing some of them — e.g.: when tagging a post with nested tag **Foo/Bar/Baz**, always add also its ancesors **Foo** and **Foo/Bar**.
* `action`: one of `add`, `remove` or `set`
* `association`: the association being managed

### Example 1: add ancestor tags on save

```php
$Posts = TableRegistry::getTableLocator()->get('Posts');
$Tags = $Posts->getAssociation('Tags');

$action = new AddAssociatedAction(['association' => $Tags]);

$action->on('Associated.beforeSave', function (Event $event) use ($Tags) {
  $relatedEntities = $event->getData('relatedEntities');
  $tag = $relatedEntities[0];  // Let's assume only one tag for simplicity.
  $name = $tag->name;

  $offset = 0;
  while (($offset = strpos($name, '/', $offset)) !== false) {
    $relatedEntities->append($Tags->newEntity(['name' => substr($name, 0, $offset)]));
    $offset++;
  }
});
```

### Example 2: prevent removal of relationships when one of the entities is locked

```php
EventManager::getInstance()->on('Associated.beforeSave', function (Event $event) {
  $association = $event->getData('association');
  if (!($association instanceof RelatedTo) || $event->getData('action') !== 'remove') {
    // Ok.
    return;
  }

  // Throw if source entity is locked.
  $entity = $event->getData('entity');
  if ($entity->locked) {
    throw new ForbiddenException();
  }

  // Silently remove (thus: do NOT unlink) locked related entities.
  $relatedEntities = $event->getData('relatedEntities');
  for ($i = 0; $i < count($relatedEntities); $i++) {
    $related = $relatedEntities[$i];
    if ($related->locked) {
      unset($relatedEntities[$i]);
    }
  }
});
```
