### PR TITLE
Restore original inherited table alias after cascading to parent finder

### DIFF
--- a/plugins/BEdita/Core/src/ORM/Inheritance/Table.php
+++ b/plugins/BEdita/Core/src/ORM/Inheritance/Table.php
@@ -207,7 +207,7 @@ class Table extends CakeTable
 
         $inheritedTable = $this->inheritedTable();
         if ($inheritedTable !== null) {
-            return $inheritedTable
+            return (clone $inheritedTable)
                 ->setAlias($this->getAlias())
                 ->callFinder($type, $query, $options);
         }

--- a/plugins/BEdita/Core/src/ORM/Inheritance/Table.php
+++ b/plugins/BEdita/Core/src/ORM/Inheritance/Table.php
@@ -207,9 +207,15 @@ class Table extends CakeTable
 
         $inheritedTable = $this->inheritedTable();
         if ($inheritedTable !== null) {
-            return (clone $inheritedTable)
-                ->setAlias($this->getAlias())
-                ->callFinder($type, $query, $options);
+            $originalAlias = $inheritedTable->getAlias();
+
+            try {
+                return $inheritedTable
+                    ->setAlias($this->getAlias())
+                    ->callFinder($type, $query, $options);
+            } finally {
+                $inheritedTable->setAlias($originalAlias);
+            }
         }
 
         throw new BadMethodCallException(

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/TableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/TableTest.php
@@ -534,11 +534,24 @@ class TableTest extends TestCase
 
         $this->fakeAnimals->addBehavior('Tree');
 
+        $animalsAlias = $this->fakeAnimals->getAlias();
+        $mammalsAlias = $this->fakeMammals->getAlias();
+        $felinesAlias = $this->fakeFelines->getAlias();
+        $checkAliases = function () use ($animalsAlias, $mammalsAlias, $felinesAlias) {
+            static::assertSame($felinesAlias, $this->fakeFelines->getAlias());
+            static::assertSame($mammalsAlias, $this->fakeMammals->getAlias());
+            static::assertSame($animalsAlias, $this->fakeAnimals->getAlias());
+        };
+
         static::assertInstanceOf(Query::class, $this->fakeMammals->find('children', ['for' => 1, 'direct' => true]));
+        $checkAliases();
         static::assertInstanceOf(Query::class, $this->fakeFelines->find('children', ['for' => 1, 'direct' => true]));
+        $checkAliases();
 
         static::assertTextNotContains('FakeAnimals', $this->fakeMammals->find('children', ['for' => 1, 'direct' => true])->sql());
+        $checkAliases();
         static::assertTextNotContains('FakeAnimals', $this->fakeFelines->find('children', ['for' => 1, 'direct' => true])->sql());
+        $checkAliases();
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue that happened after calling a finder from a table `Bar` that inherits from another table `Foo`, and such finder method was only present in the parent table. The finder was correctly being called on the parent table and the resulting query object was correct. However, the parent table remained in a dirty status where it still had the alias of the inheriting table. This caused problems in later queries involving table `Foo`.

For instance, this used to cause obscure issues when including associations:

```php
$locator = TableRegistry::getTableLocator();
$Documents = $locator->get('Documents');

// Assuming a relation `poster` between Documents and Media exists:
$documentsWithPoster = $Documents->find()->contain(['Poster']);

/*
 * The `Poster` relation is configured to use `available` finder, which is defined
 * on `ObjectsTable`. Therefore, it used an instance of `MediaTable` registered
 * as `Poster` in the registry, with `Poster` alias, but when cascading to the
 * parent table (in this example, `ObjectsTable`) to call the finder, it still uses
 * the instance registered as `Objects`, and leaves it set with `Poster` alias.
 */
var_dump($locator->get('Objects')->getAlias()); // Prints: Poster
```

This Pull Requests wraps the call to the parent table's finder with a `try` / `finally` and restores the original parent table's alias.