### PR TITLE
Fix `?include` check

### DIFF
--- a/plugins/BEdita/API/src/Controller/AppController.php
+++ b/plugins/BEdita/API/src/Controller/AppController.php
@@ -23,6 +23,8 @@ use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\ForbiddenException;
 use Cake\Http\Exception\NotAcceptableException;
 use Cake\Http\Exception\NotFoundException;
+use Cake\ORM\Association;
+use Cake\ORM\Table;
 use Cake\Routing\Router;
 
 /**
@@ -148,10 +150,11 @@ class AppController extends Controller
      * Prepare a list of associations to be contained from `?include` query parameter.
      *
      * @param string|array|null $include Association(s) to be included.
+     * @param \Cake\ORM\Table|null $table Table to consider.
      * @return array
      * @throws \Cake\Http\Exception\BadRequestException Throws an exception if a
      */
-    protected function prepareInclude($include)
+    protected function prepareInclude($include, ?Table $table = null): array
     {
         if ($include === null) {
             return [];
@@ -170,7 +173,7 @@ class AppController extends Controller
             }
 
             try {
-                $association = $this->findAssociation($relationship);
+                $association = $this->findAssociation($relationship, $table);
             } catch (NotFoundException $e) {
                 throw new BadRequestException(
                     __d('bedita', 'Invalid "{0}" query parameter ({1})', 'include', __d('bedita', 'Relationship "{0}" does not exist', $relationship))
@@ -188,11 +191,12 @@ class AppController extends Controller
      * Subclasses need to override this method.
      *
      * @param string $relationship Relationship name.
-     * @return \Cake\ORM\Association|void
+     * @param \Cake\ORM\Table|null $table Table to consider.
+     * @return \Cake\ORM\Association
      * @throws \Cake\Http\Exception\NotFoundException Throws an exception if no suitable association could be found.
      * @codeCoverageIgnore
      */
-    protected function findAssociation($relationship)
+    protected function findAssociation(string $relationship, ?Table $table = null): Association
     {
         throw new NotFoundException(__d('bedita', 'Relationship "{0}" does not exist', $relationship));
     }

--- a/plugins/BEdita/API/src/Controller/FoldersController.php
+++ b/plugins/BEdita/API/src/Controller/FoldersController.php
@@ -15,6 +15,7 @@ namespace BEdita\API\Controller;
 use BEdita\Core\Model\Action\ListRelatedFoldersAction;
 use Cake\Http\Exception\NotFoundException;
 use Cake\ORM\Association;
+use Cake\ORM\Table;
 use Cake\Utility\Hash;
 
 /**
@@ -47,14 +48,15 @@ class FoldersController extends ObjectsController
      * `parent` relationship is valid and will return `parents` association.
      * `parents` relationship is not allowed.
      */
-    protected function findAssociation($relationship)
+    protected function findAssociation(string $relationship, ?Table $table = null): Association
     {
-        if ($relationship === 'parents') {
-            throw new NotFoundException(__d('bedita', 'Relationship "{0}" does not exist', $relationship));
-        }
-
-        if ($relationship === 'parent') {
-            return $this->Table->getAssociation('Parents');
+        if ($table === null) {
+            switch ($relationship) {
+                case 'parents':
+                    throw new NotFoundException(__d('bedita', 'Relationship "{0}" does not exist', $relationship));
+                case 'parent':
+                    return $this->Table->getAssociation('Parents');
+            }
         }
 
         return parent::findAssociation($relationship);

--- a/plugins/BEdita/API/src/Controller/FoldersController.php
+++ b/plugins/BEdita/API/src/Controller/FoldersController.php
@@ -13,6 +13,7 @@
 namespace BEdita\API\Controller;
 
 use BEdita\Core\Model\Action\ListRelatedFoldersAction;
+use BEdita\Core\Model\Table\FoldersTable;
 use Cake\Http\Exception\NotFoundException;
 use Cake\ORM\Association;
 use Cake\ORM\Table;
@@ -50,7 +51,7 @@ class FoldersController extends ObjectsController
      */
     protected function findAssociation(string $relationship, ?Table $table = null): Association
     {
-        if ($table === null) {
+        if ($table === null || $table instanceof FoldersTable) {
             switch ($relationship) {
                 case 'parents':
                     throw new NotFoundException(__d('bedita', 'Relationship "{0}" does not exist', $relationship));
@@ -59,7 +60,7 @@ class FoldersController extends ObjectsController
             }
         }
 
-        return parent::findAssociation($relationship);
+        return parent::findAssociation($relationship, $table);
     }
 
     /**

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -294,7 +294,7 @@ class ObjectsController extends ResourcesController
 
         $association = $this->findAssociation($relationship);
         $filter = $this->prepareFilter();
-        $contain = $this->prepareInclude($this->request->getQuery('include'));
+        $contain = $this->prepareInclude($this->request->getQuery('include'), $association->getTarget());
         $lang = $this->request->getQuery('lang');
 
         $action = $this->getAssociatedAction($association);

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -32,6 +32,7 @@ use Cake\ORM\Association;
 use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Association\HasOne;
 use Cake\ORM\Query;
+use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Routing\Router;
 use Cake\Utility\Inflector;
@@ -92,20 +93,25 @@ abstract class ResourcesController extends AppController
      * Find the association corresponding to the relationship name.
      *
      * @param string $relationship Relationship name.
+     * @param \Cake\ORM\Table|null $table Table to consider.
      * @return \Cake\ORM\Association
      * @throws \Cake\Http\Exception\NotFoundException Throws an exception if no association could be found.
      */
-    protected function findAssociation($relationship)
+    protected function findAssociation(string $relationship, ?Table $table = null): Association
     {
+        if ($table === null) {
+            $table = $this->Table;
+        }
+
         $relationship = Inflector::underscore($relationship);
         if (array_key_exists($relationship, $this->getConfig('allowedAssociations'))) {
-            $association = $this->Table->associations()->getByProperty($relationship);
+            $association = $table->associations()->getByProperty($relationship);
             if ($association !== null) {
                 return $association;
             }
         }
 
-        throw new NotFoundException(__d('bedita', 'Relationship "{0}" does not exist', $relationship));
+        throw new NotFoundException(__d('bedita', 'Relationship "{0}" does not exist on table "{1}"', $relationship, $table->getTable()));
     }
 
     /**
@@ -244,7 +250,7 @@ abstract class ResourcesController extends AppController
 
         $association = $this->findAssociation($relationship);
         $filter = (array)$this->request->getQuery('filter') + array_filter(['query' => $this->request->getQuery('q')]);
-        $contain = $this->prepareInclude($this->request->getQuery('include'));
+        $contain = $this->prepareInclude($this->request->getQuery('include'), $association->getTarget());
 
         $action = $this->getAssociatedAction($association);
         $data = $action->execute(['primaryKey' => $relatedId] + compact('filter', 'contain'));

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -113,7 +113,7 @@ abstract class ResourcesController extends AppController
             }
         }
 
-        throw new NotFoundException(__d('bedita', 'Relationship "{0}" does not exist on table "{1}"', $relationship, $table->getTable()));
+        throw new NotFoundException(__d('bedita', 'Relationship "{0}" does not exist', $relationship));
     }
 
     /**

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -99,12 +99,14 @@ abstract class ResourcesController extends AppController
      */
     protected function findAssociation(string $relationship, ?Table $table = null): Association
     {
+        $relationship = Inflector::underscore($relationship);
+        $allowed = true;
         if ($table === null) {
             $table = $this->Table;
+            $allowed = array_key_exists($relationship, $this->getConfig('allowedAssociations'));
         }
 
-        $relationship = Inflector::underscore($relationship);
-        if (array_key_exists($relationship, $this->getConfig('allowedAssociations'))) {
+        if ($allowed) {
             $association = $table->associations()->getByProperty($relationship);
             if ($association !== null) {
                 return $association;

--- a/plugins/BEdita/API/src/Controller/TreesController.php
+++ b/plugins/BEdita/API/src/Controller/TreesController.php
@@ -18,6 +18,8 @@ use BEdita\Core\Model\Entity\Tree;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Datasource\EntityInterface;
 use Cake\Http\Exception\NotFoundException;
+use Cake\ORM\Association;
+use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 
@@ -281,18 +283,23 @@ class TreesController extends AppController
      * Find the association corresponding to the relationship name.
      *
      * @param string $relationship Relationship name.
+     * @param \Cake\ORM\Table|null $table Table to consider.
      * @return \Cake\ORM\Association
      * @throws \Cake\Http\Exception\NotFoundException Throws an exception if no association could be found.
      */
-    protected function findAssociation($relationship)
+    protected function findAssociation(string $relationship, ?Table $table = null): Association
     {
+        if ($table === null) {
+            $table = $this->Table;
+        }
+
         if (in_array($relationship, $this->getConfig('allowedAssociations'))) {
-            $association = $this->Table->associations()->getByProperty($relationship);
+            $association = $table->associations()->getByProperty($relationship);
             if ($association !== null) {
                 return $association;
             }
         }
 
-        throw new NotFoundException(__d('bedita', 'Relationship "{0}" does not exist', $relationship));
+        throw new NotFoundException(__d('bedita', 'Relationship "{0}" does not exist on table "{1}"', $relationship, $table->getTable()));
     }
 }

--- a/plugins/BEdita/API/src/Controller/TreesController.php
+++ b/plugins/BEdita/API/src/Controller/TreesController.php
@@ -289,12 +289,8 @@ class TreesController extends AppController
      */
     protected function findAssociation(string $relationship, ?Table $table = null): Association
     {
-        if ($table === null) {
-            $table = $this->Table;
-        }
-
         if (in_array($relationship, $this->getConfig('allowedAssociations'))) {
-            $association = $table->associations()->getByProperty($relationship);
+            $association = $this->Table->associations()->getByProperty($relationship);
             if ($association !== null) {
                 return $association;
             }

--- a/plugins/BEdita/API/src/Controller/TreesController.php
+++ b/plugins/BEdita/API/src/Controller/TreesController.php
@@ -296,6 +296,6 @@ class TreesController extends AppController
             }
         }
 
-        throw new NotFoundException(__d('bedita', 'Relationship "{0}" does not exist on table "{1}"', $relationship, $table->getTable()));
+        throw new NotFoundException(__d('bedita', 'Relationship "{0}" does not exist', $relationship));
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -574,6 +574,46 @@ class FoldersControllerTest extends IntegrationTestCase
     }
 
     /**
+     * Test `?include` query parameter on related endpoint.
+     *
+     * @return void
+     *
+     * @covers ::findAssociation()
+     */
+    public function testRelatedIncludeSiblings(): void
+    {
+        $this->configRequestHeaders();
+        $this->get('/folders/12/parent?include=children');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        static::assertSame(['11'], Hash::extract($result, 'data.id'));
+        static::assertSame(['12', '2'], Hash::extract($result, 'included.{n}.id'));
+    }
+
+    /**
+     * Test `?include` query parameter on related endpoint.
+     *
+     * @return void
+     *
+     * @covers ::findAssociation()
+     */
+    public function testRelatedIncludeCreatorWithRoles(): void
+    {
+        $this->configRequestHeaders();
+        $this->get('/folders/12/created_by_user?include=roles');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        static::assertSame(['1'], Hash::extract($result, 'data.id'));
+        static::assertSame(['1'], Hash::extract($result, 'included.{n}.id'));
+    }
+
+    /**
      * Data provider for `testSetRelationshipsAllowedMethods()`
      *
      * @return array

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -2452,6 +2452,27 @@ class ObjectsControllerTest extends IntegrationTestCase
     }
 
     /**
+     * Test `?include` query parameter on related endpoint.
+     *
+     * @return void
+     *
+     * @covers ::prepareIncluded()
+     */
+    public function testRelatedInclude(): void
+    {
+        $this->configRequestHeaders();
+        $this->get('/profiles/4/inverse_test?include=test');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        static::assertSame(['3', '2'], Hash::extract($result, 'data.{n}.id'));
+        static::assertSame(['4'], Hash::extract($result, 'data.0.relationships.test.data.{n}.id'));
+        static::assertSame(['4', '3'], Hash::extract($result, 'data.1.relationships.test.data.{n}.id'));
+    }
+
+    /**
      * Test listing streams for an object.
      *
      * @return void

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -2456,7 +2456,7 @@ class ObjectsControllerTest extends IntegrationTestCase
      *
      * @return void
      *
-     * @covers ::prepareIncluded()
+     * @covers ::prepareInclude()
      */
     public function testRelatedInclude(): void
     {

--- a/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
@@ -111,8 +111,10 @@ class RelationsBehavior extends Behavior
             }
 
             $className = 'BEdita/Core.Objects';
-            if (count($relation->right_object_types) === 1) {
+            $targetOT = null;
+            if ($relation->right_object_types !== null && count($relation->right_object_types) === 1) {
                 $className = $relation->right_object_types[0]->table;
+                $targetOT = $relation->right_object_types[0];
             }
 
             $through = TableRegistry::getTableLocator()->get(
@@ -136,6 +138,7 @@ class RelationsBehavior extends Behavior
                 'sort' => [
                     $through->aliasField('priority') => 'asc',
                 ],
+                'objectType' => $targetOT,
             ]);
         }
 
@@ -146,8 +149,10 @@ class RelationsBehavior extends Behavior
             }
 
             $className = 'BEdita/Core.Objects';
-            if (count($relation->left_object_types) === 1) {
+            $targetOT = null;
+            if ($relation->left_object_types !== null && count($relation->left_object_types) === 1) {
                 $className = $relation->left_object_types[0]->table;
+                $targetOT = $relation->left_object_types[0];
             }
 
             $through = TableRegistry::getTableLocator()->get(
@@ -171,6 +176,7 @@ class RelationsBehavior extends Behavior
                 'sort' => [
                     $through->aliasField('inv_priority') => 'asc',
                 ],
+                'objectType' => $targetOT,
             ]);
         }
     }

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
@@ -16,9 +16,10 @@ namespace BEdita\Core\Model\Entity;
 use BEdita\Core\Utility\JsonApiSerializable;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\ORM\Entity;
+use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Table;
-use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
+use Generator;
 
 /**
  * ObjectType Entity.
@@ -55,6 +56,7 @@ class ObjectType extends Entity implements JsonApiSerializable
     use JsonApiModelTrait {
         listAssociations as protected jsonApiListAssociations;
     }
+    use LocatorAwareTrait;
 
     /**
      * {@inheritDoc}
@@ -103,7 +105,7 @@ class ObjectType extends Entity implements JsonApiSerializable
      * @param string $name Object type name.
      * @return string
      */
-    protected function _setName($name)
+    protected function _setName(string $name): string
     {
         return Inflector::underscore($name);
     }
@@ -115,7 +117,7 @@ class ObjectType extends Entity implements JsonApiSerializable
      *
      * @return string
      */
-    protected function _getSingular()
+    protected function _getSingular(): ?string
     {
         if (!empty($this->_properties['singular'])) {
             return $this->_properties['singular'];
@@ -132,7 +134,7 @@ class ObjectType extends Entity implements JsonApiSerializable
      * @param string|null $singular Object type singular name.
      * @return string
      */
-    protected function _setSingular($singular)
+    protected function _setSingular(?string $singular): string
     {
         return Inflector::underscore($singular);
     }
@@ -142,7 +144,7 @@ class ObjectType extends Entity implements JsonApiSerializable
      *
      * @return string
      */
-    protected function _getAlias()
+    protected function _getAlias(): string
     {
         return Inflector::camelize($this->name);
     }
@@ -152,7 +154,7 @@ class ObjectType extends Entity implements JsonApiSerializable
      *
      * @return string
      */
-    protected function _getTable()
+    protected function _getTable(): string
     {
         $table = $this->plugin . '.';
         if ($table == '.') {
@@ -170,7 +172,7 @@ class ObjectType extends Entity implements JsonApiSerializable
      * @param string $table Full table name.
      * @return void
      */
-    protected function _setTable($table)
+    protected function _setTable(string $table): void
     {
         list($plugin, $model) = pluginSplit($table);
 
@@ -179,12 +181,32 @@ class ObjectType extends Entity implements JsonApiSerializable
     }
 
     /**
+     * Iterate through full inheritance chain.
+     *
+     * @return \Generator|self[]
+     */
+    public function getFullInheritanceChain(): Generator
+    {
+        /** @var \BEdita\Core\Model\Table\ObjectTypesTable $table */
+        $table = $this->getTableLocator()->get($this->getSource());
+        $objectType = $this;
+        while ($objectType !== null) {
+            yield $objectType;
+
+            if ($objectType->parent_id !== null && $objectType->parent === null) {
+                $table->loadInto($objectType, ['Parent']);
+            }
+            $objectType = $objectType->parent;
+        }
+    }
+
+    /**
      * Get all relations, including relations inherited from parent object types, indexed by their name.
      *
      * @param string $side Filter relations by side this object type stays on. Either `left`, `right` or `both`.
      * @return \BEdita\Core\Model\Entity\Relation[]
      */
-    public function getRelations($side = 'both')
+    public function getRelations(string $side = 'both'): array
     {
         if ($side === 'both') {
             return $this->getRelations('left') + $this->getRelations('right');
@@ -196,14 +218,11 @@ class ObjectType extends Entity implements JsonApiSerializable
         }
 
         $property = sprintf('%s_relations', $side);
-        $objectType = $this;
-        $relations = (array)$this->get($property);
-        while ($objectType->has('parent_id')) {
-            $objectType = TableRegistry::getTableLocator()->get($this->getSource())->get($objectType->get('parent_id'));
-            $relations = array_merge($relations, (array)$objectType->get($property));
-        }
 
-        return collection($relations)
+        return collection($this->getFullInheritanceChain())
+            ->unfold(function (self $objectType) use ($property): Generator {
+                yield from (array)$objectType->get($property);
+            })
             ->indexBy($indexBy)
             ->toArray();
     }
@@ -213,7 +232,7 @@ class ObjectType extends Entity implements JsonApiSerializable
      *
      * @return string[]|null
      */
-    protected function _getRelations()
+    protected function _getRelations(): ?array
     {
         if (!$this->has('left_relations') || !$this->has('right_relations')) {
             return null;
@@ -225,7 +244,7 @@ class ObjectType extends Entity implements JsonApiSerializable
     /**
      * {@inheritDoc}
      */
-    protected static function listAssociations(Table $Table, array $hidden = [])
+    protected static function listAssociations(Table $Table, array $hidden = []): array
     {
         $associations = static::jsonApiListAssociations($Table, $hidden);
         $associations = array_diff($associations, ['relations']);
@@ -236,19 +255,22 @@ class ObjectType extends Entity implements JsonApiSerializable
     /**
      * Getter for virtual property `parent_name`.
      *
-     * @return string
+     * @return string|null
      */
-    protected function _getParentName()
+    protected function _getParentName(): ?string
     {
-        if (!$this->parent_id) {
+        if ($this->parent_id !== null && $this->parent === null) {
+            /** @var \BEdita\Core\Model\Table\ObjectTypesTable $table */
+            $table = $this->getTableLocator()->get($this->getSource());
+
+            $table->loadInto($this, ['Parent']);
+        }
+
+        if ($this->parent === null) {
             return null;
         }
 
-        if (!empty($this->parent)) {
-            return $this->parent->get('name');
-        }
-
-        return TableRegistry::getTableLocator()->get('ObjectTypes')->get($this->parent_id)->get('name');
+        return $this->parent->name;
     }
 
     /**
@@ -257,11 +279,13 @@ class ObjectType extends Entity implements JsonApiSerializable
      * @param string $parentName Parent object type name.
      * @return string
      */
-    protected function _setParentName($parentName)
+    protected function _setParentName(string $parentName): ?string
     {
         try {
-            $objectType = TableRegistry::getTableLocator()->get('ObjectTypes')->get($parentName);
-            if (!$objectType->get('is_abstract') || !$objectType->get('enabled')) {
+            /** @var \BEdita\Core\Model\Table\ObjectTypesTable $table */
+            $table = $this->getTableLocator()->get($this->getSource());
+            $objectType = $table->get($parentName);
+            if (!$objectType->is_abstract || !$objectType->enabled) {
                 return null;
             }
 
@@ -289,11 +313,11 @@ class ObjectType extends Entity implements JsonApiSerializable
 
         // Fetch all properties, properties with `is_static` true at the end.
         // This way we can override default property type of a static property.
-        $allProperties = TableRegistry::getTableLocator()->get('Properties')
+        $allProperties = $this->getTableLocator()->get('Properties')
             ->find('objectType', [$this->id])
             ->order(['is_static' => 'ASC'])
             ->toArray();
-        $entity = TableRegistry::getTableLocator()->get($this->name)->newEntity();
+        $entity = $this->getTableLocator()->get($this->name)->newEntity();
         $hiddenProperties = $entity->getHidden();
         $typeHidden = !empty($this->hidden) ? $this->hidden : [];
 
@@ -316,5 +340,51 @@ class ObjectType extends Entity implements JsonApiSerializable
         }
 
         return compact('properties', 'required');
+    }
+
+    /**
+     * Check if an object type is child of another object type.
+     *
+     * @param \BEdita\Core\Model\Entity\ObjectType $ancestor Ancestor object type to test.
+     * @return bool
+     */
+    public function isDescendantOf(self $ancestor): bool
+    {
+        foreach ($this->getFullInheritanceChain() as $objectType) {
+            if ((int)$objectType->id === (int)$ancestor->id) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the closest common parent object type for a set of object types.
+     *
+     * @param \BEdita\Core\Model\Entity\ObjectType ...$objectTypes
+     * @return static|null
+     */
+    public static function getClosestCommonAncestor(self ...$objectTypes): ?self
+    {
+        if (empty($objectTypes)) {
+            return null;
+        }
+
+        $parent = array_shift($objectTypes);
+        foreach ($parent->getFullInheritanceChain() as $commonAncestor) {
+            $isCommonAncestor = array_reduce(
+                $objectTypes,
+                function (bool $store, ObjectType $item) use ($commonAncestor): bool {
+                    return $store && $item->isDescendantOf($commonAncestor);
+                },
+                true
+            );
+            if ($isCommonAncestor) {
+                return $commonAncestor;
+            }
+        }
+
+        return null;
     }
 }

--- a/plugins/BEdita/Core/src/ORM/Association/RelatedTo.php
+++ b/plugins/BEdita/Core/src/ORM/Association/RelatedTo.php
@@ -58,7 +58,7 @@ class RelatedTo extends BelongsToMany
     /**
      * Set target object type.
      *
-     * @param \BEdita\Core\Model\Entity\ObjectType|null $objectType
+     * @param \BEdita\Core\Model\Entity\ObjectType|null $objectType Object type for the target table (if one exists).
      * @return $this
      */
     public function setObjectType(?ObjectType $objectType): self

--- a/plugins/BEdita/Core/src/ORM/Association/RelatedTo.php
+++ b/plugins/BEdita/Core/src/ORM/Association/RelatedTo.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\ORM\Association;
 
+use BEdita\Core\Model\Entity\ObjectType;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Table;
 
@@ -33,15 +34,66 @@ class RelatedTo extends BelongsToMany
     protected $inverseKey = 'right_id';
 
     /**
+     * Target object type.
+     *
+     * @var \BEdita\Core\Model\Entity\ObjectType|null
+     */
+    private $objectType = null;
+
+    /**
      * {@inheritDoc}
      */
-    protected function _options(array $options)
+    protected function _options(array $opts)
     {
-        parent::_options($options);
+        parent::_options($opts);
 
-        if (!empty($options['inverseKey'])) {
-            $this->setInverseKey($options['inverseKey']);
+        if (!empty($opts['objectType'])) {
+            $this->setObjectType($opts['objectType']);
         }
+        if (!empty($opts['inverseKey'])) {
+            $this->setInverseKey($opts['inverseKey']);
+        }
+    }
+
+    /**
+     * Set target object type.
+     *
+     * @param \BEdita\Core\Model\Entity\ObjectType|null $objectType
+     * @return $this
+     */
+    public function setObjectType(?ObjectType $objectType): self
+    {
+        $this->objectType = $objectType;
+
+        return $this;
+    }
+
+    /**
+     * Get target object type.
+     *
+     * @return \BEdita\Core\Model\Entity\ObjectType|null
+     */
+    public function getObjectType(): ?ObjectType
+    {
+        return $this->objectType;
+    }
+
+    /** @inheritDoc */
+    public function getTarget()
+    {
+        $targetOT = $this->getObjectType();
+        /** @var \Cake\ORM\Table&\BEdita\Core\Model\Behavior\ObjectTypeBehavior&\BEdita\Core\Model\Behavior\RelationsBehavior $target */
+        $target = parent::getTarget();
+        if ($targetOT === null || !$target->hasBehavior('ObjectType')) {
+            return $target;
+        }
+
+        $objectType = $target->objectType();
+        if ($objectType === null || $objectType->id !== $targetOT->id) {
+            $target->setupRelations($targetOT);
+        }
+
+        return $target;
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Test\TestCase\Model\Entity;
 
+use BEdita\Core\Model\Entity\ObjectType;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
@@ -718,5 +719,147 @@ class ObjectTypeTest extends TestCase
 
         $expected[1]['contentMediaType'] = 'text/html';
         static::assertEquals($expected, $oneOf);
+    }
+
+    /**
+     * Data provider for {@see self::testGetFullInheritanceChain()} test case.
+     *
+     * @return array[]
+     */
+    public function getFullInheritanceChainProvider(): array
+    {
+        return [
+            'objects' => [
+                ['objects'],
+                'objects',
+            ],
+            'locations' => [
+                ['locations', 'objects'],
+                'locations',
+            ],
+            'media' => [
+                ['media', 'objects'],
+                'media',
+            ],
+            'files' => [
+                ['files', 'media', 'objects'],
+                'files',
+            ],
+        ];
+    }
+
+    /**
+     * Test {@see ObjectType::getFullInheritanceChain()}.
+     *
+     * @param string[] $expected Expected chain.
+     * @param string $name Test subject.
+     * @return void
+     *
+     * @dataProvider getFullInheritanceChainProvider()
+     * @covers ::getFullInheritanceChain
+     */
+    public function testGetFullInheritanceChain(array $expected, string $name): void
+    {
+        $objectType = $this->ObjectTypes->get($name);
+
+        $fullChain = $objectType->getFullInheritanceChain();
+        static::assertInstanceOf(\Iterator::class, $fullChain);
+
+        $fullChain = iterator_to_array($fullChain);
+        foreach ($fullChain as $ancestor) {
+            static::assertInstanceOf(ObjectType::class, $ancestor);
+        }
+
+        $actual = Hash::extract($fullChain, '{*}.name');
+        static::assertSame($expected, $actual);
+    }
+
+    /**
+     * Data provider for {@see ObjectTypeTest::testIsDescendantOf()} test case.
+     *
+     * @return array[]
+     */
+    public function isDescendantOfProvider(): array
+    {
+        return [
+            'media descendant of objects' => [true, 'media', 'objects'],
+            'files descendant of objects' => [true, 'files', 'objects'],
+            'files descendant of media' => [true, 'files', 'media'],
+            'users descendant of objects' => [true, 'users', 'objects'],
+            'users NOT descendant of media' => [false, 'users', 'media'],
+            'objects NOT descendant of media' => [false, 'objects', 'media'],
+            'objects NOT descendant of files' => [false, 'objects', 'files'],
+            'media NOT descendant of files' => [false, 'media', 'files'],
+            'objects NOT descendant of users' => [false, 'objects', 'users'],
+            'media NOT descendant of users' => [false, 'media', 'users'],
+        ];
+    }
+
+    /**
+     * Test {@see ObjectType::isDescendantOf()}.
+     *
+     * @param bool $expected Expected result.
+     * @param string $descendantName Descendant object type name.
+     * @param string $ancestorName Ancestor object type name.
+     * @return void
+     *
+     * @dataProvider isDescendantOfProvider()
+     * @covers ::isDescendantOf()
+     */
+    public function testIsDescendantOf(bool $expected, string $descendantName, string $ancestorName): void
+    {
+        $descendant = $this->ObjectTypes->get($descendantName);
+        $ancestor = $this->ObjectTypes->get($ancestorName);
+
+        $actual = $descendant->isDescendantOf($ancestor);
+        static::assertSame($expected, $actual);
+    }
+
+    /**
+     * Data provider for {@see ObjectTypeTest::testGetClosestCommonAncestor()} test case.
+     *
+     * @return array[]
+     */
+    public function getClosestCommonAncestorProvider(): array
+    {
+        return [
+            'Ø = null' => [null, []],
+            'profiles = profiles' => ['profiles', ['profiles']],
+            'files|media = media' => ['media', ['files', 'media']],
+            'media|files = media' => ['media', ['media', 'files']],
+            'locations|users|files = objects' => ['objects', ['locations', 'users', 'files']],
+        ];
+    }
+
+    /**
+     * Test {@see ObjectType::getClosestCommonAncestor()}.
+     *
+     * @param string|null $expected Expected result.
+     * @param ObjectType[]|string[] $names Object type names.
+     * @return void
+     *
+     * @dataProvider getClosestCommonAncestorProvider()
+     * @covers ::getClosestCommonAncestor()
+     */
+    public function testGetClosestCommonAncestor(?string $expected, array $names): void
+    {
+        $objectTypes = array_map(
+            function ($name): ObjectType {
+                if (is_string($name)) {
+                    return $this->ObjectTypes->get($name);
+                }
+
+                return $name;
+            },
+            $names
+        );
+
+        $actual = ObjectType::getClosestCommonAncestor(...$objectTypes);
+        if ($expected === null) {
+            static::assertNull($actual);
+        } else {
+            static::assertInstanceOf(ObjectType::class, $actual);
+            static::assertSame($expected, $actual->name);
+        }
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Test\TestCase\Model\Entity;
 
 use BEdita\Core\Model\Entity\ObjectType;
+use BEdita\Core\Model\Table\ObjectTypesTable;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
@@ -322,6 +323,59 @@ class ObjectTypeTest extends TestCase
         static::assertArrayHasKey('left_relations', $result['relationships']);
         static::assertArrayHasKey('right_relations', $result['relationships']);
         static::assertArrayNotHasKey('relations', $result['relationships']);
+    }
+
+    /**
+     * Data provider for {@see ObjectTypeTest::testGetParent()} test case.
+     *
+     * @return array[]
+     */
+    public function getParentProvider(): array
+    {
+        return [
+            'no parent' => [
+                null,
+                function (ObjectTypesTable $table): ObjectType {
+                    return $table->get('objects');
+                },
+            ],
+            'parent needs to be loaded' => [
+                'objects',
+                function (ObjectTypesTable $table): ObjectType {
+                    return $table->get('documents');
+                },
+            ],
+            'parent, preloaded' => [
+                'objects',
+                function (ObjectTypesTable $table): ObjectType {
+                    return $table->get('locations', ['contain' => ['Parent']]);
+                },
+            ],
+        ];
+    }
+
+    /**
+     * Test {@see ObjectType::getParent()}.
+     *
+     * @param string|null $expected Expected parent.
+     * @param callable $subject Function that is expected to return an {@see ObjectType} entity.
+     * @return void
+     *
+     * @dataProvider getParentProvider()
+     * @covers ::getParent()
+     */
+    public function testGetParent(?string $expected, callable $subject): void
+    {
+        /** @var ObjectType $objectType */
+        $objectType = $subject($this->ObjectTypes);
+
+        $actual = $objectType->getParent();
+        if ($expected === null) {
+            static::assertNull($actual);
+        } else {
+            static::assertInstanceOf(ObjectType::class, $actual);
+            static::assertSame($expected, $actual->name);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue that caused `?include` query parameter to be validated on source table rather than the target.

As an example, let's assume a relation "Foo" exists between **Documents** and **Locations**, and a second relation "Bar" exists between **Locations** and **Profiles**.

A request to `GET /documents/:id/foo?include=bar` would be legit. However, it resulted in a **400 Bad Request** with the following message:
> Relationship "bar" does not exist.

This happened because the relationship _Bar_ was being checked on table **Documents** (the source table for the _Foo_ relation) rather than on **Locations** (the target table), therefore it couldn't be found.

## Bonus Track

An extra improvement coming from this refactor is the Table object chosen when a relation allows multiple object types on the "other side". Previously, in case the types allowed were more than one, Objects was always chosen. Now, the closest common ancestor is chosen instead. This means that if a relation **Foo** allows both Images and Videos on the right side (and Documents on the left-hand side), the Media table would be used instead in a request like `GET /documents/42/foo`.

Please note that this is just the first step towards dealing with union and intersection types properly… for instance, if another relation **Bar** exists with both Images and Videos on the left-hand side, the following request would still fail: `GET /documents/24/foo?include=bar`.