### PR TITLE
Feat/categories migrations

### DIFF
--- a/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
@@ -17,7 +17,6 @@ use BEdita\Core\Exception\BadFilterException;
 use Cake\Event\Event;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
-use Cake\ORM\Table;
 use Cake\Validation\Validator;
 
 /**
@@ -174,7 +173,7 @@ class CategoriesTable extends CategoriesTagsBaseTable
      * @param \Cake\ORM\Query $query Query object instance.
      * @param array $options Options array.
      * @return \Cake\ORM\Query
-     * @throws BadFilterException
+     * @throws \BEdita\Core\Exception\BadFilterException
      */
     protected function findResource(Query $query, array $options): Query
     {

--- a/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
@@ -166,4 +166,25 @@ class CategoriesTable extends CategoriesTagsBaseTable
             return $query->where([$this->ObjectTypes->aliasField('name') => $options[0]]);
         });
     }
+
+    /**
+     * Find category resource by name and object type.
+     *
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @param array $options Options array.
+     * @return \Cake\ORM\Query
+     * @throws BadFilterException
+     */
+    protected function findResource(Query $query, array $options): Query
+    {
+        if (empty($options['name'])) {
+            throw new BadFilterException(__d('bedita', 'Missing required parameter "name"'));
+        }
+        if (empty($options['object_type_name'])) {
+            throw new BadFilterException(__d('bedita', 'Missing required parameter "object_type_name"'));
+        }
+
+        return $query->find('type', [$options['object_type_name']])
+            ->where([$this->aliasField('name') => $options['name']]);
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
@@ -169,6 +169,7 @@ class CategoriesTable extends CategoriesTagsBaseTable
 
     /**
      * Find category resource by name and object type.
+     * Options array argument MUST contain 'name' and 'object_type_name' keys.
      *
      * @param \Cake\ORM\Query $query Query object instance.
      * @param array $options Options array.
@@ -178,10 +179,10 @@ class CategoriesTable extends CategoriesTagsBaseTable
     protected function findResource(Query $query, array $options): Query
     {
         if (empty($options['name'])) {
-            throw new BadFilterException(__d('bedita', 'Missing required parameter "name"'));
+            throw new BadFilterException(__d('bedita', 'Missing required parameter "{0}"', 'name'));
         }
         if (empty($options['object_type_name'])) {
-            throw new BadFilterException(__d('bedita', 'Missing required parameter "object_type_name"'));
+            throw new BadFilterException(__d('bedita', 'Missing required parameter "{0}"', 'object_type_name'));
         }
 
         return $query->find('type', [$options['object_type_name']])

--- a/plugins/BEdita/Core/src/Utility/Resources.php
+++ b/plugins/BEdita/Core/src/Utility/Resources.php
@@ -81,6 +81,7 @@ class Resources
     protected static $allowed = [
         'applications',
         'auth_providers',
+        'categories',
         'config',
         'property_types',
         'object_types',

--- a/plugins/BEdita/Core/tests/Fixture/CategoriesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/CategoriesFixture.php
@@ -32,8 +32,8 @@ class CategoriesFixture extends TestFixture
             'name' => 'first-cat',
             'label' => 'First category',
             'parent_id' => null,
-            'tree_left' => null,
-            'tree_right' => null,
+            'tree_left' => 1,
+            'tree_right' => 2,
             'enabled' => 1,
             'created' => '2019-11-25 17:35:58',
             'modified' => '2019-11-25 17:35:58'
@@ -44,8 +44,8 @@ class CategoriesFixture extends TestFixture
             'name' => 'second-cat',
             'label' => 'Second category',
             'parent_id' => null,
-            'tree_left' => null,
-            'tree_right' => null,
+            'tree_left' => 3,
+            'tree_right' => 4,
             'enabled' => 1,
             'created' => '2019-11-25 17:35:58',
             'modified' => '2019-11-25 17:35:58'
@@ -56,8 +56,8 @@ class CategoriesFixture extends TestFixture
             'name' => 'disabled-cat',
             'label' => 'Disabled category',
             'parent_id' => null,
-            'tree_left' => null,
-            'tree_right' => null,
+            'tree_left' => 5,
+            'tree_right' => 6,
             'enabled' => 0,
             'created' => '2019-11-26 12:15:51',
             'modified' => '2019-11-26 12:15:51'

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/CategoriesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/CategoriesTableTest.php
@@ -81,8 +81,8 @@ class CategoriesTableTest extends TestCase
             'name' => 'first-cat',
             'label' => 'First category',
             'parent_id' => null,
-            'tree_left' => null,
-            'tree_right' => null,
+            'tree_left' => 1,
+            'tree_right' => 2,
             'enabled' => true,
         ];
         unset($category['created'], $category['modified']);
@@ -157,5 +157,58 @@ class CategoriesTableTest extends TestCase
         $this->expectExceptionMessage('Missing required parameter "type"');
 
         $this->Categories->find('type')->toArray();
+    }
+
+    /**
+     * Data provider for `testFindResource()`.
+     *
+     * @return array
+     */
+    public function findResourceProvider(): array
+    {
+        return [
+            'category' => [
+                1,
+                [
+                    'name' => 'first-cat',
+                    'object_type_name' => 'documents',
+                ],
+            ],
+            'no name' => [
+                new BadFilterException('Missing required parameter "name"'),
+                [
+                    'object_type_name' => 'documents',
+                ],
+            ],
+            'no type' => [
+                new BadFilterException('Missing required parameter "object_type_name"'),
+                [
+                    'name' => 'a-name',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test custom finder `findResource()`.
+     *
+     * @param mixed $expected The value expected
+     * @param array $options The options for the finder
+     * @return void
+     *
+     * @covers ::findResource()
+     * @dataProvider findResourceProvider()
+     */
+    public function testFindResource($expected, $options)
+    {
+        if ($expected instanceof \Exception) {
+            $this->expectException(get_class($expected));
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+        $query = $this->Categories->find('resource', $options);
+        $entity = $query->first();
+
+        static::assertEquals(1, $query->count());
+        static::assertEquals($expected, $entity->id);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/CategoriesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/CategoriesTableTest.php
@@ -192,14 +192,14 @@ class CategoriesTableTest extends TestCase
     /**
      * Test custom finder `findResource()`.
      *
-     * @param mixed $expected The value expected
+     * @param int|\Exception $expected The value expected
      * @param array $options The options for the finder
      * @return void
      *
      * @covers ::findResource()
      * @dataProvider findResourceProvider()
      */
-    public function testFindResource($expected, $options)
+    public function testFindResource($expected, $options): void
     {
         if ($expected instanceof \Exception) {
             $this->expectException(get_class($expected));

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
@@ -260,6 +260,7 @@ class ResourcesTest extends TestCase
                 [
                     [
                         'name' => 'second-cat',
+                        'object_type_name' => 'documents',
                     ],
                 ],
             ],
@@ -378,6 +379,7 @@ class ResourcesTest extends TestCase
                 [
                     [
                         'name' => 'second-cat',
+                        'object_type_name' => 'documents',
                         'label' => 'Another category',
                     ],
                 ],

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
@@ -37,6 +37,7 @@ class ResourcesTest extends TestCase
         'plugin.BEdita/Core.AuthProviders',
         'plugin.BEdita/Core.Endpoints',
         'plugin.BEdita/Core.EndpointPermissions',
+        'plugin.BEdita/Core.Categories',
         'plugin.BEdita/Core.Config',
         'plugin.BEdita/Core.Roles',
         'plugin.BEdita/Core.ObjectTypes',
@@ -88,6 +89,16 @@ class ResourcesTest extends TestCase
                             'provider_username_field' => 'owner_id',
                         ],
                         'enabled' => true,
+                    ],
+                ],
+            ],
+            'categories' => [
+                'categories',
+                [
+                    [
+                        'name' => 'third-cat',
+                        'label' => 'Third category',
+                        'object_type_name' => 'documents',
                     ],
                 ],
             ],
@@ -244,6 +255,14 @@ class ResourcesTest extends TestCase
                     ],
                 ],
             ],
+            'categories' => [
+                'categories',
+                [
+                    [
+                        'name' => 'second-cat',
+                    ],
+                ],
+            ],
             'objects' => [
                 'object_types',
                 [
@@ -351,6 +370,15 @@ class ResourcesTest extends TestCase
                         'params' => [
                             'provider_username_field' => 'another_id',
                         ],
+                    ],
+                ],
+            ],
+            'categories' => [
+                'categories',
+                [
+                    [
+                        'name' => 'second-cat',
+                        'label' => 'Another category',
                     ],
                 ],
             ],


### PR DESCRIPTION
This PR  enables use of `categories` in Resources migrations.

A new `resource` finder was added to `CategoriesTable` and some unit tests cases have been added to cover `categories` create/update/remove through `Resources` utility.
