### PR TITLE
Fix /home authorization check on object types endpoints

### DIFF
--- a/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
+++ b/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
@@ -147,7 +147,8 @@ class EndpointAuthorize extends BaseAuthorize
     }
 
     /**
-     * Load endpoint for request in $this->endpoint,
+     * Load endpoint for request in $this->endpoint.
+     * Avoid reload if endpoint with same name has already been loaded.
      *
      * @return void
      * @throws \Cake\Http\Exception\NotFoundException If endpoint is disabled

--- a/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
+++ b/plugins/BEdita/API/src/Auth/EndpointAuthorize.php
@@ -88,9 +88,7 @@ class EndpointAuthorize extends BaseAuthorize
         // For anonymous users performing write operations, use strict mode.
         $strict = ($this->isAnonymous($user) && !$this->request->is(['get', 'head']));
 
-        if (empty($this->endpoint)) {
-            $this->getEndpoint();
-        }
+        $this->getEndpoint();
 
         $permissions = $this->getPermissions($user, $strict)->toArray();
         $allPermissions = $this->getPermissions(false);
@@ -149,16 +147,19 @@ class EndpointAuthorize extends BaseAuthorize
     }
 
     /**
-     * Get endpoint for request.
+     * Load endpoint for request in $this->endpoint,
      *
-     * @return \BEdita\Core\Model\Entity\Endpoint
+     * @return void
      * @throws \Cake\Http\Exception\NotFoundException If endpoint is disabled
      */
-    protected function getEndpoint()
+    protected function getEndpoint(): void
     {
         // endpoint name is the first part of URL path
         $path = array_values(array_filter(explode('/', $this->request->getPath())));
         $endpointName = Hash::get($path, '0', '');
+        if (!empty($this->endpoint) && $endpointName === $this->endpoint->name) {
+            return;
+        }
 
         $Endpoints = TableRegistry::getTableLocator()->get('Endpoints');
         $this->endpoint = $Endpoints->find()
@@ -180,8 +181,6 @@ class EndpointAuthorize extends BaseAuthorize
         if (!$this->endpoint->enabled) {
             throw new NotFoundException(__d('bedita', 'Resource not found.'));
         }
-
-        return $this->endpoint;
     }
 
     /**

--- a/plugins/BEdita/API/src/Controller/HomeController.php
+++ b/plugins/BEdita/API/src/Controller/HomeController.php
@@ -84,7 +84,7 @@ class HomeController extends AppController
      *
      * @return void
      */
-    public function index()
+    public function index(): void
     {
         $this->request->allowMethod(['get', 'head']);
 
@@ -93,6 +93,7 @@ class HomeController extends AppController
         foreach ($endPoints as $e => $data) {
             $resources[$e] = $this->endpointFeatures($e, $data);
         }
+        $resources = array_filter($resources);
         $project = Configure::read('Project');
         $version = Configure::read('BEdita.version');
 
@@ -102,12 +103,14 @@ class HomeController extends AppController
 
     /**
      * Return endpoint features to display in `/home` response
+     * If no methods are allowed an empty array is returned and
+     * the endpoint will not be listed in `/home` response.
      *
      * @param string $endpoint Endpoint name
      * @param array $options Endpoint options - methods and multiple types flag
      * @return array Array of features
      */
-    protected function endpointFeatures($endpoint, $options)
+    protected function endpointFeatures($endpoint, $options): array
     {
         $methods = $options['methods'];
         if ($methods === 'ALL') {
@@ -118,6 +121,9 @@ class HomeController extends AppController
             if ($this->checkAuthorization($endpoint, $method)) {
                 $allow[] = $method;
             }
+        }
+        if (empty($allow)) {
+            return [];
         }
 
         return [
@@ -142,7 +148,7 @@ class HomeController extends AppController
      *
      * @return array Array of object type names
      */
-    protected function objectTypesEndpoints()
+    protected function objectTypesEndpoints(): array
     {
         $allTypes = TableRegistry::getTableLocator()->get('ObjectTypes')
                         ->find('list', ['keyField' => 'name', 'valueField' => 'is_abstract'])
@@ -167,7 +173,7 @@ class HomeController extends AppController
      * @param string $method HTTP method
      * @return bool True on granted authorization, false otherwise
      */
-    protected function checkAuthorization($endpoint, $method)
+    protected function checkAuthorization($endpoint, $method): bool
     {
         if (empty(LoggedUser::getUser()) && !$this->unloggedAuthorized($endpoint, $method)) {
             return false;
@@ -188,7 +194,7 @@ class HomeController extends AppController
      * @param string $method HTTP method
      * @return bool True on granted authorization, false otherwise
      */
-    protected function unloggedAuthorized($endpoint, $method)
+    protected function unloggedAuthorized($endpoint, $method): bool
     {
         $defaultAllow = Hash::get($this->defaultAllowUnlogged, $endpoint, $this->defaultAllowUnlogged['/*']);
 

--- a/plugins/BEdita/API/src/Controller/HomeController.php
+++ b/plugins/BEdita/API/src/Controller/HomeController.php
@@ -90,6 +90,7 @@ class HomeController extends AppController
 
         $default = Hash::insert($this->defaultEndpoints, '{*}.object_type', false);
         $endPoints = array_merge($this->objectTypesEndpoints(), $default);
+        $resources = [];
         foreach ($endPoints as $e => $data) {
             $resources[$e] = $this->endpointFeatures($e, $data);
         }

--- a/plugins/BEdita/API/tests/TestCase/Auth/EndpointAuthorizeTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/EndpointAuthorizeTest.php
@@ -18,7 +18,6 @@ use BEdita\Core\Model\Entity\Endpoint;
 use BEdita\Core\State\CurrentApplication;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
-use Cake\Http\Exception\ForbiddenException;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Exception\UnauthorizedException;
 use Cake\Http\ServerRequest;
@@ -122,6 +121,30 @@ class EndpointAuthorizeTest extends TestCase
 
         static::assertAttributeEquals($expected, 'endpoint', $authorize);
     }
+
+    /**
+     * Test `getEndpoint` method, reloading same endpoint.
+     *
+     * @covers ::getEndpoint()
+     * @return void
+     */
+   public function testGetEndpointSame(): void
+   {
+        $Endpoints = TableRegistry::getTableLocator()->get('Endpoints');
+        $expected = $Endpoints->get(2);
+
+        $authorize = new EndpointAuthorize(new ComponentRegistry(), []);
+        $request = new ServerRequest(['uri' => new Uri('/home')]);
+
+        $authorize->authorize([], $request);
+        static::assertAttributeEquals($expected, 'endpoint', $authorize);
+
+        $Endpoints->delete($expected);
+
+        $authorize->authorize([], $request);
+        static::assertAttributeEquals($expected, 'endpoint', $authorize);
+    }
+
 
     /**
      * Data provider for `testAuthorize` test case.

--- a/plugins/BEdita/API/tests/TestCase/Auth/EndpointAuthorizeTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/EndpointAuthorizeTest.php
@@ -128,8 +128,8 @@ class EndpointAuthorizeTest extends TestCase
      * @covers ::getEndpoint()
      * @return void
      */
-   public function testGetEndpointSame(): void
-   {
+    public function testGetEndpointSame(): void
+    {
         $Endpoints = TableRegistry::getTableLocator()->get('Endpoints');
         $expected = $Endpoints->get(2);
 
@@ -144,7 +144,6 @@ class EndpointAuthorizeTest extends TestCase
         $authorize->authorize([], $request);
         static::assertAttributeEquals($expected, 'endpoint', $authorize);
     }
-
 
     /**
      * Data provider for `testAuthorize` test case.

--- a/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
@@ -376,7 +376,7 @@ class HomeControllerTest extends IntegrationTestCase
         $this->configRequestHeaders('GET', $this->getUserAuthHeader('second user', 'password2'));
         $this->get('/home');
         $result = json_decode((string)$this->_response->getBody(), true);
-        $auth = Hash::get($result, 'meta.resources./documents');
-        static::assertNull($auth);
+        $meta = Hash::get($result, 'meta.resources./documents');
+        static::assertNull($meta);
     }
 }


### PR DESCRIPTION
This PR solves a problem in `/home` endpoint response: for every object type endpoint permissions are calculated via `EndpointAuthorize`. But this feature was actually not working since endpoint entities for those object types were not loaded in `EndpointAuthorize` class due to the internal use of `$this->endpoint` entity.

A new behavior is also introduced: if an endpoint has no methods available caused by endpoint permissions block this endpoint will not be listed in `meta.resources`.
