### PR TITLE
Roles as stdClass

### DIFF
--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -279,8 +279,8 @@ class LoginController extends AppController
         $user['roles'] = array_map(
             function ($role) {
                 return [
-                    'id' => $role['id'],
-                    'name' => $role['name'],
+                    'id' => Hash::get($role, 'id'),
+                    'name' => Hash::get($role, 'name'),
                 ];
             },
             (array)Hash::get($userInput, 'roles')

--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -279,8 +279,8 @@ class LoginController extends AppController
         $user['roles'] = array_map(
             function ($role) {
                 return [
-                    'id' => Hash::get($role, 'id'),
-                    'name' => Hash::get($role, 'name'),
+                    'id' => Hash::get((array)$role, 'id'),
+                    'name' => Hash::get((array)$role, 'name'),
                 ];
             },
             (array)Hash::get($userInput, 'roles')


### PR DESCRIPTION
This PR fixes a 500 error raised when user roles are stdClass instead of arrays in `LoginController::reduceUserData`.

