### PR TITLE
Lock/unlock actions

### DIFF
--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -270,7 +270,7 @@ class ObjectsController extends ResourcesController
             $action = new SaveEntityAction(['table' => $this->Table, 'objectType' => $this->objectType]);
 
             $data = (array)$this->request->getData();
-            $entityOptions = $this->patchEntityOptions($data);
+            $entityOptions = $this->saveEntityOptions($data);
             $entity = $action(compact('entity', 'data', 'entityOptions'));
         }
 
@@ -288,7 +288,7 @@ class ObjectsController extends ResourcesController
      * @param array $data Entity data
      * @return array
      */
-    protected function patchEntityOptions(array &$data): array
+    protected function saveEntityOptions(array &$data): array
     {
         $roles = (array)$this->Auth->user('roles');
         $meta = (array)Hash::get($data, '_meta');

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -73,7 +73,7 @@ class ObjectsController extends ResourcesController
      *
      * @var array
      */
-    protected const ADMIN_META_ACCESSIBLE = ['blocked', 'locked'];
+    protected const ADMIN_META_ACCESSIBLE = ['locked'];
 
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -293,7 +293,7 @@ class ObjectsController extends ResourcesController
         $roles = (array)$this->Auth->user('roles');
         $meta = (array)Hash::get($data, '_meta');
         $meta = array_intersect_key($meta, array_flip(static::ADMIN_META_ACCESSIBLE));
-        if (!in_array(RolesTable::ADMIN_ROLE, Hash::extract($roles, '{n}.id')) || empty($meta)) {
+        if (!in_array(RolesTable::ADMIN_ROLE, (array)Hash::extract($roles, '{n}.id')) || empty($meta)) {
             return [];
         }
         $data = array_merge($data, $meta);

--- a/plugins/BEdita/API/src/Controller/UsersController.php
+++ b/plugins/BEdita/API/src/Controller/UsersController.php
@@ -25,6 +25,13 @@ class UsersController extends ObjectsController
     public $modelClass = 'Users';
 
     /**
+     * Meta properties accessible for admins
+     *
+     * @var array
+     */
+    protected const ADMIN_META_ACCESSIBLE = ['blocked', 'locked'];
+
+    /**
      * {@inheritDoc}
      */
     protected $_defaultConfig = [

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -2787,7 +2787,7 @@ class ObjectsControllerTest extends IntegrationTestCase
      * @param bool $expected Expected result
      * @param string $id Test object ID
      * @param array $meta Meta data
-     * @param array $user USer data
+     * @param array $user User data
      * @return void
      *
      * @dataProvider saveEntityOptionsProvider

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -2744,4 +2744,79 @@ class ObjectsControllerTest extends IntegrationTestCase
         $this->assertResponseCode(200);
         static::assertEquals(9, Hash::get($result, 'data.0.id'));
     }
+
+    /**
+     * Provider for testSaveEntityOptions()
+     *
+     * @return array
+     */
+    public function saveEntityOptionsProvider()
+    {
+        return [
+            'lock' => [
+                true,
+                '3',
+                [
+                    'locked' => true,
+                ]
+            ],
+            'user' => [
+                false,
+                '2',
+                [
+                    'locked' => false,
+                ],
+                [
+                    'username' => 'second user',
+                    'password' => 'password2',
+                ],
+            ],
+            'no meta' => [
+                false,
+                '2',
+                [
+                    'created_by' => 3,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `saveEntityOptions()`
+     *
+     * @param bool $expected Expected result
+     * @param string $id Test object ID
+     * @param array $meta Meta data
+     * @param array $user USer data
+     * @return void
+     *
+     * @dataProvider saveEntityOptionsProvider
+     * @covers ::saveEntityOptions()
+     */
+    public function testSaveEntityOptions(bool $expected, string $id, array $meta, array $user = []): void
+    {
+        $data = [
+            'id' => $id,
+            'type' => 'documents',
+            'meta' => $meta,
+        ];
+
+        $header = $this->getUserAuthHeader(
+            Hash::get($user, 'username'),
+            Hash::get($user, 'password')
+        );
+        $this->configRequestHeaders('PATCH', $header);
+        $this->patch("/documents/$id", json_encode(compact('data')));
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        $document = TableRegistry::getTableLocator()->get('Documents')->get($id);
+        $props = $document->extract(array_keys($meta));
+        if ($expected) {
+            static::assertEquals($props, $meta);
+        } else {
+            static::assertNotEquals($props, $meta);
+        }
+    }
 }


### PR DESCRIPTION
This PR solves #1191 

With this PR users with `admin` role are allowed to change two metadata (for now):
 * `locked` common to all object types - see the logic implemented in #1800 
 * `blocked` flag for `Users`

This change can be performed via regular `PATCH` using `meta` section like this:

```
PATCH /users/123
{
"data": {
        "id": 123,
        "type": "users",
        "meta": {
            "locked" : "true",
        }
    }
}
```
