### PR TITLE
fix: avoid unwanted `uname` change

### DIFF
--- a/plugins/BEdita/Core/src/Command/CustomPropsCommand.php
+++ b/plugins/BEdita/Core/src/Command/CustomPropsCommand.php
@@ -94,8 +94,7 @@ class CustomPropsCommand extends Command
         $io->info(sprintf('Processing %s...', $type));
         $this->Table = TableRegistry::getTableLocator()->get(Inflector::camelize($type));
         $query = $this->Table
-            ->find('type', (array)$type)
-            ->select(['id', 'title', 'custom_props']);
+            ->find('type', (array)$type);
         if ($id) {
             $query = $query->where(compact('id'));
         }


### PR DESCRIPTION
This PR fixes an unwanted behavior in `CustomPropsCommand`: `uname` fields are recalculated in `UniqueNameBehavior` if not set in entity (probably a bug to be fixed in another PR...) 
 