### PR TITLE
ResourceBase class for Resources utilities

### DIFF
--- a/plugins/BEdita/Core/src/Utility/Properties.php
+++ b/plugins/BEdita/Core/src/Utility/Properties.php
@@ -14,7 +14,6 @@
 namespace BEdita\Core\Utility;
 
 use Cake\Http\Exception\BadRequestException;
-use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 
@@ -38,7 +37,7 @@ use Cake\Utility\Inflector;
  *     ],
  *   ]
  */
-class Properties
+class Properties extends ResourcesBase
 {
     /**
      * Default options array with following keys:
@@ -68,8 +67,7 @@ class Properties
      */
     public static function create(array $properties, array $options = []): void
     {
-        TableRegistry::getTableLocator()->clear();
-        $Properties = TableRegistry::getTableLocator()->get('Properties', $options);
+        $Properties = static::getTable('Properties', $options);
 
         foreach ($properties as $p) {
             static::validate($p);
@@ -93,9 +91,8 @@ class Properties
      */
     public static function remove(array $properties, array $options = []): void
     {
-        TableRegistry::getTableLocator()->clear();
-        $Properties = TableRegistry::getTableLocator()->get('Properties', $options);
-        $ObjectTypes = TableRegistry::getTableLocator()->get('ObjectTypes', $options);
+        $Properties = static::getTable('Properties', $options);
+        $ObjectTypes = static::getTable('ObjectTypes', $options);
 
         foreach ($properties as $p) {
             static::validate($p);

--- a/plugins/BEdita/Core/src/Utility/Relations.php
+++ b/plugins/BEdita/Core/src/Utility/Relations.php
@@ -15,7 +15,6 @@ namespace BEdita\Core\Utility;
 
 use Cake\Datasource\EntityInterface;
 use Cake\Http\Exception\BadRequestException;
-use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 
@@ -38,7 +37,7 @@ use Cake\Utility\Inflector;
  *     ],
  *    ]
  */
-class Relations
+class Relations extends ResourcesBase
 {
     /**
      * Default options array with following keys:
@@ -68,8 +67,7 @@ class Relations
      */
     public static function create(array $relations, array $options = []): void
     {
-        TableRegistry::getTableLocator()->clear();
-        $Relations = TableRegistry::getTableLocator()->get('Relations', $options);
+        $Relations = static::getTable('Relations', $options);
         foreach ($relations as $data) {
             static::validate($data);
             $relation = $Relations->newEntity($data);
@@ -91,8 +89,7 @@ class Relations
      */
     public static function addRelationType(string $relation, string $type, string $side, array $options = []): void
     {
-        $relation = TableRegistry::getTableLocator()
-            ->get('Relations', $options)
+        $relation = static::getTable('Relations', $options)
             ->get($relation);
         static::addTypes($relation->get('id'), [$type], $side, $options);
     }
@@ -108,9 +105,8 @@ class Relations
      */
     protected static function addTypes($relationId, array $types, string $side, array $options = []): void
     {
-        TableRegistry::getTableLocator()->clear();
-        $RelationTypes = TableRegistry::getTableLocator()->get('RelationTypes', $options);
-        $ObjectTypes = TableRegistry::getTableLocator()->get('ObjectTypes', $options);
+        $RelationTypes = static::getTable('RelationTypes', $options);
+        $ObjectTypes = static::getTable('ObjectTypes', $options);
 
         foreach ($types as $name) {
             $objectType = $ObjectTypes->get(Inflector::camelize($name));
@@ -133,8 +129,7 @@ class Relations
      */
     public static function remove(array $relations, array $options = []): void
     {
-        TableRegistry::getTableLocator()->clear();
-        $Relations = TableRegistry::getTableLocator()->get('Relations', $options);
+        $Relations = static::getTable('Relations', $options);
         foreach ($relations as $r) {
             static::validate($r);
             /** @var \Cake\Datasource\EntityInterface $relation */
@@ -160,9 +155,8 @@ class Relations
      */
     protected static function removeTypes($relationId, array $types, string $side, array $options = []): void
     {
-        TableRegistry::getTableLocator()->clear();
-        $RelationTypes = TableRegistry::getTableLocator()->get('RelationTypes', $options);
-        $ObjectTypes = TableRegistry::getTableLocator()->get('ObjectTypes', $options);
+        $RelationTypes = static::getTable('RelationTypes', $options);
+        $ObjectTypes = static::getTable('ObjectTypes', $options);
 
         foreach ($types as $name) {
             $objectType = $ObjectTypes->get(Inflector::camelize($name));
@@ -191,8 +185,7 @@ class Relations
      */
     public static function removeRelationType(string $relation, string $type, string $side, array $options = []): void
     {
-        $relation = TableRegistry::getTableLocator()
-            ->get('Relations', $options)
+        $relation = static::getTable('Relations', $options)
             ->get($relation);
         static::removeTypes($relation->get('id'), [$type], $side, $options);
     }
@@ -206,7 +199,7 @@ class Relations
      */
     public static function update(array $data, array $options = []): array
     {
-        $Relations = TableRegistry::getTableLocator()->get('Relations', $options);
+        $Relations = static::getTable('Relations', $options);
 
         $result = [];
         foreach ($data as $r) {

--- a/plugins/BEdita/Core/src/Utility/Resources.php
+++ b/plugins/BEdita/Core/src/Utility/Resources.php
@@ -16,9 +16,7 @@ namespace BEdita\Core\Utility;
 use Cake\Datasource\EntityInterface;
 use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\Table;
-use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
-use Cake\Utility\Inflector;
 
 /**
  * Utility class to resources creation/update/removal in migrations, shell scripts and similar scenarios
@@ -40,7 +38,7 @@ use Cake\Utility\Inflector;
  *     ],
  *   ],
  */
-class Resources
+class Resources extends ResourcesBase
 {
     /**
      * Default options array with following keys:
@@ -272,27 +270,6 @@ class Resources
         }
 
         return $res;
-    }
-
-    /**
-     * Get resource table with type validation
-     *
-     * @param string $type Resource type name
-     * @param array $options Table locator options
-     * @return \Cake\ORM\Table
-     * @throws BadRequestException
-     */
-    protected static function getTable(string $type, array $options = []): Table
-    {
-        if (!in_array($type, static::$allowed)) {
-            throw new BadRequestException(
-                __d('bedita', 'Resource type not allowed "{0}"', $type)
-            );
-        }
-        TableRegistry::getTableLocator()->clear();
-
-        return TableRegistry::getTableLocator()
-            ->get(Inflector::camelize($type), $options);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Utility/ResourcesBase.php
+++ b/plugins/BEdita/Core/src/Utility/ResourcesBase.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Utility;
+
+use Cake\Http\Exception\BadRequestException;
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+use Cake\Utility\Inflector;
+
+/**
+ * Resources utility base class
+ *
+ * @since 4.4.0
+ */
+abstract class ResourcesBase
+{
+    /**
+     * Allowed resource types
+     *
+     * @var array
+     */
+    protected static $allowed = [];
+
+    /**
+     * Get resource table, removing type from registry to force new options.
+     *
+     * @param string $type Resource type name
+     * @param array $options Table locator options
+     * @return \Cake\ORM\Table
+     */
+    protected static function getTable(string $type, array $options = []): Table
+    {
+        if (!empty(static::$allowed) && !in_array($type, static::$allowed)) {
+            throw new BadRequestException(
+                __d('bedita', 'Resource type not allowed "{0}"', $type)
+            );
+        }
+
+        TableRegistry::getTableLocator()->remove($type);
+
+        return TableRegistry::getTableLocator()
+            ->get(Inflector::camelize($type), $options);
+    }
+}
+

--- a/plugins/BEdita/Core/src/Utility/ResourcesBase.php
+++ b/plugins/BEdita/Core/src/Utility/ResourcesBase.php
@@ -46,11 +46,9 @@ abstract class ResourcesBase
                 __d('bedita', 'Resource type not allowed "{0}"', $type)
             );
         }
-
+        $type = Inflector::camelize($type);
         TableRegistry::getTableLocator()->remove($type);
 
-        return TableRegistry::getTableLocator()
-            ->get(Inflector::camelize($type), $options);
+        return TableRegistry::getTableLocator()->get($type, $options);
     }
 }
-

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesBaseTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesBaseTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Utility;
+
+use BEdita\Core\Utility\Resources;
+use Cake\Http\Exception\BadRequestException;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\Core\Utility\ResourcesBase} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Utility\ResourcesBase
+ */
+class ResourcesBaseTest extends TestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.RelationTypes',
+    ];
+
+    /**
+     * Test `getTable` method.
+     *
+     * @covers ::getTable()
+     */
+    public function testGetTable(): void
+    {
+        $result = Resources::create('object_types', [
+            [
+                'name' => 'cats',
+                'singular' => 'cat',
+            ],
+        ]);
+
+        static::assertNotEmpty($result);
+        static::assertEquals(1, count($result));
+    }
+
+    /**
+     * Test `getTable` method failure.
+     *
+     * @covers ::getTable()
+     */
+    public function testGetTableFail(): void
+    {
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Resource type not allowed "cats"');
+
+        Resources::create('cats', []);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
@@ -206,7 +206,6 @@ class ResourcesTest extends TestCase
      * @return void
      *
      * @covers ::create()
-     * @covers ::getTable()
      * @dataProvider createProvider
      */
     public function testCreate(string $type, array $data): void
@@ -477,19 +476,6 @@ class ResourcesTest extends TestCase
                 static::assertEquals($val, $entity->get($name));
             }
         }
-    }
-
-    /**
-     * Test `getTable` method failure.
-     *
-     * @covers ::getTable()
-     */
-    public function testGetTableFail()
-    {
-        $this->expectException(BadRequestException::class);
-        $this->expectExceptionMessage('Resource type not allowed "cats"');
-
-        Resources::create('cats', []);
     }
 
     /**


### PR DESCRIPTION
This PR adds a `ResourceBase` class to `Resources`, `Properties` and `Relations` utilities classes used mainly in `Resources::save` on resources migrations and solve some issues on TableRegistry usage.