### PR TITLE
fix: add `RelatedObjects` to default bindings of BeditaSimpleStreamModel

### DIFF
--- a/bedita-app/app_model.php
+++ b/bedita-app/app_model.php
@@ -1425,6 +1425,7 @@ class BeditaSimpleStreamModel extends BEAppObjectModel {
                 'ObjectProperty',
                 'LangText',
                 'ObjectType',
+                'RelatedObject',
                 'Annotation',
                 'Category'
             ),


### PR DESCRIPTION
This PR adds `RelatedObjects` to default model bindings of `BeditaSimpleStreamModel` models