### PR TITLE
Expose available custom properties getting related object

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/AssociatedEntitiesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/AssociatedEntitiesTest.php
@@ -212,7 +212,7 @@ class AssociatedEntitiesTest extends IntegrationTestCase
      *
      * @return void
      */
-    public function testRelated()
+    public function testRelated(): void
     {
         $this->configRequestHeaders();
         $this->get('/profiles/4/inverse_test');

--- a/plugins/BEdita/API/tests/IntegrationTest/AssociatedEntitiesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/AssociatedEntitiesTest.php
@@ -208,6 +208,20 @@ class AssociatedEntitiesTest extends IntegrationTestCase
     }
 
     /**
+     * Test that related objects correspond to the pagination count.
+     *
+     * @return void
+     */
+    public function testRelated()
+    {
+        $this->configRequestHeaders();
+        $this->get('/profiles/4/inverse_test');
+        $result = json_decode((string)$this->_response->getBody(), true);
+        static::assertCount(2, $result['data']);
+        static::assertEquals(2, $result['meta']['pagination']['count']);
+    }
+
+    /**
      * Test that `?include` query parameter for `/events/:id` will contain all relevan media data.
      *
      * @return void

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -1336,6 +1336,8 @@ class ObjectsControllerTest extends IntegrationTestCase
                         'lang' => 'en',
                         'publish_start' => '2016-05-13T07:09:23+00:00',
                         'publish_end' => '2016-05-13T07:09:23+00:00',
+                        'another_title' => null,
+                        'another_description' => null,
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/documents/2',

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -85,12 +85,12 @@ class CustomPropertiesBehavior extends Behavior
             return [];
         }
 
-        $properties = TableRegistry::getTableLocator()->get('Properties')->find('type', ['dynamic'])
+        $this->available = TableRegistry::getTableLocator()->get('Properties')
+            ->find('type', ['dynamic'])
             ->find('objectType', [$objectType->id])
             ->where(['enabled' => true, 'is_static' => false])
-            ->all();
-
-        $this->available = collection($properties)->indexBy('name')->toArray();
+            ->indexBy('name')
+            ->toArray();
 
         return $this->available;
     }

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -80,15 +80,15 @@ class CustomPropertiesBehavior extends Behavior
             return $this->available;
         }
 
-        try {
-            $objectType = $this->objectType($this->getTable()->getAlias());
-            $properties = TableRegistry::getTableLocator()->get('Properties')->find('type', ['dynamic'])
-                ->find('objectType', [$objectType->id])
-                ->where(['enabled' => true, 'is_static' => false])
-                ->all();
-        } catch (RecordNotFoundException $e) {
+        $objectType = $this->objectType();
+        if ($objectType === null) {
             return [];
         }
+
+        $properties = TableRegistry::getTableLocator()->get('Properties')->find('type', ['dynamic'])
+            ->find('objectType', [$objectType->id])
+            ->where(['enabled' => true, 'is_static' => false])
+            ->all();
 
         $this->available = collection($properties)->indexBy('name')->toArray();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
@@ -153,6 +153,31 @@ class CustomPropertiesBehaviorTest extends TestCase
     }
 
     /**
+     * Test get available properties for related object.
+     *
+     * @return void
+     *
+     * @covers ::getAvailable()
+     * @covers ::objectType()
+     */
+    public function testGetAvailableRelatedObject()
+    {
+        $table = TableRegistry::getTableLocator()->get('Profiles')
+            ->getAssociation('InverseTest')->getTarget();
+
+        static::assertEquals('InverseTest', $table->getAlias());
+
+        $behavior = $table->behaviors()->get('CustomProperties');
+        $result = $behavior->getAvailable();
+
+        $expected = ['another_title', 'another_description']; // documents custom props
+        $result = array_keys($result);
+        sort($result);
+        sort($expected);
+        static::assertEquals($expected, $result);
+    }
+
+    /**
      * Test get available when no object type is found
      *
      * @return void

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
@@ -160,7 +160,7 @@ class CustomPropertiesBehaviorTest extends TestCase
      * @covers ::getAvailable()
      * @covers ::objectType()
      */
-    public function testGetAvailableRelatedObject()
+    public function testGetAvailableRelatedObject(): void
     {
         $table = TableRegistry::getTableLocator()->get('Profiles')
             ->getAssociation('InverseTest')->getTarget();


### PR DESCRIPTION
This PR improve the result set of related objects including the related value of available custom properties.

Before this, having a relation as

```
documents <---- relation_name / inverse_realtion_name ----> profiles
```

and having defined custom prop `another_email` on `profiles` type didn't expose that property in the result set unless it wasn't valued.

So calling

```http
GET /documents/{id}/relation_name
```
the result was missing of `another_email` property. 

After the PR the result will contain `"another_email": null`.
