### PR TITLE
fix: avoid errors with options from other filters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "php": ">=7.2.0",
         "cakephp/cakephp": "~3.9.3",
         "cakephp/plugin-installer": "^1.3",
+        "guzzlehttp/psr7": "~1.1",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": ">=7.2.0",
         "cakephp/cakephp": "~3.9.3",
         "cakephp/plugin-installer": "^1.3",
-        "guzzlehttp/psr7": "~1.1",
+        "guzzlehttp/psr7": "1.8.2",
         "wikimedia/composer-merge-plugin": "^2.0.1"
     },
     "require-dev": {

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -298,19 +298,16 @@ class CustomPropertiesBehavior extends Behavior
             throw new BadFilterException(__d('bedita', 'customProp finder isn\'t supported for datasource'));
         }
 
+        $available = $this->getAvailable();
+        $options = array_intersect_key($options, $available);
         if (empty($options)) {
             // Bad filter options.
             throw new BadFilterException(__d('bedita', 'Invalid data'));
         }
 
-        $available = $this->getAvailable();
         foreach ($options as $key => &$value) {
             /** @var \BEdita\Core\Model\Entity\Property $property */
             $property = Hash::get($available, $key);
-            if (!$property) {
-                throw new BadFilterException(__d('bedita', 'Invalid custom property "{0}"', [$key]));
-            }
-
             $value = $this->formatValue($value, $property->property_type->params);
         }
         unset($value);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
@@ -516,7 +516,7 @@ class CustomPropertiesBehaviorTest extends TestCase
                 [],
             ],
             'invalid custom prop' => [
-                new BadFilterException('Invalid custom property "yeppa"'),
+                new BadFilterException('Invalid data'),
                 'Documents',
                 ['yeppa' => 12],
             ],


### PR DESCRIPTION
This PR fixes a problem with new `findCustomProp` finder when multiple finder/filters are invoked and some other options are passed to this finder.
