### PR TITLE
New `fix_history` command

### DIFF
--- a/plugins/BEdita/Core/src/Command/FixHistoryCommand.php
+++ b/plugins/BEdita/Core/src/Command/FixHistoryCommand.php
@@ -212,7 +212,7 @@ class FixHistoryCommand extends Command
             $joinConditions[] = $query->newExpr()->eq($this->History->aliasField('user_action'), 'create');
         }
 
-        $conditions = [$idField . ' IS NULL'];
+        $conditions = [$this->History->aliasField('resource_id') . ' IS NULL'];
         if ($args->getOption('id')) {
             $conditions[] = [$this->Objects->aliasField('id') => $args->getOption('id')];
         }

--- a/plugins/BEdita/Core/src/Command/FixHistoryCommand.php
+++ b/plugins/BEdita/Core/src/Command/FixHistoryCommand.php
@@ -12,19 +12,20 @@
  */
 namespace BEdita\Core\Command;
 
+use BEdita\Core\Model\Entity\History;
 use BEdita\Core\Model\Entity\ObjectEntity;
 use Cake\Console\Arguments;
 use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Database\Driver\Postgres;
-use Cake\Datasource\EntityInterface;
 use Cake\ORM\Query;
 use Cake\ORM\TableRegistry;
 use Generator;
 
 /**
- * FixHistory command.
+ * FixHistory command: add missing history items or repair existing ones
+ * looking at `objects.created_by` and `objects.modified_by` properties.
  *
  * @since 4.6.0
  *
@@ -89,6 +90,7 @@ class FixHistoryCommand extends Command
         $query = $this->missingHistoryQuery(true, $args);
         $count = 0;
         foreach ($this->objectsGenerator($query) as $object) {
+            /** @var \BEdita\Core\Model\Entity\ObjectEntity $object */
             $this->fixHistoryCreate($object);
             $count++;
         }
@@ -98,6 +100,7 @@ class FixHistoryCommand extends Command
         $query = $this->missingHistoryQuery(false, $args);
         $count = 0;
         foreach ($this->objectsGenerator($query) as $object) {
+            /** @var \BEdita\Core\Model\Entity\ObjectEntity $object */
             $this->fixHistoryUpdate($object);
             $count++;
         }
@@ -116,6 +119,7 @@ class FixHistoryCommand extends Command
      */
     protected function fixHistoryCreate(ObjectEntity $object): void
     {
+        /** @var \BEdita\Core\Model\Entity\History $history */
         $history = $this->History
             ->find()->where([
                 $this->History->aliasField('resource_id') => $object->id,
@@ -142,6 +146,7 @@ class FixHistoryCommand extends Command
      */
     protected function fixHistoryUpdate(ObjectEntity $object): void
     {
+        /** @var \BEdita\Core\Model\Entity\History $history */
         $history = $this->History
             ->find()->where([
                 $this->History->aliasField('resource_id') => $object->id,
@@ -164,9 +169,9 @@ class FixHistoryCommand extends Command
      * History entity
      *
      * @param \BEdita\Core\Model\Entity\ObjectEntity $object Object entity
-     * @return \Cake\Datasource\EntityInterface
+     * @return \BEdita\Core\Model\Entity\History
      */
-    protected function historyEntity(ObjectEntity $object): EntityInterface
+    protected function historyEntity(ObjectEntity $object): History
     {
         $history = $this->History->newEntity();
         $history->resource_id = $object->get('id');

--- a/plugins/BEdita/Core/src/Command/FixHistoryCommand.php
+++ b/plugins/BEdita/Core/src/Command/FixHistoryCommand.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Core\Command;
+
+use BEdita\Core\Model\Entity\ObjectEntity;
+use Cake\Console\Arguments;
+use Cake\Console\Command;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\Database\Driver\Postgres;
+use Cake\Datasource\EntityInterface;
+use Cake\ORM\Query;
+use Cake\ORM\TableRegistry;
+use Generator;
+
+/**
+ * FixHistory command.
+ *
+ * @since 4.6.0
+ *
+ * @property \BEdita\Core\Model\Table\ObjectsTable $Objects
+ */
+class FixHistoryCommand extends Command
+{
+    /**
+     * {@inheritDoc}
+     */
+    public $modelClass = 'Objects';
+
+    /**
+     * History table
+     *
+     * @var \Cake\ORM\Table
+     */
+    public $History;
+
+    /**
+     * Application ID
+     *
+     * @var int
+     */
+    public $appId;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        return $parser->addOption('id', [
+                'help' => 'Object ID to check',
+                'required' => false,
+            ])
+            ->addOption('type', [
+                'help' => 'Object type name to check',
+                'short' => 't',
+                'required' => false,
+            ]);
+    }
+
+    /**
+     * Setup History table and application id
+     *
+     * @return void
+     */
+    public function initialize()
+    {
+        $this->History = $this->Objects->getBehavior('History')->Table;
+        $application = TableRegistry::getTableLocator()->get('Applications')
+            ->find()->orderAsc('id')->firstOrFail();
+        $this->appId = $application->get('id');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function execute(Arguments $args, ConsoleIo $io): ?int
+    {
+        // repair missing `create` actions
+        $query = $this->missingHistoryQuery(true, $args);
+        $count = 0;
+        foreach ($this->objectsGenerator($query) as $object) {
+            $this->fixHistoryCreate($object);
+            $count++;
+        }
+        $io->success('History creation items fixed: ' . $count);
+
+        // repair missing `update` actions
+        $query = $this->missingHistoryQuery(false, $args);
+        $count = 0;
+        foreach ($this->objectsGenerator($query) as $object) {
+            $this->fixHistoryUpdate($object);
+            $count++;
+        }
+        $io->success('History update items fixed: ' . $count);
+
+        $io->success('Done');
+
+        return null;
+    }
+
+    /**
+     * Repair history `create` item
+     *
+     * @param \BEdita\Core\Model\Entity\ObjectEntity $object Object entity
+     * @return void
+     */
+    protected function fixHistoryCreate(ObjectEntity $object): void
+    {
+        $history = $this->History
+            ->find()->where([
+                $this->History->aliasField('resource_id') => $object->id,
+                $this->History->aliasField('resource_type') => 'objects',
+                $this->History->aliasField('user_action') => 'create',
+            ])
+            ->first();
+
+        if (empty($history)) {
+            $history = $this->historyEntity($object);
+            $history->user_action = 'create';
+        }
+        $history->user_id = $object->get('created_by');
+        $history->created = $object->get('created');
+
+        $this->History->saveOrFail($history);
+    }
+
+    /**
+     * Repair history `update` item
+     *
+     * @param \BEdita\Core\Model\Entity\ObjectEntity $object Object entity
+     * @return void
+     */
+    protected function fixHistoryUpdate(ObjectEntity $object): void
+    {
+        $history = $this->History
+            ->find()->where([
+                $this->History->aliasField('resource_id') => $object->id,
+                $this->History->aliasField('resource_type') => 'objects',
+                sprintf("%s != 'create'", $this->History->aliasField('user_action')),
+            ])
+            ->first();
+
+        if (empty($history)) {
+            $history = $this->historyEntity($object);
+            $history->user_action = 'update';
+        }
+        $history->user_id = $object->get('modified_by');
+        $history->created = $object->get('modified');
+
+        $this->History->saveOrFail($history);
+    }
+
+    /**
+     * History entity
+     *
+     * @param \BEdita\Core\Model\Entity\ObjectEntity $object Object entity
+     * @return \Cake\Datasource\EntityInterface
+     */
+    protected function historyEntity(ObjectEntity $object): EntityInterface
+    {
+        $history = $this->History->newEntity();
+        $history->resource_id = $object->get('id');
+        $history->resource_type = 'objects';
+        $history->application_id = $this->appId;
+
+        return $history;
+    }
+
+    /**
+     * Create query for missing history data.
+     *
+     * @param bool $created Created flag, if true look for `create` action in history
+     * @param Arguments $args Command arguments
+     * @return Query
+     */
+    public function missingHistoryQuery(bool $created, Arguments $args): Query
+    {
+        $query = $this->Objects->find();
+        if ($args->getOption('type')) {
+            $query = $query->find('type', [$args->getOption('type')]);
+        }
+        $idField = $this->History->aliasField('resource_id');
+        // On Postgres we need an explicit cast to INTEGER to avoid
+        // this error "operator does not exist: character varying = integer"
+        if ($query->getConnection()->getDriver() instanceof Postgres) {
+            $idField = $query->func()->cast($idField, 'INTEGER');
+        }
+
+        $userField = 'created_by';
+        if (!$created) {
+            $userField = 'modified_by';
+        }
+        $joinConditions = [
+            $query->newExpr()->eq($this->History->aliasField('resource_type'), 'objects'),
+            $query->newExpr()->equalFields($idField, $this->Objects->aliasField('id')),
+            $query->newExpr()->equalFields(
+                $this->History->aliasField('user_id'),
+                $this->Objects->aliasField($userField)
+            ),
+        ];
+        if ($created) {
+            $joinConditions[] = $query->newExpr()->eq($this->History->aliasField('user_action'), 'create');
+        }
+
+        $conditions = [$idField . ' IS NULL'];
+        if ($args->getOption('id')) {
+            $conditions[] = [$this->Objects->aliasField('id') => $args->getOption('id')];
+        }
+
+        return $query->leftJoin(
+            [$this->History->getAlias() => $this->History->getTable()],
+            $joinConditions
+        )->where($conditions);
+    }
+
+    /**
+     * Objects generator.
+     *
+     * @param \Cake\ORM\Query $query Query object
+     * @return \Generator
+     */
+    protected function objectsGenerator(Query $query): Generator
+    {
+        $pageSize = 1000;
+        $pages = ceil($query->count() / $pageSize);
+
+        for ($page = 1; $page <= $pages; $page++) {
+            yield from $query
+                ->page($page, $pageSize)
+                ->toArray();
+        }
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Command/FixHistoryCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/FixHistoryCommandTest.php
@@ -86,6 +86,7 @@ class FixHistoryCommandTest extends TestCase
      * @return void
      *
      * @covers ::execute()
+     * @covers ::joinConditions()
      * @covers ::missingHistoryQuery()
      */
     public function testOptionsExecute(): void

--- a/plugins/BEdita/Core/tests/TestCase/Command/FixHistoryCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/FixHistoryCommandTest.php
@@ -55,8 +55,8 @@ class FixHistoryCommandTest extends TestCase
     public function testBuildOptionParser()
     {
         $this->exec('fix_history --help');
-        $this->assertOutputContains('Object ID to check');
-        $this->assertOutputContains('Object type name to check');
+        $this->assertOutputContains('Min ID to check');
+        $this->assertOutputContains('Max ID to check');
     }
 
     /**
@@ -86,14 +86,15 @@ class FixHistoryCommandTest extends TestCase
      * @return void
      *
      * @covers ::execute()
+     * @covers ::objectDetails()
      * @covers ::joinConditions()
      * @covers ::missingHistoryQuery()
      */
     public function testOptionsExecute(): void
     {
-        $this->exec('fix_history --type users --id 5');
+        $this->exec('fix_history --from 1 --to 5');
         $this->assertExitSuccess();
-        $this->assertOutputContains('History creation items fixed: 1');
-        $this->assertOutputContains('History update items fixed: 0');
+        $this->assertOutputContains('History creation items fixed: 4');
+        $this->assertOutputContains('History update items fixed: 1');
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Command/FixHistoryCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/FixHistoryCommandTest.php
@@ -1,0 +1,98 @@
+<?php
+namespace BEdita\Core\Test\TestCase\Command;
+
+use Cake\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see BEdita\Core\Command\FixHistoryCommand} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Command\FixHistoryCommand
+ */
+class FixHistoryCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BEdita/Core.Applications',
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.RelationTypes',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.Locations',
+        'plugin.BEdita/Core.Media',
+        'plugin.BEdita/Core.Profiles',
+        'plugin.BEdita/Core.Users',
+        'plugin.BEdita/Core.Streams',
+        'plugin.BEdita/Core.History',
+    ];
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->useCommandRunner();
+    }
+
+    /**
+     * Test buildOptionParser method
+     *
+     * @return void
+     *
+     * @covers ::buildOptionParser()
+     */
+    public function testBuildOptionParser()
+    {
+        $this->exec('fix_history --help');
+        $this->assertOutputContains('Object ID to check');
+        $this->assertOutputContains('Object type name to check');
+    }
+
+    /**
+     * Test `execute` method
+     *
+     * @return void
+     *
+     * @covers ::execute()
+     * @covers ::initialize()
+     * @covers ::fixHistoryCreate()
+     * @covers ::fixHistoryUpdate()
+     * @covers ::historyEntity()
+     * @covers ::missingHistoryQuery()
+     * @covers ::objectsGenerator()
+     */
+    public function testExecute(): void
+    {
+        $this->exec('fix_history');
+        $this->assertExitSuccess();
+        $this->assertOutputContains('History creation items fixed: 14');
+        $this->assertOutputContains('History update items fixed: 1');
+    }
+
+    /**
+     * Test `execute` with `id` and `type` option
+     *
+     * @return void
+     *
+     * @covers ::execute()
+     * @covers ::missingHistoryQuery()
+     */
+    public function testOptionsExecute(): void
+    {
+        $this->exec('fix_history --type users --id 5');
+        $this->assertExitSuccess();
+        $this->assertOutputContains('History creation items fixed: 1');
+        $this->assertOutputContains('History update items fixed: 0');
+    }
+}


### PR DESCRIPTION
This PR introduces a new `fix_history` command

With this command missing items in history related to `objects.created_by` and `objects.modified_by` are added or repaired if not consistent. 