### PR TITLE
Lighter async mail payload 

### DIFF
--- a/plugins/BEdita/Core/src/Mailer/Transport/AsyncJobsTransport.php
+++ b/plugins/BEdita/Core/src/Mailer/Transport/AsyncJobsTransport.php
@@ -59,6 +59,9 @@ class AsyncJobsTransport extends AbstractTransport
             '_htmlMessage' => $email->message(Email::MESSAGE_HTML),
             '_textMessage' => $email->message(Email::MESSAGE_TEXT),
         ];
+        // Remove unnecessary attributes since templates have already been rendered
+        // `viewVars` may contain objects that "heavy" to serialize (like some entities)
+        unset($payload['viewVars'], $payload['viewConfig']);
         $asyncJob->payload = $payload;
 
         $table->saveOrFail($asyncJob);

--- a/plugins/BEdita/Core/src/Mailer/Transport/AsyncJobsTransport.php
+++ b/plugins/BEdita/Core/src/Mailer/Transport/AsyncJobsTransport.php
@@ -59,8 +59,8 @@ class AsyncJobsTransport extends AbstractTransport
             '_htmlMessage' => $email->message(Email::MESSAGE_HTML),
             '_textMessage' => $email->message(Email::MESSAGE_TEXT),
         ];
-        // Remove unnecessary attributes since templates have already been rendered
-        // `viewVars` may contain objects that "heavy" to serialize (like some entities)
+        // Remove unnecessary attributes from payload since templates have already been rendered
+        // `viewVars` may contain objects that are "heavy" to serialize (like some entities)
         unset($payload['viewVars'], $payload['viewConfig']);
         $asyncJob->payload = $payload;
 

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/Transport/AsyncJobsTransportTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/Transport/AsyncJobsTransportTest.php
@@ -172,6 +172,8 @@ class AsyncJobsTransportTest extends TestCase
         $asyncJob = $this->AsyncJobs->find()->where(['service' => 'mail'])->first();
 
         static::assertInstanceOf($this->AsyncJobs->getEntityClass(), $asyncJob);
+        static::assertArrayNotHasKey('viewVars', $asyncJob->payload);
+        static::assertArrayNotHasKey('viewConfig', $asyncJob->payload);
 
         $mailService = new MailService();
         $result = $mailService->run($asyncJob->payload, ['transport' => 'debug']);


### PR DESCRIPTION
This PR removes unnecessary attributes from Async Jobs `mail` payload that can be heavy to serialize - like some entities 