### PR TITLE
`uname` allowed in relationship management

### DIFF
--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -12,7 +12,7 @@
  */
 namespace BEdita\API\Controller;
 
-use BEdita\API\Model\Action\UpdateAssociatedAction;
+use BEdita\API\Model\Action\UpdateRelatedAction;
 use BEdita\Core\Model\Action\ActionTrait;
 use BEdita\Core\Model\Action\AddRelatedObjectsAction;
 use BEdita\Core\Model\Action\DeleteObjectAction;
@@ -359,7 +359,7 @@ class ObjectsController extends ResourcesController
                 return null;
         }
 
-        $action = new UpdateAssociatedAction(compact('action') + ['request' => $this->request]);
+        $action = new UpdateRelatedAction(compact('action') + ['request' => $this->request]);
         $count = $action(['primaryKey' => $id]);
 
         if ($count === false) {

--- a/plugins/BEdita/API/src/Model/Action/UpdateRelatedAction.php
+++ b/plugins/BEdita/API/src/Model/Action/UpdateRelatedAction.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\API\Model\Action;
+
+use BEdita\Core\Model\Table\ObjectsTable;
+use BEdita\Core\ORM\Inheritance\Table as InheritanceTable;
+use Cake\Database\Expression\QueryExpression;
+use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\ORM\Association;
+use Cake\ORM\Table;
+use Cake\Utility\Hash;
+
+/**
+ * Command to update relations between objects.
+ *
+ * @since 4.0.0
+ */
+class UpdateRelatedAction extends UpdateAssociatedAction
+{
+
+    /** @inheritDoc */
+    protected function getTargetEntities(array $data, Association $association): array
+    {
+        $target = $association->getTarget();
+        $isObjectsTable = $target instanceof ObjectsTable || ($target instanceof InheritanceTable && $target->isTableInherited('Objects', true));
+        if ($isObjectsTable) {
+            $data = $this->ensureIds($target, $data);
+        }
+
+        return parent::getTargetEntities($data, $association);
+    }
+
+    /**
+     * Assuming any non-numeric ID is a uname, convert them to IDs.
+     *
+     * Any `uname` that is not present in the database will be left as-is.
+     * An error would still be raised later on.
+     *
+     * @param \Cake\ORM\Table $table Target table.
+     * @param array $data Request data.
+     * @return array Remapped data.
+     */
+    protected function ensureIds(Table $table, array $data): array
+    {
+        $nonNumericIds = array_filter(
+            array_unique(Hash::extract($data, '{*}.id')),
+            function (string $id): bool {
+                return !is_numeric($id);
+            }
+        );
+        if (empty($nonNumericIds)) {
+            // Nothing to do.
+            return $data;
+        }
+
+        // Query database to map `uname`s to the corresponding `id`s.
+        $map = $table->find()
+            ->select(['id', 'uname'])
+            ->where(function (QueryExpression $exp) use ($nonNumericIds): QueryExpression {
+                return $exp->in('uname', $nonNumericIds);
+            })
+            ->distinct()
+            ->disableHydration()
+            ->combine('uname', 'id')
+            ->toArray();
+
+        // Update data in place to avoid duplicating possibly large array in-memory.
+        array_walk(
+            $data,
+            function (array &$item) use ($table, $map): void {
+                $id = $item['id'];
+                if (is_numeric($id)) {
+                    return;
+                }
+                if (!isset($map[$id])) {
+                    throw new RecordNotFoundException(
+                        sprintf(
+                            'Record not found in table "%s"',
+                            Hash::get($item, 'type', $table->getTable())
+                        )
+                    );
+                }
+                $item['id'] = $map[$id];
+            }
+        );
+
+        return $data;
+    }
+}

--- a/plugins/BEdita/API/src/Model/Action/UpdateRelatedAction.php
+++ b/plugins/BEdita/API/src/Model/Action/UpdateRelatedAction.php
@@ -24,7 +24,7 @@ use Cake\Utility\Hash;
 /**
  * Command to update relations between objects.
  *
- * @since 4.0.0
+ * @since 4.4.0
  */
 class UpdateRelatedAction extends UpdateAssociatedAction
 {

--- a/plugins/BEdita/API/tests/IntegrationTest/RelationshipsParamsTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/RelationshipsParamsTest.php
@@ -403,4 +403,43 @@ class RelationshipsParamsTest extends IntegrationTestCase
         static::assertEquals(1, count($related));
         static::assertEquals(5, $related[0]->get('left_id'));
     }
+
+    /**
+     * Test patch relationships passing uname in place of id.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testPatchUname(): void
+    {
+        $data = [
+            [
+                'id' => 'second-user',
+                'type' => 'users',
+                'meta' => [
+                    'relation' => [
+                        'params' => [
+                            'name' => 'Gustavo',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $endpoint = sprintf('/locations/8/relationships/inverse_another_test');
+        $this->patch($endpoint, json_encode(compact('data')));
+
+        $this->assertResponseCode(200);
+
+        $related = $this->ObjectRelations->find()
+            ->where([
+                'relation_id' => 2,
+                'right_id' => 8,
+            ])
+            ->toArray();
+        static::assertEquals(1, count($related));
+        static::assertEquals(5, $related[0]->get('left_id'));
+    }
 }

--- a/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateRelatedActionTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateRelatedActionTest.php
@@ -44,7 +44,6 @@ class UpdateRelatedActionTest extends TestCase
         'plugin.BEdita/Core.ObjectRelations',
         'plugin.BEdita/Core.Properties',
         'plugin.BEdita/Core.PropertyTypes',
-        'plugin.BEdita/Core.ObjectProperties',
         'plugin.BEdita/Core.Categories',
         'plugin.BEdita/Core.ObjectCategories',
         'plugin.BEdita/Core.History',

--- a/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateRelatedActionTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateRelatedActionTest.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\API\Test\TestCase\Model\Action;
+
+use BEdita\API\Model\Action\UpdateRelatedAction;
+use BEdita\Core\Model\Action\SetRelatedObjectsAction;
+use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\Http\ServerRequest;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
+use Cake\Utility\Text;
+use Exception;
+
+/**
+ * @covers \BEdita\API\Model\Action\UpdateRelatedAction
+ */
+class UpdateRelatedActionTest extends TestCase
+{
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.Profiles',
+        'plugin.BEdita/Core.Users',
+        'plugin.BEdita/Core.Locations',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.RelationTypes',
+        'plugin.BEdita/Core.ObjectRelations',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.ObjectProperties',
+        'plugin.BEdita/Core.Categories',
+        'plugin.BEdita/Core.ObjectCategories',
+        'plugin.BEdita/Core.History',
+        'plugin.BEdita/Core.Roles',
+        'plugin.BEdita/Core.RolesUsers',
+    ];
+
+    /**
+     * Data provider for {@see UpdateRelatedActionTest::testInvocation()} test case.
+     *
+     * @return array[]
+     */
+    public function invocationProvider(): array
+    {
+        return [
+            'simple' => [
+                [1, 2],
+                'Documents',
+                'Test',
+                3,
+                [
+                    ['id' => 'first-user', 'type' => 'users'],
+                    ['id' => 'title-one', 'type' => 'documents'],
+                ],
+            ],
+            'duplicate entry' => [
+                [1, 5],
+                'Locations',
+                'InverseAnotherTest',
+                8,
+                [
+                    [
+                        'id' => 'first-user',
+                        'type' => 'users',
+                        '_meta' => ['relation' => ['params' => ['name' => 'foo']]],
+                    ],
+                    [
+                        'id' => 'second-user',
+                        'type' => 'users',
+                        '_meta' => ['relation' => ['params' => ['name' => 'bar']]],
+                    ],
+                    [
+                        'id' => 1,
+                        'type' => 'users',
+                        '_meta' => ['relation' => ['params' => ['name' => 'baz']]],
+                    ],
+                ],
+            ],
+            'nothing to do' => [
+                [1, 5],
+                'Locations',
+                'InverseAnotherTest',
+                8,
+                [
+                    [
+                        'id' => '1',
+                        'type' => 'users',
+                        '_meta' => ['relation' => ['params' => ['name' => 'foo']]],
+                    ],
+                    [
+                        'id' => '5',
+                        'type' => 'users',
+                        '_meta' => ['relation' => ['params' => ['name' => 'bar']]],
+                    ],
+                    [
+                        'id' => 1,
+                        'type' => 'users',
+                        '_meta' => ['relation' => ['params' => ['name' => 'baz']]],
+                    ],
+                ],
+            ],
+            'uname not found' => [
+                new RecordNotFoundException('Record not found in table "users"'),
+                'Documents',
+                'Test',
+                3,
+                [
+                    ['id' => 2, 'type' => 'documents'],
+                    ['id' => Text::uuid(), 'type' => 'users'],
+                ],
+            ],
+            'not an object table' => [
+                [1, 2],
+                'Users',
+                'Roles',
+                1,
+                [
+                    ['id' => 1, 'type' => 'roles'],
+                    ['id' => 2, 'type' => 'roles'],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test invocation of command.
+     *
+     * @param int[]|\Exception Expected result.
+     * @param string $table Table to use.
+     * @param string $association Association to use.
+     * @param int $id Entity ID to update relations for.
+     * @param int|int[]|null $data Related entity(-ies).
+     * @return void
+     *
+     * @dataProvider invocationProvider()
+     */
+    public function testInvocation($expected, string $table, string $association, int $id, $data): void
+    {
+        if ($expected instanceof Exception) {
+            $this->expectException(get_class($expected));
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+
+        $request = new ServerRequest();
+        $request = $request->withParsedBody($data);
+        $association = $this->getTableLocator()->get($table)->getAssociation($association);
+        $parentAction = new SetRelatedObjectsAction(compact('association'));
+        $action = new UpdateRelatedAction(['action' => $parentAction, 'request' => $request]);
+
+        $action(['primaryKey' => $id]);
+        if ($expected instanceof Exception) {
+            return;
+        }
+
+        $matching = [];
+        if ($data !== null) {
+            $matching = Hash::extract(
+                $association->getSource()
+                    ->get($id, ['contain' => [$association->getName()]])
+                    ->get($association->getProperty()),
+                '{*}.id'
+            );
+        }
+
+        static::assertEquals($expected, $matching);
+    }
+}


### PR DESCRIPTION
This PR introduces the ability to manage BEdita semantic relations using `uname`s in place of `id`s.

Let **Foo** be a relation between **Documents** and **Users**. The following payload would now be legit:

```http
PATCH /documents/42/relationships/foo
Accept: application/vnd.api+json
Content-Type: application/json

{
    "data": [
        {
            "id": "1",
            "type": "users"
        },
        {
            "id": "some-other-user's-uname",
            "type": "users"
        }
    ]
}
```

Similarly, also `POST /documents/42/relationships/foo` and `DELETE /documents/42/relationships/foo` would admit unames in place of IDs.