### PR TITLE
Token decode error

### DIFF
--- a/plugins/BEdita/API/src/Middleware/TokenMiddleware.php
+++ b/plugins/BEdita/API/src/Middleware/TokenMiddleware.php
@@ -84,7 +84,8 @@ class TokenMiddleware
         if (empty($payload)) {
             $token = $this->getToken($request);
             if (!empty($token)) {
-                $request = $this->decodeToken($token, $request);
+                $payload = $this->decodeToken($token);
+                $request = $request->withAttribute(static::PAYLOAD_REQUEST_ATTRIBUTE, $payload);
             }
         }
         $this->readApplication($payload, $request);
@@ -93,25 +94,22 @@ class TokenMiddleware
     }
 
     /**
-     * Decode JWT token and add payload as attribute in request.
+     * Decode JWT token and return payload.
      *
-     * @param array $payload JWT Payload
-     * @param \Psr\Http\Message\ServerRequestInterface $request Request object
-     * @return \Psr\Http\Message\ServerRequestInterface
+     * @param string $token JWT token
+     * @return array
      * @throws \BEdita\API\Exception\ExpiredTokenException If he token is expired
      * @throws \Cake\Http\Exception\UnauthorizedException If the token could not be decoded.
      */
-    protected function decodeToken(string $token, ServerRequestInterface $request): ServerRequestInterface
+    protected function decodeToken(string $token): array
     {
         try {
-            $payload = JWTHandler::decode($token);
+            return JWTHandler::decode($token);
         } catch (\Firebase\JWT\ExpiredException $e) {
             throw new ExpiredTokenException();
         } catch (\Exception $e) {
             throw new UnauthorizedException($e->getMessage());
         }
-
-        return $request->withAttribute(static::PAYLOAD_REQUEST_ATTRIBUTE, $payload);
     }
 
     /**

--- a/plugins/BEdita/API/src/Utility/JWTHandler.php
+++ b/plugins/BEdita/API/src/Utility/JWTHandler.php
@@ -15,6 +15,7 @@ namespace BEdita\API\Utility;
 use BEdita\API\Exception\ExpiredTokenException;
 use BEdita\Core\State\CurrentApplication;
 use Cake\Core\Configure;
+use Cake\Http\Exception\UnauthorizedException;
 use Cake\Routing\Router;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
@@ -55,7 +56,7 @@ class JWTHandler
      * @param string $token JWT token to decode.
      * @param array $options Decode options including key and algorithms.
      * @return array The token's payload as a PHP array.
-     * @throws \Exception Throws an exception if the token could not be decoded.
+     * @throws \BEdita\API\Exception\ExpiredTokenException|\Cake\Http\Exception\UnauthorizedException Throws an exception if the token is expired or could not be decoded.
      */
     public static function decode(string $token, array $options = []): array
     {
@@ -68,6 +69,8 @@ class JWTHandler
             $payload = JWT::decode($token, $options['key'], (array)$options['algorithms']);
         } catch (\Firebase\JWT\ExpiredException $e) {
             throw new ExpiredTokenException();
+        } catch (\Exception $e) {
+            throw new UnauthorizedException($e->getMessage());
         }
 
         return (array)$payload;

--- a/plugins/BEdita/API/src/Utility/JWTHandler.php
+++ b/plugins/BEdita/API/src/Utility/JWTHandler.php
@@ -12,10 +12,8 @@
  */
 namespace BEdita\API\Utility;
 
-use BEdita\API\Exception\ExpiredTokenException;
 use BEdita\Core\State\CurrentApplication;
 use Cake\Core\Configure;
-use Cake\Http\Exception\UnauthorizedException;
 use Cake\Routing\Router;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;

--- a/plugins/BEdita/API/src/Utility/JWTHandler.php
+++ b/plugins/BEdita/API/src/Utility/JWTHandler.php
@@ -56,7 +56,6 @@ class JWTHandler
      * @param string $token JWT token to decode.
      * @param array $options Decode options including key and algorithms.
      * @return array The token's payload as a PHP array.
-     * @throws \BEdita\API\Exception\ExpiredTokenException|\Cake\Http\Exception\UnauthorizedException Throws an exception if the token is expired or could not be decoded.
      */
     public static function decode(string $token, array $options = []): array
     {
@@ -65,15 +64,7 @@ class JWTHandler
             'algorithms' => Configure::read('Security.jwt.algorithm') ?: 'HS256',
         ];
 
-        try {
-            $payload = JWT::decode($token, $options['key'], (array)$options['algorithms']);
-        } catch (\Firebase\JWT\ExpiredException $e) {
-            throw new ExpiredTokenException();
-        } catch (\Exception $e) {
-            throw new UnauthorizedException($e->getMessage());
-        }
-
-        return (array)$payload;
+        return (array)JWT::decode($token, $options['key'], (array)$options['algorithms']);
     }
 
     /**

--- a/plugins/BEdita/API/tests/IntegrationTest/AuthenticationTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/AuthenticationTest.php
@@ -102,6 +102,33 @@ class AuthenticationTest extends IntegrationTestCase
     }
 
     /**
+     * Test /auth response with wrong formatted token.
+     *
+     * @return void
+     *
+     * @coversNothing
+     */
+    public function testBadToken(): void
+    {
+        $headers = [
+            'Host' => 'api.example.com',
+            'Accept' => 'application/vnd.api+json',
+            'Authorization' => 'Bearer gustavo',
+        ];
+        $this->configRequest(compact('headers'));
+        $this->post('/auth', json_encode(['grant_type' => 'refresh_token']));
+
+        $this->assertResponseCode(401);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseNotEmpty();
+        $body = json_decode((string)$this->_response->getBody(), true);
+
+        static::assertArrayHasKey('error', $body);
+        static::assertEquals('401', $body['error']['status']);
+        static::assertEquals('Wrong number of segments', $body['error']['title']);
+    }
+
+    /**
      * Test OAuth2 flow with app credentials, user login and token renew.
      *
      * @return void

--- a/plugins/BEdita/API/tests/TestCase/Middleware/TokenMiddlewareTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Middleware/TokenMiddlewareTest.php
@@ -12,10 +12,12 @@
  */
 namespace BEdita\API\Test\TestCase\Middleware;
 
+use BEdita\API\Exception\ExpiredTokenException;
 use BEdita\API\Middleware\TokenMiddleware;
 use BEdita\Core\State\CurrentApplication;
 use Cake\Core\Configure;
 use Cake\Http\Exception\ForbiddenException;
+use Cake\Http\Exception\UnauthorizedException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
@@ -138,6 +140,7 @@ class TokenMiddlewareTest extends TestCase
      * @covers ::__invoke()
      * @covers ::readApplication()
      * @covers ::getToken()
+     * @covers ::decodeToken()
      * @covers ::applicationFromApiKey()
      * @covers ::fetchApiKey()
      * @covers ::verifyClientCredentials()
@@ -231,5 +234,61 @@ class TokenMiddlewareTest extends TestCase
 
         static::assertNull(CurrentApplication::getApplication());
         static::assertNull($result->getAttribute(TokenMiddleware::PAYLOAD_REQUEST_ATTRIBUTE));
+    }
+
+    /**
+     * Test expired token
+     *
+     * @return void
+     *
+     * @covers ::decodeToken()
+     */
+    public function testExpiredToken(): void
+    {
+        $this->expectException(ExpiredTokenException::class);
+        $this->expectExceptionCode(401);
+
+        $expiredToken = JWT::encode(['exp' => time() - 10], Security::getSalt());
+        $request = new ServerRequest([
+            'environment' => [
+                'HTTP_AUTHORIZATION' => sprintf('Bearer %s', $expiredToken),
+                'HTTP_X_API_KEY' => API_KEY,
+            ],
+        ]);
+
+        $middleware = new TokenMiddleware();
+        $middleware(
+            $request,
+            new Response(),
+            null
+        );
+    }
+
+    /**
+     * Test malformed token
+     *
+     * @return void
+     *
+     * @covers ::decodeToken()
+     */
+    public function testMalformedToken(): void
+    {
+        $this->expectException(UnauthorizedException::class);
+        $this->expectExceptionMessage('Wrong number of segments');
+        $this->expectExceptionCode(401);
+
+        $request = new ServerRequest([
+            'environment' => [
+                'HTTP_AUTHORIZATION' => 'Bearer gustavo',
+                'HTTP_X_API_KEY' => API_KEY,
+            ],
+        ]);
+
+        $middleware = new TokenMiddleware();
+        $middleware(
+            $request,
+            new Response(),
+            null
+        );
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Utility/JWTHandlerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JWTHandlerTest.php
@@ -46,15 +46,11 @@ class JWTHandlerTest extends TestCase
                 $token,
             ],
             'invalidToken' => [
-                new UnauthorizedException('Wrong number of segments'),
+                new \UnexpectedValueException('Wrong number of segments'),
                 $invalidToken,
             ],
             'expiredToken' => [
-                new ExpiredTokenException([
-                    'title' => __d('bedita', 'Expired token'),
-                    'detail' => __d('bedita', 'Provided token has expired'),
-                    'code' => 'be_token_expired',
-                ]),
+                new \Firebase\JWT\ExpiredException('Expired token'),
                 $expiredToken,
             ],
         ];

--- a/plugins/BEdita/API/tests/TestCase/Utility/JWTHandlerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JWTHandlerTest.php
@@ -17,11 +17,11 @@ use BEdita\API\Exception\ExpiredTokenException;
 use BEdita\API\Utility\JWTHandler;
 use BEdita\Core\Model\Entity\Application;
 use BEdita\Core\State\CurrentApplication;
+use Cake\Http\Exception\UnauthorizedException;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Security;
 use Firebase\JWT\JWT;
-use UnexpectedValueException;
 
 /**
  * @coversDefaultClass \BEdita\API\Utility\JWTHandler
@@ -46,7 +46,7 @@ class JWTHandlerTest extends TestCase
                 $token,
             ],
             'invalidToken' => [
-                new UnexpectedValueException('Wrong number of segments'),
+                new UnauthorizedException('Wrong number of segments'),
                 $invalidToken,
             ],
             'expiredToken' => [
@@ -78,6 +78,7 @@ class JWTHandlerTest extends TestCase
         if ($expected instanceof \Exception) {
             $this->expectException(get_class($expected));
             $this->expectExceptionMessage($expected->getMessage());
+            $this->expectExceptionCode($expected->getCode());
         }
 
         $result = JWTHandler::decode($token, $options);


### PR DESCRIPTION
This PR changes the error response in case of JWT token decode error: a `401 Unauthorized` exception is returned instead of `500 Error` restoring the previous behavior, until 4.5 version.

