### PR TITLE
Properties update utility

### DIFF
--- a/plugins/BEdita/Core/tests/TestCase/Utility/PropertiesTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/PropertiesTest.php
@@ -14,17 +14,21 @@
 namespace BEdita\Core\Test\TestCase\Utility;
 
 use BEdita\Core\Utility\Properties;
+use Cake\Datasource\ModelAwareTrait;
 use Cake\Http\Exception\BadRequestException;
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
 /**
  * {@see \BEdita\Core\Utility\Properties} Test Case
  *
  * @coversDefaultClass \BEdita\Core\Utility\Properties
+ *
+ * @property \BEdita\Core\Model\Table\PropertiesTable $Properties
  */
 class PropertiesTest extends TestCase
 {
+    use ModelAwareTrait;
+
     /**
      * Fixtures
      *
@@ -63,16 +67,27 @@ class PropertiesTest extends TestCase
     ];
 
     /**
+     * {@inheritDoc}
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->loadModel('Properties');
+    }
+
+    /**
      * Test `create` method.
+     *
+     * @return void
      *
      * @covers ::create()
      * @covers ::validate()
      */
-    public function testCreate()
+    public function testCreate(): void
     {
         Properties::create($this->properties);
 
-        $newProperties = TableRegistry::getTableLocator()->get('Properties')
+        $newProperties = $this->Properties
             ->find()
             ->where(['name IN' => ['custom_one', 'custom_two']])
             ->toArray();
@@ -82,14 +97,16 @@ class PropertiesTest extends TestCase
     /**
      * Test `remove` method.
      *
+     * @return void
+     *
      * @covers ::remove()
      */
-    public function testRemove()
+    public function testRemove(): void
     {
         Properties::create($this->properties);
 
         Properties::remove($this->properties);
-        $newProperties = TableRegistry::getTableLocator()->get('Properties')
+        $newProperties = $this->Properties
             ->find()
             ->where(['name IN' => ['custom_one', 'custom_two']])
             ->toArray();
@@ -99,14 +116,37 @@ class PropertiesTest extends TestCase
     /**
      * Test `validate` failure.
      *
+     * @return void
+     *
      * @covers ::validate()
      */
-    public function testValidate()
+    public function testValidate(): void
     {
         $this->expectException(BadRequestException::class);
         $this->expectExceptionMessage('Missing mandatory property data "name"');
 
         unset($this->properties[0]['name']);
         Properties::create($this->properties);
+    }
+
+    /**
+     * Test `update` method.
+     *
+     * @return void
+     *
+     * @covers ::update()
+     */
+    public function testUpdate(): void
+    {
+        Properties::create($this->properties);
+
+        $this->properties[1]['property'] = 'text';
+        Properties::update($this->properties);
+
+        $newProp = $this->Properties
+            ->find()
+            ->where(['name' => 'custom_two'])
+            ->first();
+        static::assertEquals('text', $newProp->get('property_type_name'));
     }
 }


### PR DESCRIPTION
This PR adds `Properties::update()` method - to be used mainly in migrations to change property type or description of a property.
`PropertiesTest` test case has been updated.
