### PR TITLE
Locked constraint logic

### DIFF
--- a/plugins/BEdita/Core/src/Model/Action/DeleteObjectAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/DeleteObjectAction.php
@@ -50,7 +50,6 @@ class DeleteObjectAction extends BaseAction
         }
 
         $entity->set('deleted', true);
-        $entity->set('locked', false);
 
         return (bool)$this->Table->save($entity);
     }

--- a/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
@@ -88,7 +88,7 @@ class UniqueNameBehavior extends Behavior
                 'replacement' => $this->getConfig('replacement'),
                 'preserve' => $this->getConfig('preserve'),
             ]));
-            if ($uname === $entity->get('uname')) {
+            if ($uname === $entity->get('uname') && !$entity->isDirty('uname')) {
                 return;
             }
         }

--- a/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
@@ -78,17 +78,19 @@ class UniqueNameBehavior extends Behavior
      * @param \Cake\Datasource\EntityInterface $entity The entity to save
      * @return void
      */
-    public function uniqueName(EntityInterface $entity)
+    public function uniqueName(EntityInterface $entity): void
     {
-        $config = $this->getConfig();
         $uname = $entity->get('uname');
         if (empty($uname)) {
             $uname = $this->generateUniqueName($entity);
         } else {
             $uname = strtolower(Text::slug($uname, [
-                'replacement' => $config['replacement'],
-                'preserve' => $config['preserve'],
+                'replacement' => $this->getConfig('replacement'),
+                'preserve' => $this->getConfig('preserve'),
             ]));
+            if ($uname === $entity->get('uname')) {
+                return;
+            }
         }
         $count = 0;
         while (

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -208,7 +208,7 @@ class ObjectsTable extends Table
      */
     protected function checkLocked(EntityInterface $entity): void
     {
-        if (empty($entity->get('locked'))) {
+        if (empty($entity->get('locked')) || $entity->isDirty('locked')) {
             return;
         }
         if ($entity->isDirty('status') || $entity->isDirty('uname') || $entity->isDirty('deleted')) {

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -204,7 +204,7 @@ class ObjectsTable extends Table
      *
      * @param \Cake\Datasource\EntityInterface $entity Entity being saved.
      * @return void
-     * @throws \Cake\Http\Exception\BadRequestException
+     * @throws \Cake\Http\Exception\ForbiddenException
      */
     protected function checkLocked(EntityInterface $entity): void
     {

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -200,6 +200,7 @@ class ObjectsTable extends Table
 
     /**
      * Check `locked` attribute.
+     * If `locked` is true `status`, `uname` and `deleted` cannot be changed.
      *
      * @param \Cake\Datasource\EntityInterface $entity Entity being saved.
      * @return void

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -23,6 +23,7 @@ use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\Http\Exception\BadRequestException;
+use Cake\Http\Exception\ForbiddenException;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
@@ -178,6 +179,7 @@ class ObjectsTable extends Table
         }
         $this->checkStatus($entity);
         $this->checkLangTag($entity);
+        $this->checkLocked($entity);
 
         return true;
     }
@@ -193,6 +195,23 @@ class ObjectsTable extends Table
     {
         if ($entity->isDirty('lang') && empty($entity->get('lang')) && Configure::check('I18n.default')) {
             $entity->set('lang', Configure::read('I18n.default'));
+        }
+    }
+
+    /**
+     * Check `locked` attribute.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity Entity being saved.
+     * @return void
+     * @throws \Cake\Http\Exception\BadRequestException
+     */
+    protected function checkLocked(EntityInterface $entity): void
+    {
+        if (empty($entity->get('locked'))) {
+            return;
+        }
+        if ($entity->isDirty('status') || $entity->isDirty('uname') || $entity->isDirty('deleted')) {
+            throw new ForbiddenException(__('Operation not allowed on "locked" objects'));
         }
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteObjectActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteObjectActionTest.php
@@ -73,13 +73,13 @@ class DeleteObjectActionTest extends TestCase
         $table = TableRegistry::getTableLocator()->get('Documents');
         $action = new DeleteObjectAction(compact('table'));
 
-        $entity = $table->get(2);
+        $entity = $table->get(3);
 
         $result = $action(compact('entity'));
 
         static::assertTrue($result);
-        static::assertTrue($table->exists(['id' => 2]));
-        static::assertTrue($table->get(2)->get('deleted'));
+        static::assertTrue($table->exists(['id' => 3]));
+        static::assertTrue($table->get(3)->get('deleted'));
     }
 
     /**
@@ -92,11 +92,11 @@ class DeleteObjectActionTest extends TestCase
         $table = TableRegistry::getTableLocator()->get('Documents');
         $action = new DeleteObjectAction(compact('table'));
 
-        $entity = $table->get(2);
+        $entity = $table->get(3);
 
         $result = $action(compact('entity') + ['hard' => true]);
 
         static::assertTrue($result);
-        static::assertFalse($table->exists(['id' => 2]));
+        static::assertFalse($table->exists(['id' => 3]));
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CategoriesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CategoriesBehaviorTest.php
@@ -67,7 +67,7 @@ class CategoriesBehaviorTest extends TestCase
                         ['name' => 'disabled-cat'],
                     ]
                 ],
-                2,
+                3,
                 'Documents',
             ],
             'profile tags' => [
@@ -97,7 +97,7 @@ class CategoriesBehaviorTest extends TestCase
                         ['name' => 'other-cat'],
                     ]
                 ],
-                2,
+                3,
                 'Documents',
             ],
             'no categories' => [
@@ -107,7 +107,7 @@ class CategoriesBehaviorTest extends TestCase
                 [
                     'description' => 'some description',
                 ],
-                2,
+                3,
                 'Documents',
             ],
             'no tags allowed' => [
@@ -119,7 +119,7 @@ class CategoriesBehaviorTest extends TestCase
                         ['name' => 'first-tag'],
                     ]
                 ],
-                2,
+                3,
                 'Documents',
             ],
             'no categories allowed' => [

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CategoriesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CategoriesBehaviorTest.php
@@ -215,7 +215,7 @@ class CategoriesBehaviorTest extends TestCase
     public function testFetchCategories(): void
     {
         $table = TableRegistry::getTableLocator()->get('Documents');
-        $entity = $table->get(2, ['contain' => ['Categories']]);
+        $entity = $table->get(3, ['contain' => ['Categories']]);
         $data = [
             'categories' => [
                 [

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/HistoryBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/HistoryBehaviorTest.php
@@ -147,7 +147,7 @@ class HistoryBehaviorTest extends TestCase
     public function testAfterSave()
     {
         $Documents = TableRegistry::getTableLocator()->get('Documents');
-        $doc = $Documents->get(2);
+        $doc = $Documents->get(3);
         $data = [
             'description' => 'new history desc'
         ];
@@ -158,14 +158,14 @@ class HistoryBehaviorTest extends TestCase
         static::assertEquals($data, $behavior->getChanged());
 
         $history = TableRegistry::getTableLocator()->get('History')->find()
-                ->where(['resource_id' => '2', 'resource_type' => 'objects'])
+                ->where(['resource_id' => '3', 'resource_type' => 'objects'])
                 ->order(['id' => 'ASC'])
                 ->last()
                 ->toArray();
         static::assertNotEmpty($history);
         $expected = [
             'id' => 3,
-            'resource_id' => '2',
+            'resource_id' => '3',
             'resource_type' => 'objects',
             'user_id' => 1,
             'application_id' => null,
@@ -187,13 +187,13 @@ class HistoryBehaviorTest extends TestCase
     public function testTrashRestore()
     {
         $Documents = TableRegistry::getTableLocator()->get('Documents');
-        $entity = $Documents->get(2);
+        $entity = $Documents->get(3);
         $entity->deleted = true;
         $entity = $Documents->saveOrFail($entity);
 
         $History = TableRegistry::getTableLocator()->get('History');
         $history = $History->find()
-                ->where(['resource_id' => '2', 'resource_type' => 'objects'])
+                ->where(['resource_id' => '3', 'resource_type' => 'objects'])
                 ->order(['id' => 'ASC'])
                 ->last();
         static::assertEquals('trash', $history->get('user_action'));
@@ -201,7 +201,7 @@ class HistoryBehaviorTest extends TestCase
         $entity->deleted = false;
         $Documents->saveOrFail($entity);
         $history = $History->find()
-                ->where(['resource_id' => '2', 'resource_type' => 'objects'])
+                ->where(['resource_id' => '3', 'resource_type' => 'objects'])
                 ->order(['id' => 'ASC'])
                 ->last();
         static::assertNotEmpty($history);
@@ -297,7 +297,7 @@ class HistoryBehaviorTest extends TestCase
         Configure::write('History', ['table' => null]);
         $Documents = TableRegistry::getTableLocator()->get('Documents');
         $entity = $Documents->get(2);
-        $Documents->patchEntity($entity, ['title' => 'new title']);
+        $Documents->patchEntity($entity, ['title' => 'new title', 'id' => 2]);
         $Documents->saveOrFail($entity);
 
         $history = TableRegistry::getTableLocator()->get('History')->find()

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
@@ -376,6 +376,23 @@ class UniqueNameBehaviorTest extends TestCase
     }
 
     /**
+     * Test `uniqueName()` when `uname` is valid an unchanged
+     *
+     * @return void
+     *
+     * @covers ::uniqueName()
+     */
+    public function testUniqueNameUnchanged(): void
+    {
+        $Documents = TableRegistry::getTableLocator()->get('Documents');
+        $behavior = $Documents->behaviors()->get('UniqueName');
+        $document = $Documents->get(2);
+        $behavior->uniqueName($document);
+
+        static::assertFalse($document->isDirty('uname'));
+    }
+
+    /**
      * test generate uname before save
      *
      * @return void

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -8,6 +8,7 @@ use BEdita\Core\Utility\LoggedUser;
 use Cake\Core\Configure;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Http\Exception\BadRequestException;
+use Cake\Http\Exception\ForbiddenException;
 use Cake\I18n\Time;
 use Cake\ORM\Exception\PersistenceFailedException;
 use Cake\ORM\TableRegistry;
@@ -711,6 +712,63 @@ class ObjectsTableTest extends TestCase
         $object = $this->Objects->save($object);
 
         static::assertSame($expected, $object->get('status'));
+    }
+
+    /**
+     * Data provider for `checkLocked`.
+     *
+     * @return array
+     */
+    public function checkLockedProvider(): array
+    {
+        return [
+            'not locked' => [
+                true,
+                [
+                    'id' => 3,
+                    'status' => 'on',
+                ],
+            ],
+            'forbidden' => [
+                new ForbiddenException('Operation not allowed on "locked" objects'),
+                [
+                    'id' => 2,
+                    'status' => 'off',
+                ],
+                'on',
+            ],
+            'allowed' => [
+                true,
+                [
+                    'id' => 1,
+                    'description' => 'new description',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `checkLocked()`.
+     *
+     * @param string|\Exception $expected result or Exception.
+     * @param array $data Save input data.
+     * @return void
+     *
+     * @dataProvider checkLockedProvider()
+     * @covers ::checkLocked()
+     */
+    public function testCheckLocked($expected, array $data): void
+    {
+        if ($expected instanceof \Exception) {
+            $this->expectException(get_class($expected));
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+
+        $object = $this->Objects->get(Hash::get($data, 'id'));
+        $object = $this->Objects->patchEntity($object, $data);
+        $object = $this->Objects->saveOrFail($object);
+
+        static::assertNotEmpty($object);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -744,6 +744,14 @@ class ObjectsTableTest extends TestCase
                     'description' => 'new description',
                 ],
             ],
+            'locked now' => [
+                true,
+                [
+                    'id' => 3,
+                    'uname' => 'new-uname',
+                    'locked' => true,
+                ],
+            ],
         ];
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -705,9 +705,7 @@ class ObjectsTableTest extends TestCase
             Configure::write('Status.level', $config);
         }
 
-        $id = Hash::get($data, 'id', 2);
-        $object = $this->Objects->get($id);
-        unset($data['id']);
+        $object = $this->Objects->get(4);
         $object = $this->Objects->patchEntity($object, $data);
         $object = $this->Objects->save($object);
 


### PR DESCRIPTION
This PR solves #1591 

Upon `ObjectsTable::beforeSave()` an additional check is performed: if `locked` is true and `uname`, `status` or `deleted` have been changed (checked via `$entity->isDirty()`) a `403 Forbidden` error is raised.

Other changes:
* `UniqueNameBehavior::uniqueName()` has been modified => `$entity->isDirty('uname')` always returned **true** even if `uname` property was unchanged and formally correct.
* many tests have been changed because one of the most used object in test fixtures - document with `id` 2 -  has `locked` set to `true` and some operations are now forbidden... 