### PR TITLE
Reload ObjectType entity to load related type's relations

### DIFF
--- a/plugins/BEdita/Core/src/ORM/Association/RelatedTo.php
+++ b/plugins/BEdita/Core/src/ORM/Association/RelatedTo.php
@@ -90,7 +90,10 @@ class RelatedTo extends BelongsToMany
 
         $objectType = $target->objectType();
         if ($objectType === null || $objectType->id !== $targetOT->id) {
-            $target->setupRelations($targetOT);
+            $target->setupRelations(
+                $this->getTableLocator()->get('ObjectTypes')
+                    ->get($targetOT->id)
+            );
         }
 
         return $target;

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Association/RelatedToTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Association/RelatedToTest.php
@@ -309,7 +309,15 @@ class RelatedToTest extends TestCase
     {
         $options = compact('className');
         if ($objectType !== null) {
-            $options['objectType'] = $this->getTableLocator()->get('ObjectTypes')->get($objectType);
+            $options['objectType'] = $this->getTableLocator()->get('ObjectTypes')
+                ->find()
+                ->clearContain()
+                ->where(['name' => $objectType])
+                ->firstOrFail();
+
+            // Ensure that relations aren't present in the ObjectType entity, to test that they will be loaded by RelatedTo::getTarget().
+            static::assertEmpty($options['objectType']['left_relations']);
+            static::assertEmpty($options['objectType']['right_relations']);
         }
         $relatedTo = new RelatedTo($alias, $options);
 


### PR DESCRIPTION
This PR fixes #1775.

The `ObjectType` entity is re-loaded when building target table in `RelatedTo::getTarget()` to make sure it has relations populated.
