### PR TITLE
Disable staging toolbar

### DIFF
--- a/bedita-app/views/elements/messages.tpl
+++ b/bedita-app/views/elements/messages.tpl
@@ -1,3 +1,4 @@
+{if $smarty.const.BACKEND_APP}
 <script type="text/javascript" charset="utf-8">
 $(document).ready ( function ()  { 
 {if ($session->check('Message.info'))}
@@ -12,6 +13,7 @@ $(document).ready ( function ()  {
 
 });
 </script>
+{/if}
 
 <div id="messagesDiv">
 

--- a/bedita-app/views/helpers/be_front.php
+++ b/bedita-app/views/helpers/be_front.php
@@ -846,7 +846,7 @@ class BeFrontHelper extends AppHelper {
 		 * Their are loaded here because in layout view doesn't work inline=false option.
 		 * In fact for the design of cakePHP layouts are simply parsed by PHP interpeter
 		 */
-		if ($this->_conf->staging) {
+		if ($this->_conf->staging && !empty($this->_conf->stagingToolbar)) {
 
 			// include js that staging toolbar needs
 			echo $this->Html->script(


### PR DESCRIPTION
Frontend apps can enable the staging toolbar via `stagingToolbar` conf.

**Bonus track**
Since `elements/messages.tpl` is inherited from frontends the js script used in backend is removed.
