### PR TITLE
Improve OAuth2 check

### DIFF
--- a/plugins/BEdita/API/src/Auth/OAuth2Authenticate.php
+++ b/plugins/BEdita/API/src/Auth/OAuth2Authenticate.php
@@ -13,11 +13,12 @@
 
 namespace BEdita\API\Auth;
 
+use BEdita\Core\Utility\OAuth2;
 use Cake\Auth\BaseAuthenticate;
-use Cake\Http\Client;
 use Cake\Http\Exception\UnauthorizedException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
+use Cake\Utility\Hash;
 
 /**
  * Authenticate users via OAuth2 providers.
@@ -74,7 +75,12 @@ class OAuth2Authenticate extends BaseAuthenticate
         }
         /** @var \BEdita\Core\Model\Entity\AuthProvider $authProvider */
         $authProvider = $authProviders[$data['auth_provider']];
-        $providerResponse = $this->getOAuth2Response($authProvider->get('url'), $data['access_token']);
+        $options = (array)Hash::get((array)$authProvider->get('params'), 'options');
+        $providerResponse = $this->getOAuth2Response(
+            $authProvider->get('url'),
+            $data['access_token'],
+            $options
+        );
         if (!$authProvider->checkAuthorization($providerResponse, $data['provider_username'])) {
             return false;
         }
@@ -101,15 +107,13 @@ class OAuth2Authenticate extends BaseAuthenticate
      *
      * @param string $url OAuth2 provider URL
      * @param string $accessToken Access token to use in request
+     * @param array $options OAuth2 request options
      * @return array Response from an OAuth2 provider
      * @codeCoverageIgnore
      */
-    protected function getOAuth2Response(string $url, string $accessToken): array
+    protected function getOAuth2Response(string $url, string $accessToken, array $options = []): array
     {
-        /** @var \Cake\Http\Client\Response $response */
-        $response = (new Client())->get($url, [], ['headers' => ['Authorization' => 'Bearer ' . $accessToken]]);
-
-        return (array)$response->getJson();
+        return (new OAuth2())->response($url, $accessToken, $options);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Utility/OAuth2.php
+++ b/plugins/BEdita/Core/src/Utility/OAuth2.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Utility;
+
+use Cake\Core\InstanceConfigTrait;
+use Cake\Http\Client;
+
+/**
+ * Class to call an OAuth2 provider URL using access tokens
+ *
+ * @since 4.6.0
+ */
+class OAuth2
+{
+    use InstanceConfigTrait;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $_defaultConfig = [
+        // HTTP client configuration
+        'client' => [],
+        // OAuth2 request options
+        'header' => 'Authorization',
+        'headerPrefix' => 'Bearer',
+        'queryParam' => 'access_token',
+        // mode can be 'header' (default) or 'query'
+        'mode' => 'header',
+    ];
+
+    /**
+     * Get a response from an OAuth2 provider usgin access token
+     *
+     * @param string $url OAuth2 provider check URL
+     * @param string $accessToken Access token to use in request
+     * @param array $options OAuth2 request options
+     * @return array Response from an OAuth2 provider
+     */
+    public function response(string $url, string $accessToken, array $options = []): array
+    {
+        $this->setConfig($options);
+        $client = new Client((array)$this->getConfig('client'));
+        $query = $this->getQuery($accessToken);
+        $headers = $this->getHeaders($accessToken);
+        $response = $client->get($url, [], compact('headers'));
+
+        return (array)$response->getJson();
+    }
+
+    /**
+     * Get OAuth2 request query params
+     *
+     * @param string $token Access token.
+     * @return array
+     */
+    protected function getQuery(string $token): array
+    {
+        if ($this->getConfig('mode') !== 'query') {
+            return [];
+        }
+
+        return [
+            $this->getConfig('queryParam') => $token,
+        ];
+    }
+
+    /**
+     * Get OAuth2 request headers
+     *
+     * @param string $token Access token.
+     * @return array
+     */
+    protected function getHeaders(string $token): array
+    {
+        if ($this->getConfig('mode') !== 'header') {
+            return [];
+        }
+
+        return [
+            $this->getConfig('header') => sprintf('%s %s', $this->getConfig('headerPrefix'), $token),
+        ];
+    }
+}

--- a/plugins/BEdita/Core/src/Utility/OAuth2.php
+++ b/plugins/BEdita/Core/src/Utility/OAuth2.php
@@ -54,7 +54,7 @@ class OAuth2
         $client = new Client((array)$this->getConfig('client'));
         $query = $this->getQuery($accessToken);
         $headers = $this->getHeaders($accessToken);
-        $response = $client->get($url, [], compact('headers'));
+        $response = $client->get($url, $query, compact('headers'));
 
         return (array)$response->getJson();
     }

--- a/plugins/BEdita/Core/tests/TestCase/Utility/OAuth2Test.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/OAuth2Test.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Utility;
+
+use BEdita\Core\Utility\OAuth2;
+use Cake\Http\Client\Adapter\Stream;
+use Cake\Http\Client\Response;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\Core\Utility\OAuth2} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Utility\OAuth2
+ */
+class OAuth2Test extends TestCase
+{
+
+    /**
+     * Data provider method for `testResponse()`
+     *
+     * @return array
+     */
+    public function responseProvider(): array
+    {
+        return [
+            'default' => [
+                ['id' => 'gustavo'],
+                '{"id":"gustavo"}',
+            ],
+            'query' => [
+                ['id' => 'gustavo'],
+                '{"id":"gustavo"}',
+                [
+                    'mode' => 'query',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `response` method
+     *
+     * @return void
+     *
+     * @dataProvider responseProvider
+     * @covers ::response()
+     * @covers ::getQuery()
+     * @covers ::getHeaders()
+     */
+    public function testResponse(array $expected, string $body, array $options = []): void
+    {
+        $response = new Response([], $body);
+        $mock = $this->getMockBuilder(Stream::class)
+            ->getMock();
+        $mock->method('send')
+            ->willReturn([$response]);
+
+        $oauth2 = new OAuth2();
+        $oauth2->setConfig('client', ['adapter' => $mock]);
+        $data = $oauth2->response('https://oauth2.example.com', 'token-example', $options);
+
+        static::assertEquals($expected, $data);
+    }
+}


### PR DESCRIPTION
This PR improves OAuth2 external provider check.

Scenario: upon signup or login via OAuth2 external providers a check on `access_token` validity is performed. An URL of the auth provider using the access token is called to get some user data. Then a match between the provider user ID and the same provider user ID in the original request is done to validate the token.

Most of the providers use an `Authorization Bearer {accessToken}` header in this OAuth2 requests, but some (like Facebook) use the access token via query string. A new `OAuth2` utility class has been added to perform this check request in a configurable way.
 