### PR TITLE
Fix: UpdateRelatedObjectsActions::prepareData, on multiple relatedEntities

### DIFF
--- a/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
@@ -63,7 +63,7 @@ abstract class UpdateRelatedObjectsAction extends UpdateAssociatedAction
         if (is_array($relatedEntities) && count($relatedEntities) === 1) {
             $relatedEntities = reset($relatedEntities);
         }
-        if (!empty($relatedEntities)) {
+        if (!empty($relatedEntities) && $relatedEntities instanceof \Cake\Datasource\EntityInterface) {
             /** @var EntityInterface $relatedEntities */
             $joinData = (array)$relatedEntities->get('_joinData');
             // set join data properties in Tree entity, on empty array no properties are set

--- a/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
@@ -58,7 +58,7 @@ abstract class UpdateRelatedObjectsAction extends UpdateAssociatedAction
 
         $relatedEntities = $data['relatedEntities'];
         if (is_array($relatedEntities) && count($relatedEntities) > 1) {
-            throw new BadRequestException('Parents association for folders allows at most one related entity');
+            throw new BadRequestException(__d('bedita', 'Parents association for folders allows at most one related entity'));
         }
 
         $table = $this->Association->junction();

--- a/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
@@ -15,6 +15,7 @@ namespace BEdita\Core\Model\Action;
 
 use BEdita\Core\Model\Entity\Folder;
 use BEdita\Core\ORM\Association\RelatedTo;
+use Cake\Http\Exception\BadRequestException;
 use Cake\Utility\Hash;
 
 /**
@@ -55,15 +56,19 @@ abstract class UpdateRelatedObjectsAction extends UpdateAssociatedAction
             return $data;
         }
 
+        $relatedEntities = $data['relatedEntities'];
+        if (is_array($relatedEntities) && count($relatedEntities) > 1) {
+            throw new BadRequestException('Parents association for folders allows at most one related entity');
+        }
+
         $table = $this->Association->junction();
         $entity = $table->find()
             ->where([$table->getAssociation('Objects')->getForeignKey() => $data['entity']->id])
             ->firstOrFail();
-        $relatedEntities = $data['relatedEntities'];
         if (is_array($relatedEntities) && count($relatedEntities) === 1) {
             $relatedEntities = reset($relatedEntities);
         }
-        if (!empty($relatedEntities) && $relatedEntities instanceof \Cake\Datasource\EntityInterface) {
+        if (!empty($relatedEntities)) {
             /** @var EntityInterface $relatedEntities */
             $joinData = (array)$relatedEntities->get('_joinData');
             // set join data properties in Tree entity, on empty array no properties are set

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
@@ -112,7 +112,7 @@ class AddRelatedObjectsActionTest extends TestCase
                 ],
             ],
             'update, more than one related entities' => [
-                new BadRequestException('Parents association for folders allows at most one related entity'),
+                new BadRequestException(__d('bedita', 'Parents association for folders allows at most one related entity')),
                 'Folders',
                 'parents',
                 4,

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
@@ -110,6 +110,26 @@ class AddRelatedObjectsActionTest extends TestCase
                     ],
                 ],
             ],
+            'update, more than one related entities' => [
+                [2, 3],
+                'Profiles',
+                'inverse_test',
+                4,
+                [
+                    2 => [
+                        'priority' => 2,
+                        'inv_priority' => 1,
+                        'params' => null,
+                    ],
+                    3 => [
+                        'priority' => 1,
+                        'inv_priority' => 1,
+                        'params' => [
+                            'key' => 'value',
+                        ],
+                    ],
+                ],
+            ],
             'noJoinData' => [
                 [2],
                 'Documents',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
@@ -18,6 +18,7 @@ use BEdita\Core\ORM\Association\RelatedTo;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
+use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Inflector;
@@ -111,9 +112,9 @@ class AddRelatedObjectsActionTest extends TestCase
                 ],
             ],
             'update, more than one related entities' => [
-                [2, 3],
-                'Profiles',
-                'inverse_test',
+                new BadRequestException('Parents association for folders allows at most one related entity'),
+                'Folders',
+                'parents',
                 4,
                 [
                     2 => [


### PR DESCRIPTION
This PR fixes a bug introduced with https://github.com/bedita/bedita/pull/1727.

# buggy behavior

When `$data['relatedEntities']` is an array of more than 1 element, an exception is thrown in `plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php:68` (`$relatedEntities` is considered as an entity, but it's an array).

# expected behavior

When `$data['relatedEntities']` is an array of more than 1 element, no errors in `prepareData`, skip `set('_join_data', ...)`.