### PR TITLE
Ensure custom properties results formatter is prepended

### DIFF
--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -110,7 +110,7 @@ class CustomPropertiesBehavior extends Behavior
      *
      * @param \Cake\Event\Event $event Fired event.
      * @param \Cake\ORM\Query $query Query object instance.
-     * @return void
+     * @return \Cake\ORM\Query
      */
     public function beforeFind(Event $event, Query $query): Query
     {

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -112,13 +112,16 @@ class CustomPropertiesBehavior extends Behavior
      * @param \Cake\ORM\Query $query Query object instance.
      * @return void
      */
-    public function beforeFind(Event $event, Query $query)
+    public function beforeFind(Event $event, Query $query): Query
     {
-        $query->formatResults(function (CollectionInterface $results) {
-            return $results->map(function ($row) {
-                return $this->promoteProperties($row);
-            });
-        });
+        return $query->formatResults(
+            function (CollectionInterface $results) {
+                return $results->map(function ($row) {
+                    return $this->promoteProperties($row);
+                });
+            },
+            Query::PREPEND
+        );
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Test\TestCase\Model\Behavior;
 
 use BEdita\Core\Filesystem\FilesystemRegistry;
+use Cake\Collection\CollectionInterface;
 use Cake\Core\Configure;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -282,6 +283,35 @@ class CustomPropertiesBehaviorTest extends TestCase
         foreach ($expectedProperties as $property) {
             static::assertArrayHasKey($property, $result);
         }
+    }
+
+    /**
+     * Test that formatter is prepended to other formatters that may be attached to the Query object.
+     *
+     * @return void
+     *
+     * @covers ::beforeFind()
+     */
+    public function testBeforeFindFormatterPrepended()
+    {
+        $expected = [
+            'files_property' => ['media-one' => null, 'media-two' => null],
+            'media_property' => ['media-one' => 'synapse', 'media-two' => null],
+            'count' => 2,
+        ];
+
+        $result = $this->getTableLocator()->get('Files')->find()
+            ->formatResults(function (CollectionInterface $results): array {
+                return [
+                    'files_property' => $results->combine('uname', 'files_property')->toArray(),
+                    'media_property' => $results->combine('uname', 'media_property')->toArray(),
+                    'count' => $results->count(),
+                ];
+            })
+            ->order('Files.id')
+            ->toArray();
+
+        static::assertSame($expected, $result);
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue that caused a fatal error in case other result formatters were set on the Query object.

This caused the `CustomPropertiesBehavior` to append its own result formatter at the end of the queue, but if the custom formatter doesn't return a CollectionInterface a fatal error is raised due to the anonymous function signature.

Since custom properties are supposed to be handled transparently, it makes sense to always prepend the result formatter rather than appending it.