### PR TITLE
Skip auth token checks on OPTIONS request

### DIFF
--- a/plugins/BEdita/API/src/Middleware/TokenMiddleware.php
+++ b/plugins/BEdita/API/src/Middleware/TokenMiddleware.php
@@ -78,6 +78,12 @@ class TokenMiddleware
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, $next)
     {
+        // Skip credentials checks on 'OPTIONS' request
+        // See https://fetch.spec.whatwg.org/#cors-protocol-and-credentials
+        if ($request->getMethod() === 'OPTIONS') {
+            return $next($request, $response);
+        }
+
         $payload = (array)$request->getAttribute(static::PAYLOAD_REQUEST_ATTRIBUTE);
         if (empty($payload)) {
             $token = $this->getToken($request);

--- a/plugins/BEdita/API/tests/TestCase/Middleware/TokenMiddlewareTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Middleware/TokenMiddlewareTest.php
@@ -232,4 +232,34 @@ class TokenMiddlewareTest extends TestCase
         static::assertNull(CurrentApplication::getApplication());
         static::assertNull($result->getAttribute(TokenMiddleware::PAYLOAD_REQUEST_ATTRIBUTE));
     }
+
+    /**
+     * Test behavior on OPTIONS request
+     *
+     * @return void
+     *
+     * @covers ::__invoke()
+     */
+    public function testOptionsRequest()
+    {
+        CurrentApplication::setApplication(null);
+
+        $request = new ServerRequest([
+            'environment' => [
+                'REQUEST_METHOD' => 'OPTIONS',
+            ],
+        ]);
+        $middleware = new TokenMiddleware();
+        /** @var \Zend\Diactoros\ServerRequest $result */
+        $result = $middleware(
+            $request,
+            new Response(),
+            function ($req, $res) {
+                return $req;
+            }
+        );
+
+        static::assertNull(CurrentApplication::getApplication());
+        static::assertNull($result->getAttribute(TokenMiddleware::PAYLOAD_REQUEST_ATTRIBUTE));
+    }
 }


### PR DESCRIPTION
This PR fixes a problem with CORS preflight OPTION request that we assume should not contain authorization tokens
See https://fetch.spec.whatwg.org/#cors-protocol-and-credentials 

