### PR TITLE
Update publications columns types

### DIFF
--- a/plugins/BEdita/Core/config/Migrations/20220217144159_PublicationsUpdate.php
+++ b/plugins/BEdita/Core/config/Migrations/20220217144159_PublicationsUpdate.php
@@ -1,0 +1,59 @@
+<?php
+use Migrations\AbstractMigration;
+
+class PublicationsUpdate extends AbstractMigration
+{
+    /**
+     * @inheritDoc
+     */
+    public function up()
+    {
+        $this->table('publications')
+            ->changeColumn('public_url', 'string', [
+                'comment' => 'the public url',
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->changeColumn('staging_url', 'string', [
+                'comment' => 'the staging url',
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->changeColumn('stats_code', 'string', [
+                'comment' => 'the code for statistics',
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->update();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function down()
+    {
+        $this->table('publications')
+            ->changeColumn('public_url', 'text', [
+                'comment' => 'the public url',
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->changeColumn('staging_url', 'text', [
+                'comment' => 'the staging url',
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->changeColumn('stats_code', 'text', [
+                'comment' => 'the code for statistics',
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->update();
+    }
+}

--- a/plugins/BEdita/Core/config/Migrations/20220217144159_PublicationsUpdate.php
+++ b/plugins/BEdita/Core/config/Migrations/20220217144159_PublicationsUpdate.php
@@ -9,19 +9,7 @@ class PublicationsUpdate extends AbstractMigration
     public function up()
     {
         $this->table('publications')
-            ->changeColumn('public_url', 'string', [
-                'comment' => 'the public url',
-                'default' => null,
-                'limit' => null,
-                'null' => true,
-            ])
-            ->changeColumn('staging_url', 'string', [
-                'comment' => 'the staging url',
-                'default' => null,
-                'limit' => null,
-                'null' => true,
-            ])
-            ->changeColumn('stats_code', 'string', [
+            ->changeColumn('stats_code', 'text', [
                 'comment' => 'the code for statistics',
                 'default' => null,
                 'limit' => null,
@@ -36,19 +24,7 @@ class PublicationsUpdate extends AbstractMigration
     public function down()
     {
         $this->table('publications')
-            ->changeColumn('public_url', 'text', [
-                'comment' => 'the public url',
-                'default' => null,
-                'limit' => null,
-                'null' => true,
-            ])
-            ->changeColumn('staging_url', 'text', [
-                'comment' => 'the staging url',
-                'default' => null,
-                'limit' => null,
-                'null' => true,
-            ])
-            ->changeColumn('stats_code', 'text', [
+            ->changeColumn('stats_code', 'string', [
                 'comment' => 'the code for statistics',
                 'default' => null,
                 'limit' => null,

--- a/plugins/BEdita/Core/config/Migrations/20220217144159_PublicationsUpdate.php
+++ b/plugins/BEdita/Core/config/Migrations/20220217144159_PublicationsUpdate.php
@@ -9,6 +9,18 @@ class PublicationsUpdate extends AbstractMigration
     public function up()
     {
         $this->table('publications')
+            ->changeColumn('public_url', 'string', [
+                'comment' => 'the public url',
+                'default' => null,
+                'limit' => 1024,
+                'null' => true,
+            ])
+            ->changeColumn('staging_url', 'string', [
+                'comment' => 'the staging url',
+                'default' => null,
+                'limit' => 1024,
+                'null' => true,
+            ])
             ->changeColumn('stats_code', 'text', [
                 'comment' => 'the code for statistics',
                 'default' => null,
@@ -24,6 +36,18 @@ class PublicationsUpdate extends AbstractMigration
     public function down()
     {
         $this->table('publications')
+            ->changeColumn('public_url', 'string', [
+                'comment' => 'the public url',
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->changeColumn('staging_url', 'string', [
+                'comment' => 'the staging url',
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
             ->changeColumn('stats_code', 'string', [
                 'comment' => 'the code for statistics',
                 'default' => null,


### PR DESCRIPTION
This PR changes columns types for table `publications`.

`public_url`, `staging_url` and `stats_code` become `text` columns.