### PR TITLE
#1740 filter related object error

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -845,4 +845,44 @@ class FilterQueryStringTest extends IntegrationTestCase
         $result = json_decode((string)$this->_response->getBody(), true);
         static::assertEquals(0, count($result['data']));
     }
+
+    /**
+     * Data provider for `testRelatedFilter`.
+     *
+     * @return array
+     */
+    public function relatedFilterProvider()
+    {
+        return [
+            'test' => [
+                [2, 3],
+                '/documents?filter[test]=4',
+            ],
+            'inverse_another_test' => [
+                [8],
+                '/locations?filter[inverse_another_test]=1',
+            ],
+        ];
+    }
+
+    /**
+     * Test `filter[{relation}]={id}`.
+     *
+     * @param array $expected Expected result
+     * @param string $url Request URL
+     * @return void
+     *
+     * @dataProvider relatedFilterProvider
+     * @coversNothing
+     */
+    public function testRelatedFilter(array $expected, string $url): void
+    {
+        $this->configRequestHeaders();
+        $this->get($url);
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        $result = json_decode((string)$this->_response->getBody(), true);
+        $found = Hash::extract($result, 'data.{n}.id');
+        static::assertEquals($expected, $found);
+    }
 }

--- a/plugins/BEdita/Core/src/ORM/Association/RelatedTo.php
+++ b/plugins/BEdita/Core/src/ORM/Association/RelatedTo.php
@@ -14,7 +14,9 @@
 namespace BEdita\Core\ORM\Association;
 
 use BEdita\Core\Model\Entity\ObjectType;
+use BEdita\Core\ORM\Inheritance\Table as InheritanceTable;
 use Cake\ORM\Association\BelongsToMany;
+use Cake\ORM\Query;
 use Cake\ORM\Table;
 
 /**
@@ -200,5 +202,20 @@ class RelatedTo extends BelongsToMany
     public function isInverse(): bool
     {
         return $this->getForeignKey() === $this->getInverseKey();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Use inheritance subquery as table for target that is an inheritance table.
+     */
+    public function attachTo(Query $query, array $options = []): void
+    {
+        $targetTable = $this->getTarget();
+        if ($targetTable instanceof InheritanceTable) {
+            $options['table'] = $targetTable->query()->getInheritanceSubQuery();
+        }
+
+        parent::attachTo($query, $options);
     }
 }

--- a/plugins/BEdita/Core/src/ORM/Inheritance/Query.php
+++ b/plugins/BEdita/Core/src/ORM/Inheritance/Query.php
@@ -92,7 +92,7 @@ class Query extends CakeQuery
      *
      * @return \Cake\ORM\Query
      */
-    protected function getInheritanceSubQuery()
+    public function getInheritanceSubQuery()
     {
         $subQuery = new parent($this->getConnection(), $this->_repository);
 

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Association/RelatedToTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Association/RelatedToTest.php
@@ -42,6 +42,7 @@ class RelatedToTest extends TestCase
         'plugin.BEdita/Core.Users',
         'plugin.BEdita/Core.ObjectRelations',
         'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.PropertyTypes',
     ];
 
     /**


### PR DESCRIPTION
This PR fixes #1740 

When the `Query` object was altered to include the associated target table and the target table of `RelatedTo` association is a `\BEdita\Core\ORM\Inheritance\Table` it set the inheritance subquery as `table`.
