### PR TITLE
Related objects utility methods

### DIFF
--- a/plugins/BEdita/Core/src/Model/Behavior/ObjectModelBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/ObjectModelBehavior.php
@@ -13,6 +13,10 @@
 
 namespace BEdita\Core\Model\Behavior;
 
+use BEdita\Core\Model\Action\AddRelatedObjectsAction;
+use BEdita\Core\Model\Action\RemoveRelatedObjectsAction;
+use BEdita\Core\Model\Action\SetRelatedObjectsAction;
+use BEdita\Core\Model\Entity\ObjectEntity;
 use Cake\ORM\Behavior;
 
 /**
@@ -46,5 +50,53 @@ class ObjectModelBehavior extends Behavior
                 'body' => 5,
             ],
         ]);
+    }
+
+    /**
+     * Add related objects
+     *
+     * @param \BEdita\Core\Model\Entity\ObjectEntity $entity Object entity
+     * @param string $relation Relation name
+     * @param array $relatedEntities The related entities
+     * @return void
+     */
+    public function addRelated(ObjectEntity $entity, string $relation, array $relatedEntities): void
+    {
+        $action = new AddRelatedObjectsAction([
+            'association' => $entity->getTable()->associations()->getByProperty($relation)
+        ]);
+        $action(compact('entity', 'relatedEntities'));
+    }
+
+    /**
+     * Replace related objects
+     *
+     * @param \BEdita\Core\Model\Entity\ObjectEntity $entity Object entity
+     * @param string $relation Relation name
+     * @param array $relatedEntities The related entities
+     * @return void
+     */
+    public function replaceRelated(ObjectEntity $entity, string $relation, array $relatedEntities): void
+    {
+        $action = new SetRelatedObjectsAction([
+            'association' => $entity->getTable()->associations()->getByProperty($relation)
+        ]);
+        $action(compact('entity', 'relatedEntities'));
+    }
+
+    /**
+     * Remove related objects
+     *
+     * @param \BEdita\Core\Model\Entity\ObjectEntity $entity Object entity
+     * @param string $relation Relation name
+     * @param array $relatedEntities The related entities
+     * @return void
+     */
+    public function removeRelated(ObjectEntity $entity, string $relation, array $relatedEntities): void
+    {
+        $action = new RemoveRelatedObjectsAction([
+            'association' => $entity->getTable()->associations()->getByProperty($relation)
+        ]);
+        $action(compact('entity', 'relatedEntities'));
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectModelBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectModelBehaviorTest.php
@@ -13,14 +13,20 @@
 
 namespace BEdita\Core\Test\TestCase\Model\Behavior;
 
+use Cake\Datasource\ModelAwareTrait;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 
 /**
+ * {@see \BEdita\Core\Model\Behavior\ObjectModelBehavior} Test Case
+ *
  * @coversDefaultClass \BEdita\Core\Model\Behavior\ObjectModelBehavior
  */
 class ObjectModelBehaviorTest extends TestCase
 {
+    use ModelAwareTrait;
+
     /**
      * Fixtures
      *
@@ -28,7 +34,16 @@ class ObjectModelBehaviorTest extends TestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.FakeAnimals',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.PropertyTypes',
         'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.RelationTypes',
+        'plugin.BEdita/Core.ObjectRelations',
+        'plugin.BEdita/Core.Locations',
+        'plugin.BEdita/Core.Profiles',
+        'plugin.BEdita/Core.Users',
     ];
 
     /**
@@ -36,7 +51,7 @@ class ObjectModelBehaviorTest extends TestCase
      *
      * @covers ::initialize()
      */
-    public function testInitialize()
+    public function testInitialize(): void
     {
         $table = TableRegistry::getTableLocator()->get('FakeAnimals');
         $count = $table->behaviors()->count();
@@ -44,5 +59,57 @@ class ObjectModelBehaviorTest extends TestCase
         $table->addBehavior('BEdita/Core.ObjectModel');
         $count = $table->behaviors()->count();
         static::assertEquals(10, $count);
+    }
+
+    /**
+     * Test `addRelated` method.
+     *
+     * @covers ::addRelated()
+     */
+    public function testAddRelated(): void
+    {
+        $this->loadModel('Documents');
+        $entity = $this->Documents->get(3);
+        $related = $this->Documents->get(2);
+        $this->Documents->addRelated($entity, 'test', [$related]);
+
+        $entity = $this->Documents->get(3, ['contain' => 'Test']);
+        $ids = Hash::extract($entity->get('test'), '{n}.id');
+        sort($ids);
+        static::assertEquals([2, 4], $ids);
+    }
+
+    /**
+     * Test `replaceRelated` method.
+     *
+     * @covers ::replaceRelated()
+     */
+    public function testReplaceRelated(): void
+    {
+        $this->loadModel('Documents');
+        $entity = $this->Documents->get(3);
+        $related = $this->Documents->get(2);
+        $this->Documents->replaceRelated($entity, 'test', [$related]);
+
+        $entity = $this->Documents->get(3, ['contain' => 'Test']);
+        $ids = Hash::extract($entity->get('test'), '{n}.id');
+        static::assertEquals([2], $ids);
+    }
+
+    /**
+     * Test `removeRelated` method.
+     *
+     * @covers ::removeRelated()
+     */
+    public function testRemoveRelated(): void
+    {
+        $this->loadModel('Documents');
+        $entity = $this->Documents->get(3);
+        $related = $this->Documents->get(4);
+        $this->Documents->removeRelated($entity, 'test', [$related]);
+
+        $entity = $this->Documents->get(3, ['contain' => 'Test']);
+        $ids = Hash::extract($entity->get('test'), '{n}.id');
+        static::assertEquals([], $ids);
     }
 }


### PR DESCRIPTION
This PR adds utility methods to add/replace/remove related objects in `ObjectModelBehavior` that can be used in all objects `Table` classes.

Some  examples below

```php
// add a `$related` entity to `owned_by` relation 
$Documents->addRelated($entity, 'owned_by', [$related]);

// replace existing `owned_by` related objects with `$related` 
$Documents->replaceRelated($entity, 'owned_by', [$related]);

// remove `$related` from existing `owned_by` related objects  
$Documents->removeRelated($entity, 'owned_by', [$related]);
```
