### PR TITLE
Introduce autocomplete for tags in object view

### DIFF
--- a/bedita-app/controllers/modules/tags_controller.php
+++ b/bedita-app/controllers/modules/tags_controller.php
@@ -241,8 +241,9 @@ class TagsController extends ModulesController {
 
         $this->set(array(
             'tags' => $tags,
+            'query' => isset($this->params['url']['q']) ? $this->params['url']['q'] : null,
             'paging' => $this->params['paging']['Category'],
-            '_serialize' => array('tags', 'paging'),
+            '_serialize' => array('tags', 'query', 'paging'),
         ));
     }
 

--- a/bedita-app/views/elements/form_tags.tpl
+++ b/bedita-app/views/elements/form_tags.tpl
@@ -1,61 +1,32 @@
 {if isset($moduleList.tags)}
 
+{literal}
 <script type="text/javascript">
 <!--
 $(document).ready(function(){
-	
-	var showTagsFirst = false;
-	var showTags = false;
-	$("#callTags").bind("click", function() {
-		if (!showTagsFirst) {
-			$("#loadingTags").show();
-			$("#listExistingTags").load("{$html->url('/tags/listAllTags')}", function() {
-				$("#loadingTags").slideUp("fast");
-				$("#listExistingTags").slideDown("fast");
-				$("#callTags").text("{t}Hide system tags{/t}");
-				showTagsFirst = true;
-				showTags = true;
-			});
-		} else {
-			if (showTags) {
-				$("#listExistingTags").slideUp("fast");
-				$("#callTags").text("{t}Show system tags{/t}");
-			} else {
-				$("#listExistingTags").slideDown("fast");
-				$("#callTags").text("{t}Hide system tags{/t}");
-			}
-			showTags = !showTags;
-		}
-	});	
+    initTagsAutocomplete('#object-tags');
 });
 //-->
 </script>
+{/literal}
 
 {$relcount = $object.Tag|@count|default:0}
 <div class="tab"><h2 {if empty($relcount)}class="empty"{/if}>{t}Tags{/t} &nbsp; {if $relcount > 0}<span class="relnumb">{$relcount}</span>{/if}</h2></div>
 <fieldset id="tags">
-
-	<label>{t}add comma separated words{/t}:</label>
-	<br/>
-	
-	{strip}
-	<textarea name="tags" class="autogrowarea" style="display:block; margin-bottom:10px; width:470px" id="tagsArea">
-	{if !empty($object.Tag)}
-		{foreach from=$object.Tag item="tag" name="ft"}
-			{$tag.label|escape}{if !$smarty.foreach.ft.last}, {/if}
-		{/foreach}
-	{/if}
-	</textarea>
-	{/strip}
-	
-	<a class="BEbutton" id="callTags" href="javascript:void(0);">
-		{t}Show system tags{/t}
-	</a>
-	
-	<div id="loadingTags" class="generalLoading" title="{t}Loading data{/t}">&nbsp;</div>
-	
-	<div id="listExistingTags" class="tag graced" style="display: none; margin-top:5px; text-align:justify;"></div>
-
+    {$tags = ''}
+    {foreach $object.Tag|default:[] as $tag}
+        {$tags = $tags|cat:$tag.label}
+        {if !$tag@last}
+            {$tags = $tags|cat:','}
+        {/if}
+    {/foreach}
+    <input
+        type="hidden"
+        name="tags"
+        id="object-tags"
+        rel="{$html->url('/tags/search')}"
+        value="{$tags|escape}"
+        data-placeholder="{t}add comma separated words{/t}" />
 </fieldset>
 
 {/if}

--- a/bedita-app/webroot/js/beditaUI.js
+++ b/bedita-app/webroot/js/beditaUI.js
@@ -794,6 +794,54 @@ var initTagsFilter = function(selector) {
     });
 };
 
+var initTagsAutocomplete = function (selector) {
+    $(selector).select2({
+        tags: [],
+        tokenSeparators: [','],
+        placeholder: $(selector).data('placeholder'),
+        width: '100%',
+        initSelection: function (element, callback) {
+            var tags = $(element).val().split(/,\s*/);
+
+            callback(tags.map(function (tag) {
+                return { id: tag, text: tag };
+            }));
+        },
+        ajax: {
+            url: $(selector).attr('rel'),
+            dataType: 'json',
+            quietMillis: 250,
+            data: function (term, page) {
+                return {
+                    q: term,
+                    page: page,
+                };
+            },
+            results: function (data, page) {
+                if (!data || !data.tags) {
+                    return { results: data.query ? [{ id: data.query, text: data.query }] : [] };
+                }
+
+                var more = data.paging && data.paging.pageCount && page < data.paging.pageCount;
+
+                found = false;
+                results = data.tags.map(function (tag) {
+                    if (tag === data.query) {
+                        found = true;
+                    }
+
+                    return { id: tag.label, text: tag.label };
+                });
+                if (page === 1 && !found && data.query) {
+                    results.push({ id: data.query, text: data.query });
+                }
+
+                return { results: results, more: more };
+            },
+        },
+    });
+};
+
 /* end of document ready() */
 
 var toggleSelectTree = function(ev) {


### PR DESCRIPTION
This PR changes the way editors can edit tags for an object.

Previously, all tags in the BEdita instance were loaded and presented as a list of checkboxes. This caused performance issues in instances with a very large amount of tags.

The changes in this Pull Request follow up on what had been done in #1847 and introduce autocompletion with Select2.