### PR TITLE
Docker: update PHP + composer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG PHP_VERSION=7.2
+ARG PHP_VERSION=7.4
 FROM chialab/php:${PHP_VERSION}-apache
-MAINTAINER dev@chialab.io
+LABEL author="dev@chialab.io"
 
 # Default config
 ARG DEBUG
@@ -15,10 +15,6 @@ RUN curl -o /wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for
     && a2enmod headers \
     && echo "[PHP]\noutput_buffering = 4096\nmemory_limit = -1" > /usr/local/etc/php/php.ini
 COPY docker-entrypoint.sh /usr/local/bin/
-
-# Set composer version until v2 is supported
-ENV COMPOSER_VERSION='1.10.16'
-RUN composer self-update $COMPOSER_VERSION
 
 # Copy files and set user to `www-data`
 COPY . /var/www/html


### PR DESCRIPTION
In this PR `Dockerfile` is updated: 
 * PHP version moved to 7.4
 * composer 2 is used
 * deprecated `MAINTAINER` instruction updated
 