### PR TITLE
fix: removed nowrap mimetype table and elasticsearch tooltip position

### DIFF
--- a/bedita-app/views/elements/form_assoc_object.tpl
+++ b/bedita-app/views/elements/form_assoc_object.tpl
@@ -103,7 +103,7 @@
 	
 	<td class="lang">{$objRelated.lang|default:''}</td>
 
-	<td nowrap class="mimetype">
+	<td class="mimetype">
 		{if !empty($objRelated.file_size)}{$objRelated.file_size|default:0|filesize}<br>{/if} {$objRelated.mime_type|default:''|truncate:60:'~':true}
 	</td>
 

--- a/bedita-app/webroot/css/bedita.css
+++ b/bedita-app/webroot/css/bedita.css
@@ -2139,21 +2139,22 @@ A.BEbutton.golink:before {
 	text-align: center;
 	border-radius: 6px;
 	padding: 5px 5px;
-	position: absolute;
+	position: relative;
 	z-index: 1;
-    bottom: 96%;
+    top: 32px;
     margin-left: -292px;
     margin-bottom: 6px;
 }
 
-.filters .cell .elastictooltiptext::after {
+.filters .cell .elastictooltiptext::before {
 	content: "";
 	position: absolute;
-	top: 100%;
+	bottom: 100%;
 	left: 5%;
 	border-width: 5px;
 	border-style: solid;
-	border-color: #555 transparent transparent transparent;
+	border-color: #555 transparent  transparent transparent;
+	transform: rotate(180deg);
   }
 
 .filters .formbuttons {


### PR DESCRIPTION
Removed the `nowrap` from mimetype in the relations objects list.
The wrap property, with long mimetypes, prevents the possibility to click the "go" button for the first 2 elements in the relations list.
Before:
<img width="914" alt="Schermata 2021-09-09 alle 14 55 07" src="https://user-images.githubusercontent.com/2228532/132689645-04e6b5f2-803c-465d-aa8c-1ebb3d9fbad4.png">

After:
<img width="914" alt="Schermata 2021-09-09 alle 14 55 31" src="https://user-images.githubusercontent.com/2228532/132689695-ab8cebd3-7d9d-44fd-9a64-a37b273b764d.png">


Moved the hint tooltip for the input elasticsearch field from top of the field to the bottom, to avoid overlapping on the string.
Before:
<img width="800" alt="Schermata 2021-09-09 alle 14 56 44" src="https://user-images.githubusercontent.com/2228532/132690023-f87c9ff7-4099-4ed5-95fc-f652d3559830.png">

After:
<img width="800" alt="Schermata 2021-09-09 alle 14 57 39" src="https://user-images.githubusercontent.com/2228532/132690045-1ca3ad62-1f15-447b-badb-413ead5877a6.png">
 