### PR TITLE
Format and validate JSON Schema properties (#1336)

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/DefaultValuesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/DefaultValuesTest.php
@@ -39,7 +39,10 @@ class DefaultValuesTest extends IntegrationTestCase
             'files on' => [
                 ['status' => 'on'],
                 'files',
-                ['title' => 'My File'],
+                [
+                    'title' => 'My File',
+                    'media_property' => true,
+                ],
                 [
                     'files' => [
                         'status' => 'on',
@@ -50,7 +53,10 @@ class DefaultValuesTest extends IntegrationTestCase
             'files draft' => [
                 ['status' => 'draft'],
                 'files',
-                ['title' => 'My File'],
+                [
+                    'title' => 'My File',
+                    'media_property' => false,
+                ],
                 [],
             ],
 

--- a/plugins/BEdita/API/tests/IntegrationTest/NewObjectTypesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/NewObjectTypesTest.php
@@ -52,6 +52,7 @@ class NewObjectTypesTest extends IntegrationTestCase
                 ],
                 [
                     'description' => 'a new song',
+                    'media_property' => true,
                 ]
             ],
         ];
@@ -88,7 +89,7 @@ class NewObjectTypesTest extends IntegrationTestCase
             'attributes' => $attributes,
         ];
 
-        TableRegistry::clear();
+        TableRegistry::getTableLocator()->clear();
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
         $endpoint = '/' . $type;
         $this->post($endpoint, json_encode(compact('data')));
@@ -96,7 +97,7 @@ class NewObjectTypesTest extends IntegrationTestCase
         $this->assertContentType('application/vnd.api+json');
 
         // VIEW
-        TableRegistry::clear();
+        TableRegistry::getTableLocator()->clear();
         $this->configRequestHeaders();
         $lastId++;
         $this->get("/$type/$lastId");

--- a/plugins/BEdita/API/tests/TestCase/Controller/MediaControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/MediaControllerTest.php
@@ -426,7 +426,7 @@ class MediaControllerTest extends IntegrationTestCase
                         'lang' => 'en',
                         'publish_start' => null,
                         'publish_end' => null,
-                        'media_property' => 'synapse', // inherited custom property
+                        'media_property' => true, // inherited custom property
                         'name' => 'My media name',
                         'provider' => null,
                         'provider_uid' => null,

--- a/plugins/BEdita/API/tests/TestCase/Controller/MediaControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/MediaControllerTest.php
@@ -350,6 +350,7 @@ class MediaControllerTest extends IntegrationTestCase
             'type' => 'files',
             'attributes' => [
                 'provider_thumbnail' => 'https://thumbs.example.org/item.jpg',
+                'media_property' => true,
             ],
         ];
         $newId = $this->lastObjectId() + 1;

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
@@ -251,7 +251,7 @@ class ProjectControllerTest extends IntegrationTestCase
                     'name' => 'another_email',
                     'description' => 'User email',
                     'is_nullable' => true,
-                    'property_type_name' => 'string',
+                    'property_type_name' => 'email',
                     'object_type_name' => 'users',
                 ],
                 [
@@ -279,14 +279,14 @@ class ProjectControllerTest extends IntegrationTestCase
                     'name' => 'media_property',
                     'description' => null,
                     'is_nullable' => true,
-                    'property_type_name' => 'string',
+                    'property_type_name' => 'boolean',
                     'object_type_name' => 'media',
                 ],
                 [
                     'name' => 'files_property',
                     'description' => null,
                     'is_nullable' => true,
-                    'property_type_name' => 'string',
+                    'property_type_name' => 'json',
                     'object_type_name' => 'files',
                 ],
                 [

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
@@ -278,7 +278,7 @@ class ProjectControllerTest extends IntegrationTestCase
                 [
                     'name' => 'media_property',
                     'description' => null,
-                    'is_nullable' => true,
+                    'is_nullable' => false,
                     'property_type_name' => 'boolean',
                     'object_type_name' => 'media',
                 ],

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertiesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertiesControllerTest.php
@@ -128,7 +128,7 @@ class PropertiesControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'name' => 'another_email',
                         'description' => 'User email',
-                        'property_type_name' => 'string',
+                        'property_type_name' => 'email',
                         'object_type_name' => 'users',
                         'label' => null,
                         'is_nullable' => true,
@@ -208,7 +208,7 @@ class PropertiesControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'name' => 'media_property',
                         'description' => null,
-                        'property_type_name' => 'string',
+                        'property_type_name' => 'boolean',
                         'object_type_name' => 'media',
                         'label' => null,
                         'is_nullable' => true,
@@ -228,7 +228,7 @@ class PropertiesControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'name' => 'files_property',
                         'description' => null,
-                        'property_type_name' => 'string',
+                        'property_type_name' => 'json',
                         'object_type_name' => 'files',
                         'label' => null,
                         'is_nullable' => true,

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertiesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertiesControllerTest.php
@@ -211,7 +211,7 @@ class PropertiesControllerTest extends IntegrationTestCase
                         'property_type_name' => 'boolean',
                         'object_type_name' => 'media',
                         'label' => null,
-                        'is_nullable' => true,
+                        'is_nullable' => false,
                         'is_static' => false,
                     ],
                     'meta' => [

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -462,7 +462,7 @@ class ObjectsControllerTest extends IntegrationTestCase
                         'lang' => 'en',
                         'publish_start' => null,
                         'publish_end' => null,
-                        'media_property' => 'synapse', // inherited custom property
+                        'media_property' => true, // inherited custom property
                     ],
                     'meta' => [
                         'locked' => false,

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -653,6 +653,7 @@ class ObjectsControllerTest extends IntegrationTestCase
                         'lang' => 'en',
                         'publish_start' => null,
                         'publish_end' => null,
+                        'media_property' => false,
                     ],
                     'meta' => [
                         'locked' => false,

--- a/plugins/BEdita/API/tests/TestCase/Controller/UploadControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/UploadControllerTest.php
@@ -15,6 +15,7 @@ namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
 use BEdita\Core\Test\Utility\TestFilesystemTrait;
+use Cake\ORM\TableRegistry;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\UploadController
@@ -58,6 +59,12 @@ class UploadControllerTest extends IntegrationTestCase
      */
     public function testUpload()
     {
+        // set proprty to `nullable` to avoid error
+        $table = TableRegistry::getTableLocator()->get('Properties');
+        $property = $table->get(8);
+        $property->is_nullable = true;
+        $table->saveOrFail($property);
+
         $fileName = 'gustavo.json';
         $contents = '{"name":"Gustavo","surname":"Supporto"}';
         $contentType = 'application/json';

--- a/plugins/BEdita/API/tests/TestConstants.php
+++ b/plugins/BEdita/API/tests/TestConstants.php
@@ -27,7 +27,7 @@ class TestConstants
         'applications' => '2244706479',
         'documents' => '4059696127',
         'events' => '1528552691',
-        'files' => '3796351097',
+        'files' => '290039203',
         'folders' => '3223993640',
         'locations' => '2540919723',
         'profiles' => '3185752423',

--- a/plugins/BEdita/API/tests/TestConstants.php
+++ b/plugins/BEdita/API/tests/TestConstants.php
@@ -27,11 +27,11 @@ class TestConstants
         'applications' => '2244706479',
         'documents' => '4059696127',
         'events' => '1528552691',
-        'files' => '1243827317',
+        'files' => '3796351097',
         'folders' => '3223993640',
         'locations' => '2540919723',
         'profiles' => '3185752423',
         'roles' => '2845943672',
-        'users' => '1532277861',
+        'users' => '3777799474',
     ];
 }

--- a/plugins/BEdita/Core/src/Command/CustomPropsCommand.php
+++ b/plugins/BEdita/Core/src/Command/CustomPropsCommand.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Core\Command;
+
+use Cake\Console\Arguments;
+use Cake\Console\Command;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\Core\Exception\Exception;
+use Cake\ORM\Query;
+use Cake\ORM\TableRegistry;
+use Cake\Utility\Inflector;
+use Generator;
+
+/**
+ * CustomProps command.
+ *
+ * Check custom properties formatting & validity
+ *
+ * @since 4.5.0
+ */
+class CustomPropsCommand extends Command
+{
+    /**
+     * Table.
+     *
+     * @var \Cake\ORM\Table
+     */
+    protected $Table;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        return $parser->addOption('id', [
+                'help' => 'Object ID to check',
+                'required' => false,
+            ])
+            ->addOption('type', [
+                'help' => 'Object type name to check',
+                'short' => 't',
+                'required' => false,
+            ]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function execute(Arguments $args, ConsoleIo $io): ?int
+    {
+        $types = TableRegistry::getTableLocator()->get('ObjectTypes')
+            ->find('list', ['valueField' => 'name'])
+            ->where(['is_abstract' => false])
+            ->toList();
+        if ($args->getOption('type')) {
+            $types = [(string)$args->getOption('type')];
+        }
+        $errors = 0;
+        foreach ($types as $type) {
+            $errors += $this->customPropsByType($type, $args->getOption('id'), $io);
+        }
+        if ($errors) {
+            $io->error(sprintf('Errors found (%d)', $errors));
+
+            return self::CODE_ERROR;
+        }
+
+        $io->success('Done');
+
+        return null;
+    }
+
+    /**
+     * Check custom properties of an object type.
+     *
+     * @param string $type Object type
+     * @param int|null $id Object ID
+     * @param ConsoleIo $io Console IO
+     * @return int Number of errors found
+     */
+    protected function customPropsByType(string $type, ?int $id, ConsoleIo $io): int
+    {
+        $io->info(sprintf('Processing %s...', $type));
+        $this->Table = TableRegistry::getTableLocator()->get(Inflector::camelize($type));
+        $query = $this->Table
+            ->find('type', (array)$type)
+            ->select(['id', 'title', 'custom_props']);
+        if ($id) {
+            $query = $query->where(compact('id'));
+        }
+
+        $count = $err = 0;
+        foreach ($this->objectsGenerator($query) as $object) {
+            $props = (array)$object->get('custom_props');
+            $object->set($props);
+            try {
+                $this->Table->saveOrFail($object);
+                $count++;
+            } catch (Exception $ex) {
+                $msg = sprintf(
+                    'Failed update on %s "%s" [id %d] - exception: %s',
+                    $type,
+                    $object->get('title'),
+                    $object->id,
+                    $ex->getMessage()
+                );
+                $this->log($msg, 'error');
+                $err++;
+            }
+        }
+        $io->success(sprintf('Updated %d %s without errors', $count, $type));
+        if ($err) {
+            $io->warning(sprintf('%d errors updating %s', $err, $type));
+        }
+
+        return $err;
+    }
+
+    /**
+     * Objects generator.
+     *
+     * @param \Cake\ORM\Query $query Query object
+     * @return \Generator
+     */
+    protected function objectsGenerator(Query $query): Generator
+    {
+        $pageSize = 1000;
+        $pages = ceil($query->count() / $pageSize);
+
+        for ($page = 1; $page <= $pages; $page++) {
+            yield from $query
+                ->page($page, $pageSize)
+                ->toArray();
+        }
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -197,7 +197,10 @@ class CustomPropertiesBehavior extends Behavior
         foreach ($available as $property) {
             /** @var \BEdita\Core\Model\Entity\Property $property */
             $name = $property->name;
-            if (!$this->isFieldSet($entity, $name) || !$entity->isDirty($name)) {
+            if (
+                (!$this->isFieldSet($entity, $name) || !$entity->isDirty($name)) &&
+                !($entity->isNew() && !$property->is_nullable)
+            ) {
                 continue;
             }
 

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -205,7 +205,7 @@ class CustomPropertiesBehavior extends Behavior
             $schema = (array)$property->property_type->params;
             $propValue = $this->formatValue($entity->get($name), $schema);
             $result = Validation::jsonSchema($propValue, $schema);
-            if ($propValue !== null && is_string($result)) {
+            if (($propValue !== null || !$property->is_nullable) && is_string($result)) {
                 $entity->setError($name, $result);
             }
             $value[$name] = $propValue;

--- a/plugins/BEdita/Core/tests/Fixture/ObjectsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ObjectsFixture.php
@@ -208,7 +208,7 @@ class ObjectsFixture extends TestFixture
             'modified_by' => 1,
             'publish_start' => null,
             'publish_end' => null,
-            'custom_props' => '{"media_property":"synapse"}',
+            'custom_props' => '{"media_property":true}',
         ],
         // 11
         [

--- a/plugins/BEdita/Core/tests/Fixture/ObjectsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ObjectsFixture.php
@@ -289,6 +289,7 @@ class ObjectsFixture extends TestFixture
             'modified_by' => 1,
             'publish_start' => null,
             'publish_end' => null,
+            'custom_props' => '{"media_property":false}',
         ],
         // 15 (ghost object)
         [

--- a/plugins/BEdita/Core/tests/Fixture/PropertiesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/PropertiesFixture.php
@@ -54,7 +54,7 @@ class PropertiesFixture extends TestFixture
         ],
         [
             'name' => 'another_email',
-            'property_type_id' => 1,
+            'property_type_id' => 4,
             'object_type_id' => 4,
             'created' => '2016-12-31 23:09:23',
             'modified' => '2016-12-31 23:09:23',
@@ -102,7 +102,7 @@ class PropertiesFixture extends TestFixture
         ],
         [
             'name' => 'media_property',
-            'property_type_id' => 1,
+            'property_type_id' => 10,
             'object_type_id' => 8,
             'created' => '2017-11-07 18:32:00',
             'modified' => '2017-11-07 18:32:00',
@@ -114,7 +114,7 @@ class PropertiesFixture extends TestFixture
         ],
         [
             'name' => 'files_property',
-            'property_type_id' => 1,
+            'property_type_id' => 11,
             'object_type_id' => 9,
             'created' => '2017-11-07 18:32:00',
             'modified' => '2017-11-07 18:32:00',

--- a/plugins/BEdita/Core/tests/Fixture/PropertiesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/PropertiesFixture.php
@@ -109,7 +109,7 @@ class PropertiesFixture extends TestFixture
             'description' => null,
             'enabled' => true,
             'label' => null,
-            'is_nullable' => true,
+            'is_nullable' => false,
             'is_static' => false,
         ],
         [

--- a/plugins/BEdita/Core/tests/TestCase/Command/CustomPropsCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/CustomPropsCommandTest.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Test\TestCase\Command;
 
 use BEdita\Core\Filesystem\Adapter\LocalAdapter;
@@ -75,6 +86,7 @@ class CustomPropsCommandTest extends TestCase
             'className' => LocalAdapter::class,
         ]);
         $this->exec('custom_props');
+        FilesystemRegistry::dropAll();
         $this->assertOutputContains('Updated 2 users without errors');
         $this->assertExitSuccess();
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
@@ -356,11 +356,9 @@ class CustomPropertiesBehaviorTest extends TestCase
                 [
                     'media_property' => true,
                     'files_property' => ['gustavo' => 'supporto'],
-                    // 'files_property' => '{"gustavo":"supporto"}',
                 ],
                 [
                     'files_property' => ['gustavo' => 'supporto'],
-                    // 'files_property' => '{"gustavo":"supporto"}',
                 ],
                 10,
                 'Files',
@@ -456,6 +454,27 @@ class CustomPropertiesBehaviorTest extends TestCase
 
         static::assertFalse($result);
         static::assertNotEmpty($entity->getErrors());
+    }
+
+    /**
+     * Test validation error on not nullable property.
+     *
+     * @return void
+     *
+     * @covers ::demoteProperties()
+     */
+    public function testValidationNewFail(): void
+    {
+        $table = TableRegistry::getTableLocator()->get('Files');
+        $entity = $table->newEntity(['title' => 'New file']);
+        $result = $table->save($entity);
+
+        static::assertFalse($result);
+        static::assertNotEmpty($entity->getErrors());
+        $expected = [
+            'media_property' => ['Boolean expected, null received'],
+        ];
+        static::assertEquals($expected, $entity->getErrors());
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
@@ -355,18 +355,19 @@ class CustomPropertiesBehaviorTest extends TestCase
             'overwrite' => [
                 [
                     'media_property' => true,
-                    'files_property' => 'gustavo@example.org',
+                    'files_property' => ['gustavo' => 'supporto'],
+                    // 'files_property' => '{"gustavo":"supporto"}',
                 ],
                 [
-                    'files_property' => 'gustavo@example.org',
+                    'files_property' => ['gustavo' => 'supporto'],
+                    // 'files_property' => '{"gustavo":"supporto"}',
                 ],
                 10,
                 'Files',
             ],
             'empty' => [
                 [
-                    'media_property' => null,
-                    'files_property' => null,
+                    'media_property' => ['Boolean expected, null received']
                 ],
                 [
                     'media_property' => null,
@@ -422,7 +423,12 @@ class CustomPropertiesBehaviorTest extends TestCase
         $entity = $table->get($id);
 
         $table->patchEntity($entity, $data);
-        $table->save($entity);
+        $success = $table->save($entity);
+        if ($success === false) {
+            static::assertSame($expected, $entity->getErrors());
+
+            return;
+        }
 
         $result = $entity->get('custom_props');
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
@@ -296,7 +296,7 @@ class CustomPropertiesBehaviorTest extends TestCase
     {
         $expected = [
             'files_property' => ['media-one' => null, 'media-two' => null],
-            'media_property' => ['media-one' => 'synapse', 'media-two' => null],
+            'media_property' => ['media-one' => true, 'media-two' => null],
             'count' => 2,
         ];
 
@@ -343,18 +343,18 @@ class CustomPropertiesBehaviorTest extends TestCase
         return [
             'simple' => [
                 [
-                    'media_property' => 'gustavo',
+                    'media_property' => false,
                     'files_property' => null,
                 ],
                 [
-                    'media_property' => 'gustavo',
+                    'media_property' => false,
                 ],
                 10,
                 'Files',
             ],
             'overwrite' => [
                 [
-                    'media_property' => 'synapse',
+                    'media_property' => true,
                     'files_property' => 'gustavo@example.org',
                 ],
                 [
@@ -370,21 +370,34 @@ class CustomPropertiesBehaviorTest extends TestCase
                 ],
                 [
                     'media_property' => null,
+                    'files_property' => '',
                 ],
                 10,
                 'Files',
             ],
             'disabledProperty' => [
                 [
-                    'media_property' => 'gustavo',
+                    'media_property' => false,
                     'files_property' => null,
                 ],
                 [
-                    'media_property' => 'gustavo',
+                    'media_property' => 0,
                     'disabled_property' => 'do not write it!',
                 ],
                 10,
                 'Files',
+            ],
+            'email' => [
+                [
+                    'another_email' => null,
+                    'another_username' => 'another'
+                ],
+                [
+                    'another_email' => '',
+                    'another_username' => 'another'
+                ],
+                5,
+                'Users',
             ],
         ];
     }
@@ -401,8 +414,9 @@ class CustomPropertiesBehaviorTest extends TestCase
      * @dataProvider beforeSaveProvider()
      * @covers ::beforeSave()
      * @covers ::demoteProperties()
+     * @covers ::formatValue()
      */
-    public function testBeforeSave(array $expected, array $data, $id, $table)
+    public function testBeforeSave(array $expected, array $data, $id, $table): void
     {
         $table = TableRegistry::getTableLocator()->get($table);
         $entity = $table->get($id);
@@ -416,6 +430,26 @@ class CustomPropertiesBehaviorTest extends TestCase
         ksort($result);
 
         static::assertSame($expected, $result);
+    }
+
+    /**
+     * Test validation error on custom properties.
+     *
+     * @return void
+     *
+     * @covers ::beforeSave()
+     * @covers ::demoteProperties()
+     */
+    public function testValidationFail(): void
+    {
+        $table = TableRegistry::getTableLocator()->get('Documents');
+        $entity = $table->get(2);
+
+        $table->patchEntity($entity, ['another_title' => true]);
+        $result = $table->save($entity);
+
+        static::assertFalse($result);
+        static::assertNotEmpty($entity->getErrors());
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
@@ -296,7 +296,7 @@ class CustomPropertiesBehaviorTest extends TestCase
     {
         $expected = [
             'files_property' => ['media-one' => null, 'media-two' => null],
-            'media_property' => ['media-one' => true, 'media-two' => null],
+            'media_property' => ['media-one' => true, 'media-two' => false],
             'count' => 2,
         ];
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/MediaTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/MediaTest.php
@@ -95,7 +95,10 @@ class MediaTest extends TestCase
      */
     public function testGetMediaUrl()
     {
-        $entity = $this->Files->newEntity(['title' => 'New file']);
+        $entity = $this->Files->newEntity([
+            'title' => 'New file',
+            'media_property' => false,
+        ]);
         $entity->created_by = 1;
         $entity->modified_by = 1;
         $entity = $this->Files->saveOrFail($entity);

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -290,7 +290,7 @@ class ProjectModelTest extends TestCase
             [
                 'name' => 'media_property',
                 'description' => null,
-                'is_nullable' => true,
+                'is_nullable' => false,
                 'property_type_name' => 'boolean',
                 'object_type_name' => 'media',
             ],

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -263,7 +263,7 @@ class ProjectModelTest extends TestCase
                 'name' => 'another_email',
                 'description' => 'User email',
                 'is_nullable' => true,
-                'property_type_name' => 'string',
+                'property_type_name' => 'email',
                 'object_type_name' => 'users',
             ],
             [
@@ -291,14 +291,14 @@ class ProjectModelTest extends TestCase
                 'name' => 'media_property',
                 'description' => null,
                 'is_nullable' => true,
-                'property_type_name' => 'string',
+                'property_type_name' => 'boolean',
                 'object_type_name' => 'media',
             ],
             [
                 'name' => 'files_property',
                 'description' => null,
                 'is_nullable' => true,
-                'property_type_name' => 'string',
+                'property_type_name' => 'json',
                 'object_type_name' => 'files',
             ],
             [


### PR DESCRIPTION
This PR fixes #1336 introducing JSON Schema validation & formatting

- `CustomPropertiesBehavior` has been changed adding a validation step in `beforeSave` - before validation a simple formattiing on some JSON Schema primitive types has been added. Also `properties.is_nullable` is now handled correctly: upon creation and update not nullable properties are checked for existence and validity. 

- a new command `CustomPropsCommand` has been added to check and properly format custom properties previously saved without validation & formatting 

- test cases have been modified with some changes to custom properties
   - `media_property` is now *boolean* and *not nullable* 
   - `another_email` is now *email* type
   - `files_property` is now *object* type 
    