### PR TITLE
Project model endpoint & command

### DIFF
--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -176,6 +176,11 @@ Router::plugin(
                     ['controller' => 'Schema', 'action' => 'jsonSchema'],
                     ['_name' => 'schema', 'pass' => ['type']]
                 );
+                $routes->get(
+                    '/project',
+                    ['controller' => 'Project', 'action' => 'index'],
+                    'project'
+                );
             }
         );
 

--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -177,10 +177,10 @@ Router::plugin(
                     ['controller' => 'Schema', 'action' => 'jsonSchema'],
                     ['_name' => 'schema', 'pass' => ['type']]
                 );
-                $routes->get(
+                $routes->connect(
                     '/project',
                     ['controller' => 'Project', 'action' => 'index'],
-                    'project'
+                    ['_name' => 'project']
                 );
             }
         );

--- a/plugins/BEdita/API/src/Controller/Model/ProjectController.php
+++ b/plugins/BEdita/API/src/Controller/Model/ProjectController.php
@@ -16,6 +16,7 @@ namespace BEdita\API\Controller\Model;
 use BEdita\API\Controller\AppController;
 use BEdita\Core\Utility\ProjectModel;
 use Cake\Event\Event;
+use Cake\Http\Response;
 
 /**
  * Controller for `/model/project` endpoint.
@@ -35,7 +36,7 @@ class ProjectController extends AppController
     /**
      * {@inheritDoc}
      */
-    public function initialize()
+    public function initialize(): void
     {
         parent::initialize();
         if ($this->components()->has('JsonApi')) {
@@ -61,7 +62,7 @@ class ProjectController extends AppController
      *
      * @return \Cake\Http\Response
      */
-    public function index()
+    public function index(): Response
     {
         $this->request->allowMethod(['get']);
 

--- a/plugins/BEdita/API/src/Controller/Model/ProjectController.php
+++ b/plugins/BEdita/API/src/Controller/Model/ProjectController.php
@@ -16,7 +16,7 @@ namespace BEdita\API\Controller\Model;
 use BEdita\API\Controller\AppController;
 use BEdita\Core\Utility\ProjectModel;
 use Cake\Event\Event;
-use Cake\Http\Response;
+use Cake\Http\Exception\NotAcceptableException;
 
 /**
  * Controller for `/model/project` endpoint.
@@ -27,13 +27,6 @@ use Cake\Http\Response;
 class ProjectController extends AppController
 {
     /**
-     * JSON content type.
-     *
-     * @var string
-     */
-    const CONTENT_TYPE = 'application/json';
-
-    /**
      * {@inheritDoc}
      */
     public function initialize(): void
@@ -42,27 +35,27 @@ class ProjectController extends AppController
         if ($this->components()->has('JsonApi')) {
             $this->components()->unload('JsonApi');
         }
-        $this->viewBuilder()->setClassName('Json');
+        $this->RequestHandler->setConfig('viewClassMap.json', 'Json');
     }
 
     /**
      * {@inheritDoc}
-     *
-     * Intentionally left blank to override parent method.
-     * Avoid content-type negotiation checks based on `Accept` header.
-     *
-     * @codeCoverageIgnore
      */
-    public function beforeFilter(Event $event)
+    public function beforeFilter(Event $event): void
     {
+        if (!$this->request->is(['json'])) {
+            throw new NotAcceptableException(
+                __d('bedita', 'Bad request content type "{0}"', $this->request->getHeaderLine('Accept'))
+            );
+        }
     }
 
     /**
      * Get project schema.
      *
-     * @return \Cake\Http\Response
+     * @return void
      */
-    public function index(): Response
+    public function index(): void
     {
         $this->request->allowMethod(['get']);
 
@@ -70,8 +63,5 @@ class ProjectController extends AppController
 
         $this->set($model);
         $this->set('_serialize', true);
-
-        return $this->render()
-            ->withType(static::CONTENT_TYPE);
     }
 }

--- a/plugins/BEdita/API/src/Controller/Model/ProjectController.php
+++ b/plugins/BEdita/API/src/Controller/Model/ProjectController.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\API\Controller\Model;
+
+use BEdita\API\Controller\AppController;
+use BEdita\Core\Utility\ProjectModel;
+use Cake\Event\Event;
+
+/**
+ * Controller for `/model/project` endpoint.
+ *
+ * @since 4.4.0
+ *
+ */
+class ProjectController extends AppController
+{
+    /**
+     * JSON content type.
+     *
+     * @var string
+     */
+    const CONTENT_TYPE = 'application/json';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function initialize()
+    {
+        parent::initialize();
+        if ($this->components()->has('JsonApi')) {
+            $this->components()->unload('JsonApi');
+        }
+        $this->viewBuilder()->setClassName('Json');
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Intentionally left blank to override parent method.
+     * Avoid content-type negotiation checks based on `Accept` header.
+     *
+     * @codeCoverageIgnore
+     */
+    public function beforeFilter(Event $event)
+    {
+    }
+
+    /**
+     * Get project schema.
+     *
+     * @return \Cake\Http\Response
+     */
+    public function index()
+    {
+        $this->request->allowMethod(['get']);
+
+        $model = ProjectModel::generate();
+
+        $this->set($model);
+        $this->set('_serialize', true);
+
+        return $this->render()
+            ->withType(static::CONTENT_TYPE);
+    }
+}

--- a/plugins/BEdita/API/src/Controller/Model/ProjectController.php
+++ b/plugins/BEdita/API/src/Controller/Model/ProjectController.php
@@ -20,7 +20,7 @@ use Cake\Event\Event;
 /**
  * Controller for `/model/project` endpoint.
  *
- * @since 4.4.0
+ * @since 4.5.0
  *
  */
 class ProjectController extends AppController

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
@@ -277,12 +277,30 @@ class ProjectControllerTest extends IntegrationTestCase
             ],
         ];
 
-        $this->configRequestHeaders();
+        $this->configRequestHeaders('GET', ['Accept' => 'application/json']);
         $this->get('/model/project');
         $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->assertResponseCode(200);
         $this->assertContentType('application/json');
         static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test `beforeFilter()` method.
+     *
+     * @return void
+     *
+     * @covers ::beforeFilter()
+     */
+    public function testBeforeFilter(): void
+    {
+        $this->configRequestHeaders();
+        $this->get('/model/project');
+        $this->assertResponseCode(406);
+
+        $this->configRequestHeaders('GET', ['Accept' => 'application/json']);
+        $this->get('/model/project');
+        $this->assertResponseCode(200);
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
@@ -1,0 +1,286 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\API\Test\TestCase\Controller\Model;
+
+use BEdita\API\TestSuite\IntegrationTestCase;
+
+/**
+ * {@see \BEdita\API\Controller\Model\ProjectController} Test Case
+ *
+ * @coversDefaultClass \BEdita\API\Controller\Model\ProjectController
+ */
+class ProjectControllerTest extends IntegrationTestCase
+{
+    /**
+     * Test `index()` method.
+     *
+     * @covers ::index()
+     * @covers ::initialize()
+     */
+    public function testIndex()
+    {
+        $expected = [
+            'property_types' => [
+                [
+                    'name' => 'unused property type',
+                    'params' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'gustavo' => [
+                                'const' => 'supporto',
+                            ],
+                        ],
+                        'required' => ['gustavo'],
+                    ],
+                ],
+            ],
+            'object_types' => [
+                [
+                    'name' => 'objects',
+                    'is_abstract' => true,
+                    'singular' => 'object',
+                    'description' => null,
+                    'associations' => null,
+                    'hidden' => null,
+                    'enabled' => true,
+                    'table' => 'BEdita/Core.Objects',
+                    'parent_name' => null,
+                ],
+                [
+                    'name' => 'documents',
+                    'is_abstract' => false,
+                    'singular' => 'document',
+                    'description' => null,
+                    'associations' => ['Categories'],
+                    'hidden' => null,
+                    'enabled' => true,
+                    'table' => 'BEdita/Core.Objects',
+                    'parent_name' => 'objects',
+                ],
+                [
+                    'name' => 'profiles',
+                    'is_abstract' => false,
+                    'singular' => 'profile',
+                    'description' => null,
+                    'associations' => ['Tags'],
+                    'hidden' => null,
+                    'enabled' => true,
+                    'table' => 'BEdita/Core.Profiles',
+                    'parent_name' => 'objects',
+                ],
+                [
+                    'name' => 'users',
+                    'is_abstract' => false,
+                    'singular' => 'user',
+                    'description' => null,
+                    'associations' => null,
+                    'hidden' => null,
+                    'enabled' => true,
+                    'table' => 'BEdita/Core.Users',
+                    'parent_name' => 'objects',
+                ],
+                [
+                    'name' => 'news',
+                    'is_abstract' => false,
+                    'singular' => 'news_item',
+                    'description' => null,
+                    'associations' => null,
+                    'hidden' => ['body'],
+                    'enabled' => false,
+                    'table' => 'BEdita/Core.Objects',
+                    'parent_name' => 'objects',
+                ],
+                [
+                    'name' => 'locations',
+                    'is_abstract' => false,
+                    'singular' => 'location',
+                    'description' => null,
+                    'associations' => null,
+                    'hidden' => null,
+                    'enabled' => true,
+                    'table' => 'BEdita/Core.Locations',
+                    'parent_name' => 'objects',
+                ],
+                [
+                    'name' => 'events',
+                    'is_abstract' => false,
+                    'singular' => 'event',
+                    'description' => null,
+                    'associations' => ['DateRanges'],
+                    'hidden' => null,
+                    'enabled' => true,
+                    'table' => 'BEdita/Core.Objects',
+                    'parent_name' => 'objects',
+                ],
+                [
+                    'name' => 'media',
+                    'is_abstract' => true,
+                    'singular' => 'media_item',
+                    'description' => null,
+                    'associations' => ['Streams'],
+                    'hidden' => null,
+                    'enabled' => true,
+                    'table' => 'BEdita/Core.Media',
+                    'parent_name' => 'objects',
+                ],
+                [
+                    'name' => 'files',
+                    'is_abstract' => false,
+                    'singular' => 'file',
+                    'description' => null,
+                    'associations' => ['Streams'],
+                    'hidden' => null,
+                    'enabled' => true,
+                    'table' => 'BEdita/Core.Media',
+                    'parent_name' => 'media',
+                ],
+                [
+                    'name' => 'folders',
+                    'is_abstract' => false,
+                    'singular' => 'folder',
+                    'description' => null,
+                    'associations' => null,
+                    'hidden' => null,
+                    'enabled' => true,
+                    'table' => 'BEdita/Core.Objects',
+                    'parent_name' => 'objects',
+                ],
+            ],
+            'relations' => [
+                [
+                    'name' => 'test',
+                    'label' => 'Test relation',
+                    'inverse_name' => 'inverse_test',
+                    'inverse_label' => 'Inverse test relation',
+                    'description' => 'Sample description.',
+                    'params' => null,
+                    'right_object_types' => ['documents', 'profiles'],
+                    'left_object_types' => ['documents'],
+                ],
+                [
+                    'name' => 'another_test',
+                    'label' => 'Another test relation',
+                    'inverse_name' => 'inverse_another_test',
+                    'inverse_label' => 'Another inverse test relation',
+                    'description' => 'Sample description /2.',
+                    'params' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'name' => [
+                                'type' => 'string',
+                            ],
+                            'age' => [
+                                'type' => 'integer',
+                                'minimum' => 0,
+                            ],
+                        ],
+                        'required' => ['name'],
+                    ],
+                    'right_object_types' => ['locations'],
+                    'left_object_types' => ['users'],
+                ],
+                [
+                    'name' => 'test_abstract',
+                    'label' => 'Test relation involving abstract types',
+                    'inverse_name' => 'inverse_test_abstract',
+                    'inverse_label' => 'Inverse test relation involving abstract types',
+                    'description' => 'Sample description.',
+                    'params' => null,
+                    'right_object_types' => ['media'],
+                    'left_object_types' => ['events'],
+                ],
+            ],
+            'properties' => [
+                [
+                    'name' => 'another_title',
+                    'description' => null,
+                    'is_nullable' => true,
+                    'property_type_name' => 'string',
+                    'object_type_name' => 'documents',
+                ],
+                [
+                    'name' => 'another_description',
+                    'description' => null,
+                    'is_nullable' => true,
+                    'property_type_name' => 'string',
+                    'object_type_name' => 'documents',
+                ],
+                [
+                    'name' => 'another_username',
+                    'description' => 'Username, unique string',
+                    'is_nullable' => true,
+                    'property_type_name' => 'string',
+                    'object_type_name' => 'users',
+                ],
+                [
+                    'name' => 'another_email',
+                    'description' => 'User email',
+                    'is_nullable' => true,
+                    'property_type_name' => 'string',
+                    'object_type_name' => 'users',
+                ],
+                [
+                    'name' => 'another_birthdate',
+                    'description' => null,
+                    'is_nullable' => true,
+                    'property_type_name' => 'date',
+                    'object_type_name' => 'profiles',
+                ],
+                [
+                    'name' => 'another_surname',
+                    'description' => null,
+                    'is_nullable' => true,
+                    'property_type_name' => 'string',
+                    'object_type_name' => 'profiles',
+                ],
+                [
+                    'name' => 'disabled_property',
+                    'description' => 'Disabled property example',
+                    'is_nullable' => true,
+                    'property_type_name' => 'string',
+                    'object_type_name' => 'files',
+                ],
+                [
+                    'name' => 'media_property',
+                    'description' => null,
+                    'is_nullable' => true,
+                    'property_type_name' => 'string',
+                    'object_type_name' => 'media',
+                ],
+                [
+                    'name' => 'files_property',
+                    'description' => null,
+                    'is_nullable' => true,
+                    'property_type_name' => 'string',
+                    'object_type_name' => 'files',
+                ],
+                [
+                    'name' => 'street_address',
+                    'description' => null,
+                    'is_nullable' => true,
+                    'property_type_name' => 'string',
+                    'object_type_name' => 'profiles',
+                ],
+            ],
+        ];
+
+        $this->configRequestHeaders();
+        $this->get('/model/project');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/json');
+        static::assertEquals($expected, $result);
+    }
+}

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
@@ -25,10 +25,12 @@ class ProjectControllerTest extends IntegrationTestCase
     /**
      * Test `index()` method.
      *
+     * @return void
+     *
      * @covers ::index()
      * @covers ::initialize()
      */
-    public function testIndex()
+    public function testIndex(): void
     {
         $expected = [
             'property_types' => [

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
@@ -33,6 +33,28 @@ class ProjectControllerTest extends IntegrationTestCase
     public function testIndex(): void
     {
         $expected = [
+            'applications' => [
+                [
+                    'name' => 'First app',
+                    'description' => 'Lorem ipsum dolor sit amet, aliquet feugiat.',
+                    'enabled' => true,
+                ],
+                [
+                    'name' => 'Disabled app',
+                    'description' => 'This app has been disabled',
+                    'enabled' => false,
+                ],
+            ],
+            'roles' => [
+                [
+                    'name' => 'first role',
+                    'description' => 'this is the very first role',
+                ],
+                [
+                    'name' => 'second role',
+                    'description' => 'this is a second role',
+                ],
+            ],
             'property_types' => [
                 [
                     'name' => 'unused property type',

--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Core\Command;
+
+use BEdita\Core\Utility\ProjectModel;
+use BEdita\Core\Utility\Resources;
+use Cake\Cache\Cache;
+use Cake\Console\Arguments;
+use Cake\Console\Command;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+
+/**
+ * Command to apply project model from input file.
+ *
+ * @since 4.5.0
+ */
+class ProjectModelCommand extends Command
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        return $parser->addArgument('file', [
+            'help' => 'Path of JSON file containing project model to apply',
+            'required' => true,
+        ]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function execute(Arguments $args, ConsoleIo $io): ?int
+    {
+        $file = $args->getArgument('file');
+        if (!file_exists($file)) {
+            $io->error(sprintf('File not found %s', $file));
+
+            return self::CODE_ERROR;
+        }
+
+        $project = json_decode(file_get_contents($file), true);
+        if (empty($project)) {
+            $io->error(sprintf('Bad file content in %s', $file));
+
+            return self::CODE_ERROR;
+        }
+
+        $diff = ProjectModel::diff($project);
+        if (!empty($diff['remove'])) {
+            $io->warning('Items to remove: ' . json_encode($diff['remove']));
+            unset($diff['remove']);
+        }
+        if (empty($diff)) {
+            $io->success('Project model in sync, exiting.');
+
+            return self::CODE_SUCCESS;
+        }
+
+        Resources::save($diff);
+        $caches = Cache::configured();
+        foreach ($caches as $cache) {
+            Cache::clear(false, $cache);
+        }
+        $io->success('Cache cleared');
+
+        return null;
+    }
+}

--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -47,6 +47,12 @@ class ProjectModelCommand extends Command
                 'short' => 'f',
                 'required' => false,
             ])
+            ->addOption('cache-clear', [
+                'help' => 'Perform cache clear after resources change',
+                'short' => 'c',
+                'boolean' => true,
+                'required' => false,
+            ])
             ->addOption('plugin', [
                 'help' => 'Plugin to use for loading default `project_model.json` file',
                 'short' => 'p',
@@ -87,10 +93,10 @@ class ProjectModelCommand extends Command
         Resources::save($diff);
         $io->success('Project model updated');
 
-        foreach (Cache::configured() as $cache) {
-            Cache::clear(false, $cache);
+        if ($args->getOption('cache-clear')) {
+            Cache::clearAll();
+            $io->success('Cache cleared');
         }
-        $io->success('Cache cleared');
 
         return null;
     }

--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -85,6 +85,7 @@ class ProjectModelCommand extends Command
         }
 
         Resources::save($diff);
+        $io->success('Project model updated');
 
         foreach (Cache::configured() as $cache) {
             Cache::clear(false, $cache);

--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -65,7 +65,7 @@ class ProjectModelCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
-        $file = $this->modelFilePath($args, $io);
+        $file = $this->modelFilePath($args);
         if (!file_exists($file)) {
             $io->error(sprintf('File not found %s', $file));
 
@@ -108,16 +108,15 @@ class ProjectModelCommand extends Command
      *  - if no option is passed default path is used
      *
      * @param \Cake\Console\Arguments $args Console arguments
-     * @param \Cake\Console\ConsoleIo $io Console IO
      * @return string
      */
-    protected function modelFilePath(Arguments $args, ConsoleIo $io): string
+    protected function modelFilePath(Arguments $args): string
     {
-        $file = $args->getOption('file');
+        $file = (string)$args->getOption('file');
         if (!empty($file)) {
             return $file;
         }
-        $plugin = $args->getOption('plugin');
+        $plugin = (string)$args->getOption('plugin');
         if (!empty($plugin)) {
             return $this->_pluginPath($plugin) . 'config' . DS . self::PROJECT_MODEL_FILE;
         }

--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -14,6 +14,7 @@
 
 namespace BEdita\Core\Utility;
 
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 
@@ -92,8 +93,7 @@ class ProjectModel
     {
         return TableRegistry::getTableLocator()->get('ObjectTypes')
             ->find()
-            ->each(function ($row) {
-                /** @var \BEdita\Core\Mode\Entity\ObjectType $row */
+            ->each(function (EntityInterface $row) {
                 $row->unsetProperty([
                     'id',
                     'left_relations',
@@ -117,15 +117,12 @@ class ProjectModel
         return TableRegistry::getTableLocator()
             ->get('Relations')
             ->find('all', ['contain' => ['LeftObjectTypes', 'RightObjectTypes']])
-            ->each(function ($row) {
-                /** @var \BEdita\Core\Mode\Entity\Relation $row */
-                $left = Hash::extract($row, 'left_object_types.{n}.name');
-                $right = Hash::extract($row, 'right_object_types.{n}.name');
+            ->each(function (EntityInterface $row) {
+                $left = (array)Hash::extract($row, 'left_object_types.{n}.name');
+                $right = (array)Hash::extract($row, 'right_object_types.{n}.name');
                 sort($left);
                 sort($right);
-                $row->unsetProperty([
-                    'id',
-                ]);
+                $row->unsetProperty('id');
                 $row->set('left_object_types', $left);
                 $row->set('right_object_types', $right);
             })
@@ -141,8 +138,7 @@ class ProjectModel
     {
         return TableRegistry::getTableLocator()->get('Properties')
             ->find('type', ['dynamic'])
-            ->each(function ($row) {
-                /** @var \BEdita\Core\Mode\Entity\Property $row */
+            ->each(function (EntityInterface $row) {
                 $row->unsetProperty([
                     'id',
                     'created',

--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -163,9 +163,11 @@ class ProjectModel
     protected static function itemsToUpdate(array $current, array $new): array
     {
         return array_filter(array_map(
-            function ($k, $v) use ($current) {
-                $diff = Hash::diff($v, $current[$k]);
-                if (empty($diff)) {
+            function ($k, array $v) use ($current) {
+                if (empty($current[$k])) {
+                    return null;
+                }
+                if (empty(Hash::diff($v, (array)$current[$k]))) {
                     return null;
                 }
 

--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -22,7 +22,7 @@ use Cake\Utility\Hash;
  *
  * Provides static methods to generate Project model
  *
- * @since 4.4.0
+ * @since 4.5.0
  */
 class ProjectModel
 {

--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Utility;
+
+use Cake\ORM\TableRegistry;
+use Cake\Utility\Hash;
+
+/**
+ * Project Model generation utilities
+ *
+ * Provides static methods to generate Project model
+ *
+ * @since 4.4.0
+ */
+class ProjectModel
+{
+    /**
+     * Generate Project model
+     *
+     * @return array
+     */
+    public static function generate(): array
+    {
+        return [
+            'property_types' => static::propertyTypes(),
+            'object_types' => static::objectTypes(),
+            'relations' => static::relations(),
+            'properties' => static::properties(),
+        ];
+    }
+
+    /**
+     * Retrieve property types
+     *
+     * @return array
+     */
+    protected static function propertyTypes(): array
+    {
+        return TableRegistry::getTableLocator()->get('PropertyTypes')
+            ->find()
+            ->select(['name', 'params'])
+            ->where(['core_type' => 0])
+            ->toArray();
+    }
+
+    /**
+     * Retrieve property types
+     *
+     * @return array
+     */
+    protected static function objectTypes(): array
+    {
+        return TableRegistry::getTableLocator()->get('ObjectTypes')
+            ->find()
+            ->each(function ($row) {
+                /** @var \BEdita\Core\Mode\Entity\ObjectType $row */
+                $row->unsetProperty([
+                    'id',
+                    'left_relations',
+                    'right_relations',
+                    'created',
+                    'modified',
+                    'core_type',
+                ]);
+                $row->setHidden(['relations', 'alias'], true);
+            })
+            ->toArray();
+    }
+
+    /**
+     * Retrieve relations.
+     *
+     * @return array
+     */
+    protected static function relations(): array
+    {
+        return TableRegistry::getTableLocator()
+            ->get('Relations')
+            ->find('all', ['contain' => ['LeftObjectTypes', 'RightObjectTypes']])
+            ->each(function ($row) {
+                /** @var \BEdita\Core\Mode\Entity\Relation $row */
+                $left = Hash::extract($row, 'left_object_types.{n}.name');
+                $right = Hash::extract($row, 'right_object_types.{n}.name');
+                sort($left);
+                sort($right);
+                $row->unsetProperty([
+                    'id',
+                ]);
+                $row->set('left_object_types', $left);
+                $row->set('right_object_types', $right);
+            })
+            ->toArray();
+    }
+
+    /**
+     * Retrieve properties.
+     *
+     * @return array
+     */
+    protected static function properties(): array
+    {
+        return TableRegistry::getTableLocator()->get('Properties')
+            ->find('type', ['dynamic'])
+            ->each(function ($row) {
+                /** @var \BEdita\Core\Mode\Entity\Property $row */
+                $row->unsetProperty([
+                    'id',
+                    'created',
+                    'modified',
+                    'label',
+                    'is_static',
+                ]);
+            })
+            ->toArray();
+    }
+}

--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -34,11 +34,39 @@ class ProjectModel
     public static function generate(): array
     {
         return [
+            'applications' => static::applications(),
+            'roles' => static::roles(),
             'property_types' => static::propertyTypes(),
             'object_types' => static::objectTypes(),
             'relations' => static::relations(),
             'properties' => static::properties(),
         ];
+    }
+
+    /**
+     * Retrieve applications
+     *
+     * @return array
+     */
+    protected static function applications(): array
+    {
+        return TableRegistry::getTableLocator()->get('Applications')
+            ->find()
+            ->select(['name', 'description', 'enabled'])
+            ->toArray();
+    }
+
+    /**
+     * Retrieve roles
+     *
+     * @return array
+     */
+    protected static function roles(): array
+    {
+        return TableRegistry::getTableLocator()->get('Roles')
+            ->find()
+            ->select(['name', 'description'])
+            ->toArray();
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
@@ -1,0 +1,182 @@
+<?php
+namespace BEdita\Core\Test\TestCase\Command;
+
+use BEdita\Core\Command\ProjectModelCommand;
+use BEdita\Core\Test\TestCase\Utility\ProjectModelTest;
+use Cake\Core\App;
+use Cake\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see BEdita\Core\Command\ProjectModelCommand} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Command\ProjectModelCommand
+ */
+class ProjectModelCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.RelationTypes',
+        'plugin.BEdita/Core.Objects',
+    ];
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->useCommandRunner();
+    }
+
+    /**
+     * Test buildOptionParser method
+     *
+     * @return void
+     *
+     * @covers ::buildOptionParser()
+     */
+    public function testBuildOptionParser()
+    {
+        $this->exec('project_model --help');
+        $this->assertOutputContains('Path of JSON file containing project model to apply');
+        $this->assertOutputContains('Plugin to use for loading default');
+    }
+
+    /**
+     * Test execute method
+     *
+     * @return void
+     *
+     * @covers ::execute()
+     * @covers ::modelFilePath()
+     */
+    public function testExecute(): void
+    {
+        $model = ProjectModelTest::PROJECT_MODEL;
+        $path = TMP . '__test.json';
+        file_put_contents($path, json_encode($model));
+        $this->exec('project_model --file ' . $path);
+        unlink($path);
+        $this->assertOutputContains('Project model in sync, exiting.');
+        $this->assertExitSuccess();
+    }
+
+    /**
+     * Test file load failure
+     *
+     * @return void
+     *
+     * @covers ::modelFilePath()
+     * @covers ::execute()
+     */
+    public function testFileFail(): void
+    {
+        $this->exec('project_model --file project.json');
+        $this->assertErrorContains('File not found project.json');
+        $this->assertExitError();
+    }
+
+    /**
+     * Test default file failure
+     *
+     * @return void
+     *
+     * @covers ::execute()
+     * @covers ::modelFilePath()
+     */
+    public function testDefaultFileFail(): void
+    {
+        $this->exec('project_model');
+        $this->assertErrorContains('File not found ' . CONFIG . ProjectModelCommand::PROJECT_MODEL_FILE);
+        $this->assertExitError();
+    }
+
+    /**
+     * Test default file failure
+     *
+     * @return void
+     *
+     * @covers ::execute()
+     * @covers ::modelFilePath()
+     */
+    public function testPluginFailure2(): void
+    {
+        $this->exec('project_model -p Test');
+        $expected = current(App::path('Plugin')) . 'Test' . DS . 'config' . DS . ProjectModelCommand::PROJECT_MODEL_FILE;
+        $this->assertErrorContains('File not found ' . $expected);
+        $this->assertExitError();
+    }
+
+    /**
+     * Test default file failure
+     *
+     * @return void
+     *
+     * @covers ::execute()
+     */
+    public function testContentFailure(): void
+    {
+        $path = TMP . '__test.json';
+        file_put_contents($path, '');
+        $this->exec('project_model --file ' . $path);
+        unlink($path);
+        $this->assertErrorContains('Bad file content in ' . $path);
+        $this->assertExitError();
+    }
+
+    /**
+     * Test remove from model
+     *
+     * @return void
+     *
+     * @covers ::execute()
+     */
+    public function testRemove(): void
+    {
+        $model = ProjectModelTest::PROJECT_MODEL;
+        unset($model['property_types'][0]);
+        $path = TMP . '__test.json';
+        file_put_contents($path, json_encode($model));
+        $this->exec('project_model --file ' . $path);
+        unlink($path);
+        $this->assertErrorContains('Items to remove');
+        $this->assertExitSuccess();
+    }
+
+    /**
+     * Test update model items
+     *
+     * @return void
+     *
+     * @covers ::execute()
+     */
+    public function testUpdate(): void
+    {
+        $model = ProjectModelTest::PROJECT_MODEL;
+        $model['relations'][0] = [
+            'name' => 'test',
+            'inverse_name' => 'inverse_test',
+            'right_object_types' => ['documents', 'profiles'],
+            'left_object_types' => ['events'],
+        ];
+        $path = TMP . '__test.json';
+        file_put_contents($path, json_encode($model));
+        $this->exec('project_model --file ' . $path);
+        unlink($path);
+        $this->assertOutputContains('Cache cleared');
+        $this->assertExitSuccess();
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
@@ -33,6 +33,8 @@ class ProjectModelCommandTest extends TestCase
      * @var array
      */
     public $fixtures = [
+        'plugin.BEdita/Core.Applications',
+        'plugin.BEdita/Core.Roles',
         'plugin.BEdita/Core.ObjectTypes',
         'plugin.BEdita/Core.PropertyTypes',
         'plugin.BEdita/Core.Properties',

--- a/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
@@ -176,6 +176,7 @@ class ProjectModelCommandTest extends TestCase
         file_put_contents($path, json_encode($model));
         $this->exec('project_model --file ' . $path);
         unlink($path);
+        $this->assertOutputContains('Project model updated');
         $this->assertOutputContains('Cache cleared');
         $this->assertExitSuccess();
     }

--- a/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Test\TestCase\Command;
 
 use BEdita\Core\Command\ProjectModelCommand;
@@ -174,7 +185,7 @@ class ProjectModelCommandTest extends TestCase
         ];
         $path = TMP . '__test.json';
         file_put_contents($path, json_encode($model));
-        $this->exec('project_model --file ' . $path);
+        $this->exec('project_model --cache-clear --file ' . $path);
         unlink($path);
         $this->assertOutputContains('Project model updated');
         $this->assertOutputContains('Cache cleared');

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -42,6 +42,256 @@ class ProjectModelTest extends TestCase
     ];
 
     /**
+     * Project model data
+     *
+     * @var array
+     */
+    public const PROJECT_MODEL = [
+        'property_types' => [
+            [
+                'name' => 'unused property type',
+                'params' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'gustavo' => [
+                            'const' => 'supporto',
+                        ],
+                    ],
+                    'required' => ['gustavo'],
+                ],
+            ],
+        ],
+        'object_types' => [
+            [
+                'name' => 'objects',
+                'is_abstract' => true,
+                'singular' => 'object',
+                'description' => null,
+                'associations' => null,
+                'hidden' => null,
+                'enabled' => true,
+                'table' => 'BEdita/Core.Objects',
+                'parent_name' => null,
+            ],
+            [
+                'name' => 'documents',
+                'is_abstract' => false,
+                'singular' => 'document',
+                'description' => null,
+                'associations' => ['Categories'],
+                'hidden' => null,
+                'enabled' => true,
+                'table' => 'BEdita/Core.Objects',
+                'parent_name' => 'objects',
+            ],
+            [
+                'name' => 'profiles',
+                'is_abstract' => false,
+                'singular' => 'profile',
+                'description' => null,
+                'associations' => ['Tags'],
+                'hidden' => null,
+                'enabled' => true,
+                'table' => 'BEdita/Core.Profiles',
+                'parent_name' => 'objects',
+            ],
+            [
+                'name' => 'users',
+                'is_abstract' => false,
+                'singular' => 'user',
+                'description' => null,
+                'associations' => null,
+                'hidden' => null,
+                'enabled' => true,
+                'table' => 'BEdita/Core.Users',
+                'parent_name' => 'objects',
+            ],
+            [
+                'name' => 'news',
+                'is_abstract' => false,
+                'singular' => 'news_item',
+                'description' => null,
+                'associations' => null,
+                'hidden' => ['body'],
+                'enabled' => false,
+                'table' => 'BEdita/Core.Objects',
+                'parent_name' => 'objects',
+            ],
+            [
+                'name' => 'locations',
+                'is_abstract' => false,
+                'singular' => 'location',
+                'description' => null,
+                'associations' => null,
+                'hidden' => null,
+                'enabled' => true,
+                'table' => 'BEdita/Core.Locations',
+                'parent_name' => 'objects',
+            ],
+            [
+                'name' => 'events',
+                'is_abstract' => false,
+                'singular' => 'event',
+                'description' => null,
+                'associations' => ['DateRanges'],
+                'hidden' => null,
+                'enabled' => true,
+                'table' => 'BEdita/Core.Objects',
+                'parent_name' => 'objects',
+            ],
+            [
+                'name' => 'media',
+                'is_abstract' => true,
+                'singular' => 'media_item',
+                'description' => null,
+                'associations' => ['Streams'],
+                'hidden' => null,
+                'enabled' => true,
+                'table' => 'BEdita/Core.Media',
+                'parent_name' => 'objects',
+            ],
+            [
+                'name' => 'files',
+                'is_abstract' => false,
+                'singular' => 'file',
+                'description' => null,
+                'associations' => ['Streams'],
+                'hidden' => null,
+                'enabled' => true,
+                'table' => 'BEdita/Core.Media',
+                'parent_name' => 'media',
+            ],
+            [
+                'name' => 'folders',
+                'is_abstract' => false,
+                'singular' => 'folder',
+                'description' => null,
+                'associations' => null,
+                'hidden' => null,
+                'enabled' => true,
+                'table' => 'BEdita/Core.Objects',
+                'parent_name' => 'objects',
+            ],
+        ],
+        'relations' => [
+            [
+                'name' => 'test',
+                'label' => 'Test relation',
+                'inverse_name' => 'inverse_test',
+                'inverse_label' => 'Inverse test relation',
+                'description' => 'Sample description.',
+                'params' => null,
+                'right_object_types' => ['documents', 'profiles'],
+                'left_object_types' => ['documents'],
+            ],
+            [
+                'name' => 'another_test',
+                'label' => 'Another test relation',
+                'inverse_name' => 'inverse_another_test',
+                'inverse_label' => 'Another inverse test relation',
+                'description' => 'Sample description /2.',
+                'params' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                        ],
+                        'age' => [
+                            'type' => 'integer',
+                            'minimum' => 0,
+                        ],
+                    ],
+                    'required' => ['name'],
+                ],
+                'right_object_types' => ['locations'],
+                'left_object_types' => ['users'],
+            ],
+            [
+                'name' => 'test_abstract',
+                'label' => 'Test relation involving abstract types',
+                'inverse_name' => 'inverse_test_abstract',
+                'inverse_label' => 'Inverse test relation involving abstract types',
+                'description' => 'Sample description.',
+                'params' => null,
+                'right_object_types' => ['media'],
+                'left_object_types' => ['events'],
+            ],
+        ],
+        'properties' => [
+            [
+                'name' => 'another_title',
+                'description' => null,
+                'is_nullable' => true,
+                'property_type_name' => 'string',
+                'object_type_name' => 'documents',
+            ],
+            [
+                'name' => 'another_description',
+                'description' => null,
+                'is_nullable' => true,
+                'property_type_name' => 'string',
+                'object_type_name' => 'documents',
+            ],
+            [
+                'name' => 'another_username',
+                'description' => 'Username, unique string',
+                'is_nullable' => true,
+                'property_type_name' => 'string',
+                'object_type_name' => 'users',
+            ],
+            [
+                'name' => 'another_email',
+                'description' => 'User email',
+                'is_nullable' => true,
+                'property_type_name' => 'string',
+                'object_type_name' => 'users',
+            ],
+            [
+                'name' => 'another_birthdate',
+                'description' => null,
+                'is_nullable' => true,
+                'property_type_name' => 'date',
+                'object_type_name' => 'profiles',
+            ],
+            [
+                'name' => 'another_surname',
+                'description' => null,
+                'is_nullable' => true,
+                'property_type_name' => 'string',
+                'object_type_name' => 'profiles',
+            ],
+            [
+                'name' => 'disabled_property',
+                'description' => 'Disabled property example',
+                'is_nullable' => true,
+                'property_type_name' => 'string',
+                'object_type_name' => 'files',
+            ],
+            [
+                'name' => 'media_property',
+                'description' => null,
+                'is_nullable' => true,
+                'property_type_name' => 'string',
+                'object_type_name' => 'media',
+            ],
+            [
+                'name' => 'files_property',
+                'description' => null,
+                'is_nullable' => true,
+                'property_type_name' => 'string',
+                'object_type_name' => 'files',
+            ],
+            [
+                'name' => 'street_address',
+                'description' => null,
+                'is_nullable' => true,
+                'property_type_name' => 'string',
+                'object_type_name' => 'profiles',
+            ],
+        ],
+    ];
+
+    /**
      * Test `generate()` method
      *
      * @return void
@@ -55,17 +305,102 @@ class ProjectModelTest extends TestCase
     public function testGenerate(): void
     {
         $result = ProjectModel::generate();
+        $result = json_decode(json_encode($result), true);
         static::assertNotEmpty($result);
-        $expected = [
-            'property_types' => 1,
-            'object_types' => 10,
-            'relations' => 3,
-            'properties' => 10,
+        static::assertEquals(self::PROJECT_MODEL, $result);
+    }
+
+    /**
+     * Test `diff()` method adding items
+     *
+     * @return void
+     *
+     * @covers ::diff()
+     * @covers ::itemsToUpdate()
+     */
+    public function testDiffAdd(): void
+    {
+        $data = self::PROJECT_MODEL;
+        $propType = [
+            'name' => 'test property type',
+            'params' => [
+                'type' => 'number',
+            ],
         ];
-        static::assertEquals(array_keys($expected), array_keys($result));
-        foreach ($result as $key => $val) {
-            static::assertNotEmpty($val);
-            static::assertCount($expected[$key], $val);
-        }
+        $data['property_types'][] = $propType;
+
+        $result = ProjectModel::diff($data);
+        $create = [
+            'property_types' => [$propType],
+        ];
+        static::assertEquals(compact('create'), $result);
+    }
+
+    /**
+     * Test `diff()` method removing items
+     *
+     * @return void
+     *
+     * @covers ::diff()
+     */
+    public function testDiffRemove(): void
+    {
+        $data = self::PROJECT_MODEL;
+        unset($data['properties'][0], $data['relations'][0]);
+        $result = ProjectModel::diff($data);
+        $remove = [
+            'properties' => [
+                [
+                    'name' => 'another_title',
+                    'description' => null,
+                    'is_nullable' => true,
+                    'property_type_name' => 'string',
+                    'object_type_name' => 'documents',
+                ],
+            ],
+            'relations' => [
+                [
+                    'name' => 'test',
+                    'label' => 'Test relation',
+                    'inverse_name' => 'inverse_test',
+                    'inverse_label' => 'Inverse test relation',
+                    'description' => 'Sample description.',
+                    'params' => null,
+                    'right_object_types' => ['documents', 'profiles'],
+                    'left_object_types' => ['documents'],
+                ],
+            ],
+        ];
+        static::assertEquals(compact('remove'), $result);
+    }
+
+    /**
+     * Test `diff()` method updating items
+     *
+     * @return void
+     *
+     * @covers ::diff()
+     * @covers ::itemsToUpdate()
+     */
+    public function testDiffUpdate(): void
+    {
+        $data = self::PROJECT_MODEL;
+        $rel = [
+            'name' => 'test',
+            'label' => 'Test test',
+            'inverse_name' => 'inverse_test',
+            'inverse_label' => 'Inverse test test',
+            'description' => 'Another description',
+            'params' => null,
+            'right_object_types' => ['documents', 'profiles'],
+            'left_object_types' => ['events'],
+        ];
+        $data['relations'][0] = $rel;
+
+        $result = ProjectModel::diff($data);
+        $update = [
+            'relations' => [$rel],
+        ];
+        static::assertEquals(compact('update'), $result);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -29,16 +29,14 @@ class ProjectModelTest extends TestCase
      * @var array
      */
     public $fixtures = [
+        'plugin.BEdita/Core.Applications',
+        'plugin.BEdita/Core.Roles',
         'plugin.BEdita/Core.ObjectTypes',
         'plugin.BEdita/Core.PropertyTypes',
         'plugin.BEdita/Core.Properties',
         'plugin.BEdita/Core.Relations',
         'plugin.BEdita/Core.RelationTypes',
         'plugin.BEdita/Core.Objects',
-        'plugin.BEdita/Core.Profiles',
-        'plugin.BEdita/Core.Users',
-        'plugin.BEdita/Core.Locations',
-        'plugin.BEdita/Core.Media',
     ];
 
     /**
@@ -47,6 +45,28 @@ class ProjectModelTest extends TestCase
      * @var array
      */
     public const PROJECT_MODEL = [
+        'applications' => [
+            [
+                'name' => 'First app',
+                'description' => 'Lorem ipsum dolor sit amet, aliquet feugiat.',
+                'enabled' => true,
+            ],
+            [
+                'name' => 'Disabled app',
+                'description' => 'This app has been disabled',
+                'enabled' => false,
+            ],
+        ],
+        'roles' => [
+            [
+                'name' => 'first role',
+                'description' => 'this is the very first role',
+            ],
+            [
+                'name' => 'second role',
+                'description' => 'this is a second role',
+            ],
+        ],
         'property_types' => [
             [
                 'name' => 'unused property type',
@@ -297,6 +317,8 @@ class ProjectModelTest extends TestCase
      * @return void
      *
      * @covers ::generate()
+     * @covers ::applications()
+     * @covers ::roles()
      * @covers ::propertyTypes()
      * @covers ::objectTypes()
      * @covers ::relations()

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Utility;
+
+use BEdita\Core\Utility\ProjectModel;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\Core\Utility\ProjectModel} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Utility\ProjectModel
+ */
+class ProjectModelTest extends TestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.RelationTypes',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.Profiles',
+        'plugin.BEdita/Core.Users',
+        'plugin.BEdita/Core.Locations',
+        'plugin.BEdita/Core.Media',
+    ];
+
+    /**
+     * Test `generate()` method
+     *
+     * @return void
+     *
+     * @covers ::generate()
+     * @covers ::propertyTypes()
+     * @covers ::objectTypes()
+     * @covers ::relations()
+     * @covers ::properties()
+     */
+    public function testGenerate(): void
+    {
+        $result = ProjectModel::generate();
+        static::assertNotEmpty($result);
+        $expected = [
+            'property_types' => 1,
+            'object_types' => 10,
+            'relations' => 3,
+            'properties' => 10,
+        ];
+        static::assertEquals(array_keys($expected), array_keys($result));
+        foreach ($result as $key => $val) {
+            static::assertNotEmpty($val);
+            static::assertCount($expected[$key], $val);
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces the `project model` concept and first tools. 
It is a first implementation of #1792

A new utility class `ProjectModel` has been added with two main methods:
* `generate()` - to generate current project model
* `diff()` - to calculate a `diff` between current project model and a new one passed by argument => resulting array will have `create`, `update` or `remove` keys containing the corresponding model items 

The **project model** is (for now) a simple array with 6 main keys where main internal resources are described in the same format used by [resources migrations](https://github.com/bedita/bedita/wiki/YAML-format-to-update-resources):
 * `applications`
 * `roles`
 * `property_types`
 * `object_types`
 * `relations`
 * `properties` (only custom properties for now)

A new `GET /model/project` endpoint is now available with a response containing the above array.
 
A new `ProjectModelCommand` class has been created to sync the current model with a new one:

Usage:
```
bin/cake project_model [-f {/path/to/file}] [-p {Plugin}] [--cache-clear]
``` 
- `/path/to/file` path to JSON file containing new project model
- if no `-f/--file` option is used a default `config/project_model.json` path is used, relative to the app root directory
- if `-p/--plugin` option is used default path `config/project_model.json` will be relative to the plugin root directory
- if `-c/--cache-clear` option is used cache is cleared after resources change 