### PR TITLE
Fix/v4/generate unique uname

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -30,11 +30,12 @@ class ObjectsControllerTest extends IntegrationTestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.BEdita/Core.Locations',
-        'plugin.BEdita/Core.ObjectRelations',
-        'plugin.BEdita/Core.Streams',
         'plugin.BEdita/Core.DateRanges',
+        'plugin.BEdita/Core.Locations',
         'plugin.BEdita/Core.Media',
+        'plugin.BEdita/Core.ObjectRelations',
+        'plugin.BEdita/Core.Profiles',
+        'plugin.BEdita/Core.Streams',
     ];
 
     /**
@@ -1205,6 +1206,41 @@ class ObjectsControllerTest extends IntegrationTestCase
         $this->patch('/profiles/3', json_encode(compact('data')));
 
         $this->assertResponseCode(409);
+        $this->assertContentType('application/vnd.api+json');
+    }
+
+    /**
+     * Test edit method with invalid data.
+     *
+     * @return void
+     *
+     * @covers ::resource()
+     * @covers ::initialize()
+     */
+    public function testEditInvalid()
+    {
+        $data = [
+            'id' => '5',
+            'type' => 'users',
+            'attributes' => [
+                'email' => 'first.user@example.com',
+            ],
+        ];
+
+        $authHeader = $this->getUserAuthHeader();
+
+        $this->configRequestHeaders('PATCH', $authHeader);
+        $this->patch('/users/5', json_encode(compact('data')));
+
+        $this->assertResponseCode(400);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertEquals('second.user@example.com', TableRegistry::getTableLocator()->get('Users')->get(5)->get('email'));
+
+        $this->configRequestHeaders('PATCH', $authHeader);
+        $data['id'] = 33;
+        $this->patch('/users/33', json_encode(compact('data')));
+
+        $this->assertResponseCode(404);
         $this->assertContentType('application/vnd.api+json');
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -1209,41 +1209,6 @@ class ObjectsControllerTest extends IntegrationTestCase
     }
 
     /**
-     * Test edit method with invalid data.
-     *
-     * @return void
-     *
-     * @covers ::resource()
-     * @covers ::initialize()
-     */
-    public function testEditInvalid()
-    {
-        $data = [
-            'id' => '2',
-            'type' => 'documents',
-            'attributes' => [
-                'uname' => 'first-user',
-            ],
-        ];
-
-        $authHeader = $this->getUserAuthHeader();
-
-        $this->configRequestHeaders('PATCH', $authHeader);
-        $this->patch('/documents/2', json_encode(compact('data')));
-
-        $this->assertResponseCode(400);
-        $this->assertContentType('application/vnd.api+json');
-        $this->assertEquals('title-one', TableRegistry::getTableLocator()->get('Documents')->get(2)->get('uname'));
-
-        $this->configRequestHeaders('PATCH', $authHeader);
-        $data['id'] = 33;
-        $this->patch('/documents/33', json_encode(compact('data')));
-
-        $this->assertResponseCode(404);
-        $this->assertContentType('application/vnd.api+json');
-    }
-
-    /**
      * Test delete method.
      *
      * @return void

--- a/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
@@ -192,7 +192,7 @@ class UniqueNameBehavior extends Behavior
      * @param \Cake\Datasource\EntityInterface $entity The entity to save
      * @return void
      */
-    public function beforeSave(Event $event, EntityInterface $entity)
+    public function beforeRules(Event $event, EntityInterface $entity)
     {
         $this->uniqueName($entity);
     }

--- a/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
@@ -24,7 +24,7 @@ use Cake\Utility\Text;
  *
  * Creates or updates a unique name of objects (see `objects.uname` field).
  *
- * Unique name is created tyipically from object title or from other object properties in case of missing title.
+ * Unique name is created typically from object title or from other object properties in case of missing title.
  * An object type may impose custom rule.
  * Name must be unique inside current project.
  *
@@ -109,6 +109,8 @@ class UniqueNameBehavior extends Behavior
     /**
      * Generate unique name string from $config parameters.
      * If $regenerate parameter is true, random hash is added to uname string.
+     * If the user has specifically set an uname, the `sourceField` config is ignored and the provided
+     * uname value is used.
      * A 'callable' item is called if set in config('generator') instead of generateUniqueName(...)
      *
      * @param \Cake\Datasource\EntityInterface $entity The entity to save
@@ -116,7 +118,7 @@ class UniqueNameBehavior extends Behavior
      * @param array $cfg Optional config parameters to override defaults
      * @return string uname
      */
-    public function generateUniqueName(EntityInterface $entity, $regenerate = false, array $cfg = [])
+    public function generateUniqueName(EntityInterface $entity, bool $regenerate = false, array $cfg = []): string
     {
         $config = array_merge($this->getConfig(), $cfg);
         $generator = $config['generator'];
@@ -124,6 +126,9 @@ class UniqueNameBehavior extends Behavior
             return $generator($entity, $regenerate);
         }
         $fieldValue = $entity->get($config['sourceField']);
+        if ($entity->isDirty('uname') && !empty($entity->get('uname'))) {
+            $fieldValue = $entity->get('uname');
+        }
         if (empty($fieldValue)) {
             $fieldValue = (string)$entity->get('type');
             $regenerate = true;
@@ -141,7 +146,7 @@ class UniqueNameBehavior extends Behavior
      * @param array $cfg parameters to create unique name
      * @return string uname
      */
-    public function uniqueNameFromValue($value, $regenerate = false, array $cfg = [])
+    public function uniqueNameFromValue(string $value, bool $regenerate = false, array $cfg = []): string
     {
         $config = array_merge($this->getConfig(), $cfg);
         $slug = Text::slug($value, [
@@ -166,10 +171,10 @@ class UniqueNameBehavior extends Behavior
      * Verify $uname is unique
      *
      * @param string $uname to check
-     * @param int $id object id to exclude from check
+     * @param int|null $id object id to exclude from check
      * @return bool
      */
-    public function uniqueNameExists($uname, $id = null)
+    public function uniqueNameExists(string $uname, int $id = null): bool
     {
         $options = ['uname' => $uname];
         if (!empty($id)) {

--- a/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
@@ -77,6 +77,8 @@ class FoldersTable extends ObjectsTable
      */
     public function buildRules(RulesChecker $rules)
     {
+        $rules = parent::buildRules($rules);
+
         $rules->add(
             [$this, 'hasAtMostOneParent'],
             'hasAtMostOneParent',
@@ -160,6 +162,8 @@ class FoldersTable extends ObjectsTable
      */
     public function beforeSave(Event $event, EntityInterface $entity)
     {
+        parent::beforeSave($event, $entity);
+
         $entity->setDirty('parents', false);
     }
 

--- a/plugins/BEdita/Core/src/Model/Validation/ObjectsValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/ObjectsValidator.php
@@ -45,7 +45,6 @@ class ObjectsValidator extends Validator
 
             ->ascii('uname')
             ->allowEmptyString('uname')
-            ->add('uname', 'unique', ['rule' => 'validateUnique', 'provider' => 'objectsTable'])
 
             ->boolean('locked')
             ->allowEmptyString('locked')

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
@@ -414,19 +414,19 @@ class UniqueNameBehaviorTest extends TestCase
     }
 
     /**
-     * test generate uname before save
+     * test generate uname before rules
      *
      * @return void
-     * @covers ::beforeSave()
+     * @covers ::beforeRules()
      */
-    public function testBeforeSave()
+    public function testBeforeRules()
     {
         $Documents = TableRegistry::getTableLocator()->get('Documents');
         $entity = $Documents->newEntity([
             'title' => 'uh là la'
         ]);
 
-        $Documents->getEventManager()->on('Model.beforeSave', function (Event $event, EntityInterface $entity) {
+        $Documents->getEventManager()->on('Model.beforeRules', function (Event $event, EntityInterface $entity) {
             $uname = $entity->get('uname');
             static::assertNotEmpty($uname);
             static::assertEquals('uh-la-la', $uname);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
@@ -227,6 +227,50 @@ class UniqueNameBehaviorTest extends TestCase
     }
 
     /**
+     * Data provider for `testRegenerate` test case.
+     *
+     * @return array
+     */
+    public function regenerateUniqueNameProvider()
+    {
+        return [
+            'providedUname' => [
+                'provided-uname',
+                'provided-title',
+            ],
+            'noUname' => [
+                null,
+                'my-title'
+            ],
+        ];
+    }
+
+    /**
+     * testRegenerate method
+     *
+     * @param string $uname Uname.
+     * @param string $title Title.
+     * @return void
+     *
+     * @dataProvider regenerateUniqueNameProvider
+     * @covers ::generateUniqueName()
+     */
+    public function testRegenerateUniqueName($uname, $title)
+    {
+        $Folders = TableRegistry::getTableLocator()->get('Folders');
+        $folder = $Folders->newEntity();
+        $Folders->patchEntity($folder, compact('uname', 'title'));
+        $behavior = $Folders->behaviors()->get('UniqueName');
+        $generated = $behavior->generateUniqueName($folder, true);
+
+        if ($uname !== null) {
+            $this->assertTextContains($uname, $generated);
+        } else {
+            $this->assertTextContains($title, $generated);
+        }
+    }
+
+    /**
      * Data provider for `testNameExists` test case.
      *
      * @return array

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
@@ -38,11 +38,15 @@ class LocationsTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
+        'plugin.BEdita/Core.History',
+        'plugin.BEdita/Core.Locations',
+        'plugin.BEdita/Core.Objects',
         'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.Profiles',
+        'plugin.BEdita/Core.Properties',
         'plugin.BEdita/Core.Relations',
         'plugin.BEdita/Core.RelationTypes',
-        'plugin.BEdita/Core.Objects',
-        'plugin.BEdita/Core.Locations',
+        'plugin.BEdita/Core.Users',
     ];
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
@@ -123,7 +123,7 @@ class LocationsTableTest extends TestCase
 
         if ($changed) {
             $this->assertNotEquals($data['uname'], $entity->uname);
-        } else if (isset($data['uname'])) {
+        } elseif (isset($data['uname'])) {
             $this->assertEquals($data['uname'], $entity->uname);
         }
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
@@ -44,6 +44,7 @@ class LocationsTableTest extends TestCase
         'plugin.BEdita/Core.ObjectTypes',
         'plugin.BEdita/Core.Profiles',
         'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.PropertyTypes',
         'plugin.BEdita/Core.Relations',
         'plugin.BEdita/Core.RelationTypes',
         'plugin.BEdita/Core.Users',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
+use BEdita\Core\Utility\LoggedUser;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -54,6 +55,7 @@ class LocationsTableTest extends TestCase
         parent::setUp();
 
         $this->Locations = TableRegistry::getTableLocator()->get('Locations');
+        LoggedUser::setUser(['id' => 1]);
     }
 
     /**
@@ -64,17 +66,65 @@ class LocationsTableTest extends TestCase
     public function tearDown()
     {
         unset($this->Locations);
+        LoggedUser::resetUser();
 
         parent::tearDown();
     }
 
     /**
-     * Test initialization method.
+     * Data provider for `testSave` test case.
      *
-     * @return void
+     * @return array
      */
-    public function testInitialize()
+    public function saveProvider()
     {
-        static::markTestIncomplete('Not yet implemented');
+        return [
+            'valid' => [
+                false,
+                [
+                    'coords' => 'POINT(11.3441359 44.4959174)',
+                    'address' => 'Piazza del Nettuno',
+                    'locality' => 'Bologna',
+                    'postal_code' => '40126',
+                    'country_name' => 'Italy',
+                    'region' => 'Emilia-romagna',
+                ],
+            ],
+            'notUniqueUname' => [
+                true,
+                [
+                    'coords' => 'POINT(11.3464055 44.4944183)',
+                    'address' => 'Piazza di Porta Ravegnana',
+                    'locality' => 'Bologna',
+                    'postal_code' => '40126',
+                    'country_name' => 'Italy',
+                    'region' => 'Emilia-romagna',
+                    'uname' => 'the-two-towers',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test entity save.
+     *
+     * @param bool $changed
+     * @param array $data
+     * @return void
+     * @dataProvider saveProvider
+     * @coversNothing
+     */
+    public function testSave(bool $changed, array $data)
+    {
+        $entity = $this->Locations->newEntity($data);
+        $success = (bool)$this->Locations->save($entity);
+
+        $this->assertTrue($success);
+
+        if ($changed) {
+            $this->assertNotEquals($data['uname'], $entity->uname);
+        } else if (isset($data['uname'])) {
+            $this->assertEquals($data['uname'], $entity->uname);
+        }
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/MediaTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/MediaTableTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
+use BEdita\Core\Utility\LoggedUser;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -38,8 +39,9 @@ class MediaTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $config = TableRegistry::exists('Media') ? [] : ['className' => 'BEdita\Core\Model\Table\MediaTable'];
-        $this->Media = TableRegistry::getTableLocator()->get('Media', $config);
+
+        $this->Media = TableRegistry::getTableLocator()->get('Media');
+        LoggedUser::setUser(['id' => 1]);
     }
 
     /**
@@ -50,27 +52,70 @@ class MediaTableTest extends TestCase
     public function tearDown()
     {
         unset($this->Media);
+        LoggedUser::resetUser();
 
         parent::tearDown();
     }
 
     /**
-     * Test initialize method
+     * Data provider for `testSave` test case.
      *
-     * @return void
+     * @return array
      */
-    public function testInitialize()
+    public function saveProvider()
     {
-        $this->markTestIncomplete('Not implemented yet.');
+        return [
+            'valid' => [
+                false,
+                [
+                    'name' => 'Cool media file',
+                    'width' => null,
+                    'height' => null,
+                    'duration' => null,
+                    'provider' => null,
+                    'provider_uid' => null,
+                    'provider_url' => null,
+                    'provider_thumbnail' => null,
+                ],
+            ],
+            'notUniqueUname' => [
+                true,
+                [
+                    'name' => 'Cooler media file',
+                    'width' => null,
+                    'height' => null,
+                    'duration' => null,
+                    'provider' => null,
+                    'provider_uid' => null,
+                    'provider_url' => null,
+                    'provider_thumbnail' => null,
+                    'uname' => 'media-one',
+                ],
+            ],
+        ];
     }
 
     /**
-     * Test validationDefault method
+     * Test entity save.
      *
+     * @param bool $changed
+     * @param array $data
      * @return void
+     * @dataProvider saveProvider
+     * @coversNothing
      */
-    public function testValidationDefault()
+    public function testSave(bool $changed, array $data)
     {
-        $this->markTestIncomplete('Not implemented yet.');
+        $entity = $this->Media->newEntity($data);
+        $entity->object_type_id = 9;
+        $success = (bool)$this->Media->save($entity);
+
+        $this->assertTrue($success);
+
+        if ($changed) {
+            $this->assertNotEquals($data['uname'], $entity->uname);
+        } else if (isset($data['uname'])) {
+            $this->assertEquals($data['uname'], $entity->uname);
+        }
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/MediaTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/MediaTableTest.php
@@ -24,11 +24,16 @@ class MediaTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.BEdita/Core.ObjectTypes',
-        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.History',
         'plugin.BEdita/Core.Media',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.Profiles',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.PropertyTypes',
         'plugin.BEdita/Core.Relations',
         'plugin.BEdita/Core.RelationTypes',
+        'plugin.BEdita/Core.Users',
     ];
 
     /**
@@ -76,6 +81,7 @@ class MediaTableTest extends TestCase
                     'provider_uid' => null,
                     'provider_url' => null,
                     'provider_thumbnail' => null,
+                    'media_property' => false,
                 ],
             ],
             'notUniqueUname' => [
@@ -89,6 +95,7 @@ class MediaTableTest extends TestCase
                     'provider_uid' => null,
                     'provider_url' => null,
                     'provider_thumbnail' => null,
+                    'media_property' => false,
                     'uname' => 'media-one',
                 ],
             ],
@@ -110,7 +117,7 @@ class MediaTableTest extends TestCase
         $entity->object_type_id = 9;
         $success = (bool)$this->Media->save($entity);
 
-        $this->assertTrue($success);
+        $this->assertTrue($success, print_r($entity->getErrors(), true));
 
         if ($changed) {
             $this->assertNotEquals($data['uname'], $entity->uname);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/MediaTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/MediaTableTest.php
@@ -114,7 +114,7 @@ class MediaTableTest extends TestCase
 
         if ($changed) {
             $this->assertNotEquals($data['uname'], $entity->uname);
-        } else if (isset($data['uname'])) {
+        } elseif (isset($data['uname'])) {
             $this->assertEquals($data['uname'], $entity->uname);
         }
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -93,6 +93,56 @@ class ObjectsTableTest extends TestCase
     }
 
     /**
+     * Data provider for `testSave` test case.
+     *
+     * @return array
+     */
+    public function saveProvider()
+    {
+        return [
+            'valid' => [
+                false,
+                [
+                    'title' => 'doc title',
+                    'description' => 'doc description',
+                ],
+            ],
+            'notUniqueUname' => [
+                true,
+                [
+                    'title' => 'another doc title',
+                    'description' => 'another doc description',
+                    'uname' => 'title-one',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test entity save.
+     *
+     * @param bool $changed
+     * @param array $data
+     * @return void
+     * @dataProvider saveProvider
+     * @coversNothing
+     */
+    public function testSave(bool $changed, array $data)
+    {
+        $entity = $this->Objects->newEntity($data);
+        $entity->type = 'documents';
+        $success = (bool)$this->Objects->save($entity);
+
+        $this->assertTrue($success);
+
+        if ($changed) {
+            $this->assertNotEquals($data['uname'], $entity->uname);
+        } else if (isset($data['uname'])) {
+            $this->assertEquals($data['uname'], $entity->uname);
+        }
+    }
+
+    /**
      * Data provider for `testValidation` test case.
      *
      * @return array
@@ -106,16 +156,6 @@ class ObjectsTableTest extends TestCase
                     'title' => 'title three',
                     'description' => 'another description',
                     'uname' => 'title-three',
-                ],
-            ],
-            'notUniqueUname' => [
-                false,
-                [
-                    'title' => 'title four',
-                    'description' => 'another description',
-                    'status' => 'on',
-                    'uname' => 'title-one',
-                    'lang' => 'en',
                 ],
             ],
             'titleOnly' => [
@@ -152,11 +192,6 @@ class ObjectsTableTest extends TestCase
 
         $error = (bool)$object->getErrors();
         $this->assertEquals($expected, !$error);
-
-        if ($expected) {
-            $success = $this->Objects->save($object);
-            $this->assertTrue((bool)$success);
-        }
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -137,7 +137,7 @@ class ObjectsTableTest extends TestCase
 
         if ($changed) {
             $this->assertNotEquals($data['uname'], $entity->uname);
-        } else if (isset($data['uname'])) {
+        } elseif (isset($data['uname'])) {
             $this->assertEquals($data['uname'], $entity->uname);
         }
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
@@ -148,7 +148,7 @@ class ProfilesTableTest extends TestCase
 
         if ($changed) {
             $this->assertNotEquals($data['uname'], $entity->uname);
-        } else if (isset($data['uname'])) {
+        } elseif (isset($data['uname'])) {
             $this->assertEquals($data['uname'], $entity->uname);
         }
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
@@ -61,6 +61,7 @@ class ProfilesTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
+
         $this->Profiles = TableRegistry::getTableLocator()->get('Profiles');
         LoggedUser::setUser(['id' => 1]);
     }
@@ -91,6 +92,65 @@ class ProfilesTableTest extends TestCase
         $this->assertEquals('profiles', $this->Profiles->getTable());
         $this->assertEquals('id', $this->Profiles->getPrimaryKey());
         $this->assertEquals('name', $this->Profiles->getDisplayField());
+    }
+
+    /**
+     * Data provider for `testSave` test case.
+     *
+     * @return array
+     */
+    public function saveProvider()
+    {
+        return [
+            'valid' => [
+                false,
+                [
+                    'name' => 'Fake',
+                    'surname' => 'User',
+                    'email' => 'fake.user@example.com',
+                    'person_title' => 'Miss',
+                    'gender' => null,
+                    'birthdate' => null,
+                    'deathdate' => null,
+                ],
+            ],
+            'notUniqueUname' => [
+                true,
+                [
+                    'name' => 'Real',
+                    'surname' => 'User',
+                    'email' => 'real.user@example.com',
+                    'person_title' => 'Mr',
+                    'gender' => null,
+                    'birthdate' => null,
+                    'deathdate' => null,
+                    'uname' => 'gustavo-supporto',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test entity save.
+     *
+     * @param bool $changed
+     * @param array $data
+     * @return void
+     * @dataProvider saveProvider
+     * @coversNothing
+     */
+    public function testSave(bool $changed, array $data)
+    {
+        $entity = $this->Profiles->newEntity($data);
+        $success = (bool)$this->Profiles->save($entity);
+
+        $this->assertTrue($success);
+
+        if ($changed) {
+            $this->assertNotEquals($data['uname'], $entity->uname);
+        } else if (isset($data['uname'])) {
+            $this->assertEquals($data['uname'], $entity->uname);
+        }
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -15,6 +15,7 @@ namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use BEdita\Core\Model\Table\UsersTable;
 use BEdita\Core\Utility\LoggedUser;
+use Cake\Auth\WeakPasswordHasher;
 use Cake\Core\Configure;
 use Cake\Http\Exception\BadRequestException;
 use Cake\I18n\Time;
@@ -99,6 +100,65 @@ class UsersTableTest extends TestCase
 
         $this->assertInstanceOf('\Cake\ORM\Association\HasMany', $this->Users->ExternalAuth);
         $this->assertInstanceOf('\Cake\ORM\Association\BelongsToMany', $this->Users->Roles);
+    }
+
+    /**
+     * Data provider for `testSave` test case.
+     *
+     * @return array
+     */
+    public function saveProvider()
+    {
+        return [
+            'valid' => [
+                false,
+                [
+                    'username' => 'globetrotter user',
+                    'password_hash' => (new WeakPasswordHasher(['hashType' => 'md5']))->hash('hunter1'),
+                    'blocked' => 0,
+                    'last_login' => null,
+                    'last_login_err' => null,
+                    'num_login_err' => 1,
+                    'verified' => '2017-05-29 11:36:00',
+                ],
+            ],
+            'notUniqueUname' => [
+                true,
+                [
+                    'username' => 'support user',
+                    'password_hash' => (new WeakPasswordHasher(['hashType' => 'md5']))->hash('hunter2'),
+                    'blocked' => 0,
+                    'last_login' => null,
+                    'last_login_err' => null,
+                    'num_login_err' => 1,
+                    'verified' => '2017-05-29 11:36:00',
+                    'uname' => 'gustavo-supporto',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test entity save.
+     *
+     * @param bool $changed
+     * @param array $data
+     * @return void
+     * @dataProvider saveProvider
+     * @coversNothing
+     */
+    public function testSave(bool $changed, array $data)
+    {
+        $entity = $this->Users->newEntity($data);
+        $success = (bool)$this->Users->save($entity);
+
+        $this->assertTrue($success);
+
+        if ($changed) {
+            $this->assertNotEquals($data['uname'], $entity->uname);
+        } else if (isset($data['uname'])) {
+            $this->assertEquals($data['uname'], $entity->uname);
+        }
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -156,7 +156,7 @@ class UsersTableTest extends TestCase
 
         if ($changed) {
             $this->assertNotEquals($data['uname'], $entity->uname);
-        } else if (isset($data['uname'])) {
+        } elseif (isset($data['uname'])) {
             $this->assertEquals($data['uname'], $entity->uname);
         }
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/LocationsValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/LocationsValidatorTest.php
@@ -85,14 +85,6 @@ class LocationsValidatorTest extends TestCase
                     'publish_end' => 'somewhen',
                 ],
             ],
-            'not unique' => [
-                [
-                    'uname.unique',
-                ],
-                [
-                    'uname' => 'title-one',
-                ],
-            ],
             'invalid coordinates' => [
                 [
                     'coords.valid',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/MediaValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/MediaValidatorTest.php
@@ -92,14 +92,6 @@ class MediaValidatorTest extends TestCase
                     'provider_thumbnail' => 'gustavo.supporto@example.org',
                 ],
             ],
-            'not unique' => [
-                [
-                    'uname.unique',
-                ],
-                [
-                    'uname' => 'title-one',
-                ],
-            ],
         ];
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/ObjectsValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/ObjectsValidatorTest.php
@@ -84,14 +84,6 @@ class ObjectsValidatorTest extends TestCase
                     'publish_end' => 'somewhen',
                 ],
             ],
-            'not unique' => [
-                [
-                    'uname.unique',
-                ],
-                [
-                    'uname' => 'title-one',
-                ],
-            ],
         ];
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/ProfilesValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/ProfilesValidatorTest.php
@@ -95,15 +95,6 @@ class ProfilesValidatorTest extends TestCase
                     'website' => 'not.an.url@example.org',
                 ],
             ],
-            'not unique' => [
-                [
-                    'uname.unique',
-                ],
-                [
-                    'uname' => 'title-one',
-                    'email' => 'first.user@example.com',
-                ],
-            ],
         ];
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/UsersValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/UsersValidatorTest.php
@@ -104,7 +104,6 @@ class UsersValidatorTest extends TestCase
             ],
             'not unique' => [
                 [
-                    'uname.unique',
                     'email.unique',
                     'username.unique',
                 ],


### PR DESCRIPTION
This PR changes `UniqueNameBehavior`'s behavior when the user has explicitly set an uname. Previously the behavior was to fallback to `title` (or configured) field and append a random suffix, now it preserves the uname value set by the user and appends a random suffix to that.

Furthermore, for `Folders` objects the `UniqueNameBehavior` was prevented from working because of a _validation_ rule set on uname field (see edit to `ObjectsValidator`). This _validation_ rule has been removed, and now the behavior runs before [rules](https://book.cakephp.org/3/en/orm/validation.html#applying-application-rules) are evaluated (the `FoldersTable` has a rule for uniqueness of the uname field).