### PR TITLE
Status level check

### DIFF
--- a/plugins/BEdita/Core/src/Model/Behavior/DataCleanupBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/DataCleanupBehavior.php
@@ -83,7 +83,7 @@ class DataCleanupBehavior extends Behavior
         if (Configure::read('Status.level') === 'on') {
             $fields['status'] = 'on';
         }
-        $defaults = Configure::read(sprintf('DefaultValues.%s', $type), []);
+        $defaults = (array)Configure::read(sprintf('DefaultValues.%s', $type));
 
         return array_merge($fields, $defaults);
     }

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -200,7 +200,7 @@ class ObjectsTable extends Table
      *
      * @param \Cake\Datasource\EntityInterface $entity Entity being saved.
      * @return void
-     * @throws \Cake\Http\Exception\BadRequestException If a wrong lang tag is specified
+     * @throws \Cake\Http\Exception\BadRequestException
      */
     protected function checkStatus(EntityInterface $entity): void
     {

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -22,6 +22,7 @@ use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
+use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
@@ -174,6 +175,7 @@ class ObjectsTable extends Table
             // Cannot save objects of an abstract type.
             return false;
         }
+        $this->checkStatus($entity);
         $this->checkLangTag($entity);
 
         return true;
@@ -190,6 +192,30 @@ class ObjectsTable extends Table
     {
         if ($entity->isDirty('lang') && empty($entity->get('lang')) && Configure::check('I18n.default')) {
             $entity->set('lang', Configure::read('I18n.default'));
+        }
+    }
+
+    /**
+     * Check that `status` is consistent with `Status.level` configuration.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity Entity being saved.
+     * @return void
+     * @throws \Cake\Http\Exception\BadRequestException If a wrong lang tag is specified
+     */
+    protected function checkStatus(EntityInterface $entity): void
+    {
+        if ($entity->isNew() || !Configure::check('Status.level') || !$entity->isDirty('status')) {
+            return;
+        }
+        $level = Configure::read('Status.level');
+        $status = $entity->get('status');
+        if (($level === 'on' && $status !== 'on') || ($level === 'draft' && $status === 'off')) {
+            throw new BadRequestException(__d(
+                'bedita',
+                'Status "{0}" is not consistent with configured Status.level "{1}"',
+                $status,
+                $level
+            ));
         }
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/DataCleanupBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/DataCleanupBehaviorTest.php
@@ -154,7 +154,7 @@ class DataCleanupBehaviorTest extends TestCase
      *
      * @return array
      */
-    public function statusLevelProvider()
+    public function statusLevelProvider(): array
     {
         return [
             'status' => [
@@ -203,7 +203,7 @@ class DataCleanupBehaviorTest extends TestCase
      * @dataProvider statusLevelProvider
      * @covers ::defaultFields()
      */
-    public function testStatusLevel(array $inputData, array $expected, string $level = '')
+    public function testStatusLevel(array $inputData, array $expected, string $level = ''): void
     {
         if (!empty($level)) {
             Configure::write('Status.level', $level);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/DataCleanupBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/DataCleanupBehaviorTest.php
@@ -136,10 +136,78 @@ class DataCleanupBehaviorTest extends TestCase
      *
      * @dataProvider cleanupProvider
      * @covers ::beforeMarshal()
+     * @covers ::defaultFields()
      */
     public function testDataCleanup(array $inputData, array $expected, array $defaultValues)
     {
         Configure::write('DefaultValues', $defaultValues);
+        $Users = TableRegistry::getTableLocator()->get('Users');
+
+        $user = $Users->newEntity($inputData);
+        foreach ($expected as $k => $v) {
+            $this->assertEquals($user[$k], $v);
+        }
+    }
+
+    /**
+     * Data provider for `testStatusLevel` test case.
+     *
+     * @return array
+     */
+    public function statusLevelProvider()
+    {
+        return [
+            'status' => [
+                [
+                    'username' => 'lorem',
+                    'password_hash' => 'ipsum',
+                    'status' => null,
+                ],
+                [
+                    'status' => 'draft'
+                ],
+                'draft',
+            ],
+            'status2' => [
+                [
+                    'username' => 'lorem',
+                    'password_hash' => 'ipsum',
+                    'status' => '',
+                ],
+                [
+                    'status' => 'on'
+                ],
+                'on',
+            ],
+            'status from config' => [
+                [
+                    'username' => 'lorem',
+                    'password_hash' => 'ipsum',
+                    'status' => '',
+                ],
+                [
+                    'status' => 'draft'
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `Status.level` configurations
+     *
+     * @param array $inputData Input data.
+     * @param array $expected Expected result.
+     * @param string $level Status level.
+     * @return void
+     *
+     * @dataProvider statusLevelProvider
+     * @covers ::defaultFields()
+     */
+    public function testStatusLevel(array $inputData, array $expected, string $level = '')
+    {
+        if (!empty($level)) {
+            Configure::write('Status.level', $level);
+        }
         $Users = TableRegistry::getTableLocator()->get('Users');
 
         $user = $Users->newEntity($inputData);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -654,29 +654,29 @@ class ObjectsTableTest extends TestCase
      *
      * @return array
      */
-    public function checkStatusProvider()
+    public function checkStatusProvider(): array
     {
         return [
             'no conf' => [
                 'draft',
-                '',
                 [
                     'status' => 'draft',
                 ],
+                '',
             ],
             'error' => [
                 new BadRequestException('Status "draft" is not consistent with configured Status.level "on"'),
-                'on',
                 [
                     'status' => 'draft',
                 ],
+                'on',
             ],
             'ok' => [
                 'draft',
-                'draft',
                 [
                     'status' => 'draft',
                 ],
+                'draft',
             ],
         ];
     }
@@ -692,14 +692,16 @@ class ObjectsTableTest extends TestCase
      * @dataProvider checkStatusProvider()
      * @covers ::checkStatus()
      */
-    public function testCheckStatus($expected, string $config, array $data): void
+    public function testCheckStatus($expected, array $data, string $config = ''): void
     {
         if ($expected instanceof \Exception) {
             $this->expectException(get_class($expected));
             $this->expectExceptionMessage($expected->getMessage());
         }
 
-        Configure::write('Status.level', $config);
+        if (!empty($config)) {
+            Configure::write('Status.level', $config);
+        }
 
         $id = Hash::get($data, 'id', 2);
         $object = $this->Objects->get($id);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -650,6 +650,67 @@ class ObjectsTableTest extends TestCase
     }
 
     /**
+     * Data provider for `checkStatus`.
+     *
+     * @return array
+     */
+    public function checkStatusProvider()
+    {
+        return [
+            'no conf' => [
+                'draft',
+                '',
+                [
+                    'status' => 'draft',
+                ],
+            ],
+            'error' => [
+                new BadRequestException('Status "draft" is not consistent with configured Status.level "on"'),
+                'on',
+                [
+                    'status' => 'draft',
+                ],
+            ],
+            'ok' => [
+                'draft',
+                'draft',
+                [
+                    'status' => 'draft',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `checkStatus()`.
+     *
+     * @param string|\Exception $expected Status value or Exception.
+     * @param string $config Status level config.
+     * @param array $data Save input data.
+     * @return void
+     *
+     * @dataProvider checkStatusProvider()
+     * @covers ::checkStatus()
+     */
+    public function testCheckStatus($expected, string $config, array $data): void
+    {
+        if ($expected instanceof \Exception) {
+            $this->expectException(get_class($expected));
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+
+        Configure::write('Status.level', $config);
+
+        $id = Hash::get($data, 'id', 2);
+        $object = $this->Objects->get($id);
+        unset($data['id']);
+        $object = $this->Objects->patchEntity($object, $data);
+        $object = $this->Objects->save($object);
+
+        static::assertSame($expected, $object->get('status'));
+    }
+
+    /**
      * Test `findTranslations()`.
      *
      * @return void


### PR DESCRIPTION
This PR fixes two possible problems creating new objects on an application having a configured `Status.level`

 *  if `Status.level` is `on` newly created objects must have `on` as default status, otherwise creation via `POST` will fail (object is created, but not read and a `404` error is generated) 
 * if `status` is specified
   - it must be `on` if `Status.level` is `on`
   - cannot be `off` is `Status.level` is `draft`
   
