### PR TITLE
Fix V3: Reserved word group with mysql v8

### DIFF
--- a/bedita-app/config/sql/bedita_init_data.sql
+++ b/bedita-app/config/sql/bedita_init_data.sql
@@ -26,12 +26,12 @@ INSERT INTO object_types (id, name, module_name) VALUES (51, 'caption', 'multime
 -- ----------------------------------
 INSERT INTO users (userid , realname , passwd ) VALUES ('bedita', 'BEdita', MD5( 'bedita' ));
 
-INSERT INTO groups ( name, backend_auth, immutable ) VALUES ('administrator', true, true);
-INSERT INTO groups ( name, backend_auth, immutable ) VALUES ('manager', true, false);
-INSERT INTO groups ( name, backend_auth, immutable ) VALUES ('editor', true, false);
-INSERT INTO groups ( name, backend_auth, immutable ) VALUES ('reader', true, false);
-INSERT INTO groups ( name, backend_auth, immutable ) VALUES ('translator', true, false);
-INSERT INTO groups ( name, backend_auth, immutable ) VALUES ('frontend', false, false);
+INSERT INTO `groups` ( name, backend_auth, immutable ) VALUES ('administrator', true, true);
+INSERT INTO `groups` ( name, backend_auth, immutable ) VALUES ('manager', true, false);
+INSERT INTO `groups` ( name, backend_auth, immutable ) VALUES ('editor', true, false);
+INSERT INTO `groups` ( name, backend_auth, immutable ) VALUES ('reader', true, false);
+INSERT INTO `groups` ( name, backend_auth, immutable ) VALUES ('translator', true, false);
+INSERT INTO `groups` ( name, backend_auth, immutable ) VALUES ('frontend', false, false);
 
 INSERT INTO groups_users ( user_id , group_id ) VALUES (1, 1);
 

--- a/bedita-app/config/sql/bedita_mysql_schema.sql
+++ b/bedita-app/config/sql/bedita_mysql_schema.sql
@@ -248,7 +248,7 @@ CREATE TABLE `groups` (
   created datetime default NULL,
   modified datetime default NULL,
   PRIMARY KEY(id),
-  UNIQUE KEY (name)
+  UNIQUE KEY name (name)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT = 'generic groups';
 
 CREATE TABLE `groups_users` (

--- a/bedita-app/config/sql/bedita_mysql_schema.sql
+++ b/bedita-app/config/sql/bedita_mysql_schema.sql
@@ -240,7 +240,7 @@ CREATE TABLE geo_tags (
       ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT = 'geotagging informations' ;
 
-CREATE TABLE groups (
+CREATE TABLE `groups` (
   id INTEGER UNSIGNED NOT NULL AUTO_INCREMENT,
   name VARCHAR(32) NOT NULL COMMENT 'group name',
   backend_auth BOOL NOT NULL DEFAULT '0' COMMENT 'group authorized to backend (default: false)',
@@ -248,10 +248,10 @@ CREATE TABLE groups (
   created datetime default NULL,
   modified datetime default NULL,
   PRIMARY KEY(id),
-  UNIQUE KEY name (name)
+  UNIQUE KEY (name)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT = 'generic groups';
 
-CREATE TABLE groups_users (
+CREATE TABLE `groups_users` (
   id INTEGER UNSIGNED NOT NULL AUTO_INCREMENT,
   group_id INTEGER UNSIGNED NOT NULL,
   user_id INTEGER UNSIGNED NOT NULL,
@@ -263,7 +263,7 @@ CREATE TABLE groups_users (
       ON DELETE CASCADE
       ON UPDATE NO ACTION,
   FOREIGN KEY(group_id)
-    REFERENCES groups(id)
+    REFERENCES `groups` (id)
       ON DELETE CASCADE
       ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT = 'join table for groups/users';

--- a/bedita-app/config/sql/bedita_mysql_schema.sql
+++ b/bedita-app/config/sql/bedita_mysql_schema.sql
@@ -251,7 +251,7 @@ CREATE TABLE `groups` (
   UNIQUE KEY name (name)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT = 'generic groups';
 
-CREATE TABLE `groups_users` (
+CREATE TABLE groups_users (
   id INTEGER UNSIGNED NOT NULL AUTO_INCREMENT,
   group_id INTEGER UNSIGNED NOT NULL,
   user_id INTEGER UNSIGNED NOT NULL,


### PR DESCRIPTION
This PR fixes bug reserved word for `groups` when lunch command `./cake.sh bedita initDb <namedb>` on version 8 of MySQL.
It was fixed using backtick on table `groups`.