### PR TITLE
Filter `publish_start` and `publish_end`

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/PublishStartEndTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/PublishStartEndTest.php
@@ -19,7 +19,7 @@ use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 
 /**
- * Test `PublishDate.check` configuration and `publish_start` + `publish_date`
+ * Test `Publish.checkDate` configuration and `publish_start` + `publish_date`
  */
 class PublisStartEndTest extends IntegrationTestCase
 {
@@ -45,10 +45,10 @@ class PublisStartEndTest extends IntegrationTestCase
     }
 
     /**
-     * Test `PublishDate.check` config on objects list
+     * Test `Publish.checkDate` config on objects list
      *
      * @param array $expected Object ids in response
-     * @param bool $config The `PublishDate.check` config
+     * @param bool $config The `Publish.checkDate` config
      * @param string $url The test URL
      * @return void
      *
@@ -57,7 +57,7 @@ class PublisStartEndTest extends IntegrationTestCase
      */
     public function testListObjects($expected, $config, $url): void
     {
-        Configure::write('PublishDate.check', $config);
+        Configure::write('Publish.checkDate', $config);
 
         $this->configRequestHeaders();
         $this->get($url);
@@ -110,10 +110,10 @@ class PublisStartEndTest extends IntegrationTestCase
     }
 
     /**
-     * Test `PublishDate.check` config on single objects
+     * Test `Publish.checkDate` config on single objects
      *
      * @param int $expected The HTTP status code expected
-     * @param bool $config The `PublishDate.check` config
+     * @param bool $config The `Publish.checkDate` config
      * @param array $data The fields data
      * @return void
      *
@@ -122,7 +122,7 @@ class PublisStartEndTest extends IntegrationTestCase
      */
     public function testSingleObject($expected, $config, array $data): void
     {
-        Configure::write('PublishDate.check', $config);
+        Configure::write('Publish.checkDate', $config);
 
         $table = TableRegistry::getTableLocator()->get('Documents');
         $document = $table->get(3);

--- a/plugins/BEdita/API/tests/IntegrationTest/PublishStartEndTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/PublishStartEndTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Test\IntegrationTest;
+
+use BEdita\API\TestSuite\IntegrationTestCase;
+use Cake\Core\Configure;
+use Cake\I18n\Time;
+use Cake\ORM\TableRegistry;
+use Cake\Utility\Hash;
+
+/**
+ * Test `PublishDate.check` configuration and `publish_start` + `publish_date`
+ */
+class PublisStartEndTest extends IntegrationTestCase
+{
+    /**
+     * Provider for testListObjects()
+     *
+     * @return array
+     */
+    public function listProvider(): array
+    {
+        return [
+            'publishable docs' => [
+                ['3'],
+                true,
+                '/documents',
+            ],
+            'all docs' => [
+                ['2', '3'],
+                false,
+                '/documents',
+            ],
+        ];
+    }
+
+    /**
+     * Test `PublishDate.check` config on objects list
+     *
+     * @param array $expected Object ids in response
+     * @param bool $config The `PublishDate.check` config
+     * @param string $url The test URL
+     * @return void
+     *
+     * @dataProvider listProvider
+     * @coversNothing
+     */
+    public function testListObjects($expected, $config, $url): void
+    {
+        Configure::write('PublishDate.check', $config);
+
+        $this->configRequestHeaders();
+        $this->get($url);
+        $this->assertResponseCode(200);
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $ids = Hash::extract($result, 'data.{n}.id');
+        sort($ids);
+        static::assertEquals($expected, $ids);
+    }
+
+    /**
+     * Provider for testSingleObject()
+     *
+     * @return array
+     */
+    public function singleProvider(): array
+    {
+        return [
+            'not started' => [
+                404,
+                true,
+                [
+                    'publish_start' => Time::parse(time() + DAY),
+                ]
+            ],
+            'no conf' => [
+                200,
+                false,
+                [
+                    'publish_start' => Time::parse(time() + DAY),
+                ]
+            ],
+            'ended' => [
+                404,
+                true,
+                [
+                    'publish_end' => Time::parse(time() - DAY),
+                ]
+            ],
+            'started' => [
+                200,
+                true,
+                [
+                    'publish_start' => Time::parse(time() - DAY),
+                    'publish_end' => Time::parse(time() + DAY),
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * Test `PublishDate.check` config on single objects
+     *
+     * @param int $expected The HTTP status code expected
+     * @param bool $config The `PublishDate.check` config
+     * @param array $data The fields data
+     * @return void
+     *
+     * @dataProvider singleProvider
+     * @coversNothing
+     */
+    public function testSingleObject($expected, $config, array $data): void
+    {
+        Configure::write('PublishDate.check', $config);
+
+        $table = TableRegistry::getTableLocator()->get('Documents');
+        $document = $table->get(3);
+        $document->set($data);
+        $table->saveOrFail($document);
+
+        $this->configRequestHeaders();
+        $this->get('/documents/3');
+        $this->assertResponseCode($expected);
+    }
+}

--- a/plugins/BEdita/API/tests/IntegrationTest/PublishStartEndTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/PublishStartEndTest.php
@@ -19,7 +19,8 @@ use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 
 /**
- * Test `Publish.checkDate` configuration and `publish_start` + `publish_date`
+ * Integration test for `Publish.checkDate` configuration
+ * using `publish_start` and `publish_date` values.
  */
 class PublisStartEndTest extends IntegrationTestCase
 {

--- a/plugins/BEdita/Core/src/Model/Action/GetObjectAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/GetObjectAction.php
@@ -66,7 +66,7 @@ class GetObjectAction extends BaseAction
         $contain = array_merge(['ObjectTypes'], (array)Hash::get($data, 'contain'));
 
         // Build query and add finders.
-        $query = $this->Table->find()
+        $query = $this->Table->find('publishable')
             ->contain($contain)
             ->where($conditions);
         if (isset($this->objectType)) {
@@ -75,9 +75,6 @@ class GetObjectAction extends BaseAction
                 $query = $query->contain($assoc);
             }
             $query = $query->find('type', (array)$this->objectType->id);
-        }
-        if (Configure::check('Status.level')) {
-            $query = $query->find('statusLevel', [Configure::read('Status.level')]);
         }
         if (!empty($data['lang'])) {
             $query = $query->find('translations', ['lang' => $data['lang']]);

--- a/plugins/BEdita/Core/src/Model/Action/ListObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListObjectsAction.php
@@ -80,14 +80,11 @@ class ListObjectsAction extends BaseAction
         if (isset($type)) {
             $query = $query->find('type', (array)$type);
         }
-        if (Configure::check('Status.level')) {
-            $query = $query->find('statusLevel', [Configure::read('Status.level')]);
-        }
 
         if (!empty($data['lang'])) {
             $query = $query->find('translations', ['lang' => $data['lang']]);
         }
 
-        return $query;
+        return $query->find('publishable');
     }
 }

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
@@ -79,11 +79,8 @@ class ListRelatedObjectsAction extends ListAssociatedAction
                 $this->Association->getTarget()->aliasField('object_type_id'),
             ]);
         }
-        if (Configure::check('Status.level')) {
-            $query = $query->find('statusLevel', [Configure::read('Status.level')]);
-        }
 
-        return $query;
+        return $query->find('publishable');
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -502,7 +502,7 @@ class ObjectsTable extends Table
     /**
      * Finder for publishable objects based on these rules:
      *  - `status` should be acceptable checking 'Status.level' configuration
-     *  - `publish_start` and `publish_end` should be acceptable
+     *  - `publish_start` and `publish_end` should be acceptable, checking 'PublishDate.check' configuration
      *
      * @param \Cake\ORM\Query $query Query object instance.
      * @return \Cake\ORM\Query

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -502,7 +502,7 @@ class ObjectsTable extends Table
     /**
      * Finder for publishable objects based on these rules:
      *  - `status` should be acceptable checking 'Status.level' configuration
-     *  - `publish_start` and `publish_end` should be acceptable, checking 'PublishDate.check' configuration
+     *  - `publish_start` and `publish_end` should be acceptable, checking 'Publish.checkDate' configuration
      *
      * @param \Cake\ORM\Query $query Query object instance.
      * @return \Cake\ORM\Query
@@ -512,7 +512,7 @@ class ObjectsTable extends Table
         if (Configure::check('Status.level')) {
             $query = $query->find('statusLevel', [Configure::read('Status.level')]);
         }
-        if ((bool)Configure::read('PublishDate.check', false)) {
+        if ((bool)Configure::read('Publish.checkDate', false)) {
             $query = $query->find('publishDateAllowed');
         }
 

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -525,7 +525,7 @@ class ObjectsTable extends Table
      * @param \Cake\ORM\Query $query Query object instance.
      * @return \Cake\ORM\Query
      */
-    protected function findPublishDateAllowed(Query $query)
+    protected function findPublishDateAllowed(Query $query): Query
     {
         $now = $query->func()->now();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -800,7 +800,7 @@ class ObjectsTableTest extends TestCase
      * Test `findPublishable()`.
      *
      * @param int $expected Expected results.
-     * @param string $statusLevel Configuration to write.
+     * @param string $config Configuration to write.
      * @return void
      *
      * @dataProvider findPublishableProvider()
@@ -823,7 +823,7 @@ class ObjectsTableTest extends TestCase
      *
      * @covers ::findPublishDateAllowed()
      */
-    public function testFindPublishDateAllowed()
+    public function testFindPublishDateAllowed(): void
     {
         $result = $this->Objects->find('publishDateAllowed')->toArray();
         static::assertSame(12, count($result));
@@ -836,7 +836,7 @@ class ObjectsTableTest extends TestCase
      *
      * @covers ::findPublishDateAllowed()
      */
-    public function testFindPublishDateAllowedSingle()
+    public function testFindPublishDateAllowedSingle(): void
     {
         $result = $this->Objects->find('publishDateAllowed')->where(['id' => 2])->first();
         static::assertNull($result);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -8,6 +8,7 @@ use BEdita\Core\Utility\LoggedUser;
 use Cake\Core\Configure;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Http\Exception\BadRequestException;
+use Cake\I18n\Time;
 use Cake\ORM\Exception\PersistenceFailedException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -735,7 +736,7 @@ class ObjectsTableTest extends TestCase
      *
      * @return array
      */
-    public function findAvailableProvider()
+    public function findAvailableProvider(): array
     {
         return [
             'no status' => [
@@ -753,20 +754,66 @@ class ObjectsTableTest extends TestCase
     /**
      * Test `findAvailable()`.
      *
+     * @param int $expected Expected results.
+     * @param array $condition Search condition.
+     * @param string $statusLevel Configuration to write.
      * @return void
      *
      * @dataProvider findAvailableProvider()
      * @covers ::findAvailable()
      */
-    public function testFindAvailable(int $expected, array $condition, string $statusLevel = null)
+    public function testFindAvailable(int $expected, array $condition, string $statusLevel = null): void
     {
-        $result = $this->Objects->find('available')
-            ->where($condition)
-            ->toArray();
         if (!empty($statusLevel)) {
             Configure::write('Status.level', $statusLevel);
         }
-        static::assertSame($expected, count($result));
+
+        $count = $this->Objects->find('available')->where($condition)->count();
+        static::assertSame($expected, $count);
+    }
+
+    /**
+     * Data provider for `testFindPublishable`.
+     *
+     * @return array
+     */
+    public function findPublishableProvider(): array
+    {
+        return [
+            'on + publish' => [
+                10,
+                [
+                    'Status.level' => 'on',
+                    'PublishDate.check' => true,
+                ],
+            ],
+            'draft' => [
+                15,
+                [
+                    'Status.level' => 'draft',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `findPublishable()`.
+     *
+     * @param int $expected Expected results.
+     * @param string $statusLevel Configuration to write.
+     * @return void
+     *
+     * @dataProvider findPublishableProvider()
+     * @covers ::findPublishable()
+     */
+    public function testFindPublishable(int $expected, array $config = null): void
+    {
+        if (!empty($config)) {
+            Configure::write($config);
+        }
+
+        $result = $this->Objects->find('publishable')->count();
+        static::assertSame($expected, $result);
     }
 
     /**
@@ -780,6 +827,26 @@ class ObjectsTableTest extends TestCase
     {
         $result = $this->Objects->find('publishDateAllowed')->toArray();
         static::assertSame(12, count($result));
+    }
+
+    /**
+     * Test `findPublishDateAllowed()` on a single object changing `publish_end`.
+     *
+     * @return void
+     *
+     * @covers ::findPublishDateAllowed()
+     */
+    public function testFindPublishDateAllowedSingle()
+    {
+        $result = $this->Objects->find('publishDateAllowed')->where(['id' => 2])->first();
+        static::assertNull($result);
+
+        $object = $this->Objects->get(2);
+        $object->publish_end = Time::parse(time() + DAY);
+        $this->Objects->saveOrFail($object);
+
+        $result = $this->Objects->find('publishDateAllowed')->where(['id' => 2])->first();
+        static::assertNotNull($result);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -784,7 +784,7 @@ class ObjectsTableTest extends TestCase
                 10,
                 [
                     'Status.level' => 'on',
-                    'PublishDate.check' => true,
+                    'Publish.checkDate' => true,
                 ],
             ],
             'draft' => [

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -770,6 +770,19 @@ class ObjectsTableTest extends TestCase
     }
 
     /**
+     * Test `findPublishDateAllowed()`.
+     *
+     * @return void
+     *
+     * @covers ::findPublishDateAllowed()
+     */
+    public function testFindPublishDateAllowed()
+    {
+        $result = $this->Objects->find('publishDateAllowed')->toArray();
+        static::assertSame(12, count($result));
+    }
+
+    /**
      * Test `findCategories` method.
      *
      * @return void


### PR DESCRIPTION
This PR introduces new finders in `ObjectsTable` (and filters consequently) to deal with `publish_start` and `publish_end` fields properly.

* `findPublishDateAllowed` adds conditions to see if an object is allowed to be published checking `publish_start` and `publish_end` fields
*  `findPublishable`: check for publishable objects based on these rules:
    - `status` should be acceptable checking `'Status.level'` configuration
    - `publish_start` and `publish_end` should be acceptable, checking new `'Publish.checkDate'` configuration

Corresponding filters `filter[publish_date_allowed]` and `filter[publishable]` may also be directly used (if necessary).

`'Publish.checkDate'` can be set as an application specific configuration like `Status.level` usually via database configuration.

Consequently:

* `findAvailable` finder has been updated to include the new conditions via `publishable` finder - it only adds condition on `deleted` 
* `GetObjectAction`, `ListObjectsAction` and `ListRelatedObjectsAction` have been modified to use the new `publishable` finder
 
