### PR TITLE
Renew token expiry

### DIFF
--- a/plugins/BEdita/API/src/Utility/JWTHandler.php
+++ b/plugins/BEdita/API/src/Utility/JWTHandler.php
@@ -91,11 +91,10 @@ class JWTHandler
             'iss' => Router::fullBaseUrl(),
             'iat' => time(),
             'nbf' => time(),
-            'exp' => strtotime($duration),
             'app' => static::applicationData(),
         ];
         // Access token payload
-        $payload = $claims + $user;
+        $payload = $claims + $user + ['exp' => strtotime($duration)];
         $jwt = JWT::encode($payload, $salt, $algorithm);
 
         // Renew token payload

--- a/plugins/BEdita/API/tests/TestCase/Utility/JWTHandlerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JWTHandlerTest.php
@@ -121,7 +121,7 @@ class JWTHandlerTest extends TestCase
 
         static::assertArrayHasKey('iat', $renew);
         static::assertArrayHasKey('nbf', $renew);
-        static::assertArrayHasKey('exp', $renew);
+        static::assertArrayNotHasKey('exp', $renew);
 
         $expected = [
             'iss' => Router::fullBaseUrl(),


### PR DESCRIPTION
This PR fixes a bug in JWT tokens: the same `exp` claim of the access token has been added (by mistake) to the renew token => this was causing the failure of token refresh operation because expired token expections were raised also for renew tokens.