### PR TITLE
Allow empty relation `label/inverse_label`

### DIFF
--- a/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
@@ -19,6 +19,8 @@ use BEdita\Core\ORM\Rule\IsUniqueAmongst;
 use Cake\Cache\Cache;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\TableSchema;
+use Cake\Datasource\EntityInterface;
+use Cake\Event\Event;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
@@ -106,15 +108,13 @@ class RelationsTable extends Table
             ->notEmptyString('name')
             ->add('name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table'])
 
-            ->requirePresence('label', 'create')
-            ->notEmptyString('label')
+            ->allowEmptyString('label')
 
             ->requirePresence('inverse_name', 'create')
             ->notEmptyString('inverse_name')
             ->add('inverse_name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table'])
 
-            ->requirePresence('inverse_label', 'create')
-            ->notEmptyString('inverse_label')
+            ->allowEmptyString('inverse_label')
 
             ->allowEmptyString('description')
 
@@ -198,6 +198,24 @@ class RelationsTable extends Table
                     ->eq($this->aliasField('inverse_name'), $name);
             });
         });
+    }
+
+    /**
+     * Populate default `label` and `inverse_label` properties if not set.
+     *
+     * {@inheritDoc}
+     */
+    public function beforeSave(Event $event, EntityInterface $entity): void
+    {
+        if (!$entity->isNew()) {
+            return;
+        }
+        if (empty($entity->get('label'))) {
+            $entity->set('label', Inflector::humanize((string)$entity->get('name')));
+        }
+        if (empty($entity->get('inverse_label'))) {
+            $entity->set('inverse_label', Inflector::humanize((string)$entity->get('inverse_name')));
+        }
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
@@ -108,13 +108,15 @@ class RelationsTable extends Table
             ->notEmptyString('name')
             ->add('name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table'])
 
-            ->allowEmptyString('label')
+            ->allowEmptyString('label', null, 'create')
+            ->notEmptyString('label', null, 'update')
 
             ->requirePresence('inverse_name', 'create')
             ->notEmptyString('inverse_name')
             ->add('inverse_name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table'])
 
-            ->allowEmptyString('inverse_label')
+            ->allowEmptyString('inverse_label', null, 'create')
+            ->notEmptyString('inverse_label', null, 'update')
 
             ->allowEmptyString('description')
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
@@ -121,6 +121,14 @@ class RelationsTableTest extends TestCase
                     'inverse_name' => 'some_inverse_relation',
                 ],
             ],
+            'empty label' => [
+                false,
+                [
+                    'id' => 1,
+                    'inverse_name' => 'reverse_test',
+                    'inverse_label' => '',
+                ],
+            ],
         ];
     }
 
@@ -136,7 +144,11 @@ class RelationsTableTest extends TestCase
      */
     public function testValidation($expected, array $data)
     {
-        $objectType = $this->Relations->newEntity();
+        if (empty($data['id'])) {
+            $objectType = $this->Relations->newEntity();
+        } else {
+            $objectType = $this->Relations->get($data['id']);
+        }
         $this->Relations->patchEntity($objectType, $data);
 
         $success = $this->Relations->save($objectType);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
@@ -223,7 +223,33 @@ class RelationsTableTest extends TestCase
     }
 
     /**
-     * Test before save callback.
+     * Test before save callback on an existing entity.
+     *
+     * @return void
+     *
+     * @covers ::beforeSave()
+     */
+    public function testBeforeSaveExisting()
+    {
+        $entity = $this->Relations->get(1);
+        $originalLabel = $entity->label;
+        $originalInverseLabel = $entity->inverse_label;
+
+        $entity = $this->Relations->patchEntity($entity, [
+            'name' => 'foo_bar',
+            'inverse_name' => 'bar_foo',
+        ]);
+        $this->Relations->saveOrFail($entity);
+
+        $entity = $this->Relations->get(1);
+        static::assertSame('foo_bar', $entity->name);
+        static::assertSame($originalLabel, $entity->label);
+        static::assertSame('bar_foo', $entity->inverse_name);
+        static::assertSame($originalInverseLabel, $entity->inverse_label);
+    }
+
+    /**
+     * Test before save callback with a new entity.
      *
      * @return void
      *
@@ -231,17 +257,14 @@ class RelationsTableTest extends TestCase
      */
     public function testBeforeSave()
     {
-        $entity = $this->Relations->get(1);
-        $entity = $this->Relations->patchEntity($entity, ['description' => 'New description']);
-        $this->Relations->save($entity);
-
         $entity = $this->Relations->newEntity([
             'name' => 'some_name',
             'inverse_name' => 'some_inverse_name',
         ]);
-        $entity = $this->Relations->save($entity);
-        static::assertEquals('Some Name', $entity->get('label'));
-        static::assertEquals('Some Inverse Name', $entity->get('inverse_label'));
+        $entity = $this->Relations->saveOrFail($entity);
+
+        static::assertSame('Some Name', $entity->get('label'));
+        static::assertSame('Some Inverse Name', $entity->get('inverse_label'));
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
@@ -114,6 +114,13 @@ class RelationsTableTest extends TestCase
                     'params' => null,
                 ],
             ],
+            'simple' => [
+                true,
+                [
+                    'name' => 'some_relation',
+                    'inverse_name' => 'some_inverse_relation',
+                ],
+            ],
         ];
     }
 
@@ -213,6 +220,28 @@ class RelationsTableTest extends TestCase
         static::assertFalse(Cache::read('id_3_rel', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('map', ObjectTypesTable::CACHE_CONFIG));
         static::assertFalse(Cache::read('map_singular', ObjectTypesTable::CACHE_CONFIG));
+    }
+
+    /**
+     * Test before save callback.
+     *
+     * @return void
+     *
+     * @covers ::beforeSave()
+     */
+    public function testBeforeSave()
+    {
+        $entity = $this->Relations->get(1);
+        $entity = $this->Relations->patchEntity($entity, ['description' => 'New description']);
+        $this->Relations->save($entity);
+
+        $entity = $this->Relations->newEntity([
+            'name' => 'some_name',
+            'inverse_name' => 'some_inverse_name',
+        ]);
+        $entity = $this->Relations->save($entity);
+        static::assertEquals('Some Name', $entity->get('label'));
+        static::assertEquals('Some Inverse Name', $entity->get('inverse_label'));
     }
 
     /**


### PR DESCRIPTION
This PR avoids required specification of `label` and `inverse_label` fields in relation creation.

The `humanized` version of relation names and inverse names are used as default for these fields.