### PR TITLE
More tables searchable

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -27,6 +27,7 @@ class FilterQueryStringTest extends IntegrationTestCase
      * {@inheritDoc}
      */
     public $fixtures = [
+        'plugin.BEdita/Core.Annotations',
         'plugin.BEdita/Core.DateRanges',
         'plugin.BEdita/Core.Locations',
         'plugin.BEdita/Core.Media',
@@ -348,6 +349,30 @@ class FilterQueryStringTest extends IntegrationTestCase
                     '4',
                     '5',
                     '6',
+                ],
+            ],
+            'translations' => [
+                '/translations?filter[query]=ici',
+                [
+                    '2',
+                ],
+            ],
+            'annotations' => [
+                '/annotations?q=ipsum',
+                [
+                    '1',
+                ],
+            ],
+            'categories' => [
+                '/model/categories?filter[query]=second',
+                [
+                    '2',
+                ],
+            ],
+            'tags' => [
+                '/model/tags?q=first',
+                [
+                    '4',
                 ],
             ],
         ];

--- a/plugins/BEdita/Core/src/Model/Table/AnnotationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/AnnotationsTable.php
@@ -61,6 +61,11 @@ class AnnotationsTable extends Table
                 ],
             ],
         ]);
+        $this->addBehavior('BEdita/Core.Searchable', [
+            'fields' => [
+                'description' => 10,
+            ],
+        ]);
 
         $this->belongsTo('Objects', [
             'foreignKey' => 'object_id',

--- a/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
@@ -56,6 +56,12 @@ class CategoriesTable extends CategoriesTagsBaseTable
         $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
+        $this->addBehavior('BEdita/Core.Searchable', [
+            'fields' => [
+                'label' => 10,
+                'name' => 8,
+            ],
+        ]);
 
         $this->belongsTo('ObjectTypes', [
             'foreignKey' => 'object_type_id',

--- a/plugins/BEdita/Core/src/Model/Table/PropertyTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/PropertyTypesTable.php
@@ -55,6 +55,12 @@ class PropertyTypesTable extends Table
         $this->setDisplayField('name');
 
         $this->addBehavior('Timestamp');
+        $this->addBehavior('BEdita/Core.Searchable', [
+            'fields' => [
+                'name' => 10,
+                'params' => 8,
+            ],
+        ]);
 
         $this->hasMany('Properties');
     }

--- a/plugins/BEdita/Core/src/Model/Table/TagsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TagsTable.php
@@ -53,6 +53,12 @@ class TagsTable extends CategoriesTagsBaseTable
         $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
+        $this->addBehavior('BEdita/Core.Searchable', [
+            'fields' => [
+                'label' => 10,
+                'name' => 8,
+            ],
+        ]);
 
         $this->hasMany('ObjectTags', [
             'foreignKey' => 'category_id',

--- a/plugins/BEdita/Core/src/Model/Table/TranslationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TranslationsTable.php
@@ -54,6 +54,11 @@ class TranslationsTable extends Table
 
         $this->addBehavior('Timestamp');
         $this->addBehavior('BEdita/Core.UserModified');
+        $this->addBehavior('BEdita/Core.Searchable', [
+            'fields' => [
+                'translated_fields' => 10,
+            ],
+        ]);
 
         $this->belongsTo('Objects', [
             'className' => 'Objects',

--- a/plugins/BEdita/Core/src/Model/Table/TranslationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TranslationsTable.php
@@ -58,6 +58,10 @@ class TranslationsTable extends Table
             'fields' => [
                 'translated_fields' => 10,
             ],
+            'columnTypes' => [
+                'json',
+                'text',
+            ],
         ]);
 
         $this->belongsTo('Objects', [


### PR DESCRIPTION
This adds `Core.Searchable` behavior to the following tables:

 -  `Annotations`
 -  `Categories`
 -  `PropertyTypes`
 -  `Tags`
 -  `Translations`

Expected: providing use of query filter, i.e. `GET /:tablename?filter[query]=something`