### PR TITLE
External Auth Signup: add `verified`, remove reference on `anonymize`

### DIFF
--- a/plugins/BEdita/API/src/Auth/OAuth2Authenticate.php
+++ b/plugins/BEdita/API/src/Auth/OAuth2Authenticate.php
@@ -104,12 +104,12 @@ class OAuth2Authenticate extends BaseAuthenticate
      * @return array Response from an OAuth2 provider
      * @codeCoverageIgnore
      */
-    protected function getOAuth2Response($url, $accessToken)
+    protected function getOAuth2Response($url, $accessToken): array
     {
         /** @var \Cake\Http\Client\Response $response */
         $response = (new Client())->get($url, [], ['headers' => ['Authorization' => 'Bearer ' . $accessToken]]);
 
-        return !empty($response->getJson()) ? $response->getJson() : [];
+        return (array)$response->getJson();
     }
 
     /**

--- a/plugins/BEdita/API/src/Auth/OAuth2Authenticate.php
+++ b/plugins/BEdita/API/src/Auth/OAuth2Authenticate.php
@@ -104,7 +104,7 @@ class OAuth2Authenticate extends BaseAuthenticate
      * @return array Response from an OAuth2 provider
      * @codeCoverageIgnore
      */
-    protected function getOAuth2Response($url, $accessToken): array
+    protected function getOAuth2Response(string $url, string $accessToken): array
     {
         /** @var \Cake\Http\Client\Response $response */
         $response = (new Client())->get($url, [], ['headers' => ['Authorization' => 'Bearer ' . $accessToken]]);

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -358,7 +358,7 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
      * @return array Response from an OAuth2 provider
      * @codeCoverageIgnore
      */
-    protected function getOAuth2Response($url, $accessToken): array
+    protected function getOAuth2Response(string $url, string $accessToken): array
     {
         $response = (new Client())->get($url, [], ['headers' => ['Authorization' => 'Bearer ' . $accessToken]]);
 

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -357,11 +357,11 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
      * @return array Response from an OAuth2 provider
      * @codeCoverageIgnore
      */
-    protected function getOAuth2Response($url, $accessToken)
+    protected function getOAuth2Response($url, $accessToken): array
     {
         $response = (new Client())->get($url, [], ['headers' => ['Authorization' => 'Bearer ' . $accessToken]]);
 
-        return !empty($response->json) ? $response->json : [];
+        return (array)$response->getJson();
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -277,8 +277,7 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
 
         $authProvider = $this->checkExternalAuth($data);
 
-        $data['verified'] = Time::now();
-        $user = $this->createUserEntity($data, 'on', 'signupExternal');
+        $user = $this->createUserEntity($data, 'on', 'signupExternal', true);
 
         // create `ExternalAuth` entry
         $this->Users->dispatchEvent('Auth.externalAuth', [
@@ -297,10 +296,12 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
      * @param array $data The signup data
      * @param string $status User `status`, `on` or `draft`
      * @param string $validate Validation options to use
+     * @param bool $verified Add `verified` value to entity
+     *
      * @return \BEdita\Core\Model\Entity\User The User entity created
      * @throws \Cake\Http\Exception\BadRequestException When some data is invalid.
      */
-    protected function createUserEntity(array $data, $status, $validate)
+    protected function createUserEntity(array $data, $status, $validate, bool $verified = false)
     {
         if ($this->Users->exists(['username' => $data['username']])) {
             $this->dispatchEvent('Auth.signupUserExists', [$data], $this->Users);
@@ -313,10 +314,10 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
 
         $data['status'] = $status;
         $entity = $this->Users->newEntity();
-        $entityOptions = compact('validate');
-        if (!empty($data['verified'])) {
-            $entityOptions['accessibleFields'] = ['verified' => true];
+        if ($verified === true) {
+            $entity->set('verified', Time::now());
         }
+        $entityOptions = compact('validate');
 
         return $action(compact('entity', 'data', 'entityOptions'));
     }

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -310,7 +310,9 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
             ]);
         }
         $action = new SaveEntityAction(['table' => $this->Users]);
-        $entity = $this->Users->newEntity()->set(compact('status'));
+
+        $data['status'] = $status;
+        $entity = $this->Users->newEntity();
         $entityOptions = compact('validate');
         if (!empty($data['verified'])) {
             $entityOptions['accessibleFields'] = ['verified' => true];

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -298,13 +298,13 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
     }
 
     /**
-     * Create User model entity.
+     * Create User entity.
      *
      * @param array $data The signup data
      * @param array $entityOptions Entity options to use
-     * @return @return \BEdita\Core\Model\Entity\User The User entity created
+     * @return \BEdita\Core\Model\Entity\User The User entity created
      */
-    protected function createUserEntity(array $data, array $entityOptions)
+    protected function createUserEntity(array $data, array $entityOptions): User
     {
         if ($this->Users->exists(['username' => $data['username']])) {
             $this->dispatchEvent('Auth.signupUserExists', [$data], $this->Users);

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -394,7 +394,7 @@ class UsersTable extends Table
 
         $this->loadInto($entity, ['ExternalAuth']);
         array_walk(
-            $entity->external_auths,
+            $entity->external_auth,
             function ($item) {
                 $this->ExternalAuth->deleteOrFail($item);
             }

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -392,7 +392,14 @@ class UsersTable extends Table
         $entity->set('deleted', true);
         $entity->set('locked', true);
 
-        $this->ExternalAuth->deleteAll([$this->ExternalAuth->aliasField('user_id') => $entity->get('id')]);
+        $condition = [$this->ExternalAuth->aliasField('user_id') => $entity->get('id')];
+        $extAuthList = $this->ExternalAuth->find()->where($condition)->toList();
+        array_walk(
+            $extAuthList,
+            function ($item) {
+                $this->ExternalAuth->deleteOrFail($item);
+            }
+        );
 
         return $this->save($entity);
     }

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -392,6 +392,8 @@ class UsersTable extends Table
         $entity->set('deleted', true);
         $entity->set('locked', true);
 
+        $this->ExternalAuth->deleteAll([$this->ExternalAuth->aliasField('user_id') => $entity->get('id')]);
+
         return $this->save($entity);
     }
 

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -392,10 +392,9 @@ class UsersTable extends Table
         $entity->set('deleted', true);
         $entity->set('locked', true);
 
-        $condition = [$this->ExternalAuth->aliasField('user_id') => $entity->get('id')];
-        $extAuthList = $this->ExternalAuth->find()->where($condition)->toList();
+        $this->loadInto($entity, ['ExternalAuth']);
         array_walk(
-            $extAuthList,
+            $entity->external_auths,
             function ($item) {
                 $this->ExternalAuth->deleteOrFail($item);
             }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -324,6 +324,7 @@ class SignupUserActionTest extends TestCase
         static::assertTrue((bool)$result);
         static::assertInstanceOf(User::class, $result);
         static::assertSame('on', $result->status);
+        static::assertNotEmpty($result->verified);
         static::assertSame(1, $eventDispatched, 'Event not dispatched');
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -724,6 +724,8 @@ class UsersTableTest extends TestCase
         static::assertEquals('__deleted-5', $result->get('uname'));
         static::assertEquals(true, $result->get('locked'));
         static::assertNull($result->get('last_login'));
+        // verify external_auth records have been removed
+        static::assertFalse($this->Users->ExternalAuth->exists(['user_id' => 5]));
     }
 
     /**
@@ -749,6 +751,8 @@ class UsersTableTest extends TestCase
         static::assertEquals('__deleted-5', $result->get('uname'));
         static::assertEquals(true, $result->get('locked'));
         static::assertNull($result->get('last_login'));
+        // verify external_auth records have been removed
+        static::assertFalse($this->Users->ExternalAuth->exists(['user_id' => 5]));
     }
 
     /**


### PR DESCRIPTION
This PR solves some issues in `SignupUserAction`

* `verified` timestamp is set upon external auth provider signup - there's no other way to set this meta attribute since no validation link is sent to users signing with external auth (user is actually verified by provider) 
* `external_auth` records are removed in `UsersTable::anonymizeUser` - a user previously anonymized ws unable to signup again due to conflicting record with same `auth_provider_id` and `provider_username`
* deprecated code removed in `getOAuth2Response`

