### PR TITLE
Mark join entity as new when it is a new association for source entity

### DIFF
--- a/plugins/BEdita/Core/src/Model/Action/AssociatedTrait.php
+++ b/plugins/BEdita/Core/src/Model/Action/AssociatedTrait.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ * Copyright 2022 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -193,6 +193,14 @@ trait AssociatedTrait
         }
 
         $joinData->set($this->getJunctionExtraFields($source, $target), ['guard' => false]);
+
+        // ensure that if source was not linked to target through joinData the join entity is marked as new
+        // foreign key corresponds to source primary key
+        $fk = $this->Association->getForeignKey();
+        if (!$joinData->isNew() && !empty($joinData->extractOriginalChanged([$fk]))) {
+            $joinData->setNew(true);
+        }
+
         $this->Association->junction()->patchEntity($joinData, $data ?: []);
         $errors = $joinData->getErrors();
         if (!empty($errors)) {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
@@ -54,7 +54,7 @@ class AddRelatedObjectsActionTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -64,7 +64,7 @@ class AddRelatedObjectsActionTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
@@ -253,4 +253,30 @@ class SetRelatedObjectsActionTest extends TestCase
 
         static::assertSame(1, $result);
     }
+
+    /**
+     * Test that setting related entities loaded from another entity works.
+     *
+     * @return void
+     */
+    public function testSetEntitiesRelatedToOtherObject(): void
+    {
+        $Documents = TableRegistry::getTableLocator()->get('Documents');
+        $relatedEntities = ($Documents->get(3, ['contain' => ['Test']]))->get('test');
+
+        $entity = $Documents->get(2, ['contain' => ['Test']]);
+        static::assertCount(2, $entity->get('test'));
+
+        $association = $Documents->getAssociation('Test');
+        $action = new SetRelatedObjectsAction(compact('association'));
+        $action(compact('entity', 'relatedEntities'));
+
+        $entity = $Documents->get(2, ['contain' => ['Test']]);
+        static::assertCount(1, $entity->get('test'));
+
+        $expected = collection($relatedEntities)->sortBy('id')->extract('id')->toList();
+        $actual = collection($entity->get('test'))->sortBy('id')->extract('id')->toList();
+
+        static::assertEquals($expected, $actual);
+    }
 }


### PR DESCRIPTION
This PR fixes an issue we have trying to add related objects loaded from another entity.

Before this PR doing

```php
$Documents = \Cake\ORM\TableRegistry::get('Documents');

// assuming to have an existing document with id = 5 with "attach" relation
$doc = $Documents->get(5);
$Documents->loadInto($doc, ['Attach']);
$relatedEntities = $doc->get('attach');

$entity = $Documents->newEntity(['title' => 'My title']);
$entity = $Documents->save($entity);

$action = new \BEdita\Core\Model\Action\AddRelatedObjectsAction(compact('association'));
$action(compact('entity', 'relatedEntities'));
```

save `$entity` with no errors but the related entities were not linked to `$entity`.

The reason was in the way we hydrate related entities in source entity. The join entity is updated with the right primary keys (`left_id`, `right_id`, `relation_id`), but since that join entity was loaded from another entity it results already persisted and not saved.

Now it is marked as new to ensure to store it.
