### PR TITLE
Enable `locked` save via `ObjectsHandler`

### DIFF
--- a/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
+++ b/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
@@ -83,7 +83,8 @@ class ObjectsHandler
         } else {
             $entity = $table->newEntity();
         }
-        $entity = $table->patchEntity($entity, $data);
+        $options = ['accessibleFields' => ['locked' => true]];
+        $entity = $table->patchEntity($entity, $data, $options);
         $entity->set('type', $objectType->name);
         $saveResult = $table->saveOrFail($entity);
 

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHandlerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHandlerTest.php
@@ -127,6 +127,20 @@ class ObjectsHandlerTest extends TestCase
     }
 
     /**
+     * Test `save` with `locked` attribute
+     *
+     * @return void
+     * @covers ::save()
+     */
+    public function testSaveLocked()
+    {
+        $data = ['id' => 5, 'locked' => true];
+        $entity = ObjectsHandler::save('users', $data);
+        $this->assertNotEmpty($entity);
+        $this->assertTrue($entity->locked);
+    }
+
+    /**
      * Test `delete` failure
      *
      * @return void


### PR DESCRIPTION
This PR enables `locked` attribute to be saved via `ObjectsHandler` CLI utility