### PR TITLE
update composer dependency bedita/dev-tools to 1.5.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "cakephp/debug_kit": "^3.23.0",
         "cakephp/cakephp-codesniffer": "~3.2.1",
         "psy/psysh": "@stable",
-        "bedita/dev-tools": "1.4.*",
+        "bedita/dev-tools": "1.5.*",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": "^6.5"
     },


### PR DESCRIPTION
This PR updates a composer dev dependency: `bedita/dev-tools` from 1.4.* to 1.5.*.