### PR TITLE
Avoid `uname` change when absent

### DIFF
--- a/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
@@ -80,6 +80,9 @@ class UniqueNameBehavior extends Behavior
      */
     public function uniqueName(EntityInterface $entity): void
     {
+        if (!$entity->isNew() && !$entity->has('uname')) {
+            return;
+        }
         $uname = $entity->get('uname');
         if (empty($uname)) {
             $uname = $this->generateUniqueName($entity);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
@@ -393,6 +393,27 @@ class UniqueNameBehaviorTest extends TestCase
     }
 
     /**
+     * Test `uniqueName()` when `uname` is unchanged and not in entity
+     *
+     * @return void
+     *
+     * @covers ::uniqueName()
+     */
+    public function testUniqueNameIgnore(): void
+    {
+        $Documents = TableRegistry::getTableLocator()->get('Documents');
+        $document = $Documents->get(2);
+        $document->set('title', 'a new title');
+        $document->unsetProperty('uname');
+
+        $behavior = $Documents->behaviors()->get('UniqueName');
+        $behavior->uniqueName($document);
+
+        static::assertFalse($document->isDirty('uname'));
+        static::assertFalse($document->has('uname'));
+    }
+
+    /**
      * test generate uname before save
      *
      * @return void


### PR DESCRIPTION
This PR fixes the unwanted `uname` change when no `uname` is present in an existing entity and saved
