### PR TITLE
Display only "available" children and parents

### DIFF
--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -6,6 +6,7 @@ on:
       - '**'
     paths:
       - 'plugins/BEdita/**'
+      - '.github/workflows/*'
 
 jobs:
   filter-tree:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     paths:
       - '**/*.php'
+      - '.github/workflows/*'
   push:
     paths:
       - '**/*.php'
+      - '.github/workflows/*'
 
 jobs:
   cs:

--- a/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
@@ -57,6 +57,7 @@ class FoldersTable extends ObjectsTable
             'through' => 'Trees',
             'foreignKey' => 'parent_id',
             'targetForeignKey' => 'object_id',
+            'finder' => 'available',
             'sort' => [
                 'Trees.tree_left' => 'asc',
             ],

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -115,6 +115,7 @@ class ObjectsTable extends Table
             'through' => 'BEdita/Core.Trees',
             'foreignKey' => 'object_id',
             'targetForeignKey' => 'parent_id',
+            'finder' => 'available',
             'cascadeCallbacks' => true,
         ]);
         $this->belongsToMany('Categories', [

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
@@ -52,6 +52,7 @@ class FoldersTableTest extends TestCase
         'plugin.BEdita/Core.Profiles',
         'plugin.BEdita/Core.Users',
         'plugin.BEdita/Core.Trees',
+        'plugin.BEdita/Core.Categories',
         'plugin.BEdita/Core.ObjectCategories',
         'plugin.BEdita/Core.History',
     ];

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use BEdita\Core\Utility\LoggedUser;
+use Cake\Core\Configure;
 use Cake\Database\Expression\QueryExpression;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\TableRegistry;
@@ -51,6 +52,8 @@ class FoldersTableTest extends TestCase
         'plugin.BEdita/Core.Profiles',
         'plugin.BEdita/Core.Users',
         'plugin.BEdita/Core.Trees',
+        'plugin.BEdita/Core.ObjectCategories',
+        'plugin.BEdita/Core.History',
     ];
 
     /**
@@ -478,5 +481,32 @@ class FoldersTableTest extends TestCase
             $child->deleted = false;
             static::assertFalse($this->Folders->isFolderRestorable($child));
         }
+    }
+
+    /**
+     * Test that only available children are returned.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testChildrenAvailable(): void
+    {
+        $folder = $this->Folders->get(11, ['contain' => ['Children']]);
+        static::assertNotEmpty($folder->children);
+
+        $firstChild = $folder->children[0];
+        $firstChild->status = 'off';
+        $this->Folders->Children->saveOrFail($firstChild);
+
+        Configure::write('Status.level', 'off');
+        $folder = $this->Folders->get(11, ['contain' => ['Children']]);
+        $childrenIds = Hash::extract($folder->children, '{*}.id');
+        static::assertContains($firstChild->id, $childrenIds);
+
+        Configure::write('Status.level', 'draft');
+        $folder = $this->Folders->get(11, ['contain' => ['Children']]);
+        $childrenIds = Hash::extract($folder->children, '{*}.id');
+        static::assertNotContains($firstChild->id, $childrenIds);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -761,4 +761,31 @@ class ObjectsTableTest extends TestCase
             ->firstOrFail();
         static::assertSame('gustavo-supporto', $result->get('uname'));
     }
+
+    /**
+     * Test that only available children are returned.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testParentsAvailable(): void
+    {
+        $object = $this->Objects->get(2, ['contain' => ['Parents']]);
+        static::assertNotEmpty($object->parents);
+
+        $firstParent = $object->parents[0];
+        $firstParent->status = 'off';
+        $this->Objects->Parents->saveOrFail($firstParent);
+
+        Configure::write('Status.level', 'off');
+        $object = $this->Objects->get(2, ['contain' => ['Parents']]);
+        $childrenIds = Hash::extract($object->parents, '{*}.id');
+        static::assertContains($firstParent->id, $childrenIds);
+
+        Configure::write('Status.level', 'draft');
+        $object = $this->Objects->get(2, ['contain' => ['Parents']]);
+        $childrenIds = Hash::extract($object->parents, '{*}.id');
+        static::assertNotContains($firstParent->id, $childrenIds);
+    }
 }


### PR DESCRIPTION
This PR fixes an issue that caused child object(s) and parent folder(s) to be returned even if their status was not compatible with the one configured. For instance, assuming `Status.level` is `on`, `GET /folder/11/children` would include objects with status `draft` and `off`.

This PR adds the `available` finder to both associations' configurations, which mimics the configuration used for BEdita relations and other associations (e.g. objects belongs to many categories).