### PR TITLE
Create writable bedita_core folder for cache

### DIFF
--- a/src/Console/Installer.php
+++ b/src/Console/Installer.php
@@ -33,6 +33,7 @@ class Installer
         'logs',
         'tmp',
         'tmp/cache',
+        'tmp/cache/bedita_core',
         'tmp/cache/models',
         'tmp/cache/object_types',
         'tmp/cache/persistent',


### PR DESCRIPTION
This PR add `bedita_core` cache folder in the list of writable folders to setup after install avoiding warning in docker image 

```
127.0.0.1 - - [03/Jan/2022:16:25:54 +0000] "GET /status HTTP/1.1" 403 431 "-" "curl/7.64.0"
2022-01-03 16:26:25 Warning: Warning (512): /var/www/html/tmp/cache/bedita_core/ is not writable in [/var/www/html/vendor/cakephp/cakephp/src/Cache/Engine/FileEngine.php, line 461
```