### PR TITLE
Db config and applications cache

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -106,7 +106,7 @@ return [
         '_bedita_core_' => [
             'className' => 'File',
             'prefix' => 'bedita_core_',
-            'path' => CACHE . 'object_types/',
+            'path' => CACHE . 'core/',
             'serialize' => true,
             'duration' => '+1 year',
             'url' => env('CACHE_BEDITACORE_URL', null),

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -106,7 +106,7 @@ return [
         '_bedita_core_' => [
             'className' => 'File',
             'prefix' => 'bedita_core_',
-            'path' => CACHE . 'core/',
+            'path' => CACHE . 'bedita_core/',
             'serialize' => true,
             'duration' => '+1 year',
             'url' => env('CACHE_BEDITACORE_URL', null),

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -100,6 +100,19 @@ return [
         ],
 
         /**
+         * Configure the cache used for BEdita internal resources caching.
+         * Duration will be set to '+2 minutes' in bootstrap.php when debug = true
+         */
+        '_bedita_core_' => [
+            'className' => 'File',
+            'prefix' => 'bedita_core_',
+            'path' => CACHE . 'object_types/',
+            'serialize' => true,
+            'duration' => '+1 year',
+            'url' => env('CACHE_BEDITACORE_URL', null),
+        ],
+
+        /**
          * Configure the cache used for object types caching.
          * Duration will be set to '+2 minutes' in bootstrap.php when debug = true
          */

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -90,12 +90,22 @@ if (!Configure::check('Cache._bedita_object_types_')) {
         'duration' => '+1 year',
     ]);
 }
+if (!Configure::check('Cache._bedita_core_')) {
+    Configure::write('Cache._bedita_core_', [
+        'className' => 'File',
+        'prefix' => 'bedita_core_',
+        'path' => CACHE . 'object_types/',
+        'serialize' => true,
+        'duration' => '+1 year',
+    ]);
+}
 
 /* When debug = true the metadata cache should last
  * for a very very short time, as we want
  * to refresh the cache while developers are making changes.
  */
 if (Configure::read('debug')) {
+    Configure::write('Cache._bedita_core_.duration', '+2 minutes');
     Configure::write('Cache._bedita_object_types_.duration', '+2 minutes');
     Configure::write('Cache._cake_model_.duration', '+2 minutes');
     Configure::write('Cache._cake_core_.duration', '+2 minutes');

--- a/plugins/BEdita/Core/src/Configure/Engine/DatabaseConfig.php
+++ b/plugins/BEdita/Core/src/Configure/Engine/DatabaseConfig.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ * Copyright 2016 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -67,7 +67,7 @@ class DatabaseConfig implements ConfigEngineInterface
     /**
      * Read `$key` parameters group from database using cache.
      *
-     * @param string!null $key The group of parameters to read from database (see `config.context`).
+     * @param string|null $key The group of parameters to read from database (see `config.context`).
      * @return array Parsed configuration values.
      */
     public function read($key): array
@@ -84,8 +84,8 @@ class DatabaseConfig implements ConfigEngineInterface
     }
 
     /**
-     * Read configuration from DB of `$key` parameters group (see database `config.context`)
-     * and return the results as an array.
+     * Read configuration from DB of `$key` parameters group and return the results as an array.
+     * Parameter group is mapped to database column `config.context`.
      *
      * @param string|null $key The group of parameters to read from database (see `config.context`).
      * @return array Parsed configuration values.

--- a/plugins/BEdita/Core/src/Configure/Engine/DatabaseConfig.php
+++ b/plugins/BEdita/Core/src/Configure/Engine/DatabaseConfig.php
@@ -29,7 +29,9 @@ use Cake\Datasource\ModelAwareTrait;
  * DatabaseConfig also manipulates how 'null', 'true', 'false' are handled.
  * These values will be converted to their boolean equivalents or to null.
  *
- * @param \BEdita\Core\Model\Table\ConfigTable $Config
+ * @since 4.0.0
+ *
+ * @property \BEdita\Core\Model\Table\ConfigTable $Config
  */
 class DatabaseConfig implements ConfigEngineInterface
 {

--- a/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
@@ -51,6 +51,13 @@ class ApplicationsTable extends Table
     const DEFAULT_APPLICATION = 1;
 
     /**
+     * Cache config name.
+     *
+     * @var string
+     */
+    const CACHE_CONFIG = '_bedita_core_';
+
+    /**
      * {@inheritDoc}
      *
      * @codeCoverageIgnore
@@ -154,7 +161,7 @@ class ApplicationsTable extends Table
      * @param array $options Options array. It requires an `apiKey` key.
      * @return \Cake\ORM\Query
      */
-    protected function findApiKey(Query $query, array $options)
+    protected function findApiKey(Query $query, array $options): Query
     {
         if (empty($options['apiKey']) || !is_string($options['apiKey'])) {
             throw new \BadMethodCallException('Required option "apiKey" must be a not empty string');
@@ -164,7 +171,8 @@ class ApplicationsTable extends Table
             ->where([
                 $this->aliasField('api_key') => $options['apiKey'],
                 $this->aliasField('enabled') => true,
-            ]);
+            ])
+            ->cache(sprintf('app_%s', $options['apiKey']), static::CACHE_CONFIG);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
@@ -15,6 +15,7 @@ namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Exception\ImmutableResourceException;
 use BEdita\Core\State\CurrentApplication;
+use Cake\Cache\Cache;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\ORM\Query;
@@ -117,6 +118,26 @@ class ApplicationsTable extends Table
         $rules->add($rules->isUnique(['api_key']));
 
         return $rules;
+    }
+
+    /**
+     * Invalidate applications cache after saving an application entity.
+     *
+     * @return void
+     */
+    public function afterSave(): void
+    {
+        Cache::clear(false, self::CACHE_CONFIG);
+    }
+
+    /**
+     * Invalidate applications cache after deleting an application entity.
+     *
+     * @return void
+     */
+    public function afterDelete(): void
+    {
+        Cache::clear(false, self::CACHE_CONFIG);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/ConfigTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ConfigTable.php
@@ -185,4 +185,29 @@ class ConfigTable extends Table
     {
         return $query->find('name', $options);
     }
+
+    /**
+     * Fetch configuration from database using cache.
+     *
+     * @param int|null $applicationId Application ID.
+     * @param string|null $context Config context.
+     * @return \Cake\ORM\Query
+     */
+    public function fetchConfig(?int $applicationId, ?string $context): Query
+    {
+        return $this->find()
+            ->select(['name', 'content'])
+            ->disableHydration()
+            ->where(function (QueryExpression $exp) use ($applicationId, $context): QueryExpression {
+                if (!empty($context)) {
+                    $exp = $exp->eq($this->aliasField('context'), $context);
+                }
+                if ($applicationId !== null) {
+                    return $exp->eq($this->aliasField('application_id'), $applicationId);
+                }
+
+                return $exp->isNull($this->aliasField('application_id'));
+            })
+            ->cache(sprintf('config_%s_%s', $applicationId ?: '*', $context ?: '*'));
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Table/ConfigTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ConfigTable.php
@@ -13,7 +13,9 @@
 
 namespace BEdita\Core\Model\Table;
 
+use BEdita\Core\Configure\Engine\DatabaseConfig;
 use BEdita\Core\State\CurrentApplication;
+use Cake\Cache\Cache;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\Query;
@@ -97,6 +99,26 @@ class ConfigTable extends Table
             ->notEmpty('content');
 
         return $validator;
+    }
+
+    /**
+     * Invalidate database config cache after saving a config entity.
+     *
+     * @return void
+     */
+    public function afterSave()
+    {
+        Cache::clear(false, DatabaseConfig::CACHE_CONFIG);
+    }
+
+    /**
+     * Invalidate database config cache after deleting a config entity.
+     *
+     * @return void
+     */
+    public function afterDelete()
+    {
+        Cache::clear(false, DatabaseConfig::CACHE_CONFIG);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/ConfigTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ConfigTable.php
@@ -111,7 +111,7 @@ class ConfigTable extends Table
      *
      * @return void
      */
-    public function afterSave()
+    public function afterSave(): void
     {
         Cache::clear(false, self::CACHE_CONFIG);
     }
@@ -121,7 +121,7 @@ class ConfigTable extends Table
      *
      * @return void
      */
-    public function afterDelete()
+    public function afterDelete(): void
     {
         Cache::clear(false, self::CACHE_CONFIG);
     }

--- a/plugins/BEdita/Core/src/Model/Table/ConfigTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ConfigTable.php
@@ -13,7 +13,6 @@
 
 namespace BEdita\Core\Model\Table;
 
-use BEdita\Core\Configure\Engine\DatabaseConfig;
 use BEdita\Core\State\CurrentApplication;
 use Cake\Cache\Cache;
 use Cake\Database\Expression\QueryExpression;
@@ -43,6 +42,12 @@ use Cake\Validation\Validator;
  */
 class ConfigTable extends Table
 {
+    /**
+     * Cache config name.
+     *
+     * @var string
+     */
+    const CACHE_CONFIG = '_bedita_core_';
 
     /**
      * {@inheritDoc}
@@ -89,14 +94,14 @@ class ConfigTable extends Table
     {
         $validator
             ->requirePresence('name', 'create')
-            ->notEmpty('name')
+            ->notEmptyString('name')
             ->alphaNumeric('name')
 
             ->requirePresence('context', 'create')
-            ->notEmpty('context')
+            ->notEmptyString('context')
 
             ->requirePresence('content', 'create')
-            ->notEmpty('content');
+            ->notEmptyString('content');
 
         return $validator;
     }
@@ -108,7 +113,7 @@ class ConfigTable extends Table
      */
     public function afterSave()
     {
-        Cache::clear(false, DatabaseConfig::CACHE_CONFIG);
+        Cache::clear(false, self::CACHE_CONFIG);
     }
 
     /**
@@ -118,7 +123,7 @@ class ConfigTable extends Table
      */
     public function afterDelete()
     {
-        Cache::clear(false, DatabaseConfig::CACHE_CONFIG);
+        Cache::clear(false, self::CACHE_CONFIG);
     }
 
     /**
@@ -208,6 +213,9 @@ class ConfigTable extends Table
 
                 return $exp->isNull($this->aliasField('application_id'));
             })
-            ->cache(sprintf('config_%s_%s', $applicationId ?: '*', $context ?: '*'));
+            ->cache(
+                sprintf('config_%s_%s', $applicationId ?: '*', $context ?: '*'),
+                self::CACHE_CONFIG
+            );
     }
 }

--- a/plugins/BEdita/Core/src/State/CurrentApplication.php
+++ b/plugins/BEdita/Core/src/State/CurrentApplication.php
@@ -29,13 +29,6 @@ class CurrentApplication
     use SingletonTrait;
 
     /**
-     * Cache config name.
-     *
-     * @var string
-     */
-    const CACHE_CONFIG = '_bedita_core_';
-
-    /**
      * Current application entity.
      *
      * @var \BEdita\Core\Model\Entity\Application|null
@@ -135,7 +128,6 @@ class CurrentApplication
         static::getInstance()->set(
             TableRegistry::getTableLocator()->get('Applications')
                 ->find('apiKey', compact('apiKey'))
-                ->cache('app_' . $apiKey, self::CACHE_CONFIG)
                 ->firstOrFail()
         );
     }

--- a/plugins/BEdita/Core/src/State/CurrentApplication.php
+++ b/plugins/BEdita/Core/src/State/CurrentApplication.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published

--- a/plugins/BEdita/Core/src/State/CurrentApplication.php
+++ b/plugins/BEdita/Core/src/State/CurrentApplication.php
@@ -16,7 +16,6 @@ namespace BEdita\Core\State;
 use BEdita\Core\Configure\Engine\DatabaseConfig;
 use BEdita\Core\Model\Entity\Application;
 use BEdita\Core\SingletonTrait;
-use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\ORM\TableRegistry;
 
@@ -131,20 +130,14 @@ class CurrentApplication
      * @return void
      * @throws \Cake\Datasource\Exception\RecordNotFoundException
      */
-    public static function setFromApiKey($apiKey)
+    public static function setFromApiKey(string $apiKey): void
     {
-        $app = Cache::remember(
-            'app_' . $apiKey,
-            function () use ($apiKey) {
-                return TableRegistry::getTableLocator()
-                    ->get('Applications')
-                    ->find('apiKey', compact('apiKey'))
-                    ->firstOrFail();
-            },
-            self::CACHE_CONFIG
+        static::getInstance()->set(
+            TableRegistry::getTableLocator()->get('Applications')
+                ->find('apiKey', compact('apiKey'))
+                ->cache('app_' . $apiKey, self::CACHE_CONFIG)
+                ->firstOrFail()
         );
-
-        static::getInstance()->set($app);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Configure/Engine/DatabaseConfigTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Configure/Engine/DatabaseConfigTest.php
@@ -71,7 +71,6 @@ class DatabaseConfigTest extends TestCase
      *
      * @return void
      * @covers ::read()
-     * @covers ::fetchConfig()
      * @covers ::valueFromString()
      */
     public function testRead()
@@ -101,7 +100,6 @@ class DatabaseConfigTest extends TestCase
      *
      * @return void
      * @covers ::read()
-     * @covers ::fetchConfig()
      * @covers ::__construct()
      */
     public function testReadAppId()

--- a/plugins/BEdita/Core/tests/TestCase/Configure/Engine/DatabaseConfigTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Configure/Engine/DatabaseConfigTest.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Test\TestCase\Configure\Engine;
 
 use BEdita\Core\Configure\Engine\DatabaseConfig;
+use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 
@@ -50,8 +51,8 @@ class DatabaseConfigTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-
         $this->DatabaseConfig = new DatabaseConfig();
+        Cache::clear(false, '_bedita_core_');
     }
 
     /**
@@ -70,11 +71,12 @@ class DatabaseConfigTest extends TestCase
      *
      * @return void
      * @covers ::read()
+     * @covers ::fetchConfig()
      * @covers ::valueFromString()
      */
     public function testRead()
     {
-        $configData = $this->DatabaseConfig->read();
+        $configData = $this->DatabaseConfig->read(null);
         static::assertEquals(true, $configData['Name2']);
         static::assertEquals(14, $configData['IntVal']);
 
@@ -99,6 +101,7 @@ class DatabaseConfigTest extends TestCase
      *
      * @return void
      * @covers ::read()
+     * @covers ::fetchConfig()
      * @covers ::__construct()
      */
     public function testReadAppId()

--- a/plugins/BEdita/Core/tests/TestCase/Configure/Engine/DatabaseConfigTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Configure/Engine/DatabaseConfigTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class DatabaseConfigTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ApplicationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ApplicationsTableTest.php
@@ -15,6 +15,7 @@ namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use BEdita\Core\Model\Table\ApplicationsTable;
 use BEdita\Core\State\CurrentApplication;
+use Cake\Cache\Cache;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -300,6 +301,51 @@ class ApplicationsTableTest extends TestCase
         $count = $this->Applications->find('apiKey', compact('apiKey'))->count();
 
         static::assertSame($expected, $count);
+    }
+
+    /**
+     * Test `afterDelete` method
+     *
+     * @return void
+     *
+     * @covers ::afterDelete()
+     */
+    public function testAfterDelete(): void
+    {
+        $app = $this->Applications->get(2);
+        $apiKey = $app->get('api_key');
+        $app->set('enabled', true);
+        $this->Applications->saveOrFail($app);
+
+        $app = $this->Applications->find('apiKey', compact('apiKey'))->first();
+        $read = Cache::read(sprintf('app_%s', $apiKey), ApplicationsTable::CACHE_CONFIG);
+        static::assertNotEmpty($read);
+
+        $this->Applications->deleteOrFail($app);
+
+        $read = Cache::read(sprintf('app_%s', $apiKey), ApplicationsTable::CACHE_CONFIG);
+        static::assertFalse($read);
+    }
+
+    /**
+     * Test `afterSave` method
+     *
+     * @return void
+     *
+     * @covers ::afterSave()
+     */
+    public function testAfterSave(): void
+    {
+        $app = $this->Applications->find('apiKey', ['apiKey' => API_KEY])->first();
+        $read = Cache::read(sprintf('app_%s', API_KEY), ApplicationsTable::CACHE_CONFIG);
+        static::assertNotEmpty($read);
+
+        $app = $this->Applications->get(1);
+        $app->set('description', 'new app description');
+        $this->Applications->saveOrFail($app);
+
+        $read = Cache::read(sprintf('app_%s', API_KEY), ApplicationsTable::CACHE_CONFIG);
+        static::assertFalse($read);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
@@ -266,4 +266,14 @@ class ConfigTableTest extends TestCase
 
         $read = Cache::read('db_conf__0', DatabaseConfig::CACHE_CONFIG);
         static::assertFalse($read);
-    }}
+    }
+
+    /**
+     *
+     * @return void
+     */
+    public function testFetchConfig(): void
+    {
+
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
@@ -302,9 +302,10 @@ class ConfigTableTest extends TestCase
      * @param array $expected Expected result.
      * @param int|null $appId Application ID.
      * @param string|null $context Context key.
-     * @dataProvider fetchConfigProvider
-     *
      * @return void
+     *
+     * @dataProvider fetchConfigProvider
+     * @covers ::fetchConfig()
      */
     public function testFetchConfig(array $expected, ?int $appId, ?string $context): void
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
@@ -13,7 +13,6 @@
 
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
-use BEdita\Core\Configure\Engine\DatabaseConfig;
 use BEdita\Core\Model\Table\ConfigTable;
 use BEdita\Core\State\CurrentApplication;
 use Cake\Cache\Cache;
@@ -236,14 +235,14 @@ class ConfigTableTest extends TestCase
      */
     public function testAfterDelete(): void
     {
-        $configData = (new DatabaseConfig())->read(null);
-        $read = Cache::read('db_conf__0', DatabaseConfig::CACHE_CONFIG);
+        $config = $this->Config->fetchConfig(null, null)->toArray();
+        $read = Cache::read('config_*_*', ConfigTable::CACHE_CONFIG);
         static::assertNotEmpty($read);
 
         $config = $this->Config->get(1);
         $this->Config->deleteOrFail($config);
 
-        $read = Cache::read('db_conf__0', DatabaseConfig::CACHE_CONFIG);
+        $read = Cache::read('config_*_*', ConfigTable::CACHE_CONFIG);
         static::assertFalse($read);
     }
 
@@ -256,15 +255,15 @@ class ConfigTableTest extends TestCase
      */
     public function testAfterSave(): void
     {
-        $configData = (new DatabaseConfig())->read(null);
-        $read = Cache::read('db_conf__0', DatabaseConfig::CACHE_CONFIG);
+        $config = $this->Config->fetchConfig(null, null)->toArray();
+        $read = Cache::read('config_*_*', ConfigTable::CACHE_CONFIG);
         static::assertNotEmpty($read);
 
         $config = $this->Config->get(1);
         $config->content = 'new content';
         $this->Config->saveOrFail($config);
 
-        $read = Cache::read('db_conf__0', DatabaseConfig::CACHE_CONFIG);
+        $read = Cache::read('config_*_*', ConfigTable::CACHE_CONFIG);
         static::assertFalse($read);
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
@@ -13,7 +13,9 @@
 
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
+use BEdita\Core\Configure\Engine\DatabaseConfig;
 use BEdita\Core\State\CurrentApplication;
+use Cake\Cache\Cache;
 use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -224,4 +226,44 @@ class ConfigTableTest extends TestCase
         $config = $this->Config->find('name', $data)->toArray();
         static::assertEquals($expected, count($config));
     }
-}
+
+    /**
+     * Test `afterDelete` method
+     *
+     * @return void
+     *
+     * @covers ::afterDelete()
+     */
+    public function testAfterDelete(): void
+    {
+        $configData = (new DatabaseConfig())->read(null);
+        $read = Cache::read('db_conf__0', DatabaseConfig::CACHE_CONFIG);
+        static::assertNotEmpty($read);
+
+        $config = $this->Config->get(1);
+        $this->Config->deleteOrFail($config);
+
+        $read = Cache::read('db_conf__0', DatabaseConfig::CACHE_CONFIG);
+        static::assertFalse($read);
+    }
+
+    /**
+     * Test `afterSave` method
+     *
+     * @return void
+     *
+     * @covers ::afterSave()
+     */
+    public function testAfterSave(): void
+    {
+        $configData = (new DatabaseConfig())->read(null);
+        $read = Cache::read('db_conf__0', DatabaseConfig::CACHE_CONFIG);
+        static::assertNotEmpty($read);
+
+        $config = $this->Config->get(1);
+        $config->content = 'new content';
+        $this->Config->saveOrFail($config);
+
+        $read = Cache::read('db_conf__0', DatabaseConfig::CACHE_CONFIG);
+        static::assertFalse($read);
+    }}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use BEdita\Core\Configure\Engine\DatabaseConfig;
+use BEdita\Core\Model\Table\ConfigTable;
 use BEdita\Core\State\CurrentApplication;
 use Cake\Cache\Cache;
 use Cake\Http\Exception\BadRequestException;
@@ -28,7 +29,6 @@ use Cake\Utility\Hash;
  */
 class ConfigTableTest extends TestCase
 {
-
     /**
      * Test subject
      *
@@ -269,11 +269,48 @@ class ConfigTableTest extends TestCase
     }
 
     /**
+     * Data provider for `testFetchConfig`
+     */
+    public function fetchConfigProvider(): array
+    {
+        return [
+            'group2' => [
+                [
+                    [
+                        'name' => 'IntVal',
+                        'content' => '14',
+                    ],
+                ],
+                null,
+                'group2',
+            ],
+            'somecontext' => [
+                [
+                    [
+                        'name' => 'someVal',
+                        'content' => '42',
+                    ],
+                ],
+                1,
+                'somecontext',
+            ],
+        ];
+    }
+
+    /**
+     * Test `fetchConfig` method
+     *
+     * @param array $expected Expected result.
+     * @param int|null $appId Application ID.
+     * @param string|null $context Context key.
+     * @dataProvider fetchConfigProvider
      *
      * @return void
      */
-    public function testFetchConfig(): void
+    public function testFetchConfig(array $expected, ?int $appId, ?string $context): void
     {
-
+        Cache::clear(false, ConfigTable::CACHE_CONFIG);
+        $result = $this->Config->fetchConfig($appId, $context)->toArray();
+        static::assertEquals($expected, $result);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/State/CurrentApplicationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/State/CurrentApplicationTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Test\TestCase\State;
 
 use BEdita\Core\State\CurrentApplication;
+use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -51,6 +52,7 @@ class CurrentApplicationTest extends TestCase
         parent::setUp();
 
         $this->Applications = TableRegistry::getTableLocator()->get('Applications');
+        Cache::clear(false, '_bedita_core_');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/State/CurrentApplicationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/State/CurrentApplicationTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published


### PR DESCRIPTION
This PR enables caching, via `_bedita_core_` configuration, of `applications` and `config` resources that are rarely changed but read from DB on every request.

 