### PR TITLE
Fix coding style

### DIFF
--- a/plugins/BEdita/API/src/Auth/AnonymousAuthenticate.php
+++ b/plugins/BEdita/API/src/Auth/AnonymousAuthenticate.php
@@ -24,7 +24,6 @@ use Cake\Http\ServerRequest;
  */
 class AnonymousAuthenticate extends BaseAuthenticate
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/src/Auth/JwtAuthenticate.php
+++ b/plugins/BEdita/API/src/Auth/JwtAuthenticate.php
@@ -44,7 +44,6 @@ use Firebase\JWT\JWT;
  */
 class JwtAuthenticate extends BaseAuthenticate
 {
-
     /**
      * Default config for this object.
      *

--- a/plugins/BEdita/API/src/Auth/OAuth2Authenticate.php
+++ b/plugins/BEdita/API/src/Auth/OAuth2Authenticate.php
@@ -26,7 +26,6 @@ use Cake\Http\ServerRequest;
  */
 class OAuth2Authenticate extends BaseAuthenticate
 {
-
     /**
      * Default config for this object.
      *

--- a/plugins/BEdita/API/src/Auth/UuidAuthenticate.php
+++ b/plugins/BEdita/API/src/Auth/UuidAuthenticate.php
@@ -33,7 +33,6 @@ use Cake\Validation\Validation;
  */
 class UuidAuthenticate extends BaseAuthenticate
 {
-
     /**
      * Default config for this object.
      *

--- a/plugins/BEdita/API/src/Controller/Admin/AdminController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/AdminController.php
@@ -22,7 +22,6 @@ use BEdita\API\Controller\ResourcesController;
  */
 abstract class AdminController extends ResourcesController
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/src/Controller/Admin/ApplicationsController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/ApplicationsController.php
@@ -22,7 +22,6 @@ namespace BEdita\API\Controller\Admin;
  */
 class ApplicationsController extends AdminController
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/src/Controller/Admin/AsyncJobsController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/AsyncJobsController.php
@@ -22,7 +22,6 @@ namespace BEdita\API\Controller\Admin;
  */
 class AsyncJobsController extends AdminController
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/src/Controller/Admin/ConfigController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/ConfigController.php
@@ -22,7 +22,6 @@ namespace BEdita\API\Controller\Admin;
  */
 class ConfigController extends AdminController
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/src/Controller/Admin/EndpointsController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/EndpointsController.php
@@ -22,7 +22,6 @@ namespace BEdita\API\Controller\Admin;
  */
 class EndpointsController extends AdminController
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/src/Controller/HomeController.php
+++ b/plugins/BEdita/API/src/Controller/HomeController.php
@@ -28,7 +28,6 @@ use Laminas\Diactoros\Uri;
  */
 class HomeController extends AppController
 {
-
     /**
      * Default endpoints with:
      *  - supported methods, where 'ALL' means 'GET', 'POST', 'PATCH' and 'DELETE' are supported

--- a/plugins/BEdita/API/src/Controller/MediaController.php
+++ b/plugins/BEdita/API/src/Controller/MediaController.php
@@ -26,7 +26,6 @@ use Cake\Utility\Hash;
  */
 class MediaController extends ObjectsController
 {
-
     /**
      * Get and validate IDs in request URL.
      *

--- a/plugins/BEdita/API/src/Controller/Model/CategoriesController.php
+++ b/plugins/BEdita/API/src/Controller/Model/CategoriesController.php
@@ -22,7 +22,6 @@ namespace BEdita\API\Controller\Model;
  */
 class CategoriesController extends ModelController
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/src/Controller/Model/ModelController.php
+++ b/plugins/BEdita/API/src/Controller/Model/ModelController.php
@@ -22,7 +22,6 @@ use BEdita\API\Controller\ResourcesController;
  */
 abstract class ModelController extends ResourcesController
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/src/Controller/Model/ObjectTypesController.php
+++ b/plugins/BEdita/API/src/Controller/Model/ObjectTypesController.php
@@ -22,7 +22,6 @@ namespace BEdita\API\Controller\Model;
  */
 class ObjectTypesController extends ModelController
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/src/Controller/Model/PropertiesController.php
+++ b/plugins/BEdita/API/src/Controller/Model/PropertiesController.php
@@ -22,7 +22,6 @@ namespace BEdita\API\Controller\Model;
  */
 class PropertiesController extends ModelController
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/src/Controller/Model/PropertyTypesController.php
+++ b/plugins/BEdita/API/src/Controller/Model/PropertyTypesController.php
@@ -22,7 +22,6 @@ namespace BEdita\API\Controller\Model;
  */
 class PropertyTypesController extends ModelController
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/src/Controller/Model/RelationsController.php
+++ b/plugins/BEdita/API/src/Controller/Model/RelationsController.php
@@ -22,7 +22,6 @@ namespace BEdita\API\Controller\Model;
  */
 class RelationsController extends ModelController
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/src/Controller/Model/TagsController.php
+++ b/plugins/BEdita/API/src/Controller/Model/TagsController.php
@@ -22,7 +22,6 @@ namespace BEdita\API\Controller\Model;
  */
 class TagsController extends ModelController
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/src/Controller/RolesController.php
+++ b/plugins/BEdita/API/src/Controller/RolesController.php
@@ -21,7 +21,6 @@ namespace BEdita\API\Controller;
  */
 class RolesController extends ResourcesController
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/src/Controller/StatusController.php
+++ b/plugins/BEdita/API/src/Controller/StatusController.php
@@ -22,7 +22,6 @@ use Cake\Core\Configure;
  */
 class StatusController extends AppController
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/src/Controller/StreamsController.php
+++ b/plugins/BEdita/API/src/Controller/StreamsController.php
@@ -31,7 +31,6 @@ use Cake\Utility\Hash;
  */
 class StreamsController extends ResourcesController
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/src/Controller/TranslationsController.php
+++ b/plugins/BEdita/API/src/Controller/TranslationsController.php
@@ -25,7 +25,6 @@ use Cake\Routing\Router;
  */
 class TranslationsController extends ResourcesController
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/src/Datasource/JsonApiPaginator.php
+++ b/plugins/BEdita/API/src/Datasource/JsonApiPaginator.php
@@ -28,7 +28,6 @@ use Cake\ORM\Query;
  */
 class JsonApiPaginator extends Paginator
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/src/Model/Action/UpdateAssociatedAction.php
+++ b/plugins/BEdita/API/src/Model/Action/UpdateAssociatedAction.php
@@ -29,7 +29,6 @@ use Cake\Utility\Hash;
  */
 class UpdateAssociatedAction extends BaseAction
 {
-
     /**
      * Add associated action.
      *

--- a/plugins/BEdita/API/src/Model/Action/UpdateRelatedAction.php
+++ b/plugins/BEdita/API/src/Model/Action/UpdateRelatedAction.php
@@ -28,7 +28,6 @@ use Cake\Utility\Hash;
  */
 class UpdateRelatedAction extends UpdateAssociatedAction
 {
-
     /** @inheritDoc */
     protected function getTargetEntities(array $data, Association $association): array
     {

--- a/plugins/BEdita/API/src/Network/Exception/UnsupportedMediaTypeException.php
+++ b/plugins/BEdita/API/src/Network/Exception/UnsupportedMediaTypeException.php
@@ -20,7 +20,6 @@ use Cake\Http\Exception\HttpException;
  */
 class UnsupportedMediaTypeException extends HttpException
 {
-
     /**
      * Constructor
      *

--- a/plugins/BEdita/API/src/Shell/SpecShell.php
+++ b/plugins/BEdita/API/src/Shell/SpecShell.php
@@ -25,7 +25,6 @@ use Symfony\Component\Yaml\Yaml;
  */
 class SpecShell extends Shell
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/API/tests/IntegrationTest/ChildrenRelationshipTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ChildrenRelationshipTest.php
@@ -23,7 +23,6 @@ use Cake\Utility\Hash;
  */
 class ChildrenRelationshipTest extends IntegrationTestCase
 {
-
     /**
      * Keep the TreesTable instance
      *

--- a/plugins/BEdita/API/tests/IntegrationTest/DeleteFolderTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/DeleteFolderTest.php
@@ -21,7 +21,6 @@ use Cake\Utility\Hash;
  */
 class DeleteFolderTest extends IntegrationTestCase
 {
-
     /**
      * Test that restoring a folder is allowed only if no ancestors are deleted.
      *

--- a/plugins/BEdita/API/tests/IntegrationTest/ExceptionRendererTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ExceptionRendererTest.php
@@ -25,7 +25,6 @@ use Cake\Http\Exception\HttpException;
  */
 class ExceptionRendererTest extends IntegrationTestCase
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/tests/IntegrationTest/I18nTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/I18nTest.php
@@ -22,7 +22,6 @@ use Cake\Utility\Hash;
  */
 class I18nTest extends IntegrationTestCase
 {
-
     /**
      * Test wrong lang tag.
      *

--- a/plugins/BEdita/API/tests/IntegrationTest/MetadataTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/MetadataTest.php
@@ -24,7 +24,6 @@ use Cake\Utility\Text;
  */
 class MetadataTest extends IntegrationTestCase
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/tests/IntegrationTest/PaginationTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/PaginationTest.php
@@ -21,7 +21,6 @@ use Cake\Core\Configure;
  */
 class PaginationTest extends IntegrationTestCase
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
@@ -23,7 +23,6 @@ use Cake\Utility\Hash;
  */
 class ParentsRelationshipTest extends IntegrationTestCase
 {
-
     /**
      * Keep the TreesTable instance
      *

--- a/plugins/BEdita/API/tests/IntegrationTest/RelationshipsParamsTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/RelationshipsParamsTest.php
@@ -20,7 +20,6 @@ use Cake\ORM\TableRegistry;
  */
 class RelationshipsParamsTest extends IntegrationTestCase
 {
-
     /**
      * Locations table.
      *

--- a/plugins/BEdita/API/tests/IntegrationTest/UuidLoginTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/UuidLoginTest.php
@@ -25,7 +25,6 @@ use Cake\Utility\Text;
  */
 class UuidLoginTest extends IntegrationTestCase
 {
-
     /**
      * Test anonymous login with a UUID.
      *

--- a/plugins/BEdita/API/tests/TestCase/Auth/AnonymousAuthenticateTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/AnonymousAuthenticateTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class AnonymousAuthenticateTest extends TestCase
 {
-
     /**
      * Test `authenticate` method.
      *

--- a/plugins/BEdita/API/tests/TestCase/Auth/JwtAuthenticateTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/JwtAuthenticateTest.php
@@ -31,7 +31,6 @@ use Firebase\JWT\JWT;
  */
 class JwtAuthenticateTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/API/tests/TestCase/Auth/OAuth2AuthenticateTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/OAuth2AuthenticateTest.php
@@ -29,7 +29,6 @@ use Cake\TestSuite\TestCase;
  */
 class OAuth2AuthenticateTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/API/tests/TestCase/Auth/OTPAuthenticateTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/OTPAuthenticateTest.php
@@ -30,7 +30,6 @@ use Cake\TestSuite\TestCase;
  */
 class OTPAuthenticateTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/API/tests/TestCase/Auth/UuidAuthenticateTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/UuidAuthenticateTest.php
@@ -27,7 +27,6 @@ use Cake\TestSuite\TestCase;
  */
 class UuidAuthenticateTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/AdminControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/AdminControllerTest.php
@@ -20,7 +20,6 @@ use BEdita\API\TestSuite\IntegrationTestCase;
  */
 class AdminControllerTest extends IntegrationTestCase
 {
-
     /**
      * Test unauthorized response for unauthenticated calls.
      *

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/ApplicationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/ApplicationsControllerTest.php
@@ -22,7 +22,6 @@ use Cake\ORM\TableRegistry;
  */
 class ApplicationsControllerTest extends IntegrationTestCase
 {
-
     /**
      * Test index method.
      *

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/AsyncJobsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/AsyncJobsControllerTest.php
@@ -22,7 +22,6 @@ use Cake\Utility\Text;
  */
 class AsyncJobsControllerTest extends IntegrationTestCase
 {
-
     /**
      * Test index method.
      *

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/EndpointsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/EndpointsControllerTest.php
@@ -21,7 +21,6 @@ use Cake\ORM\TableRegistry;
  */
 class EndpointsControllerTest extends IntegrationTestCase
 {
-
     /**
      * Test index method.
      *

--- a/plugins/BEdita/API/tests/TestCase/Controller/AppControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AppControllerTest.php
@@ -27,7 +27,6 @@ use Cake\Http\ServerRequest;
  */
 class AppControllerTest extends IntegrationTestCase
 {
-
     /**
      * Test API meta info header.
      *

--- a/plugins/BEdita/API/tests/TestCase/Controller/ApplicationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ApplicationsControllerTest.php
@@ -20,7 +20,6 @@ use BEdita\API\Test\TestConstants;
  */
 class ApplicationsControllerTest extends IntegrationTestCase
 {
-
     /**
      * Test index method.
      *

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
@@ -27,7 +27,6 @@ use Cake\TestSuite\TestCase;
  */
 class JsonApiComponentTest extends TestCase
 {
-
     /**
      * Fixtures.
      *

--- a/plugins/BEdita/API/tests/TestCase/Controller/ConfigControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ConfigControllerTest.php
@@ -19,7 +19,6 @@ use BEdita\API\TestSuite\IntegrationTestCase;
  */
 class ConfigControllerTest extends IntegrationTestCase
 {
-
     /**
      * Test index method.
      *

--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -24,7 +24,6 @@ use Cake\Utility\Hash;
  */
 class FoldersControllerTest extends IntegrationTestCase
 {
-
     /**
      * Folders table.
      *

--- a/plugins/BEdita/API/tests/TestCase/Controller/MediaControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/MediaControllerTest.php
@@ -26,7 +26,6 @@ use Cake\Utility\Hash;
  */
 class MediaControllerTest extends IntegrationTestCase
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/tests/TestCase/Controller/StatusControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/StatusControllerTest.php
@@ -20,7 +20,6 @@ use BEdita\Core\Utility\System;
  */
 class StatusControllerTest extends IntegrationTestCase
 {
-
     /**
      * Test index method.
      *

--- a/plugins/BEdita/API/tests/TestCase/Controller/StreamsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/StreamsControllerTest.php
@@ -23,7 +23,6 @@ use Cake\Validation\Validation;
  */
 class StreamsControllerTest extends IntegrationTestCase
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/API/tests/TestCase/Datasource/JsonApiPaginatorTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Datasource/JsonApiPaginatorTest.php
@@ -24,7 +24,6 @@ use Cake\Utility\Hash;
  */
 class JsonApiPaginatorTest extends TestCase
 {
-
     /**
      * Fixtures.
      *

--- a/plugins/BEdita/API/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Error/ErrorHandlerTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class ErrorHandlerTest extends TestCase
 {
-
     /**
      * Data provider for `testDisplayError` test case.
      *

--- a/plugins/BEdita/API/tests/TestCase/Event/CommonEventHandlerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Event/CommonEventHandlerTest.php
@@ -27,7 +27,6 @@ use Cake\TestSuite\TestCase;
  */
 class CommonEventHandlerTest extends TestCase
 {
-
     /**
      * Fixtures.
      *

--- a/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateAssociatedActionTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateAssociatedActionTest.php
@@ -28,7 +28,6 @@ use Cake\Utility\Inflector;
  */
 class UpdateAssociatedActionTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateRelatedActionTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateRelatedActionTest.php
@@ -27,7 +27,6 @@ use Exception;
  */
 class UpdateRelatedActionTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/API/tests/TestCase/Network/Exception/UnsupportedMediaTypeExceptionTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Network/Exception/UnsupportedMediaTypeExceptionTest.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\TestCase;
  */
 class UnsupportedMediaTypeExceptionTest extends TestCase
 {
-
     /**
      * Test `__construct()` method.
      *

--- a/plugins/BEdita/API/tests/TestCase/Shell/SpecShellTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Shell/SpecShellTest.php
@@ -22,7 +22,6 @@ use Symfony\Component\Yaml\Yaml;
  */
 class SpecShellTest extends ConsoleIntegrationTestCase
 {
-
     /**
      * Name for temporary configuration file.
      *

--- a/plugins/BEdita/Core/src/Database/Type/JsonObjectType.php
+++ b/plugins/BEdita/Core/src/Database/Type/JsonObjectType.php
@@ -23,7 +23,6 @@ use Cake\Database\Type\JsonType;
  */
 class JsonObjectType extends JsonType
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Filesystem/Adapter/LocalAdapter.php
+++ b/plugins/BEdita/Core/src/Filesystem/Adapter/LocalAdapter.php
@@ -24,7 +24,6 @@ use League\Flysystem\Adapter\Local;
  */
 class LocalAdapter extends FilesystemAdapter
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Filesystem/Exception/InvalidStreamException.php
+++ b/plugins/BEdita/Core/src/Filesystem/Exception/InvalidStreamException.php
@@ -22,5 +22,4 @@ use Cake\Core\Exception\Exception;
  */
 class InvalidStreamException extends Exception
 {
-
 }

--- a/plugins/BEdita/Core/src/Filesystem/Exception/InvalidThumbnailOptionsException.php
+++ b/plugins/BEdita/Core/src/Filesystem/Exception/InvalidThumbnailOptionsException.php
@@ -22,7 +22,6 @@ use Cake\Core\Exception\Exception;
  */
 class InvalidThumbnailOptionsException extends Exception
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Filesystem/GeneratorInterface.php
+++ b/plugins/BEdita/Core/src/Filesystem/GeneratorInterface.php
@@ -30,7 +30,6 @@ use BEdita\Core\Model\Entity\Stream;
  */
 interface GeneratorInterface
 {
-
     /**
      * Get URL for a generated thumbnail.
      *

--- a/plugins/BEdita/Core/src/Filesystem/Thumbnail/AsyncGenerator.php
+++ b/plugins/BEdita/Core/src/Filesystem/Thumbnail/AsyncGenerator.php
@@ -25,7 +25,6 @@ use Cake\ORM\TableRegistry;
  */
 class AsyncGenerator extends ThumbnailGenerator
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Filesystem/Thumbnail/GlideGenerator.php
+++ b/plugins/BEdita/Core/src/Filesystem/Thumbnail/GlideGenerator.php
@@ -33,7 +33,6 @@ use League\Glide\Manipulators\Size as SizeManipulator;
  */
 class GlideGenerator extends ThumbnailGenerator
 {
-
     /**
      * Enforced maximum image size.
      *

--- a/plugins/BEdita/Core/src/Filesystem/ThumbnailRegistry.php
+++ b/plugins/BEdita/Core/src/Filesystem/ThumbnailRegistry.php
@@ -26,7 +26,6 @@ use Cake\Core\ObjectRegistry;
  */
 class ThumbnailRegistry extends ObjectRegistry
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/I18n/MessagesFileLoader.php
+++ b/plugins/BEdita/Core/src/I18n/MessagesFileLoader.php
@@ -26,7 +26,6 @@ use Locale;
  */
 class MessagesFileLoader extends BaseLoader
 {
-
     /**
      * List of plugins where lookup should happen for the given domain.
      *

--- a/plugins/BEdita/Core/src/Job/Service/MailService.php
+++ b/plugins/BEdita/Core/src/Job/Service/MailService.php
@@ -24,7 +24,6 @@ use Cake\Utility\Hash;
  */
 class MailService implements JobService
 {
-
     /**
      * Send a single email.
      *

--- a/plugins/BEdita/Core/src/Job/Service/ThumbnailService.php
+++ b/plugins/BEdita/Core/src/Job/Service/ThumbnailService.php
@@ -27,7 +27,6 @@ use Cake\Utility\Hash;
  */
 class ThumbnailService implements JobService
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Job/ServiceRegistry.php
+++ b/plugins/BEdita/Core/src/Job/ServiceRegistry.php
@@ -23,7 +23,6 @@ use Cake\Utility\Inflector;
  */
 class ServiceRegistry
 {
-
     /**
      * Registered instances.
      *

--- a/plugins/BEdita/Core/src/Mailer/Email.php
+++ b/plugins/BEdita/Core/src/Mailer/Email.php
@@ -25,7 +25,6 @@ use Cake\Mailer\Email as CakeEmail;
  */
 class Email extends CakeEmail
 {
-
     /**
      * Send a raw email.
      *

--- a/plugins/BEdita/Core/src/Mailer/Transport/AsyncJobsTransport.php
+++ b/plugins/BEdita/Core/src/Mailer/Transport/AsyncJobsTransport.php
@@ -28,7 +28,6 @@ use Cake\ORM\TableRegistry;
  */
 class AsyncJobsTransport extends AbstractTransport
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Action/DeleteEntityAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/DeleteEntityAction.php
@@ -20,7 +20,6 @@ namespace BEdita\Core\Model\Action;
  */
 class DeleteEntityAction extends BaseAction
 {
-
     /**
      * Table.
      *

--- a/plugins/BEdita/Core/src/Model/Action/DeleteObjectAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/DeleteObjectAction.php
@@ -20,7 +20,6 @@ namespace BEdita\Core\Model\Action;
  */
 class DeleteObjectAction extends BaseAction
 {
-
     /**
      * Table.
      *

--- a/plugins/BEdita/Core/src/Model/Action/GetEntityAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/GetEntityAction.php
@@ -20,7 +20,6 @@ namespace BEdita\Core\Model\Action;
  */
 class GetEntityAction extends BaseAction
 {
-
     /**
      * Table.
      *

--- a/plugins/BEdita/Core/src/Model/Action/GetObjectAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/GetObjectAction.php
@@ -24,7 +24,6 @@ use Cake\Utility\Hash;
  */
 class GetObjectAction extends BaseAction
 {
-
     /**
      * Table.
      *

--- a/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
@@ -37,7 +37,6 @@ use Cake\Utility\Inflector;
  */
 class ListAssociatedAction extends BaseAction
 {
-
     /**
      * Name of inverse association.
      *

--- a/plugins/BEdita/Core/src/Model/Action/ListObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListObjectsAction.php
@@ -23,7 +23,6 @@ use Cake\Utility\Hash;
  */
 class ListObjectsAction extends BaseAction
 {
-
     /**
      * Table.
      *

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
@@ -29,7 +29,6 @@ use Cake\ORM\TableRegistry;
  */
 class ListRelatedObjectsAction extends ListAssociatedAction
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Action/UpdateAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/UpdateAssociatedAction.php
@@ -24,7 +24,6 @@ use Cake\Datasource\EntityInterface;
  */
 abstract class UpdateAssociatedAction extends BaseAction
 {
-
     /**
      * Association.
      *

--- a/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
@@ -27,7 +27,6 @@ use Cake\Utility\Hash;
  */
 abstract class UpdateRelatedObjectsAction extends UpdateAssociatedAction
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -35,7 +35,6 @@ use Cake\Utility\Hash;
  */
 class CustomPropertiesBehavior extends Behavior
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Behavior/DataCleanupBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/DataCleanupBehavior.php
@@ -30,7 +30,6 @@ use Cake\Utility\Inflector;
  */
 class DataCleanupBehavior extends Behavior
 {
-
     /**
      * Default configuration.
      *

--- a/plugins/BEdita/Core/src/Model/Behavior/GeometryBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/GeometryBehavior.php
@@ -29,7 +29,6 @@ use Cake\Utility\Hash;
  */
 class GeometryBehavior extends Behavior
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Behavior/ObjectTypeBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/ObjectTypeBehavior.php
@@ -24,7 +24,6 @@ use Cake\ORM\TableRegistry;
  */
 class ObjectTypeBehavior extends Behavior
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Behavior/PriorityBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/PriorityBehavior.php
@@ -24,7 +24,6 @@ use Cake\Utility\Hash;
  */
 class PriorityBehavior extends Behavior
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
@@ -25,7 +25,6 @@ use Swaggest\JsonSchema\Schema;
  */
 class RelationsBehavior extends Behavior
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
@@ -28,7 +28,6 @@ use Cake\ORM\Table;
  */
 class SearchableBehavior extends Behavior
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
@@ -25,7 +25,6 @@ use Cake\ORM\Table;
  */
 class TreeBehavior extends CakeTreeBehavior
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Model/Behavior/UploadableBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UploadableBehavior.php
@@ -27,7 +27,6 @@ use Psr\Http\Message\StreamInterface;
  */
 class UploadableBehavior extends Behavior
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Behavior/UserModifiedBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UserModifiedBehavior.php
@@ -28,7 +28,6 @@ use Cake\ORM\Behavior;
  */
 class UserModifiedBehavior extends Behavior
 {
-
     /**
      * Default config
      *

--- a/plugins/BEdita/Core/src/Model/Entity/AuthProvider.php
+++ b/plugins/BEdita/Core/src/Model/Entity/AuthProvider.php
@@ -38,7 +38,6 @@ use Cake\Utility\Text;
  */
 class AuthProvider extends Entity
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Entity/DateRange.php
+++ b/plugins/BEdita/Core/src/Model/Entity/DateRange.php
@@ -28,7 +28,6 @@ use Cake\ORM\Entity;
  */
 class DateRange extends Entity
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Entity/EndpointPermission.php
+++ b/plugins/BEdita/Core/src/Model/Entity/EndpointPermission.php
@@ -39,7 +39,6 @@ use Cake\ORM\TableRegistry;
  */
 class EndpointPermission extends Entity
 {
-
     /**
      * Bits to shift for read permissions.
      *

--- a/plugins/BEdita/Core/src/Model/Entity/ExternalAuth.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ExternalAuth.php
@@ -32,7 +32,6 @@ use Cake\ORM\Entity;
  */
 class ExternalAuth extends Entity
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Entity/Location.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Location.php
@@ -26,7 +26,6 @@ namespace BEdita\Core\Model\Entity;
  */
 class Location extends ObjectEntity
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectPermission.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectPermission.php
@@ -16,7 +16,6 @@ use Cake\ORM\Entity;
  */
 class ObjectPermission extends Entity
 {
-
     /**
      * Fields that can be mass assigned using newEntity() or patchEntity().
      *

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectProperty.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectProperty.php
@@ -16,7 +16,6 @@ use Cake\ORM\Entity;
  */
 class ObjectProperty extends Entity
 {
-
     /**
      * Fields that can be mass assigned using newEntity() or patchEntity().
      *

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectRelation.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectRelation.php
@@ -18,7 +18,6 @@ use Cake\ORM\Entity;
  */
 class ObjectRelation extends Entity
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Entity/RelationType.php
+++ b/plugins/BEdita/Core/src/Model/Entity/RelationType.php
@@ -27,7 +27,6 @@ use Cake\ORM\Entity;
  */
 class RelationType extends Entity
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Entity/RolesUser.php
+++ b/plugins/BEdita/Core/src/Model/Entity/RolesUser.php
@@ -27,7 +27,6 @@ use Cake\ORM\Entity;
  */
 class RolesUser extends Entity
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Entity/StaticProperty.php
+++ b/plugins/BEdita/Core/src/Model/Entity/StaticProperty.php
@@ -28,7 +28,6 @@ use Cake\Utility\Hash;
  */
 class StaticProperty extends Property
 {
-
     /**
      * Convert a property into a static property.
      *

--- a/plugins/BEdita/Core/src/Model/Entity/Tree.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Tree.php
@@ -41,7 +41,6 @@ use Cake\ORM\TableRegistry;
  */
 class Tree extends Entity
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Table/AnnotationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/AnnotationsTable.php
@@ -41,7 +41,6 @@ use Cake\Validation\Validator;
  */
 class AnnotationsTable extends Table
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Table/AsyncJobsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/AsyncJobsTable.php
@@ -27,7 +27,6 @@ use Cake\Validation\Validator;
  */
 class AsyncJobsTable extends Table
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Table/AuthProvidersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/AuthProvidersTable.php
@@ -42,7 +42,6 @@ use Cake\Validation\Validator;
  */
 class AuthProvidersTable extends Table
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Model/Table/ExternalAuthTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ExternalAuthTable.php
@@ -41,7 +41,6 @@ use Cake\Validation\Validator;
  */
 class ExternalAuthTable extends Table
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
@@ -40,7 +40,6 @@ use Cake\ORM\Rule\ValidCount;
  */
 class FoldersTable extends ObjectsTable
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Model/Table/LinksTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/LinksTable.php
@@ -31,7 +31,6 @@ use Cake\Validation\Validator;
  */
 class LinksTable extends Table
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Table/MediaTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/MediaTable.php
@@ -20,7 +20,6 @@ use Cake\Database\Schema\TableSchema;
  */
 class MediaTable extends Table
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Table/ObjectPermissionsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectPermissionsTable.php
@@ -21,7 +21,6 @@ use Cake\Validation\Validator;
  */
 class ObjectPermissionsTable extends Table
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Model/Table/ObjectPropertiesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectPropertiesTable.php
@@ -21,7 +21,6 @@ use Cake\Validation\Validator;
  */
 class ObjectPropertiesTable extends Table
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Model/Table/ObjectRelationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectRelationsTable.php
@@ -24,7 +24,6 @@ use Cake\Validation\Validator;
  */
 class ObjectRelationsTable extends Table
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -57,7 +57,6 @@ use Cake\Utility\Hash;
  */
 class ObjectsTable extends Table
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
@@ -34,7 +34,6 @@ use Cake\Utility\Hash;
  */
 class ProfilesTable extends Table
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Table/PropertiesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/PropertiesTable.php
@@ -46,7 +46,6 @@ use Cake\Validation\Validator;
  */
 class PropertiesTable extends Table
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Model/Table/PropertyTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/PropertyTypesTable.php
@@ -40,7 +40,6 @@ use Cake\Validation\Validator;
  */
 class PropertyTypesTable extends Table
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Model/Table/PublicationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/PublicationsTable.php
@@ -31,7 +31,6 @@ use Cake\Validation\Validator;
  */
 class PublicationsTable extends Table
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Table/RelationTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationTypesTable.php
@@ -35,7 +35,6 @@ use Cake\Validation\Validator;
  */
 class RelationTypesTable extends Table
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
@@ -44,7 +44,6 @@ use Cake\Validation\Validator;
  */
 class RelationsTable extends Table
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Model/Table/RolesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RolesTable.php
@@ -40,7 +40,6 @@ use Cake\Validation\Validator;
  */
 class RolesTable extends Table
 {
-
     /**
      * Administrator role id
      *

--- a/plugins/BEdita/Core/src/Model/Table/RolesUsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RolesUsersTable.php
@@ -36,7 +36,6 @@ use Cake\Validation\Validator;
  */
 class RolesUsersTable extends Table
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Model/Table/StaticPropertiesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/StaticPropertiesTable.php
@@ -44,7 +44,6 @@ use Cake\ORM\TableRegistry;
  */
 class StaticPropertiesTable extends Table
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Model/Table/StreamsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/StreamsTable.php
@@ -39,7 +39,6 @@ use Cake\Validation\Validator;
  */
 class StreamsTable extends Table
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Model/Table/TranslationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TranslationsTable.php
@@ -38,7 +38,6 @@ use Cake\Validation\Validator;
  */
 class TranslationsTable extends Table
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Model/Table/TreesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TreesTable.php
@@ -45,7 +45,6 @@ use Cake\Validation\Validator;
  */
 class TreesTable extends Table
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Model/Validation/LocationsValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/LocationsValidator.php
@@ -20,7 +20,6 @@ namespace BEdita\Core\Model\Validation;
  */
 class LocationsValidator extends ObjectsValidator
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Model/Validation/MediaValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/MediaValidator.php
@@ -20,7 +20,6 @@ namespace BEdita\Core\Model\Validation;
  */
 class MediaValidator extends ObjectsValidator
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Model/Validation/ObjectsValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/ObjectsValidator.php
@@ -23,7 +23,6 @@ use Cake\Validation\Validator;
  */
 class ObjectsValidator extends Validator
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Model/Validation/ProfilesValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/ProfilesValidator.php
@@ -22,7 +22,6 @@ use Cake\ORM\TableRegistry;
  */
 class ProfilesValidator extends ObjectsValidator
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Model/Validation/SqlConventionsValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/SqlConventionsValidator.php
@@ -52,7 +52,6 @@ use Cake\Validation\Validator;
  */
 class SqlConventionsValidator extends Validator
 {
-
     /**
      * Comma-separated list of reserved words to be allowed anyway.
      *

--- a/plugins/BEdita/Core/src/Model/Validation/UsersValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/UsersValidator.php
@@ -22,7 +22,6 @@ use Cake\ORM\TableRegistry;
  */
 class UsersValidator extends ProfilesValidator
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/ORM/Inheritance/AssociationCollection.php
+++ b/plugins/BEdita/Core/src/ORM/Inheritance/AssociationCollection.php
@@ -28,7 +28,6 @@ use Cake\ORM\AssociationCollection as CakeAssociationCollection;
  */
 class AssociationCollection extends CakeAssociationCollection
 {
-
     /**
      * Inner association collection.
      *

--- a/plugins/BEdita/Core/src/ORM/Inheritance/Query.php
+++ b/plugins/BEdita/Core/src/ORM/Inheritance/Query.php
@@ -26,7 +26,6 @@ use Cake\ORM\Table as CakeTable;
  */
 class Query extends CakeQuery
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/ORM/Inheritance/Table.php
+++ b/plugins/BEdita/Core/src/ORM/Inheritance/Table.php
@@ -29,7 +29,6 @@ use Cake\ORM\TableRegistry;
  */
 class Table extends CakeTable
 {
-
     /**
      * Table that is being inherited by this one.
      *

--- a/plugins/BEdita/Core/src/ORM/Rule/IsUniqueAmongst.php
+++ b/plugins/BEdita/Core/src/ORM/Rule/IsUniqueAmongst.php
@@ -23,7 +23,6 @@ use Cake\ORM\Rule\IsUnique;
  */
 class IsUniqueAmongst extends IsUnique
 {
-
     /**
      * Build uniqueness conditions.
      *

--- a/plugins/BEdita/Core/src/Shell/BeditaShell.php
+++ b/plugins/BEdita/Core/src/Shell/BeditaShell.php
@@ -40,7 +40,6 @@ use Cake\Datasource\ConnectionManager;
  */
 class BeditaShell extends Shell
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Shell/DbAdminShell.php
+++ b/plugins/BEdita/Core/src/Shell/DbAdminShell.php
@@ -31,7 +31,6 @@ use Cake\Datasource\ConnectionManager;
  */
 class DbAdminShell extends Shell
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Shell/JobsShell.php
+++ b/plugins/BEdita/Core/src/Shell/JobsShell.php
@@ -24,7 +24,6 @@ use Cake\Datasource\Exception\RecordNotFoundException;
  */
 class JobsShell extends Shell
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Shell/ResourcesShell.php
+++ b/plugins/BEdita/Core/src/Shell/ResourcesShell.php
@@ -28,7 +28,6 @@ use Cake\Utility\Inflector;
  */
 class ResourcesShell extends Shell
 {
-
     /**
      * Accepted resource types
      *

--- a/plugins/BEdita/Core/src/Shell/StreamsShell.php
+++ b/plugins/BEdita/Core/src/Shell/StreamsShell.php
@@ -24,7 +24,6 @@ use Cake\Console\Shell;
  */
 class StreamsShell extends Shell
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Shell/Task/CheckApiKeyTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/CheckApiKeyTask.php
@@ -26,7 +26,6 @@ use Cake\Datasource\Exception\RecordNotFoundException;
  */
 class CheckApiKeyTask extends Shell
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Shell/Task/CheckFilesystemTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/CheckFilesystemTask.php
@@ -22,7 +22,6 @@ use Cake\Console\Shell;
  */
 class CheckFilesystemTask extends Shell
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Shell/Task/CheckSchemaTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/CheckSchemaTask.php
@@ -31,7 +31,6 @@ use Migrations\Migrations;
  */
 class CheckSchemaTask extends Shell
 {
-
     /**
      * Registry of all issues found.
      *

--- a/plugins/BEdita/Core/src/Shell/Task/CheckTreeTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/CheckTreeTask.php
@@ -28,7 +28,6 @@ use Cake\Utility\Hash;
  */
 class CheckTreeTask extends Shell
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Shell/Task/InitSchemaTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/InitSchemaTask.php
@@ -25,7 +25,6 @@ use Migrations\Migrations;
  */
 class InitSchemaTask extends Shell
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Shell/Task/RecoverTreeTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/RecoverTreeTask.php
@@ -24,7 +24,6 @@ use Cake\Console\Shell;
  */
 class RecoverTreeTask extends Shell
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/Shell/Task/SetupAdminUserTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/SetupAdminUserTask.php
@@ -27,7 +27,6 @@ use Cake\ORM\Exception\PersistenceFailedException;
  */
 class SetupAdminUserTask extends Shell
 {
-
     /**
      * Default username of first user.
      *

--- a/plugins/BEdita/Core/src/Shell/Task/SetupConnectionTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/SetupConnectionTask.php
@@ -28,7 +28,6 @@ use Cake\Utility\Hash;
  */
 class SetupConnectionTask extends Shell
 {
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Shell/TreeShell.php
+++ b/plugins/BEdita/Core/src/Shell/TreeShell.php
@@ -27,7 +27,6 @@ use Cake\Console\Shell;
  */
 class TreeShell extends Shell
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/src/SingletonTrait.php
+++ b/plugins/BEdita/Core/src/SingletonTrait.php
@@ -21,7 +21,6 @@ namespace BEdita\Core;
  */
 trait SingletonTrait
 {
-
     /**
      * Singleton instance.
      *

--- a/plugins/BEdita/Core/src/Utility/Database.php
+++ b/plugins/BEdita/Core/src/Utility/Database.php
@@ -24,7 +24,6 @@ use Cake\Utility\Hash;
  */
 class Database
 {
-
     /**
      * Returns an array with current database schema information (tables, columns,
      * indexes, constraints)

--- a/plugins/BEdita/Core/src/Utility/JsonApiSerializable.php
+++ b/plugins/BEdita/Core/src/Utility/JsonApiSerializable.php
@@ -20,7 +20,6 @@ namespace BEdita\Core\Utility;
  */
 interface JsonApiSerializable
 {
-
     /**
      * Tell JSON API serializer to exclude `attributes` from resource.
      *

--- a/plugins/BEdita/Core/src/Utility/System.php
+++ b/plugins/BEdita/Core/src/Utility/System.php
@@ -23,7 +23,6 @@ use Cake\Core\Plugin;
  */
 class System
 {
-
     /**
      * Get status information
      *

--- a/plugins/BEdita/Core/src/Utility/Text.php
+++ b/plugins/BEdita/Core/src/Utility/Text.php
@@ -20,7 +20,6 @@ use Cake\Utility\Text as CakeText;
  */
 class Text extends CakeText
 {
-
     /**
      * Null UUID.
      *

--- a/plugins/BEdita/Core/tests/Fixture/AsyncJobsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/AsyncJobsFixture.php
@@ -10,7 +10,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class AsyncJobsFixture extends TestFixture
 {
-
     /**
      * Records
      *

--- a/plugins/BEdita/Core/tests/Fixture/AuthProvidersFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/AuthProvidersFixture.php
@@ -20,7 +20,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class AuthProvidersFixture extends TestFixture
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/Fixture/DateRangesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/DateRangesFixture.php
@@ -21,7 +21,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class DateRangesFixture extends TestFixture
 {
-
     /**
      * Records
      *

--- a/plugins/BEdita/Core/tests/Fixture/EndpointPermissionsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/EndpointPermissionsFixture.php
@@ -22,7 +22,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class EndpointPermissionsFixture extends TestFixture
 {
-
     /**
      * Records
      *

--- a/plugins/BEdita/Core/tests/Fixture/ExternalAuthFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ExternalAuthFixture.php
@@ -20,7 +20,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class ExternalAuthFixture extends TestFixture
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/Fixture/FakeAnimalsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeAnimalsFixture.php
@@ -20,7 +20,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class FakeAnimalsFixture extends TestFixture
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/Fixture/FakeArticlesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeArticlesFixture.php
@@ -20,7 +20,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class FakeArticlesFixture extends TestFixture
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/Fixture/FakeArticlesTagsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeArticlesTagsFixture.php
@@ -20,7 +20,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class FakeArticlesTagsFixture extends TestFixture
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/Fixture/FakeCategoriesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeCategoriesFixture.php
@@ -20,7 +20,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class FakeCategoriesFixture extends TestFixture
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/Fixture/FakeFelinesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeFelinesFixture.php
@@ -20,7 +20,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class FakeFelinesFixture extends TestFixture
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/Fixture/FakeLabelsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeLabelsFixture.php
@@ -20,7 +20,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class FakeLabelsFixture extends TestFixture
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/Fixture/FakeMammalsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeMammalsFixture.php
@@ -20,7 +20,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class FakeMammalsFixture extends TestFixture
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/Fixture/FakeSearchesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeSearchesFixture.php
@@ -20,7 +20,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class FakeSearchesFixture extends TestFixture
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/Fixture/FakeTagsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeTagsFixture.php
@@ -20,7 +20,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class FakeTagsFixture extends TestFixture
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/Fixture/JsonSchemaTableFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/JsonSchemaTableFixture.php
@@ -20,7 +20,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class JsonSchemaTableFixture extends TestFixture
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/Fixture/LocationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/LocationsFixture.php
@@ -9,7 +9,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class LocationsFixture extends TestFixture
 {
-
     /**
      * Records
      *

--- a/plugins/BEdita/Core/tests/Fixture/MediaFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/MediaFixture.php
@@ -9,7 +9,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class MediaFixture extends TestFixture
 {
-
     /**
      * Records
      *

--- a/plugins/BEdita/Core/tests/Fixture/ObjectPropertiesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ObjectPropertiesFixture.php
@@ -9,7 +9,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class ObjectPropertiesFixture extends TestFixture
 {
-
     /**
      * Records
      *

--- a/plugins/BEdita/Core/tests/Fixture/ObjectRelationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ObjectRelationsFixture.php
@@ -8,7 +8,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class ObjectRelationsFixture extends TestFixture
 {
-
     /**
      * Records
      *

--- a/plugins/BEdita/Core/tests/Fixture/ObjectTypesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ObjectTypesFixture.php
@@ -20,7 +20,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class ObjectTypesFixture extends TestFixture
 {
-
     /**
      * Records
      *

--- a/plugins/BEdita/Core/tests/Fixture/ObjectsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ObjectsFixture.php
@@ -9,7 +9,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class ObjectsFixture extends TestFixture
 {
-
     /**
      * Records
      *

--- a/plugins/BEdita/Core/tests/Fixture/ProfilesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ProfilesFixture.php
@@ -20,7 +20,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class ProfilesFixture extends TestFixture
 {
-
     /**
      * Records
      *

--- a/plugins/BEdita/Core/tests/Fixture/PropertiesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/PropertiesFixture.php
@@ -9,7 +9,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class PropertiesFixture extends TestFixture
 {
-
     /**
      * Records
      *

--- a/plugins/BEdita/Core/tests/Fixture/RelationTypesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/RelationTypesFixture.php
@@ -21,7 +21,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class RelationTypesFixture extends TestFixture
 {
-
     /**
      * Records
      *

--- a/plugins/BEdita/Core/tests/Fixture/RelationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/RelationsFixture.php
@@ -21,7 +21,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class RelationsFixture extends TestFixture
 {
-
     /**
      * Records
      *

--- a/plugins/BEdita/Core/tests/Fixture/RolesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/RolesFixture.php
@@ -20,7 +20,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class RolesFixture extends TestFixture
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/Fixture/RolesUsersFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/RolesUsersFixture.php
@@ -20,7 +20,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class RolesUsersFixture extends TestFixture
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/Fixture/StreamsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/StreamsFixture.php
@@ -22,7 +22,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class StreamsFixture extends TestFixture
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/Fixture/TranslationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/TranslationsFixture.php
@@ -21,7 +21,6 @@ use Cake\I18n\Time;
  */
 class TranslationsFixture extends TestFixture
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/Fixture/TreesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/TreesFixture.php
@@ -9,7 +9,6 @@ use BEdita\Core\TestSuite\Fixture\TestFixture;
  */
 class TreesFixture extends TestFixture
 {
-
     /**
      * Records
      *

--- a/plugins/BEdita/Core/tests/Fixture/UsersFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/UsersFixture.php
@@ -22,7 +22,6 @@ use Cake\Auth\WeakPasswordHasher;
  */
 class UsersFixture extends TestFixture
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -24,7 +24,6 @@ use DateTime;
  */
 class DateTimeTypeTest extends TestCase
 {
-
     /**
      * Data provider for `testMarshalSuccess`.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Database/Type/DateTypeTest.php
@@ -24,7 +24,6 @@ use DateTime;
  */
 class DateTypeTest extends TestCase
 {
-
     /**
      * Data provider for `testMarshal`.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Database/Type/JsonObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Database/Type/JsonObjectTypeTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class JsonObjectTypeTest extends TestCase
 {
-
     /**
      * Data provider for `testToPHP` test case.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/FilesystemAdapterTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/FilesystemAdapterTest.php
@@ -22,7 +22,6 @@ use League\Flysystem\AdapterInterface;
  */
 class FilesystemAdapterTest extends TestCase
 {
-
     /**
      * Test class initialization.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/FilesystemRegistryTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/FilesystemRegistryTest.php
@@ -26,7 +26,6 @@ use League\Flysystem\MountManager;
  */
 class FilesystemRegistryTest extends TestCase
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/AsyncGeneratorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/AsyncGeneratorTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class AsyncGeneratorTest extends TestCase
 {
-
     /**
      * Fixtures.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/TestGenerator.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/TestGenerator.php
@@ -21,7 +21,6 @@ use BEdita\Core\Model\Entity\Stream;
  */
 class TestGenerator extends ThumbnailGenerator
 {
-
     /**
      * Fake thumbnail URL.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/ThumbnailGeneratorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/ThumbnailGeneratorTest.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\TestCase;
  */
 class ThumbnailGeneratorTest extends TestCase
 {
-
     /**
      * Test `initialize` method.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/ThumbnailRegistryTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/ThumbnailRegistryTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class ThumbnailRegistryTest extends TestCase
 {
-
     /**
      * Test load when everything goes just fine.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/ThumbnailTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/ThumbnailTest.php
@@ -28,7 +28,6 @@ use Cake\TestSuite\TestCase;
  */
 class ThumbnailTest extends TestCase
 {
-
     /**
      * Name of test configuration for generating thumbnails.
      *

--- a/plugins/BEdita/Core/tests/TestCase/I18n/MessagesFileLoaderTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/I18n/MessagesFileLoaderTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class MessagesFileLoaderTest extends TestCase
 {
-
     /**
      * Test constructor.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Job/Service/MailServiceTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/Service/MailServiceTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class MailServiceTest extends TestCase
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/TestCase/Job/Service/ThumbnailServiceTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/Service/ThumbnailServiceTest.php
@@ -26,7 +26,6 @@ use PHPUnit\Framework\MockObject\Matcher\InvokedCount;
  */
 class ThumbnailServiceTest extends TestCase
 {
-
     /**
      * Fixtures.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Job/ServiceRegistryTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/ServiceRegistryTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class ServiceRegistryTest extends TestCase
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/EmailTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/EmailTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class EmailTest extends TestCase
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/Transport/AsyncJobsTransportTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/Transport/AsyncJobsTransportTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class AsyncJobsTransportTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddAssociatedActionTest.php
@@ -28,7 +28,6 @@ use Cake\Utility\Inflector;
  */
 class AddAssociatedActionTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
@@ -30,7 +30,6 @@ use Cake\Utility\Inflector;
  */
 class AddRelatedObjectsActionTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/BaseActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/BaseActionTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class BaseActionTest extends TestCase
 {
-
     /**
      * Test constructor method.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ChangeCredentialsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ChangeCredentialsActionTest.php
@@ -32,7 +32,6 @@ use Cake\TestSuite\TestCase;
  */
 class ChangeCredentialsActionTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ChangeCredentialsRequestActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ChangeCredentialsRequestActionTest.php
@@ -29,7 +29,6 @@ use Cake\TestSuite\TestCase;
  */
 class ChangeCredentialsRequestActionTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteEntityActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteEntityActionTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class DeleteEntityActionTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteObjectActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteObjectActionTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class DeleteObjectActionTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/GetEntityActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/GetEntityActionTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class GetEntityActionTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/GetObjectActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/GetObjectActionTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class GetObjectActionTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
@@ -26,7 +26,6 @@ use Cake\TestSuite\TestCase;
  */
 class ListAssociatedActionTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListEntitiesActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListEntitiesActionTest.php
@@ -27,7 +27,6 @@ use Cake\TestSuite\TestCase;
  */
 class ListEntitiesActionTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListObjectsActionTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class ListObjectsActionTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedFoldersActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedFoldersActionTest.php
@@ -27,7 +27,6 @@ use Cake\Utility\Inflector;
  */
 class ListRelatedFoldersActionTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsActionTest.php
@@ -25,7 +25,6 @@ use Cake\Utility\Inflector;
  */
 class ListRelatedObjectsActionTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveAssociatedActionTest.php
@@ -27,7 +27,6 @@ use Cake\Utility\Inflector;
  */
 class RemoveAssociatedActionTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
@@ -26,7 +26,6 @@ use Cake\Utility\Inflector;
  */
 class RemoveRelatedObjectsActionTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SaveEntityActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SaveEntityActionTest.php
@@ -26,7 +26,6 @@ use Cake\Validation\Validator;
  */
 class SaveEntityActionTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SetAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SetAssociatedActionTest.php
@@ -30,7 +30,6 @@ use Cake\Utility\Inflector;
  */
 class SetAssociatedActionTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
@@ -30,7 +30,6 @@ use Cake\Utility\Inflector;
  */
 class SetRelatedObjectsActionTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/DataCleanupBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/DataCleanupBehaviorTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class DataCleanupBehaviorTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectTypeBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectTypeBehaviorTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class ObjectTypeBehaviorTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/RelationsBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/RelationsBehaviorTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class RelationsBehaviorTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class SearchableBehaviorTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -10,7 +10,6 @@ use Cake\TestSuite\TestCase;
  */
 class TreeBehaviorTest extends TestCase
 {
-
     /**
      * Fixtures.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
@@ -28,7 +28,6 @@ use Cake\TestSuite\TestCase;
  */
 class UniqueNameBehaviorTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UserModifiedBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UserModifiedBehaviorTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class UserModifiedBehaviorTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ApplicationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ApplicationTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class ApplicationTest extends TestCase
 {
-
     /**
      * Test subject's table
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/AsyncJobTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/AsyncJobTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class AsyncJobTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/AuthProviderTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/AuthProviderTest.php
@@ -26,7 +26,6 @@ use Cake\Utility\Hash;
  */
 class AuthProviderTest extends TestCase
 {
-
     /**
      * Test subject's table
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ConfigTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ConfigTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class ConfigTest extends TestCase
 {
-
     /**
      * Test subject's table
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/DateRangeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/DateRangeTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class DateRangeTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointPermissionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointPermissionTest.php
@@ -30,7 +30,6 @@ use Cake\TestSuite\TestCase;
  */
 class EndpointPermissionTest extends TestCase
 {
-
     /**
      * Test subject's table
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointTest.php
@@ -26,7 +26,6 @@ use Cake\TestSuite\TestCase;
  */
 class EndpointTest extends TestCase
 {
-
     /**
      * Test subject's table
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ExternalAuthTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ExternalAuthTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class ExternalAuthTest extends TestCase
 {
-
     /**
      * Test subject's table
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiAdminTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiAdminTraitTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class JsonApiAdminTraitTest extends TestCase
 {
-
     /**
      * Helper table.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -23,7 +23,6 @@ use Cake\Utility\Hash;
  */
 class JsonApiTraitTest extends TestCase
 {
-
     /**
      * Helper table.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/LocationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/LocationTest.php
@@ -21,7 +21,6 @@ use Cake\TestSuite\TestCase;
  */
 class LocationTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectEntityTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectEntityTest.php
@@ -26,7 +26,6 @@ use Cake\Utility\Hash;
  */
 class ObjectEntityTest extends TestCase
 {
-
     /**
      * Test subject's table
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -26,7 +26,6 @@ use Cake\Utility\Hash;
  */
 class ObjectTypeTest extends TestCase
 {
-
     /**
      * Test subject's table
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ProfileTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ProfileTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class ProfileTest extends TestCase
 {
-
     /**
      * Test subject's table
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/PropertyTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/PropertyTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class PropertyTest extends TestCase
 {
-
     /**
      * Test subject's table
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/PropertyTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/PropertyTypeTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class PropertyTypeTest extends TestCase
 {
-
     /**
      * Test subject's table
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/RelationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/RelationTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class RelationTest extends TestCase
 {
-
     /**
      * Test subject's table
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/RoleTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/RoleTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class RoleTest extends TestCase
 {
-
     /**
      * Test subject's table
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/StaticPropertyTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/StaticPropertyTest.php
@@ -28,7 +28,6 @@ use Cake\TestSuite\TestCase;
  */
 class StaticPropertyTest extends TestCase
 {
-
     /**
      * Test subject's table
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/UserTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/UserTest.php
@@ -28,7 +28,6 @@ use Cake\Utility\Hash;
  */
 class UserTest extends TestCase
 {
-
     /**
      * Test subject's table
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/AnnotationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/AnnotationsTableTest.php
@@ -15,7 +15,6 @@ use Cake\Utility\Hash;
  */
 class AnnotationsTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/AsyncJobsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/AsyncJobsTableTest.php
@@ -12,7 +12,6 @@ use Cake\TestSuite\TestCase;
  */
 class AsyncJobsTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/AuthProvidersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/AuthProvidersTableTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class AuthProvidersTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/DateRangesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/DateRangesTableTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class DateRangesTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ExternalAuthTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ExternalAuthTableTest.php
@@ -29,7 +29,6 @@ use Cake\Utility\Hash;
  */
 class ExternalAuthTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
@@ -28,7 +28,6 @@ use Cake\Utility\Hash;
  */
 class FoldersTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class LocationsTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/MediaTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/MediaTableTest.php
@@ -10,7 +10,6 @@ use Cake\TestSuite\TestCase;
  */
 class MediaTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectPermissionsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectPermissionsTableTest.php
@@ -9,7 +9,6 @@ use Cake\TestSuite\TestCase;
  */
 class ObjectPermissionsTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectPropertiesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectPropertiesTableTest.php
@@ -9,7 +9,6 @@ use Cake\TestSuite\TestCase;
  */
 class ObjectPropertiesTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectRelationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectRelationsTableTest.php
@@ -11,7 +11,6 @@ use Cake\Utility\Hash;
  */
 class ObjectRelationsTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
@@ -32,7 +32,6 @@ use Cake\Utility\Hash;
  */
 class ObjectTypesTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -22,7 +22,6 @@ use Cake\Utility\Hash;
  */
 class ObjectsTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\TestCase;
  */
 class ProfilesTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertiesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertiesTableTest.php
@@ -15,7 +15,6 @@ use Cake\Validation\Validation;
  */
 class PropertiesTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertyTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertyTypesTableTest.php
@@ -27,7 +27,6 @@ use Cake\Validation\Validator;
  */
 class PropertyTypesTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationTypesTableTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class RelationTypesTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
@@ -26,7 +26,6 @@ use Cake\TestSuite\TestCase;
  */
 class RelationsTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class RolesTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesUsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesUsersTableTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class RolesUsersTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/StaticPropertiesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/StaticPropertiesTableTest.php
@@ -27,7 +27,6 @@ use Cake\TestSuite\TestCase;
  */
 class StaticPropertiesTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/TranslationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/TranslationsTableTest.php
@@ -23,7 +23,6 @@ use Cake\Utility\Hash;
  */
 class TranslationsTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/TreesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/TreesTableTest.php
@@ -30,7 +30,6 @@ use Cake\TestSuite\TestCase;
  */
 class TreesTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -29,7 +29,6 @@ use Cake\TestSuite\TestCase;
  */
 class UsersTableTest extends TestCase
 {
-
     /**
      * Test subject
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/LocationsValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/LocationsValidatorTest.php
@@ -22,7 +22,6 @@ use Cake\Utility\Hash;
  */
 class LocationsValidatorTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/MediaValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/MediaValidatorTest.php
@@ -22,7 +22,6 @@ use Cake\Utility\Hash;
  */
 class MediaValidatorTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/ObjectsValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/ObjectsValidatorTest.php
@@ -22,7 +22,6 @@ use Cake\Utility\Hash;
  */
 class ObjectsValidatorTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/ProfilesValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/ProfilesValidatorTest.php
@@ -22,7 +22,6 @@ use Cake\Utility\Hash;
  */
 class ProfilesValidatorTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/SqlConventionsValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/SqlConventionsValidatorTest.php
@@ -23,7 +23,6 @@ use Cake\Utility\Hash;
  */
 class SqlConventionsValidatorTest extends TestCase
 {
-
     /**
      * Data provider for `testValidation` provider.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/UsersValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/UsersValidatorTest.php
@@ -22,7 +22,6 @@ use Cake\Utility\Hash;
  */
 class UsersValidatorTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/ValidationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/ValidationTest.php
@@ -26,7 +26,6 @@ use DateTime;
  */
 class ValidationTest extends TestCase
 {
-
     /**
      * Data provider for `testReserved` test case.
      *

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Association/RelatedToTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Association/RelatedToTest.php
@@ -26,7 +26,6 @@ use Cake\TestSuite\TestCase;
  */
 class RelatedToTest extends TestCase
 {
-
     /**
      * Fixtures.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Shell/BeditaShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/BeditaShellTest.php
@@ -25,7 +25,6 @@ use Cake\Utility\Hash;
  */
 class BeditaShellTest extends ConsoleIntegrationTestCase
 {
-
     /**
      * Name for temporary configuration file.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Shell/JobsShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/JobsShellTest.php
@@ -26,7 +26,6 @@ use Cake\Utility\Text;
  */
 class JobsShellTest extends ConsoleIntegrationTestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckApiKeyTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckApiKeyTaskTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\ConsoleIntegrationTestCase;
  */
 class CheckApiKeyTaskTest extends ConsoleIntegrationTestCase
 {
-
     /**
      * Applications table.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckFilesystemTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckFilesystemTaskTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\ConsoleIntegrationTestCase;
  */
 class CheckFilesystemTaskTest extends ConsoleIntegrationTestCase
 {
-
     /**
      * Temporary directory for permissions tests.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckSchemaTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckSchemaTaskTest.php
@@ -29,7 +29,6 @@ use Cake\Utility\Hash;
  */
 class CheckSchemaTaskTest extends ConsoleIntegrationTestCase
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckTreeTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckTreeTaskTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\ConsoleIntegrationTestCase;
  */
 class CheckTreeTaskTest extends ConsoleIntegrationTestCase
 {
-
     /**
      * Trees table.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/InitSchemaTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/InitSchemaTaskTest.php
@@ -27,7 +27,6 @@ use Cake\TestSuite\ConsoleIntegrationTestCase;
  */
 class InitSchemaTaskTest extends ConsoleIntegrationTestCase
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/RecoverTreeTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/RecoverTreeTaskTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\ConsoleIntegrationTestCase;
  */
 class RecoverTreeTaskTest extends ConsoleIntegrationTestCase
 {
-
     /**
      * Trees table.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/SetupAdminUserTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/SetupAdminUserTaskTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\ConsoleIntegrationTestCase;
  */
 class SetupAdminUserTaskTest extends ConsoleIntegrationTestCase
 {
-
     /**
      * Users table.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/SetupConnectionTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/SetupConnectionTaskTest.php
@@ -27,7 +27,6 @@ use Cake\Utility\Text;
  */
 class SetupConnectionTaskTest extends ConsoleIntegrationTestCase
 {
-
     /**
      * Name for temporary connection.
      *

--- a/plugins/BEdita/Core/tests/TestCase/SingletonTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/SingletonTraitTest.php
@@ -22,7 +22,6 @@ use Cake\TestSuite\TestCase;
  */
 class SingletonTraitTest extends TestCase
 {
-
     /**
      * Assert that the class cannot be instantiated.
      *

--- a/plugins/BEdita/Core/tests/TestCase/State/CurrentApplicationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/State/CurrentApplicationTest.php
@@ -26,7 +26,6 @@ use Cake\TestSuite\TestCase;
  */
 class CurrentApplicationTest extends TestCase
 {
-
     /**
      * Test subject's table
      *

--- a/plugins/BEdita/Core/tests/TestCase/Utility/DatabaseTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/DatabaseTest.php
@@ -24,7 +24,6 @@ use Cake\Utility\Inflector;
  */
 class DatabaseTest extends TestCase
 {
-
     /**
      * {@inheritDoc}
      */

--- a/plugins/BEdita/Core/tests/TestCase/Utility/OAuth2Test.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/OAuth2Test.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class OAuth2Test extends TestCase
 {
-
     /**
      * Data provider method for `testResponse()`
      *

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHandlerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHandlerTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class ObjectsHandlerTest extends TestCase
 {
-
     /**
      * Fixtures
      *

--- a/plugins/BEdita/Core/tests/TestCase/Utility/SystemTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/SystemTest.php
@@ -25,7 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class SystemTest extends TestCase
 {
-
     /**
      * Test status method
      *

--- a/plugins/BEdita/Core/tests/TestCase/Utility/TextTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/TextTest.php
@@ -23,7 +23,6 @@ use Cake\TestSuite\TestCase;
  */
 class TextTest extends TestCase
 {
-
     /**
      * Data provider for `testUuid5` test case.
      *

--- a/src/Console/Installer.php
+++ b/src/Console/Installer.php
@@ -26,7 +26,6 @@ use Exception;
  */
 class Installer
 {
-
     /**
      * An array of directories to be made writable
      */

--- a/src/Shell/ConsoleShell.php
+++ b/src/Shell/ConsoleShell.php
@@ -24,7 +24,6 @@ use Psy\Shell as PsyShell;
  */
 class ConsoleShell extends Shell
 {
-
     /**
      * Start the shell and interactive console.
      *


### PR DESCRIPTION
This PR fixes `phpcs` errors generated after update to https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.6.2 

```
Fixed bug #3437 : PSR12 does not forbid blank lines at the start of the class body
Added new PSR12.Classes.OpeningBraceSpace sniff to enforce this
```