### PR TITLE
Refactor: port some Cake 4 changes in Unit Tests

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/ChildrenRelationshipTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ChildrenRelationshipTest.php
@@ -33,7 +33,7 @@ class ChildrenRelationshipTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -43,7 +43,7 @@ class ChildrenRelationshipTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/plugins/BEdita/API/tests/IntegrationTest/CustomPropertiesFilterTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/CustomPropertiesFilterTest.php
@@ -45,7 +45,7 @@ class CustomPropertiesFilterTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/plugins/BEdita/API/tests/IntegrationTest/ExceptionRendererTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ExceptionRendererTest.php
@@ -28,7 +28,7 @@ class ExceptionRendererTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         ConnectionManager::alias('test', 'default');
         ConnectionManager::drop('__fail_db_connection');

--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -48,7 +48,7 @@ class FilterQueryStringTest extends IntegrationTestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         if (!isset(static::$geoSupport)) {

--- a/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
@@ -33,7 +33,7 @@ class ParentsRelationshipTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -43,7 +43,7 @@ class ParentsRelationshipTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/plugins/BEdita/API/tests/IntegrationTest/RelationshipsParamsTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/RelationshipsParamsTest.php
@@ -51,7 +51,7 @@ class RelationshipsParamsTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -64,7 +64,7 @@ class RelationshipsParamsTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Locations, $this->Users, $this->Relations, $this->ObjectRelations);
 

--- a/plugins/BEdita/API/tests/IntegrationTest/RelationshipsPriorityTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/RelationshipsPriorityTest.php
@@ -33,7 +33,7 @@ class RelationshipsPriorityTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         FilesystemRegistry::setConfig(Configure::read('Filesystem'));
@@ -42,7 +42,7 @@ class RelationshipsPriorityTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         FilesystemRegistry::dropAll();
         parent::tearDown();

--- a/plugins/BEdita/API/tests/TestCase/Auth/EndpointAuthorizeTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/EndpointAuthorizeTest.php
@@ -47,7 +47,7 @@ class EndpointAuthorizeTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Cache::clear(false, '_bedita_core_');
@@ -273,11 +273,11 @@ class EndpointAuthorizeTest extends TestCase
      * @covers ::isAnonymous()
      * @covers ::checkPermissions()
      * @covers ::unauthenticated()
-     * @expectedException \Cake\Http\Exception\UnauthorizedException
-     * @expectedExceptionMessage Unauthorized
      */
     public function testBlockAnonymousWritesByDefault()
     {
+        $this->expectException(\Cake\Http\Exception\UnauthorizedException::class);
+        $this->expectExceptionMessage('Unauthorized');
         // Ensure no permissions apply to anonymous user on `/home` endpoint.
         TableRegistry::getTableLocator()->get('EndpointPermissions')->deleteAll(['role_id IS' => null, 'endpoint_id' => 2]);
 
@@ -314,11 +314,11 @@ class EndpointAuthorizeTest extends TestCase
      * @covers ::authorize()
      * @covers ::isAnonymous()
      * @covers ::unauthenticated()
-     * @expectedException \Cake\Http\Exception\UnauthorizedException
-     * @expectedExceptionMessage Unauthorized
      */
     public function testBlockUnloggedByDefault()
     {
+        $this->expectException(\Cake\Http\Exception\UnauthorizedException::class);
+        $this->expectExceptionMessage('Unauthorized');
         // Ensure no permissions apply to anonymous user on `/home` endpoint.
         TableRegistry::getTableLocator()->get('EndpointPermissions')->deleteAll(['role_id IS' => null, 'endpoint_id' => 2]);
 

--- a/plugins/BEdita/API/tests/TestCase/Auth/JwtAuthenticateTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/JwtAuthenticateTest.php
@@ -50,7 +50,7 @@ class JwtAuthenticateTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -260,12 +260,12 @@ class JwtAuthenticateTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \Cake\Http\Exception\UnauthorizedException
-     * @expectedExceptionMessage MyExceptionMessage
      * @covers ::unauthenticated()
      */
     public function testUnauthenticated()
     {
+        $this->expectException(\Cake\Http\Exception\UnauthorizedException::class);
+        $this->expectExceptionMessage('MyExceptionMessage');
         $controller = new Controller();
         $controller->loadComponent('Auth', [
             'authError' => 'MyExceptionMessage',
@@ -273,7 +273,7 @@ class JwtAuthenticateTest extends TestCase
 
         $auth = new JwtAuthenticate($controller->components(), []);
 
-        $auth->unauthenticated($controller->request, $controller->response);
+        $auth->unauthenticated($controller->getRequest(), $controller->getResponse());
     }
 
     /**
@@ -281,12 +281,12 @@ class JwtAuthenticateTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \Cake\Http\Exception\UnauthorizedException
-     * @expectedExceptionMessage Invalid audience
      * @covers ::unauthenticated()
      */
     public function testUnauthenticatedWithInternalErrorMessage()
     {
+        $this->expectException(\Cake\Http\Exception\UnauthorizedException::class);
+        $this->expectExceptionMessage('Invalid audience');
         $request = new ServerRequest([
             'params' => [
                 'plugin' => 'BEdita/API',
@@ -309,10 +309,10 @@ class JwtAuthenticateTest extends TestCase
 
         $auth = new JwtAuthenticate($controller->components(), []);
 
-        $result = $auth->authenticate($controller->request, $controller->response);
+        $result = $auth->authenticate($controller->getRequest(), $controller->getResponse());
 
         static::assertFalse($result);
 
-        $auth->unauthenticated($controller->request, $controller->response);
+        $auth->unauthenticated($controller->getRequest(), $controller->getResponse());
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Auth/OAuth2AuthenticateTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/OAuth2AuthenticateTest.php
@@ -176,12 +176,12 @@ class OAuth2AuthenticateTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \Cake\Http\Exception\UnauthorizedException
-     * @expectedExceptionMessage MyExceptionMessage
      * @covers ::unauthenticated()
      */
     public function testUnauthenticated()
     {
+        $this->expectException(\Cake\Http\Exception\UnauthorizedException::class);
+        $this->expectExceptionMessage('MyExceptionMessage');
         $controller = new Controller();
         $controller->loadComponent('Auth', [
             'authError' => 'MyExceptionMessage',
@@ -189,6 +189,6 @@ class OAuth2AuthenticateTest extends TestCase
 
         $auth = new OAuth2Authenticate($controller->components(), []);
 
-        $auth->unauthenticated($controller->request, $controller->response);
+        $auth->unauthenticated($controller->getRequest(), $controller->getResponse());
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Auth/UuidAuthenticateTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Auth/UuidAuthenticateTest.php
@@ -219,12 +219,12 @@ class UuidAuthenticateTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \Cake\Http\Exception\UnauthorizedException
-     * @expectedExceptionMessage MyExceptionMessage
      * @covers ::unauthenticated()
      */
     public function testUnauthenticated()
     {
+        $this->expectException(\Cake\Http\Exception\UnauthorizedException::class);
+        $this->expectExceptionMessage('MyExceptionMessage');
         $controller = new Controller();
         $controller->loadComponent('Auth', [
             'authError' => 'MyExceptionMessage',
@@ -232,6 +232,6 @@ class UuidAuthenticateTest extends TestCase
 
         $auth = new UuidAuthenticate($controller->components(), []);
 
-        $auth->unauthenticated($controller->request, $controller->response);
+        $auth->unauthenticated($controller->getRequest(), $controller->getResponse());
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
@@ -46,7 +46,7 @@ class JsonApiComponentTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -89,7 +89,7 @@ class JsonApiComponentTest extends TestCase
     {
         $component = new JsonApiComponent(new ComponentRegistry(new Controller()), $config);
 
-        static::assertEquals($expectedMimeType, $component->getController()->response->getHeaderLine('content-type'));
+        static::assertEquals($expectedMimeType, $component->getController()->getResponse()->getHeaderLine('content-type'));
         static::assertArrayHasKey('jsonapi', $component->RequestHandler->getConfig('inputTypeMap'));
         static::assertArrayHasKey('jsonapi', $component->RequestHandler->getConfig('viewClassMap'));
     }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/UploadComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/UploadComponentTest.php
@@ -35,7 +35,7 @@ class UploadComponentTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->filesystemSetup();
@@ -44,7 +44,7 @@ class UploadComponentTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->filesystemRestore();
         parent::tearDown();

--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -34,7 +34,7 @@ class FoldersControllerTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -44,7 +44,7 @@ class FoldersControllerTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Folders);
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
@@ -382,7 +382,7 @@ class HomeControllerTest extends IntegrationTestCase
         // setup new permission to block `/documents` endpoint
         $EndpointPermissions = TableRegistry::getTableLocator()->get('EndpointPermissions');
         $EndpointPermissions->deleteAll([]);
-        $permission = $EndpointPermissions->newEntity();
+        $permission = $EndpointPermissions->newEntity([]);
         $permission->permission = 0b0000;
         $permission->application_id = 1;
         $permission->role_id = 2;

--- a/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
@@ -49,7 +49,7 @@ class LoginControllerTest extends IntegrationTestCase
     /**
      * @inheritDoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Cache::clear(false, '_bedita_core_');
@@ -187,7 +187,7 @@ class LoginControllerTest extends IntegrationTestCase
         } catch (\Cake\Routing\Exception\MissingRouteException $e) {
         }
 
-        static::assertEquals($expected, $controller->request->getData('grant_type'));
+        static::assertEquals($expected, $controller->getRequest()->getData('grant_type'));
     }
 
     /**
@@ -579,7 +579,7 @@ class LoginControllerTest extends IntegrationTestCase
         $action = new SaveEntityAction(['table' => TableRegistry::getTableLocator()->get('AsyncJobs')]);
 
         return $action([
-            'entity' => TableRegistry::getTableLocator()->get('AsyncJobs')->newEntity(),
+            'entity' => TableRegistry::getTableLocator()->get('AsyncJobs')->newEntity([]),
             'data' => [
                 'service' => 'credentials_change',
                 'payload' => [

--- a/plugins/BEdita/API/tests/TestCase/Controller/MediaControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/MediaControllerTest.php
@@ -64,7 +64,7 @@ class MediaControllerTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -103,7 +103,7 @@ class MediaControllerTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
@@ -36,7 +36,7 @@ class SignupControllerTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/StreamsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/StreamsControllerTest.php
@@ -40,7 +40,7 @@ class StreamsControllerTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -62,7 +62,7 @@ class StreamsControllerTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         // Cleanup test filesystem.
         $mountManager = FilesystemRegistry::getMountManager();

--- a/plugins/BEdita/API/tests/TestCase/Controller/TrashControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TrashControllerTest.php
@@ -32,7 +32,7 @@ class TrashControllerTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/UploadControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/UploadControllerTest.php
@@ -34,7 +34,7 @@ class UploadControllerTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->filesystemSetup();
@@ -43,7 +43,7 @@ class UploadControllerTest extends IntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->filesystemRestore();
         parent::tearDown();

--- a/plugins/BEdita/API/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Error/ExceptionRendererTest.php
@@ -52,7 +52,7 @@ class ExceptionRendererTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->backupConf = [
@@ -65,7 +65,7 @@ class ExceptionRendererTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         foreach ($this->backupConf as $key => $val) {
             Configure::write($key, $val);
@@ -150,7 +150,7 @@ class ExceptionRendererTest extends TestCase
         }
 
         $renderer = new MyExceptionRenderer($exception);
-        $renderer->getController()->request = $renderer->getController()->request->withEnv('HTTP_ACCEPT', 'application/json');
+        $renderer->getController()->setRequest($renderer->getController()->getRequest()->withEnv('HTTP_ACCEPT', 'application/json'));
         $response = $renderer->render();
 
         $responseBody = json_decode((string)$response->getBody(), true);
@@ -231,7 +231,7 @@ class ExceptionRendererTest extends TestCase
         }
 
         $renderer = new MyExceptionRenderer(new NotFoundException('test html'));
-        $renderer->getController()->request = $renderer->getController()->request->withEnv('HTTP_ACCEPT', $accept);
+        $renderer->getController()->setRequest($renderer->getController()->getRequest->withEnv('HTTP_ACCEPT', $accept));
         $response = $renderer->render();
 
         $this->checkResponseJson($renderer, $response, $config['debug']);
@@ -257,7 +257,7 @@ class ExceptionRendererTest extends TestCase
         }
 
         $renderer = new MyExceptionRenderer(new NotFoundException('test html'));
-        $renderer->getController()->request = $renderer->getController()->request->withEnv('HTTP_ACCEPT', $accept);
+        $renderer->getController()->setRequest($renderer->getController()->getRequest()->withEnv('HTTP_ACCEPT', $accept));
 
         $renderer->getController()->getEventManager()->on('Controller.beforeRender', function () {
             throw new InternalErrorException();
@@ -278,7 +278,7 @@ class ExceptionRendererTest extends TestCase
      */
     protected function checkResponseJson(MyExceptionRenderer $renderer, Response $response, $debug)
     {
-        $accept = $renderer->getController()->request->getHeaderLine('accept');
+        $accept = $renderer->getController()->getRequest()->getHeaderLine('accept');
         $contentTypeExpected = ($accept == 'application/json') ? $accept : 'application/vnd.api+json';
         $this->assertStringStartsWith($contentTypeExpected, $response->getType());
         $responseBody = json_decode((string)$response->getBody(), true);

--- a/plugins/BEdita/API/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Error/ExceptionRendererTest.php
@@ -231,7 +231,7 @@ class ExceptionRendererTest extends TestCase
         }
 
         $renderer = new MyExceptionRenderer(new NotFoundException('test html'));
-        $renderer->getController()->setRequest($renderer->getController()->getRequest->withEnv('HTTP_ACCEPT', $accept));
+        $renderer->getController()->setRequest($renderer->getController()->getRequest()->withEnv('HTTP_ACCEPT', $accept));
         $response = $renderer->render();
 
         $this->checkResponseJson($renderer, $response, $config['debug']);

--- a/plugins/BEdita/API/tests/TestCase/Middleware/CorsMiddlewareTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Middleware/CorsMiddlewareTest.php
@@ -29,7 +29,7 @@ class CorsMiddlewareTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
     }

--- a/plugins/BEdita/API/tests/TestCase/Middleware/TokenMiddlewareTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Middleware/TokenMiddlewareTest.php
@@ -46,7 +46,7 @@ class TokenMiddlewareTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         CurrentApplication::setApplication(null);
     }

--- a/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateAssociatedActionTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateAssociatedActionTest.php
@@ -43,7 +43,7 @@ class UpdateAssociatedActionTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -253,7 +253,7 @@ class UpdateAssociatedActionTest extends TestCase
     {
         // Prepare link with junction data.
         $junction = TableRegistry::getTableLocator()->get('FakeArticlesTags');
-        $junctionEntity = $junction->newEntity();
+        $junctionEntity = $junction->newEntity([]);
         $junction->patchEntity($junctionEntity, [
             'fake_article_id' => 2,
             'fake_tag_id' => 1,

--- a/plugins/BEdita/API/tests/TestCase/Shell/SpecShellTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Shell/SpecShellTest.php
@@ -32,7 +32,7 @@ class SpecShellTest extends ConsoleIntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->loadPlugins(['BEdita/API' => []]);
@@ -41,7 +41,7 @@ class SpecShellTest extends ConsoleIntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         if (file_exists(static::TEMP_FILE)) {
             unlink(static::TEMP_FILE);

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -60,7 +60,7 @@ class JsonApiTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -72,7 +72,7 @@ class JsonApiTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Roles);
 

--- a/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
+++ b/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
@@ -58,7 +58,7 @@ class JsonApiViewTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -69,7 +69,7 @@ class JsonApiViewTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Roles);
 

--- a/plugins/BEdita/Core/tests/Fixture/TranslationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/TranslationsFixture.php
@@ -24,7 +24,7 @@ class TranslationsFixture extends TestFixture
     /**
      * {@inheritDoc}
      */
-    public function init()
+    public function init(): void
     {
         $this->records = [
             [

--- a/plugins/BEdita/Core/tests/Fixture/UserTokensFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/UserTokensFixture.php
@@ -23,7 +23,7 @@ class UserTokensFixture extends TestFixture
     /**
      * {@inheritDoc}
      */
-    public function init()
+    public function init(): void
     {
         $this->records = [
             [

--- a/plugins/BEdita/Core/tests/Fixture/UsersFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/UsersFixture.php
@@ -25,7 +25,7 @@ class UsersFixture extends TestFixture
     /**
      * {@inheritDoc}
      */
-    public function init()
+    public function init(): void
     {
         $this->records = [
             [

--- a/plugins/BEdita/Core/tests/TestCase/Cache/Engine/LayeredEngineTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Cache/Engine/LayeredEngineTest.php
@@ -42,7 +42,7 @@ class LayeredEngineTest extends TestCase
     /**
      * @inheritDoc
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         Cache::enable();
@@ -52,7 +52,7 @@ class LayeredEngineTest extends TestCase
     /**
      * @inheritDoc
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/plugins/BEdita/Core/tests/TestCase/Command/CustomPropsCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/CustomPropsCommandTest.php
@@ -51,7 +51,7 @@ class CustomPropsCommandTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->useCommandRunner();

--- a/plugins/BEdita/Core/tests/TestCase/Command/FixHistoryCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/FixHistoryCommandTest.php
@@ -39,7 +39,7 @@ class FixHistoryCommandTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->useCommandRunner();

--- a/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
@@ -48,7 +48,7 @@ class ProjectModelCommandTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->useCommandRunner();

--- a/plugins/BEdita/Core/tests/TestCase/Configure/Engine/DatabaseConfigTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Configure/Engine/DatabaseConfigTest.php
@@ -47,7 +47,7 @@ class DatabaseConfigTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->DatabaseConfig = new DatabaseConfig();
@@ -59,7 +59,7 @@ class DatabaseConfigTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->DatabaseConfig);
         parent::tearDown();

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/Adapter/LocalAdapterTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/Adapter/LocalAdapterTest.php
@@ -32,7 +32,7 @@ class LocalAdapterTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         if (file_exists(self::FILES_PATH)) {
             rmdir(self::FILES_PATH);

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/FilesystemRegistryTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/FilesystemRegistryTest.php
@@ -29,7 +29,7 @@ class FilesystemRegistryTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 
@@ -219,11 +219,11 @@ class FilesystemRegistryTest extends TestCase
      * @return void
      *
      * @covers ::dropAll()
-     * @expectedException \League\Flysystem\FilesystemNotFoundException
-     * @expectedExceptionMessage No filesystem mounted with prefix default
      */
     public function testDropAll()
     {
+        $this->expectException(\League\Flysystem\FilesystemNotFoundException::class);
+        $this->expectExceptionMessage('No filesystem mounted with prefix default');
         FilesystemRegistry::setConfig('default', [
             'className' => LocalAdapter::class,
         ]);

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/AsyncGeneratorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/AsyncGeneratorTest.php
@@ -75,7 +75,7 @@ class AsyncGeneratorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -102,7 +102,7 @@ class AsyncGeneratorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         foreach (Thumbnail::configured() as $config) {
             Thumbnail::drop($config);

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/GlideGeneratorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/GlideGeneratorTest.php
@@ -57,7 +57,7 @@ class GlideGeneratorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -72,7 +72,7 @@ class GlideGeneratorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->filesystemRestore();
         unset($this->generator, $this->Streams);

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/ThumbnailRegistryTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/ThumbnailRegistryTest.php
@@ -52,13 +52,13 @@ class ThumbnailRegistryTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessageRegExp /^Thumbnail generators must use .+ as a base class\.$/
      * @covers ::_create()
      * @covers ::_resolveClassName()
      */
     public function testLoadNotAGenerator()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageRegExp('/^Thumbnail generators must use .+ as a base class\.$/');
         $object = new \stdClass();
 
         $registry = new ThumbnailRegistry();
@@ -71,13 +71,13 @@ class ThumbnailRegistryTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessageRegExp /^Thumbnail generator .+ is not properly configured\.$/
      * @covers ::_create()
      * @covers ::_resolveClassName()
      */
     public function testLoadNotInitialized()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageRegExp('/^Thumbnail generator .+ is not properly configured\.$/');
         $config = [
             'my' => 'config',
         ];
@@ -99,12 +99,12 @@ class ThumbnailRegistryTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessageRegExp /^Thumbnail generator .+ is not available\.$/
      * @covers ::_throwMissingClassError()
      */
     public function testLoadMissingClass()
     {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessageRegExp('/^Thumbnail generator .+ is not available\.$/');
         $registry = new ThumbnailRegistry();
 
         $registry->load('\This\Class\Does\Not\Exist');

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/ThumbnailTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/ThumbnailTest.php
@@ -52,7 +52,7 @@ class ThumbnailTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -72,7 +72,7 @@ class ThumbnailTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         foreach (Thumbnail::configured() as $config) {
             Thumbnail::drop($config);
@@ -269,13 +269,13 @@ class ThumbnailTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \BEdita\Core\Filesystem\Exception\InvalidThumbnailOptionsException
-     * @expectedExceptionCode 400
-     * @expectedExceptionMessage Preset "gustavo" not found
      * @covers ::getOptions()
      */
     public function testGetOptionsMissingPreset()
     {
+        $this->expectException(\BEdita\Core\Filesystem\Exception\InvalidThumbnailOptionsException::class);
+        $this->expectExceptionCode('400');
+        $this->expectExceptionMessage('Preset "gustavo" not found');
         Configure::delete('Thumbnails.presets.gustavo');
 
         Thumbnail::get(new Stream(), 'gustavo');
@@ -286,13 +286,13 @@ class ThumbnailTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \BEdita\Core\Filesystem\Exception\InvalidThumbnailOptionsException
-     * @expectedExceptionCode 400
-     * @expectedExceptionMessage Thumbnails can only be generated for one of the configured presets
      * @covers ::getOptions()
      */
     public function testGetOptionsCustomNotAllowed()
     {
+        $this->expectException(\BEdita\Core\Filesystem\Exception\InvalidThumbnailOptionsException::class);
+        $this->expectExceptionCode('400');
+        $this->expectExceptionMessage('Thumbnails can only be generated for one of the configured presets');
         Configure::write('Thumbnails.allowAny', false);
 
         Thumbnail::get(new Stream(), ['generator' => 'whatever', 'w' => -1, 'h' => 'maybe']);

--- a/plugins/BEdita/Core/tests/TestCase/Job/Service/MailServiceTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/Service/MailServiceTest.php
@@ -28,7 +28,7 @@ class MailServiceTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         TransportFactory::drop('test');
         TransportFactory::setConfig('test', [
@@ -41,7 +41,7 @@ class MailServiceTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/plugins/BEdita/Core/tests/TestCase/Job/Service/ThumbnailServiceTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/Service/ThumbnailServiceTest.php
@@ -62,7 +62,7 @@ class ThumbnailServiceTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -84,7 +84,7 @@ class ThumbnailServiceTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         foreach (Thumbnail::configured() as $config) {
             Thumbnail::drop($config);

--- a/plugins/BEdita/Core/tests/TestCase/Job/ServiceRegistryTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/ServiceRegistryTest.php
@@ -26,7 +26,7 @@ class ServiceRegistryTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 
@@ -81,11 +81,11 @@ class ServiceRegistryTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \LogicException
      * @covers ::get()
      */
     public function testGetFail()
     {
+        $this->expectException(\LogicException::class);
         ServiceRegistry::get('gustavo');
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/EmailTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/EmailTest.php
@@ -25,7 +25,7 @@ class EmailTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         TransportFactory::setConfig('test', [
             'className' => 'Debug',
@@ -37,7 +37,7 @@ class EmailTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/Transport/AsyncJobsTransportTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/Transport/AsyncJobsTransportTest.php
@@ -43,7 +43,7 @@ class AsyncJobsTransportTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         TransportFactory::drop('test');
         TransportFactory::setConfig('test', [
@@ -69,7 +69,7 @@ class AsyncJobsTransportTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTest.php
@@ -65,7 +65,7 @@ class UserMailerTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -90,7 +90,7 @@ class UserMailerTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ActionTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ActionTraitTest.php
@@ -31,7 +31,7 @@ class ActionTraitTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -41,7 +41,7 @@ class ActionTraitTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddAssociatedActionTest.php
@@ -43,7 +43,7 @@ class AddAssociatedActionTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -199,12 +199,11 @@ class AddAssociatedActionTest extends TestCase
      * Test that an exception is raised with details about the validation error.
      *
      * @return void
-     *
-     * @expectedException \Cake\Http\Exception\BadRequestException
-     * @expectedExceptionCode 400
      */
     public function testInvocationWithLinkErrors()
     {
+        $this->expectException(\Cake\Http\Exception\BadRequestException::class);
+        $this->expectExceptionCode('400');
         try {
             $table = TableRegistry::getTableLocator()->get('FakeArticles');
             /** @var \Cake\ORM\Association\BelongsToMany $association */

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ChangeCredentialsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ChangeCredentialsActionTest.php
@@ -54,7 +54,7 @@ class ChangeCredentialsActionTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -74,7 +74,7 @@ class ChangeCredentialsActionTest extends TestCase
         $action = new SaveEntityAction(['table' => TableRegistry::getTableLocator()->get('AsyncJobs')]);
 
         return $action([
-            'entity' => TableRegistry::getTableLocator()->get('AsyncJobs')->newEntity(),
+            'entity' => TableRegistry::getTableLocator()->get('AsyncJobs')->newEntity([]),
             'data' => [
                 'service' => 'credentials_change',
                 'payload' => [
@@ -128,10 +128,10 @@ class ChangeCredentialsActionTest extends TestCase
      *
      * @covers ::execute()
      * @covers ::validate()
-     * @expectedException \Cake\Http\Exception\BadRequestException
      */
     public function testValidationFail()
     {
+        $this->expectException(\Cake\Http\Exception\BadRequestException::class);
         $data = [
             'uuid' => 'whatatoken!',
         ];
@@ -151,10 +151,10 @@ class ChangeCredentialsActionTest extends TestCase
      *
      * @covers ::execute()
      * @covers ::validate()
-     * @expectedException \Cake\Datasource\Exception\RecordNotFoundException
      */
     public function testExecuteFail()
     {
+        $this->expectException(\Cake\Datasource\Exception\RecordNotFoundException::class);
         $data = [
             'uuid' => '66594f3c-8888-49d2-9999-382baf1a12b3',
             'password' => 'unbreakablepassword',
@@ -175,10 +175,10 @@ class ChangeCredentialsActionTest extends TestCase
      *
      * @covers ::execute()
      * @covers ::validate()
-     * @expectedException \LogicException
      */
     public function testPayloadFail()
     {
+        $this->expectException(\LogicException::class);
         $data = [
             'uuid' => '66594f3c-995f-49d2-9192-382baf1a12b3',
             'password' => 'unbreakablepassword',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ChangeCredentialsRequestActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ChangeCredentialsRequestActionTest.php
@@ -49,7 +49,7 @@ class ChangeCredentialsRequestActionTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -93,11 +93,10 @@ class ChangeCredentialsRequestActionTest extends TestCase
      * Test validate failure.
      *
      * @return void
-     *
-     * @expectedException \Cake\Http\Exception\BadRequestException
      */
     public function testValidationFail()
     {
+        $this->expectException(\Cake\Http\Exception\BadRequestException::class);
         $data = [
             'contact' => 'ask gustavo',
         ];
@@ -114,11 +113,10 @@ class ChangeCredentialsRequestActionTest extends TestCase
      * Test find contact failure.
      *
      * @return void
-     *
-     * @expectedException \Cake\Datasource\Exception\RecordNotFoundException
      */
     public function testExecuteFail()
     {
+        $this->expectException(\Cake\Datasource\Exception\RecordNotFoundException::class);
         $data = [
             'contact' => 'mr.gustavo@example.com',
             'change_url' => 'http://users.example.com',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/CountRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/CountRelatedObjectsActionTest.php
@@ -55,7 +55,7 @@ class CountRelatedObjectsActionTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteObjectActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteObjectActionTest.php
@@ -45,7 +45,7 @@ class DeleteObjectActionTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -55,7 +55,7 @@ class DeleteObjectActionTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/GetEntityActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/GetEntityActionTest.php
@@ -36,7 +36,7 @@ class GetEntityActionTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/GetObjectActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/GetObjectActionTest.php
@@ -62,11 +62,10 @@ class GetObjectActionTest extends TestCase
      * Test command execution with filter by object type.
      *
      * @return void
-     *
-     * @expectedException \Cake\Datasource\Exception\RecordNotFoundException
      */
     public function testExecuteObjectTypeFilter()
     {
+        $this->expectException(\Cake\Datasource\Exception\RecordNotFoundException::class);
         $objectType = TableRegistry::getTableLocator()->get('ObjectTypes')->get('Events');
         $table = TableRegistry::getTableLocator()->get('Objects');
         $action = new GetObjectAction(compact('table', 'objectType'));
@@ -78,11 +77,10 @@ class GetObjectActionTest extends TestCase
      * Test command execution with filter by deletion status.
      *
      * @return void
-     *
-     * @expectedException \Cake\Datasource\Exception\RecordNotFoundException
      */
     public function testExecuteObjectDeleted()
     {
+        $this->expectException(\Cake\Datasource\Exception\RecordNotFoundException::class);
         $table = TableRegistry::getTableLocator()->get('Objects');
         $action = new GetObjectAction(compact('table'));
 
@@ -93,11 +91,10 @@ class GetObjectActionTest extends TestCase
      * Test command execution filter with deleted and locked filter.
      *
      * @return void
-     *
-     * @expectedException \Cake\Datasource\Exception\RecordNotFoundException
      */
     public function testExecuteObjectDeletedLocked()
     {
+        $this->expectException(\Cake\Datasource\Exception\RecordNotFoundException::class);
         $table = TableRegistry::getTableLocator()->get('Objects');
         $action = new GetObjectAction(compact('table'));
 
@@ -108,11 +105,10 @@ class GetObjectActionTest extends TestCase
      * Test command execution with conditions on objects status.
      *
      * @return void
-     *
-     * @expectedException \Cake\Datasource\Exception\RecordNotFoundException
      */
     public function testExecuteObjectStatusNotAvailable()
     {
+        $this->expectException(\Cake\Datasource\Exception\RecordNotFoundException::class);
         Configure::write('Status.level', 'on');
 
         $table = TableRegistry::getTableLocator()->get('Objects');
@@ -125,12 +121,11 @@ class GetObjectActionTest extends TestCase
      * Test command execution with an invalid primary key.
      *
      * @return void
-     *
-     * @expectedException \Cake\Datasource\Exception\InvalidPrimaryKeyException
-     * @expectedExceptionMessage Record not found in table "objects" with primary key [1, 2]
      */
     public function testExecuteInvalidPrimaryKey()
     {
+        $this->expectException(\Cake\Datasource\Exception\InvalidPrimaryKeyException::class);
+        $this->expectExceptionMessage('Record not found in table "objects" with primary key [1, 2]');
         $table = TableRegistry::getTableLocator()->get('Objects');
         $action = new GetObjectAction(compact('table'));
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
@@ -42,7 +42,7 @@ class ListAssociatedActionTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -211,12 +211,11 @@ class ListAssociatedActionTest extends TestCase
      * Test invocation of command with an unknown association type.
      *
      * @return void
-     *
-     * @expectedException \LogicException
-     * @expectedExceptionMessageRegExp /^Unknown association type "\w+"$/
      */
     public function testUnknownAssociationType()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageRegExp('/^Unknown association type "\w+"$/');
         $sourceTable = TableRegistry::getTableLocator()->get('FakeArticles');
         $association = static::getMockForAbstractClass(Association::class, [
             'TestAssociation',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListEntitiesActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListEntitiesActionTest.php
@@ -51,7 +51,7 @@ class ListEntitiesActionTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveAssociatedActionTest.php
@@ -42,7 +42,7 @@ class RemoveAssociatedActionTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SaveEntityActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SaveEntityActionTest.php
@@ -48,7 +48,7 @@ class SaveEntityActionTest extends TestCase
         $table = TableRegistry::getTableLocator()->get('FakeAnimals');
         $action = new SaveEntityAction(compact('table'));
 
-        $entity = $table->newEntity();
+        $entity = $table->newEntity([]);
         $data = [
             'name' => 'monkey',
             'legs' => 2,
@@ -65,12 +65,12 @@ class SaveEntityActionTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \Cake\Http\Exception\BadRequestException
      * @covers ::initialize()
      * @covers ::execute()
      */
     public function testExecuteValitationErrors()
     {
+        $this->expectException(\Cake\Http\Exception\BadRequestException::class);
         $table = TableRegistry::getTableLocator()->get('FakeAnimals');
         $table->setValidator(
             $table::DEFAULT_VALIDATOR,
@@ -93,12 +93,12 @@ class SaveEntityActionTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \Cake\Http\Exception\InternalErrorException
      * @covers ::initialize()
      * @covers ::execute()
      */
     public function testExecuteSaveErrors()
     {
+        $this->expectException(\Cake\Http\Exception\InternalErrorException::class);
         $entity = TableRegistry::getTableLocator()->get('FakeAnimals')->get(1);
 
         $table = $this->getMockBuilder(Table::class)

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SetAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SetAssociatedActionTest.php
@@ -46,7 +46,7 @@ class SetAssociatedActionTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -266,12 +266,11 @@ class SetAssociatedActionTest extends TestCase
      * Test that an exception is raised with details about the validation error.
      *
      * @return void
-     *
-     * @expectedException \Cake\Http\Exception\BadRequestException
-     * @expectedExceptionCode 400
      */
     public function testInvocationWithLinkErrors()
     {
+        $this->expectException(\Cake\Http\Exception\BadRequestException::class);
+        $this->expectExceptionCode('400');
         try {
             $table = TableRegistry::getTableLocator()->get('FakeArticles');
             /** @var \Cake\ORM\Association\BelongsToMany $association */
@@ -330,11 +329,11 @@ class SetAssociatedActionTest extends TestCase
      * @return void
      *
      * @dataProvider invocationWithValidationErrorsProvider()
-     * @expectedException \Cake\Http\Exception\BadRequestException
-     * @expectedExceptionCode 400
      */
     public function testInvocationWithValidationErrors($source, $target)
     {
+        $this->expectException(\Cake\Http\Exception\BadRequestException::class);
+        $this->expectExceptionCode('400');
         $field = 'some_field';
         $validationErrorMessage = 'Invalid email';
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
@@ -52,7 +52,7 @@ class SetRelatedObjectsActionTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -62,7 +62,7 @@ class SetRelatedObjectsActionTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -62,7 +62,7 @@ class SignupUserActionTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -370,11 +370,10 @@ class SignupUserActionTest extends TestCase
      * Test execute when exception was raised sending email
      *
      * @return void
-     *
-     * @expectedException \Cake\Http\Exception\InternalErrorException
      */
     public function testExceptionSendMail()
     {
+        $this->expectException(\Cake\Http\Exception\InternalErrorException::class);
         $data = [
             'data' => [
                 'username' => 'testsignup',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActivationActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActivationActionTest.php
@@ -74,7 +74,7 @@ class SignupUserActivationActionTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
@@ -52,7 +52,7 @@ class CustomPropertiesBehaviorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -62,7 +62,7 @@ class CustomPropertiesBehaviorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         FilesystemRegistry::dropAll();
         parent::tearDown();

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/GeometryBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/GeometryBehaviorTest.php
@@ -56,7 +56,7 @@ class GeometryBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -71,7 +71,7 @@ class GeometryBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Geometry);
 
@@ -183,7 +183,6 @@ class GeometryBehaviorTest extends TestCase
      *
      * @param array $conditions Filter options.
      * @return void
-     * @expectedException \BEdita\Core\Exception\BadFilterException
      *
      * @dataProvider badGeoProvider
      * @covers ::findGeo()
@@ -191,6 +190,7 @@ class GeometryBehaviorTest extends TestCase
      */
     public function testBadGeo($conditions)
     {
+        $this->expectException(\BEdita\Core\Exception\BadFilterException::class);
         $this->Locations->find('geo', $conditions)->toArray();
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/HistoryBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/HistoryBehaviorTest.php
@@ -48,7 +48,7 @@ class HistoryBehaviorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         LoggedUser::setUser(['id' => 1]);
@@ -57,7 +57,7 @@ class HistoryBehaviorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         LoggedUser::resetUser();
@@ -216,7 +216,7 @@ class HistoryBehaviorTest extends TestCase
     public function testCreate()
     {
         $Users = TableRegistry::getTableLocator()->get('Users');
-        $entity = $Users->newEntity();
+        $entity = $Users->newEntity([]);
         $data = [
             'username' => 'aurelio',
             'name' => 'Aurelio',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/PriorityBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/PriorityBehaviorTest.php
@@ -114,7 +114,7 @@ class PriorityBehaviorTest extends TestCase
     {
         $table = TableRegistry::getTableLocator()->get('ObjectRelations');
 
-        $entity = $table->newEntity();
+        $entity = $table->newEntity([]);
         $entity->set([
             'left_id' => 9,
             'relation_id' => 3,

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
@@ -40,7 +40,7 @@ class SearchableBehaviorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -29,7 +29,7 @@ class TreeBehaviorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -43,7 +43,7 @@ class TreeBehaviorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Table);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
@@ -50,7 +50,7 @@ class UniqueNameBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -60,7 +60,7 @@ class UniqueNameBehaviorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 
@@ -107,7 +107,7 @@ class UniqueNameBehaviorTest extends TestCase
     public function testUniqueUser($username, $uname)
     {
         $Users = TableRegistry::getTableLocator()->get('Users');
-        $user = $Users->newEntity();
+        $user = $Users->newEntity([]);
 
         $user = $Users->patchEntity($user, compact('username'));
         $Users->uniqueName($user);
@@ -216,7 +216,7 @@ class UniqueNameBehaviorTest extends TestCase
     public function testGenerateUniqueName($username, $name, $config)
     {
         $Users = TableRegistry::getTableLocator()->get('Users');
-        $user = $Users->newEntity();
+        $user = $Users->newEntity([]);
         $Users->patchEntity($user, compact('username', 'name'));
         $behavior = $Users->behaviors()->get('UniqueName');
         $uname1 = $behavior->generateUniqueName($user, false, $config);
@@ -257,7 +257,7 @@ class UniqueNameBehaviorTest extends TestCase
     public function testRegenerateUniqueName($uname, $title)
     {
         $Folders = TableRegistry::getTableLocator()->get('Folders');
-        $folder = $Folders->newEntity();
+        $folder = $Folders->newEntity([]);
         $Folders->patchEntity($folder, compact('uname', 'title'));
         $behavior = $Folders->behaviors()->get('UniqueName');
         $generated = $behavior->generateUniqueName($folder, true);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
@@ -48,7 +48,7 @@ class UploadableBehaviorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->filesystemSetup();
@@ -58,7 +58,7 @@ class UploadableBehaviorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->filesystemRestore();
         unset($this->Streams);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UserModifiedBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UserModifiedBehaviorTest.php
@@ -51,7 +51,7 @@ class UserModifiedBehaviorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -62,7 +62,7 @@ class UserModifiedBehaviorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 
@@ -142,7 +142,7 @@ class UserModifiedBehaviorTest extends TestCase
      */
     public function testHandleEvent()
     {
-        $object = $this->Objects->newEntity();
+        $object = $this->Objects->newEntity([]);
         $object->type = 'documents';
         $object = $this->Objects->save($object);
 
@@ -157,20 +157,20 @@ class UserModifiedBehaviorTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \UnexpectedValueException
-     * @expectedExceptionMessage When should be one of "always", "new" or "existing". The passed value "sometimes" is invalid
      * @covers ::handleEvent()
      * @covers ::updateField()
      */
     public function testHandleEventFailure()
     {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('When should be one of "always", "new" or "existing". The passed value "sometimes" is invalid');
         $this->Objects->behaviors()->get('UserModified')->setConfig('events', [
             'Model.beforeSave' => [
                 'modified_by' => 'sometimes',
             ],
         ], false);
 
-        $object = $this->Objects->newEntity();
+        $object = $this->Objects->newEntity([]);
         $object->type = 'documents';
         $this->Objects->save($object);
     }
@@ -225,7 +225,7 @@ class UserModifiedBehaviorTest extends TestCase
      */
     public function testTouchUserDirtyField()
     {
-        $object = $this->Objects->newEntity();
+        $object = $this->Objects->newEntity([]);
         $object->type = 'documents';
         $object->created_by = 5;
         $this->Objects->saveOrFail($object);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ApplicationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ApplicationTest.php
@@ -43,7 +43,7 @@ class ApplicationTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -53,7 +53,7 @@ class ApplicationTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Applications);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/AsyncJobTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/AsyncJobTest.php
@@ -52,7 +52,7 @@ class AsyncJobTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -69,7 +69,7 @@ class AsyncJobTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->AsyncJobs);
 
@@ -141,12 +141,12 @@ class AsyncJobTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Only locked jobs can be run
      * @covers ::run()
      */
     public function testRunNotLocked()
     {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Only locked jobs can be run');
         $this->AsyncJobs->get('1e2d1c66-c0bb-47d7-be5a-5bc92202333e')->run();
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/AuthProviderTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/AuthProviderTest.php
@@ -46,7 +46,7 @@ class AuthProviderTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -56,7 +56,7 @@ class AuthProviderTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->AuthProviders);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ConfigTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ConfigTest.php
@@ -43,7 +43,7 @@ class ConfigTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->Config = TableRegistry::getTableLocator()->get('Config');
@@ -52,7 +52,7 @@ class ConfigTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Config);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/DateRangeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/DateRangeTest.php
@@ -44,7 +44,7 @@ class DateRangeTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointPermissionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointPermissionTest.php
@@ -53,7 +53,7 @@ class EndpointPermissionTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -63,7 +63,7 @@ class EndpointPermissionTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->EndpointPermissions);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointTest.php
@@ -50,7 +50,7 @@ class EndpointTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -60,7 +60,7 @@ class EndpointTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Endpoints);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ExternalAuthTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ExternalAuthTest.php
@@ -48,7 +48,7 @@ class ExternalAuthTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -58,7 +58,7 @@ class ExternalAuthTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->ExternalAuth);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
@@ -52,7 +52,7 @@ class FolderTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -64,7 +64,7 @@ class FolderTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Folders);
 
@@ -254,7 +254,7 @@ class FolderTest extends TestCase
      */
     public function testGetPathNull()
     {
-        $folder = $this->Folders->newEntity();
+        $folder = $this->Folders->newEntity([]);
         static::assertNull($folder->path);
     }
 
@@ -264,11 +264,11 @@ class FolderTest extends TestCase
      * @return void
      *
      * @covers ::_getPath()
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Folder "12" is not on the tree.
      */
     public function testGetPathOrphanFolder()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Folder "12" is not on the tree.');
         TableRegistry::getTableLocator()->get('Trees')->deleteAll(['object_id' => 12]);
         TableRegistry::getTableLocator()->get('Trees')->recover();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiAdminTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiAdminTraitTest.php
@@ -42,7 +42,7 @@ class JsonApiAdminTraitTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -54,7 +54,7 @@ class JsonApiAdminTraitTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Applications);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -65,7 +65,7 @@ class JsonApiTraitTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -78,7 +78,7 @@ class JsonApiTraitTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Roles);
         unset($this->ObjectTypes);
@@ -95,7 +95,7 @@ class JsonApiTraitTest extends TestCase
      */
     public function testGetTable()
     {
-        $role = $this->Roles->newEntity();
+        $role = $this->Roles->newEntity([]);
         $table = $role->getTable();
 
         static::assertInstanceOf(get_class($this->Roles), $table);
@@ -126,7 +126,7 @@ class JsonApiTraitTest extends TestCase
      */
     public function testGetType()
     {
-        $role = $this->Roles->newEntity()->jsonApiSerialize();
+        $role = $this->Roles->newEntity([])->jsonApiSerialize();
 
         $type = $role['type'];
 
@@ -215,7 +215,7 @@ class JsonApiTraitTest extends TestCase
      */
     public function testGetRelationshipsHidden()
     {
-        $role = $this->Roles->newEntity();
+        $role = $this->Roles->newEntity([]);
         $role->setHidden(['users' => true], true);
         $role = $role->jsonApiSerialize();
 
@@ -362,14 +362,14 @@ class JsonApiTraitTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Objects must implement "BEdita\Core\Utility\JsonApiSerializable", got "string" instead
      * @covers ::getRelationships()
      * @covers ::getIncluded()
      * @covers ::listAssociations()
      */
     public function testGetRelationshipsIncludedNotSerializable()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Objects must implement "BEdita\Core\Utility\JsonApiSerializable", got "string" instead');
         $role = $this->Roles->get(2);
         $role->users = 'Gustavo';
         $role->jsonApiSerialize();

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/LocationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/LocationTest.php
@@ -44,7 +44,7 @@ class LocationTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -60,7 +60,7 @@ class LocationTest extends TestCase
      */
     public function testGetMeta()
     {
-        $location = $this->Locations->newEntity();
+        $location = $this->Locations->newEntity([]);
 
         static::assertFalse($location->isAccessible('distance'));
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/MediaTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/MediaTest.php
@@ -55,7 +55,7 @@ class MediaTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         FilesystemRegistry::setConfig(Configure::read('Filesystem'));
@@ -65,7 +65,7 @@ class MediaTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         FilesystemRegistry::dropAll();
         parent::tearDown();

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectEntityTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectEntityTest.php
@@ -58,7 +58,7 @@ class ObjectEntityTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -70,7 +70,7 @@ class ObjectEntityTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Objects);
 
@@ -394,7 +394,7 @@ class ObjectEntityTest extends TestCase
             'translations',
         ];
 
-        $entity = TableRegistry::getTableLocator()->get('Documents')->newEntity();
+        $entity = TableRegistry::getTableLocator()->get('Documents')->newEntity([]);
         $entity->set('type', 'documents');
         $entity = $entity->jsonApiSerialize();
 
@@ -441,7 +441,7 @@ class ObjectEntityTest extends TestCase
             ],
         ];
 
-        $entity = TableRegistry::getTableLocator()->get('Users')->newEntity();
+        $entity = TableRegistry::getTableLocator()->get('Users')->newEntity([]);
         $entity->set('id', 1);
         $entity->set('type', 'users');
         $entity = $entity->jsonApiSerialize();
@@ -467,7 +467,7 @@ class ObjectEntityTest extends TestCase
             'translations',
         ];
 
-        $entity = TableRegistry::getTableLocator()->get('Documents')->getAssociation('Test')->newEntity();
+        $entity = TableRegistry::getTableLocator()->get('Documents')->getAssociation('Test')->newEntity([]);
         $entity->set('type', 'profile');
         $entity = $entity->jsonApiSerialize();
 
@@ -494,7 +494,7 @@ class ObjectEntityTest extends TestCase
             'translations',
         ];
 
-        $entity = TableRegistry::getTableLocator()->get('Objects')->newEntity();
+        $entity = TableRegistry::getTableLocator()->get('Objects')->newEntity([]);
         $entity->set('type', 'folders');
         $entity = $entity->jsonApiSerialize();
 
@@ -514,7 +514,7 @@ class ObjectEntityTest extends TestCase
      */
     public function testGetRelationshipsDeleted()
     {
-        $entity = TableRegistry::getTableLocator()->get('Documents')->newEntity();
+        $entity = TableRegistry::getTableLocator()->get('Documents')->newEntity([]);
         $entity->set('type', 'documents');
         $entity->set('deleted', true);
         $entity = $entity->jsonApiSerialize();
@@ -572,7 +572,7 @@ class ObjectEntityTest extends TestCase
     public function testGetRelationshipsCount(): void
     {
         $count = ['test' => 12];
-        $entity = TableRegistry::getTableLocator()->get('Documents')->newEntity();
+        $entity = TableRegistry::getTableLocator()->get('Documents')->newEntity([]);
         $entity->set('type', 'documents');
         $entity->set('_countData', $count);
         $entity = $entity->jsonApiSerialize();

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -54,7 +54,7 @@ class ObjectTypeTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -66,7 +66,7 @@ class ObjectTypeTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->ObjectTypes);
 
@@ -449,7 +449,7 @@ class ObjectTypeTest extends TestCase
             'is_abstract' => true,
             'enabled' => false,
         ];
-        $objectType = $this->ObjectTypes->newEntity();
+        $objectType = $this->ObjectTypes->newEntity([]);
         $this->ObjectTypes->patchEntity($objectType, $data);
         $success = $this->ObjectTypes->save($objectType);
         static::assertTrue((bool)$success);
@@ -1009,7 +1009,7 @@ class ObjectTypeTest extends TestCase
      */
     public function testGetSchemaNoProperties()
     {
-        $objectType = $this->ObjectTypes->newEntity();
+        $objectType = $this->ObjectTypes->newEntity([]);
         $objectType->is_abstract = false;
 
         $schema = $objectType->schema;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ProfileTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ProfileTest.php
@@ -50,7 +50,7 @@ class ProfileTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -60,7 +60,7 @@ class ProfileTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Profiles);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/PropertyTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/PropertyTest.php
@@ -53,7 +53,7 @@ class PropertyTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -63,7 +63,7 @@ class PropertyTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Properties);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/PropertyTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/PropertyTypeTest.php
@@ -42,7 +42,7 @@ class PropertyTypeTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->PropertyTypes = TableRegistry::getTableLocator()->get('PropertyTypes');
@@ -51,7 +51,7 @@ class PropertyTypeTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->PropertyTypes);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/RelationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/RelationTest.php
@@ -43,7 +43,7 @@ class RelationTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -53,7 +53,7 @@ class RelationTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Relations);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/RoleTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/RoleTest.php
@@ -43,7 +43,7 @@ class RoleTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -53,7 +53,7 @@ class RoleTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Roles);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/StaticPropertyTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/StaticPropertyTest.php
@@ -57,7 +57,7 @@ class StaticPropertyTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -67,7 +67,7 @@ class StaticPropertyTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Properties);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/StreamTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/StreamTest.php
@@ -53,7 +53,7 @@ class StreamTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->filesystemSetup();
@@ -63,7 +63,7 @@ class StreamTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->filesystemRestore();
         unset($this->Streams);
@@ -135,7 +135,7 @@ class StreamTest extends TestCase
      */
     public function testFilesystemPath($expected, array $data, $filesystem = 'default', $subLevels = 0)
     {
-        $stream = $this->Streams->newEntity();
+        $stream = $this->Streams->newEntity([]);
         $stream->set($data, ['guard' => false]);
 
         $path = $stream->filesystemPath($filesystem, $subLevels);
@@ -187,7 +187,7 @@ class StreamTest extends TestCase
      */
     public function testGetContentsNotUploaded()
     {
-        $stream = $this->Streams->newEntity();
+        $stream = $this->Streams->newEntity([]);
         $contents = $stream->contents;
 
         static::assertNull($contents);
@@ -278,7 +278,7 @@ class StreamTest extends TestCase
             $this->expectExceptionMessage($expected->getMessage());
         }
 
-        $stream = $this->Streams->newEntity();
+        $stream = $this->Streams->newEntity([]);
         $stream->contents = $contents;
 
         static::assertInstanceOf(StreamInterface::class, $stream->contents);
@@ -383,13 +383,13 @@ class StreamTest extends TestCase
         $imageTest = new Stream($path . '/a4fbe302-3d5b-4774-a9df-18598def690e-image-metadata.jpeg', 'r');
         $gifTest = new Stream($path . '/6aceb0eb-bd30-4f60-ac74-273083b921b6-bedita-logo-gray.gif', 'r');
 
-        $stream = $this->Streams->newEntity();
+        $stream = $this->Streams->newEntity([]);
         $stream->mime_type = 'image/jpeg';
         $stream->contents = $imageTest;
 
         $this->readDataFromImage($stream);
         // mime type not allowed
-        $stream = $this->Streams->newEntity();
+        $stream = $this->Streams->newEntity([]);
         $stream->mime_type = 'image/gif';
         $stream->contents = $gifTest;
         $this->readDataFromImage($stream);
@@ -405,7 +405,7 @@ class StreamTest extends TestCase
     {
         $path = Configure::read('Filesystem.default.path');
         $gifTest = new Stream($path . '/6aceb0eb-bd30-4f60-ac74-273083b921b6-bedita-logo-gray.gif', 'r');
-        $stream = $this->Streams->newEntity();
+        $stream = $this->Streams->newEntity([]);
         $stream->mime_type = 'image/jpeg';
         $stream->contents = $gifTest;
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/TreeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/TreeTest.php
@@ -52,7 +52,7 @@ class TreeTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -62,7 +62,7 @@ class TreeTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Trees);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/UserTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/UserTest.php
@@ -58,7 +58,7 @@ class UserTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -68,7 +68,7 @@ class UserTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Users);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/AnnotationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/AnnotationsTableTest.php
@@ -87,6 +87,7 @@ class AnnotationsTableTest extends TestCase
             ],
             'invalid 1' => [
                 [
+                    'object_id._required',
                     'object_id.integer',
                 ],
                 [

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/AnnotationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/AnnotationsTableTest.php
@@ -40,7 +40,7 @@ class AnnotationsTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -50,7 +50,7 @@ class AnnotationsTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Annotations);
 
@@ -116,7 +116,7 @@ class AnnotationsTableTest extends TestCase
      */
     public function testValidation(array $expected, array $data)
     {
-        $entity = $this->Annotations->newEntity();
+        $entity = $this->Annotations->newEntity([]);
         $entity = $this->Annotations->patchEntity($entity, $data);
         $errors = array_keys(Hash::flatten($entity->getErrors()));
 
@@ -176,7 +176,7 @@ class AnnotationsTableTest extends TestCase
         if ($id) {
             $entity = $this->Annotations->get($id);
         } else {
-            $entity = $this->Annotations->newEntity();
+            $entity = $this->Annotations->newEntity([]);
         }
         $entity = $this->Annotations->patchEntity($entity, $data);
 
@@ -201,12 +201,11 @@ class AnnotationsTableTest extends TestCase
      * Test `beforeDelete` failure.
      *
      * @covers ::beforeDelete()
-     *
-     * @expectedException \Cake\Http\Exception\ForbiddenException
-     * @expectedExceptionMessage Could not delete annotation "1" of user "1"
      */
     public function testBeforeDeleteFailure()
     {
+        $this->expectException(\Cake\Http\Exception\ForbiddenException::class);
+        $this->expectExceptionMessage('Could not delete annotation "1" of user "1"');
         LoggedUser::setUser(['id' => 5]);
         $annotation = $this->Annotations->get(1);
         $success = $this->Annotations->delete($annotation);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ApplicationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ApplicationsTableTest.php
@@ -402,7 +402,7 @@ class ApplicationsTableTest extends TestCase
         $this->Applications->saveOrFail($app);
 
         $read = Cache::read(sprintf('app_%s', API_KEY), $cacheConf);
-        static::assertassertFalseNull($read);
+        static::assertFalse($read);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ApplicationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ApplicationsTableTest.php
@@ -60,7 +60,7 @@ class ApplicationsTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->Applications = TableRegistry::getTableLocator()->get('Applications');
@@ -72,7 +72,7 @@ class ApplicationsTableTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Applications);
         CurrentApplication::setApplication($this->currentApplication);
@@ -402,7 +402,7 @@ class ApplicationsTableTest extends TestCase
         $this->Applications->saveOrFail($app);
 
         $read = Cache::read(sprintf('app_%s', API_KEY), $cacheConf);
-        static::assertFalse($read);
+        static::assertassertFalseNull($read);
     }
 
     /**
@@ -410,13 +410,13 @@ class ApplicationsTableTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \BEdita\Core\Exception\ImmutableResourceException
-     * @expectedExceptionCode 403
-     * @expectedExceptionMessage Could not delete "Application" 1
      * @covers ::beforeDelete()
      */
     public function testDeleteDefaultApplication()
     {
+        $this->expectException(\BEdita\Core\Exception\ImmutableResourceException::class);
+        $this->expectExceptionCode('403');
+        $this->expectExceptionMessage('Could not delete "Application" 1');
         $application = $this->Applications->get(ApplicationsTable::DEFAULT_APPLICATION);
         $this->Applications->delete($application);
     }
@@ -426,13 +426,13 @@ class ApplicationsTableTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \BEdita\Core\Exception\ImmutableResourceException
-     * @expectedExceptionCode 403
-     * @expectedExceptionMessage Could not delete "Application" 2
      * @covers ::beforeDelete()
      */
     public function testDeleteCurrentApplication()
     {
+        $this->expectException(\BEdita\Core\Exception\ImmutableResourceException::class);
+        $this->expectExceptionCode('403');
+        $this->expectExceptionMessage('Could not delete "Application" 2');
         $application = $this->Applications->get(2);
         CurrentApplication::setApplication($application);
         $this->Applications->delete($application);
@@ -443,13 +443,13 @@ class ApplicationsTableTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \BEdita\Core\Exception\ImmutableResourceException
-     * @expectedExceptionCode 403
-     * @expectedExceptionMessage Could not disable "Application" 1
      * @covers ::beforeSave()
      */
     public function testDisableDefaultApplication()
     {
+        $this->expectException(\BEdita\Core\Exception\ImmutableResourceException::class);
+        $this->expectExceptionCode('403');
+        $this->expectExceptionMessage('Could not disable "Application" 1');
         $application = $this->Applications->get(ApplicationsTable::DEFAULT_APPLICATION);
         $application->enabled = 0;
         $this->Applications->save($application);
@@ -460,13 +460,13 @@ class ApplicationsTableTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \BEdita\Core\Exception\ImmutableResourceException
-     * @expectedExceptionCode 403
-     * @expectedExceptionMessage Could not disable "Application" 2
      * @covers ::beforeSave()
      */
     public function testDisableCurrentApplication()
     {
+        $this->expectException(\BEdita\Core\Exception\ImmutableResourceException::class);
+        $this->expectExceptionCode('403');
+        $this->expectExceptionMessage('Could not disable "Application" 2');
         $application = $this->Applications->get(2);
         $application->enabled = 1;
         $this->Applications->save($application);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/AsyncJobsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/AsyncJobsTableTest.php
@@ -40,7 +40,7 @@ class AsyncJobsTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -57,7 +57,7 @@ class AsyncJobsTableTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->AsyncJobs);
 
@@ -128,10 +128,10 @@ class AsyncJobsTableTest extends TestCase
      * @return void
      *
      * @covers ::lock()
-     * @expectedException \Cake\Datasource\Exception\RecordNotFoundException
      */
     public function testLockNotPending()
     {
+        $this->expectException(\Cake\Datasource\Exception\RecordNotFoundException::class);
         $this->AsyncJobs->lock('6407afa6-96a3-4aeb-90c1-1541756efdef');
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/AuthProvidersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/AuthProvidersTableTest.php
@@ -42,7 +42,7 @@ class AuthProvidersTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -52,7 +52,7 @@ class AuthProvidersTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->AuthProviders);
 
@@ -127,7 +127,7 @@ class AuthProvidersTableTest extends TestCase
      */
     public function testValidation($expected, array $data)
     {
-        $authProvider = $this->AuthProviders->newEntity();
+        $authProvider = $this->AuthProviders->newEntity([]);
         $this->AuthProviders->patchEntity($authProvider, $data);
 
         $error = (bool)$authProvider->getErrors();

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/CategoriesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/CategoriesTableTest.php
@@ -51,7 +51,7 @@ class CategoriesTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->Categories = TableRegistry::getTableLocator()->get('Categories');
@@ -60,7 +60,7 @@ class CategoriesTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Categories);
         parent::tearDown();

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
@@ -48,7 +48,7 @@ class ConfigTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->Config = TableRegistry::getTableLocator()->get('Config');
@@ -57,7 +57,7 @@ class ConfigTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Config);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/DateRangesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/DateRangesTableTest.php
@@ -45,7 +45,7 @@ class DateRangesTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->DateRanges = TableRegistry::getTableLocator()->get('DateRanges');
@@ -54,7 +54,7 @@ class DateRangesTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->DateRanges);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointPermissionsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointPermissionsTableTest.php
@@ -55,7 +55,7 @@ class EndpointPermissionsTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->EndpointPermissions = TableRegistry::getTableLocator()->get('EndpointPermissions');
@@ -67,7 +67,7 @@ class EndpointPermissionsTableTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->EndpointPermissions);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointsTableTest.php
@@ -49,7 +49,7 @@ class EndpointsTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->Endpoints = TableRegistry::getTableLocator()->get('Endpoints');
@@ -60,7 +60,7 @@ class EndpointsTableTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Endpoints);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ExternalAuthTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ExternalAuthTableTest.php
@@ -60,7 +60,7 @@ class ExternalAuthTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -70,7 +70,7 @@ class ExternalAuthTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->ExternalAuth);
         LoggedUser::resetUser();
@@ -149,7 +149,7 @@ class ExternalAuthTableTest extends TestCase
      */
     public function testValidation($expected, array $data)
     {
-        $externalAuth = $this->ExternalAuth->newEntity();
+        $externalAuth = $this->ExternalAuth->newEntity([]);
         $this->ExternalAuth->patchEntity($externalAuth, $data);
 
         $success = $this->ExternalAuth->save($externalAuth);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
@@ -59,7 +59,7 @@ class FoldersTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -70,7 +70,7 @@ class FoldersTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Folders);
         LoggedUser::resetUser();
@@ -360,12 +360,12 @@ class FoldersTableTest extends TestCase
         $folderIds = [12];
 
         // add subfolders
-        $subfolder = $this->Folders->newEntity();
+        $subfolder = $this->Folders->newEntity([]);
         $subfolder->parent = $parentFolder;
         $this->Folders->save($subfolder);
         $folderIds[] = $subfolder->id;
 
-        $anotherSubfolder = $this->Folders->newEntity();
+        $anotherSubfolder = $this->Folders->newEntity([]);
         $anotherSubfolder->parent = $subfolder;
         $this->Folders->save($anotherSubfolder);
         $folderIds[] = $anotherSubfolder->id;
@@ -420,7 +420,7 @@ class FoldersTableTest extends TestCase
     public function testIsFolderRestorableNoCheckOnParents()
     {
         // new entity
-        $folder = $this->Folders->newEntity();
+        $folder = $this->Folders->newEntity([]);
         static::assertTrue($this->Folders->isFolderRestorable($folder));
 
         // deleted is not dirty

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/HistoryTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/HistoryTableTest.php
@@ -42,7 +42,7 @@ class HistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -54,7 +54,7 @@ class HistoryTableTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->History);
 
@@ -100,7 +100,7 @@ class HistoryTableTest extends TestCase
      */
     public function testValidation(array $expected, array $data)
     {
-        $entity = $this->History->newEntity();
+        $entity = $this->History->newEntity([]);
         $entity = $this->History->patchEntity($entity, $data);
         $errors = array_keys(Hash::flatten($entity->getErrors()));
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/HistoryTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/HistoryTableTest.php
@@ -100,7 +100,7 @@ class HistoryTableTest extends TestCase
      */
     public function testValidation(array $expected, array $data)
     {
-        $entity = $this->History->newEntity([]);
+        $entity = $this->History->newEntity();
         $entity = $this->History->patchEntity($entity, $data);
         $errors = array_keys(Hash::flatten($entity->getErrors()));
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/LinksTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/LinksTableTest.php
@@ -79,7 +79,7 @@ class LinksTableTest extends TestCase
     public function testValidation(array $expected, array $data)
     {
         $this->Links = TableRegistry::getTableLocator()->get('Links');
-        $entity = $this->Links->newEntity();
+        $entity = $this->Links->newEntity([]);
         $entity = $this->Links->patchEntity($entity, $data);
         $errors = array_keys(Hash::flatten($entity->getErrors()));
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
@@ -54,7 +54,7 @@ class LocationsTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -67,7 +67,7 @@ class LocationsTableTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Locations);
         LoggedUser::resetUser();

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/MediaTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/MediaTableTest.php
@@ -40,7 +40,7 @@ class MediaTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -53,7 +53,7 @@ class MediaTableTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Media);
         LoggedUser::resetUser();

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectCategoriesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectCategoriesTableTest.php
@@ -50,7 +50,7 @@ class ObjectCategoriesTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->ObjectCategories = TableRegistry::getTableLocator()->get('ObjectCategories');
@@ -61,7 +61,7 @@ class ObjectCategoriesTableTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->ObjectCategories);
 
@@ -106,7 +106,7 @@ class ObjectCategoriesTableTest extends TestCase
      */
     public function testValidation(array $expected, array $data)
     {
-        $entity = $this->ObjectCategories->newEntity();
+        $entity = $this->ObjectCategories->newEntity([]);
         $entity = $this->ObjectCategories->patchEntity($entity, $data);
         $errors = array_keys(Hash::flatten($entity->getErrors()));
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectPermissionsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectPermissionsTableTest.php
@@ -34,7 +34,7 @@ class ObjectPermissionsTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $config = TableRegistry::exists('ObjectPermissions') ? [] : ['className' => 'BEdita\Core\Model\Table\ObjectPermissionsTable'];
@@ -46,7 +46,7 @@ class ObjectPermissionsTableTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->ObjectPermissions);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectPropertiesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectPropertiesTableTest.php
@@ -34,7 +34,7 @@ class ObjectPropertiesTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $config = TableRegistry::exists('ObjectProperties') ? [] : ['className' => 'BEdita\Core\Model\Table\ObjectPropertiesTable'];
@@ -46,7 +46,7 @@ class ObjectPropertiesTableTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->ObjectProperties);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectRelationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectRelationsTableTest.php
@@ -147,7 +147,7 @@ class ObjectRelationsTableTest extends TestCase
     {
         $this->ObjectRelations->getValidator()->setProvider('jsonSchema', $jsonSchema);
 
-        $objectRelation = $this->ObjectRelations->newEntity([]);
+        $objectRelation = $this->ObjectRelations->newEntity();
         $objectRelation->setNew($isNew);
         $this->ObjectRelations->patchEntity($objectRelation, $data);
         $objectRelation->left_id = 1;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectRelationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectRelationsTableTest.php
@@ -36,7 +36,7 @@ class ObjectRelationsTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -48,7 +48,7 @@ class ObjectRelationsTableTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->ObjectRelations);
 
@@ -147,8 +147,8 @@ class ObjectRelationsTableTest extends TestCase
     {
         $this->ObjectRelations->getValidator()->setProvider('jsonSchema', $jsonSchema);
 
-        $objectRelation = $this->ObjectRelations->newEntity();
-        $objectRelation->isNew($isNew);
+        $objectRelation = $this->ObjectRelations->newEntity([]);
+        $objectRelation->setNew($isNew);
         $this->ObjectRelations->patchEntity($objectRelation, $data);
         $objectRelation->left_id = 1;
         $objectRelation->relation_id = 1;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTagsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTagsTableTest.php
@@ -49,7 +49,7 @@ class ObjectTagsTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->ObjectTags = TableRegistry::getTableLocator()->get('ObjectTags');
@@ -60,7 +60,7 @@ class ObjectTagsTableTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->ObjectTags);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
@@ -60,7 +60,7 @@ class ObjectTypesTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -73,7 +73,7 @@ class ObjectTypesTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->ObjectTypes);
 
@@ -224,7 +224,7 @@ class ObjectTypesTableTest extends TestCase
      */
     public function testValidation($expected, array $data)
     {
-        $objectType = $this->ObjectTypes->newEntity();
+        $objectType = $this->ObjectTypes->newEntity([]);
         if (!empty($data['id'])) {
             $objectType = $this->ObjectTypes->get($data['id']);
         }
@@ -527,7 +527,8 @@ class ObjectTypesTableTest extends TestCase
         $result = $this->ObjectTypes
             ->find('byRelation', $options)
             ->find('list')
-            ->toArray();
+            ->all()
+            ->toList();
 
         static::assertEquals($expected, $result, '', 0, 10, true);
     }
@@ -585,7 +586,7 @@ class ObjectTypesTableTest extends TestCase
      */
     public function testDefaultModelRules(array $data)
     {
-        $objectType = $this->ObjectTypes->newEntity();
+        $objectType = $this->ObjectTypes->newEntity([]);
         $this->ObjectTypes->patchEntity($objectType, $data);
 
         $success = $this->ObjectTypes->save($objectType);
@@ -658,7 +659,7 @@ class ObjectTypesTableTest extends TestCase
             'singular' => 'foo',
             'name' => 'foos',
         ];
-        $entity = $this->ObjectTypes->newEntity();
+        $entity = $this->ObjectTypes->newEntity([]);
         $entity = $this->ObjectTypes->patchEntity($entity, $data);
         $this->ObjectTypes->save($entity);
 
@@ -666,7 +667,7 @@ class ObjectTypesTableTest extends TestCase
             'title' => 'Foo',
         ];
         $table = TableRegistry::getTableLocator()->get('Foos');
-        $entity = $table->newEntity();
+        $entity = $table->newEntity([]);
         $entity = $table->patchEntity($entity, $data);
         $entity->created_by = 1;
         $entity->modified_by = 1;
@@ -682,12 +683,11 @@ class ObjectTypesTableTest extends TestCase
      *
      * @return void
      * @covers ::beforeRules()
-     *
-     * @expectedException \Cake\Http\Exception\ForbiddenException
-     * @expectedExceptionMessage Parent type change forbidden: objects of this type exist
      */
     public function testChangeParent()
     {
+        $this->expectException(\Cake\Http\Exception\ForbiddenException::class);
+        $this->expectExceptionMessage('Parent type change forbidden: objects of this type exist');
         $objectType = $this->ObjectTypes->get('users');
         $objectType->set('parent_name', 'media');
         $this->ObjectTypes->save($objectType);
@@ -763,7 +763,7 @@ class ObjectTypesTableTest extends TestCase
             $this->expectException(get_class($expected));
             $this->expectExceptionMessage($expected->getMessage());
         }
-        $objectType = $this->ObjectTypes->newEntity();
+        $objectType = $this->ObjectTypes->newEntity([]);
         if (!empty($data['id'])) {
             $objectType = $this->ObjectTypes->get($data['id']);
         }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -55,7 +55,7 @@ class ObjectsTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -66,7 +66,7 @@ class ObjectsTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Objects);
         LoggedUser::resetUser();
@@ -353,7 +353,7 @@ class ObjectsTableTest extends TestCase
      */
     public function testSaveDateRanges()
     {
-        $object = $this->Objects->newEntity();
+        $object = $this->Objects->newEntity([]);
         $object->type = 'events';
 
         $data = [
@@ -478,7 +478,7 @@ class ObjectsTableTest extends TestCase
             $this->expectException(PersistenceFailedException::class);
         }
 
-        $object = $this->Objects->newEntity();
+        $object = $this->Objects->newEntity([]);
         $object->type = $type;
 
         $result = $this->Objects->saveOrFail($object);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
@@ -57,7 +57,7 @@ class ProfilesTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -70,7 +70,7 @@ class ProfilesTableTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Profiles);
         LoggedUser::resetUser();

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertiesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertiesTableTest.php
@@ -43,7 +43,7 @@ class PropertiesTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -53,7 +53,7 @@ class PropertiesTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Properties);
 
@@ -114,7 +114,7 @@ class PropertiesTableTest extends TestCase
      */
     public function testValidation($expected, array $data)
     {
-        $property = $this->Properties->newEntity();
+        $property = $this->Properties->newEntity([]);
         $this->Properties->patchEntity($property, $data);
         $property->object_type_id = 1;
         $property->property_type_id = 1;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertyTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertyTypesTableTest.php
@@ -57,7 +57,7 @@ class PropertyTypesTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -70,7 +70,7 @@ class PropertyTypesTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->PropertyTypes);
 
@@ -192,12 +192,12 @@ class PropertyTypesTableTest extends TestCase
      * @return void
      *
      * @covers ::beforeDelete()
-     * @expectedException \Cake\Http\Exception\ForbiddenException
-     * @expectedExceptionCode 403
-     * @expectedExceptionMessage Property type with existing properties
      */
     public function testBeforeDeleteInUse()
     {
+        $this->expectException(\Cake\Http\Exception\ForbiddenException::class);
+        $this->expectExceptionCode('403');
+        $this->expectExceptionMessage('Property type with existing properties');
         $propertyType = $this->PropertyTypes->get(1);
 
         $this->PropertyTypes->delete($propertyType);
@@ -311,12 +311,12 @@ class PropertyTypesTableTest extends TestCase
      * @return void
      *
      * @covers ::beforeSave()
-     * @expectedException \BEdita\Core\Exception\ImmutableResourceException
-     * @expectedExceptionCode 403
-     * @expectedExceptionMessage Could not modify core property
      */
     public function testBeforeSaveForbidden()
     {
+        $this->expectException(\BEdita\Core\Exception\ImmutableResourceException::class);
+        $this->expectExceptionCode('403');
+        $this->expectExceptionMessage('Could not modify core property');
         $propertyType = $this->PropertyTypes->get(1);
         $propertyType->set('name', 'gustavo');
         $this->PropertyTypes->save($propertyType);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/PublicationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/PublicationsTableTest.php
@@ -80,7 +80,7 @@ class PublicationsTableTest extends TestCase
     public function testValidation(array $expected, array $data)
     {
         $this->Publications = TableRegistry::getTableLocator()->get('Publications');
-        $entity = $this->Publications->newEntity();
+        $entity = $this->Publications->newEntity([]);
         $entity = $this->Publications->patchEntity($entity, $data);
         $errors = array_keys(Hash::flatten($entity->getErrors()));
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationTypesTableTest.php
@@ -46,7 +46,7 @@ class RelationTypesTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -61,7 +61,7 @@ class RelationTypesTableTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->RelationTypes);
 
@@ -119,7 +119,7 @@ class RelationTypesTableTest extends TestCase
      */
     public function testValidation($expected, array $data)
     {
-        $objectType = $this->RelationTypes->newEntity();
+        $objectType = $this->RelationTypes->newEntity([]);
         $this->RelationTypes->patchEntity($objectType, $data);
 
         $success = $this->RelationTypes->save($objectType);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
@@ -50,7 +50,7 @@ class RelationsTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -65,7 +65,7 @@ class RelationsTableTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Relations);
 
@@ -144,7 +144,7 @@ class RelationsTableTest extends TestCase
     public function testValidation($expected, array $data)
     {
         if (empty($data['id'])) {
-            $objectType = $this->Relations->newEntity();
+            $objectType = $this->Relations->newEntity([]);
         } else {
             $objectType = $this->Relations->get($data['id']);
         }
@@ -200,6 +200,7 @@ class RelationsTableTest extends TestCase
 
         $result = $this->Relations
             ->find('byName', $options)
+            ->all()
             ->extract('id')
             ->toArray();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
@@ -54,7 +54,7 @@ class RolesTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -65,7 +65,7 @@ class RolesTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Roles);
         LoggedUser::resetUser();
@@ -127,7 +127,7 @@ class RolesTableTest extends TestCase
      */
     public function testValidation($expected, array $data)
     {
-        $role = $this->Roles->newEntity();
+        $role = $this->Roles->newEntity([]);
         $this->Roles->patchEntity($role, $data);
 
         $error = (bool)$role->getErrors();
@@ -162,13 +162,13 @@ class RolesTableTest extends TestCase
     /**
      * Test delete admin role
      *
-     * @expectedException \BEdita\Core\Exception\ImmutableResourceException
-     * @expectedExceptionCode 403
-     * @expectedExceptionMessage Could not delete "Role" 1
      * @covers ::beforeDelete
      */
     public function testDeleteAdminRole()
     {
+        $this->expectException(\BEdita\Core\Exception\ImmutableResourceException::class);
+        $this->expectExceptionCode('403');
+        $this->expectExceptionMessage('Could not delete "Role" 1');
         $role = $this->Roles->get(RolesTable::ADMIN_ROLE);
         $this->Roles->delete($role);
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesUsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesUsersTableTest.php
@@ -49,7 +49,7 @@ class RolesUsersTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -59,7 +59,7 @@ class RolesUsersTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->RolesUsers);
 
@@ -103,7 +103,7 @@ class RolesUsersTableTest extends TestCase
      */
     public function testValidation($expected, array $data)
     {
-        $objectType = $this->RolesUsers->newEntity();
+        $objectType = $this->RolesUsers->newEntity([]);
         $this->RolesUsers->patchEntity($objectType, $data);
 
         $success = $this->RolesUsers->save($objectType);
@@ -113,13 +113,13 @@ class RolesUsersTableTest extends TestCase
     /**
      * Test delete admin role association
      *
-     * @expectedException \BEdita\Core\Exception\ImmutableResourceException
-     * @expectedExceptionCode 403
-     * @expectedExceptionMessage Could not update relationship for users/roles for ADMIN_USER and ADMIN_ROLE
      * @covers ::beforeDelete
      */
     public function testDeleteAdminRole()
     {
+        $this->expectException(\BEdita\Core\Exception\ImmutableResourceException::class);
+        $this->expectExceptionCode('403');
+        $this->expectExceptionMessage('Could not update relationship for users/roles for ADMIN_USER and ADMIN_ROLE');
         $entity = $this->RolesUsers->get(1);
         $this->RolesUsers->delete($entity);
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/StaticPropertiesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/StaticPropertiesTableTest.php
@@ -55,7 +55,7 @@ class StaticPropertiesTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -65,7 +65,7 @@ class StaticPropertiesTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->StaticProperties);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/StreamsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/StreamsTableTest.php
@@ -51,7 +51,7 @@ class StreamsTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->Streams = TableRegistry::getTableLocator()->get('Streams');
@@ -61,7 +61,7 @@ class StreamsTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->filesystemRestore();
         unset($this->Streams);
@@ -139,7 +139,7 @@ class StreamsTableTest extends TestCase
      */
     public function testValidation($expected, array $data, $uuid = false)
     {
-        $stream = $this->Streams->newEntity();
+        $stream = $this->Streams->newEntity([]);
         if ($uuid !== false) {
             $stream = $this->Streams->get($uuid);
         }
@@ -175,7 +175,7 @@ class StreamsTableTest extends TestCase
             'contents' => 'Not really GZipped',
         ];
 
-        $stream = $this->Streams->newEntity();
+        $stream = $this->Streams->newEntity([]);
         $stream = $this->Streams->patchEntity($stream, $data);
 
         $this->Streams->saveOrFail($stream);
@@ -205,7 +205,7 @@ class StreamsTableTest extends TestCase
             'contents' => 'Not really GZipped',
         ];
 
-        $stream = $this->Streams->newEntity();
+        $stream = $this->Streams->newEntity([]);
         $stream->uuid = $uuid;
         $stream = $this->Streams->patchEntity($stream, $data);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/TagsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/TagsTableTest.php
@@ -51,7 +51,7 @@ class TagsTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->Tags = TableRegistry::getTableLocator()->get('Tags');
@@ -60,7 +60,7 @@ class TagsTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Tags);
         parent::tearDown();

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/TranslationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/TranslationsTableTest.php
@@ -46,7 +46,7 @@ class TranslationsTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -56,7 +56,7 @@ class TranslationsTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Translations);
 
@@ -137,7 +137,7 @@ class TranslationsTableTest extends TestCase
      */
     public function testValidation(array $expected, array $data)
     {
-        $entity = $this->Translations->newEntity();
+        $entity = $this->Translations->newEntity([]);
         $entity = $this->Translations->patchEntity($entity, $data);
         $errors = array_keys(Hash::flatten($entity->getErrors()));
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/TranslationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/TranslationsTableTest.php
@@ -137,7 +137,7 @@ class TranslationsTableTest extends TestCase
      */
     public function testValidation(array $expected, array $data)
     {
-        $entity = $this->Translations->newEntity([]);
+        $entity = $this->Translations->newEntity();
         $entity = $this->Translations->patchEntity($entity, $data);
         $errors = array_keys(Hash::flatten($entity->getErrors()));
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/TreesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/TreesTableTest.php
@@ -60,7 +60,7 @@ class TreesTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -72,7 +72,7 @@ class TreesTableTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Trees);
 
@@ -144,7 +144,7 @@ class TreesTableTest extends TestCase
      */
     public function testIsParentValid($expected, $parentId, $objectId = null)
     {
-        $entity = $this->Trees->newEntity();
+        $entity = $this->Trees->newEntity([]);
         if ($objectId !== null) {
             $entity->object_id = $objectId;
         }
@@ -200,7 +200,7 @@ class TreesTableTest extends TestCase
         $this->Trees->deleteAll(['object_id' => 13]);
         $this->Trees->recover();
 
-        $entity = $this->Trees->newEntity();
+        $entity = $this->Trees->newEntity([]);
         $entity->object_id = $objectId;
         $entity->parent_id = $parentId;
         static::assertEquals($expected, $this->Trees->isPositionUnique($entity));
@@ -240,13 +240,13 @@ class TreesTableTest extends TestCase
     {
         $node = $this->Trees->get(2);
         static::assertEquals(11, $node->root_id);
-        $children = $this->Trees->find('children', ['for' => 2])->toList();
+        $children = $this->Trees->find('children', ['for' => 2])->all()->toList();
 
         $node->parent_id = $parentId;
         static::assertTrue((bool)$this->Trees->save($node));
 
         $node = $this->Trees->get(2);
-        $actualChildren = $this->Trees->find('children', ['for' => 2])->toList();
+        $actualChildren = $this->Trees->find('children', ['for' => 2])->all()->toList();
 
         static::assertEquals($rootExpected, $node->root_id);
         static::assertCount(count($children), $actualChildren);
@@ -280,10 +280,10 @@ class TreesTableTest extends TestCase
      *
      * @return void
      * @coversNothing
-     * @expectedException \RuntimeException
      */
     public function testMoveParentAsChild()
     {
+        $this->expectException(\RuntimeException::class);
         // create new Folder
         LoggedUser::setUser(['id' => 1]);
         $Folders = TableRegistry::getTableLocator()->get('Folders');

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UserTokensTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UserTokensTableTest.php
@@ -39,7 +39,7 @@ class UserTokensTableTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->UserTokens = TableRegistry::getTableLocator()->get('UserTokens');
@@ -50,7 +50,7 @@ class UserTokensTableTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->UserTokens);
 
@@ -116,7 +116,7 @@ class UserTokensTableTest extends TestCase
      */
     public function testValidation(array $expected, array $data)
     {
-        $entity = $this->UserTokens->newEntity();
+        $entity = $this->UserTokens->newEntity([]);
         $entity = $this->UserTokens->patchEntity($entity, $data);
         $errors = array_keys(Hash::flatten($entity->getErrors()));
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -64,7 +64,7 @@ class UsersTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -75,7 +75,7 @@ class UsersTableTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Users);
         LoggedUser::resetUser();
@@ -197,7 +197,7 @@ class UsersTableTest extends TestCase
      */
     public function testValidation($expected, array $data)
     {
-        $user = $this->Users->newEntity();
+        $user = $this->Users->newEntity([]);
         $this->Users->patchEntity($user, $data);
         $user->type = 'users';
 
@@ -352,13 +352,13 @@ class UsersTableTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \BEdita\Core\Exception\ImmutableResourceException
-     * @expectedExceptionCode 403
-     * @expectedExceptionMessage Could not delete "User" 1
      * @covers ::beforeSave
      */
     public function testSoftDeleteAdminUser()
     {
+        $this->expectException(\BEdita\Core\Exception\ImmutableResourceException::class);
+        $this->expectExceptionCode('403');
+        $this->expectExceptionMessage('Could not delete "User" 1');
         $user = $this->Users->get(UsersTable::ADMIN_USER);
         $user->deleted = true;
         $this->Users->save($user);
@@ -369,13 +369,13 @@ class UsersTableTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \Cake\Http\Exception\BadRequestException
-     * @expectedExceptionCode 400
-     * @expectedExceptionMessage Logged users cannot delete their own account
      * @covers ::beforeSave
      */
     public function testSoftDeleteLoggedUser()
     {
+        $this->expectException(\Cake\Http\Exception\BadRequestException::class);
+        $this->expectExceptionCode('400');
+        $this->expectExceptionMessage('Logged users cannot delete their own account');
         LoggedUser::setUser(['id' => 5]);
         $user = $this->Users->get(5);
         $user->deleted = true;
@@ -401,13 +401,13 @@ class UsersTableTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \BEdita\Core\Exception\ImmutableResourceException
-     * @expectedExceptionCode 403
-     * @expectedExceptionMessage Could not delete "User" 1
      * @covers ::beforeDelete
      */
     public function testHardDeleteAdminUser()
     {
+        $this->expectException(\BEdita\Core\Exception\ImmutableResourceException::class);
+        $this->expectExceptionCode('403');
+        $this->expectExceptionMessage('Could not delete "User" 1');
         $user = $this->Users->get(UsersTable::ADMIN_USER);
         $this->Users->delete($user);
     }
@@ -539,7 +539,7 @@ class UsersTableTest extends TestCase
     {
         Configure::write('Signup', $config);
 
-        $user = $this->Users->newEntity();
+        $user = $this->Users->newEntity([]);
         $this->Users->patchEntity($user, $data, ['validate' => 'signup']);
         $user->type = 'users';
 
@@ -565,7 +565,7 @@ class UsersTableTest extends TestCase
             'email' => 'test@email.com',
         ];
 
-        $user = $this->Users->newEntity();
+        $user = $this->Users->newEntity([]);
         $this->Users->patchEntity($user, $data, ['validate' => 'signupExternal']);
 
         $error = (bool)$user->getErrors();
@@ -619,12 +619,12 @@ class UsersTableTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \BEdita\Core\Exception\BadFilterException
-     * @expectedExceptionMessage Missing required parameter "roles"
      * @covers ::findRoles()
      */
     public function testFindRolesFail()
     {
+        $this->expectException(\BEdita\Core\Exception\BadFilterException::class);
+        $this->expectExceptionMessage('Missing required parameter "roles"');
         $this->Users->find('roles', [])
             ->toArray();
     }
@@ -679,7 +679,7 @@ class UsersTableTest extends TestCase
             $this->expectExceptionMessage($expected->getMessage());
         }
 
-        $user = $this->Users->newEntity();
+        $user = $this->Users->newEntity([]);
         $user = $this->Users->patchEntity($user, $data);
         $success = $this->Users->save($user);
 
@@ -727,7 +727,7 @@ class UsersTableTest extends TestCase
      */
     public function testCustomPropsCreate(array $data)
     {
-        $user = $this->Users->newEntity();
+        $user = $this->Users->newEntity([]);
         $user = $this->Users->patchEntity($user, $data);
         $user->type = 'users';
         $success = $this->Users->save($user);
@@ -886,7 +886,7 @@ class UsersTableTest extends TestCase
             $this->expectExceptionMessage($expected->getMessage());
         }
 
-        $user = $this->Users->newEntity();
+        $user = $this->Users->newEntity([]);
         $this->Users->patchEntity($user, $data);
 
         $success = $this->Users->save($user);

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/AssociationCollectionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/AssociationCollectionTest.php
@@ -32,7 +32,7 @@ class AssociationCollectionTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/FakeAnimalsTrait.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/FakeAnimalsTrait.php
@@ -51,7 +51,7 @@ trait FakeAnimalsTrait
      *
      * @return array
      */
-    public function getFixtures()
+    public function getFixtures(): array
     {
         return [
             'plugin.BEdita/Core.FakeAnimals',

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/InheritanceEventHandlerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/InheritanceEventHandlerTest.php
@@ -36,7 +36,7 @@ class InheritanceEventHandlerTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -216,7 +216,7 @@ class InheritanceEventHandlerTest extends TestCase
      */
     public function testBeforeSave($expected, $data)
     {
-        $feline = $this->fakeFelines->newEntity();
+        $feline = $this->fakeFelines->newEntity([]);
         if (!empty($data['id'])) {
             $feline = $this->fakeFelines->get($data['id']);
         }
@@ -264,7 +264,7 @@ class InheritanceEventHandlerTest extends TestCase
             return false; // This table is not meant to store data of your pet!
         });
 
-        $feline = $this->fakeFelines->newEntity();
+        $feline = $this->fakeFelines->newEntity([]);
         $feline = $this->fakeFelines->patchEntity($feline, $data);
         $result = $this->fakeFelines->save($feline);
 

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/MarshallerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/MarshallerTest.php
@@ -28,7 +28,7 @@ class MarshallerTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/QueryTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/QueryTest.php
@@ -32,7 +32,7 @@ class QueryTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/TableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/TableTest.php
@@ -36,7 +36,7 @@ class TableTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -560,11 +560,11 @@ class TableTest extends TestCase
      * @return void
      *
      * @covers ::callFinder()
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Unknown finder method "gustavo"
      */
     public function testCallMissingFinder()
     {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Unknown finder method "gustavo"');
         $this->fakeMammals->find('gustavo');
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
@@ -46,7 +46,7 @@ class QueryFilterTraitTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/BEdita/Core/tests/TestCase/ORM/TableLocatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/TableLocatorTest.php
@@ -43,7 +43,7 @@ class TableLocatorTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/BEdita/Core/tests/TestCase/Shell/BeditaShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/BeditaShellTest.php
@@ -18,16 +18,13 @@ use Cake\Console\Shell;
 use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\ConsoleIntegrationTestCase;
-use Cake\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Utility\Hash;
 
 /**
  * @coversDefaultClass \BEdita\Core\Shell\BeditaShell
  */
-class BeditaShellTest
+class BeditaShellTest extends ConsoleIntegrationTestCase
 {
-    use ConsoleIntegrationTestTrait;
-
     /**
      * Name for temporary configuration file.
      *
@@ -47,7 +44,9 @@ class BeditaShellTest
      */
     public function setUp(): void
     {
-        static::$fixtureManager->shutDown();
+        parent::setUp();
+
+        $this->fixtureManager->shutDown();
 
         // Try to avoid "database schema has changed" error on SQLite.
         try {

--- a/plugins/BEdita/Core/tests/TestCase/Shell/BeditaShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/BeditaShellTest.php
@@ -18,13 +18,16 @@ use Cake\Console\Shell;
 use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\ConsoleIntegrationTestCase;
+use Cake\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Utility\Hash;
 
 /**
  * @coversDefaultClass \BEdita\Core\Shell\BeditaShell
  */
-class BeditaShellTest extends ConsoleIntegrationTestCase
+class BeditaShellTest
 {
+    use ConsoleIntegrationTestTrait;
+
     /**
      * Name for temporary configuration file.
      *
@@ -42,11 +45,9 @@ class BeditaShellTest extends ConsoleIntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
-        parent::setUp();
-
-        $this->fixtureManager->shutDown();
+        static::$fixtureManager->shutDown();
 
         // Try to avoid "database schema has changed" error on SQLite.
         try {
@@ -59,7 +60,7 @@ class BeditaShellTest extends ConsoleIntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         ConnectionManager::alias('test', 'default'); // Restore alias which is dropped by `BeditaShell`.
         ConnectionManager::get('default')->getDriver()->disconnect();
@@ -86,8 +87,6 @@ class BeditaShellTest extends ConsoleIntegrationTestCase
         if (file_exists(static::TEMP_FILE)) {
             unlink(static::TEMP_FILE);
         }
-
-        parent::tearDown();
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Shell/JobsShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/JobsShellTest.php
@@ -38,7 +38,7 @@ class JobsShellTest extends ConsoleIntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/plugins/BEdita/Core/tests/TestCase/Shell/StreamsShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/StreamsShellTest.php
@@ -31,7 +31,7 @@ class StreamsShellTest extends ConsoleIntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->filesystemSetup(true, true);
@@ -41,7 +41,7 @@ class StreamsShellTest extends ConsoleIntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->filesystemRestore();
         unset($this->Streams);

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckApiKeyTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckApiKeyTaskTest.php
@@ -43,7 +43,7 @@ class CheckApiKeyTaskTest extends ConsoleIntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -53,7 +53,7 @@ class CheckApiKeyTaskTest extends ConsoleIntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Applications);
 

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckFilesystemTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckFilesystemTaskTest.php
@@ -32,7 +32,7 @@ class CheckFilesystemTaskTest extends ConsoleIntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         if (file_exists(static::TEMP_DIR)) {
             if (!is_writable(static::TEMP_DIR)) {

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckSchemaTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckSchemaTaskTest.php
@@ -21,22 +21,22 @@ use Cake\Database\Driver\Mysql;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
-use Cake\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\ConsoleIntegrationTestCase;
 use Cake\Utility\Hash;
 
 /**
  * @coversDefaultClass \BEdita\Core\Shell\Task\CheckSchemaTask
  */
-class CheckSchemaTaskTest
+class CheckSchemaTaskTest extends ConsoleIntegrationTestCase
 {
-    use ConsoleIntegrationTestTrait;
-
     /**
      * {@inheritDoc}
      */
     public function setUp(): void
     {
-        static::$fixtureManager->shutDown();
+        parent::setUp();
+
+        $this->fixtureManager->shutDown();
 
         $this->exec('db_admin init -fs');
     }

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckSchemaTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckSchemaTaskTest.php
@@ -21,22 +21,22 @@ use Cake\Database\Driver\Mysql;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
-use Cake\TestSuite\ConsoleIntegrationTestCase;
+use Cake\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Utility\Hash;
 
 /**
  * @coversDefaultClass \BEdita\Core\Shell\Task\CheckSchemaTask
  */
-class CheckSchemaTaskTest extends ConsoleIntegrationTestCase
+class CheckSchemaTaskTest
 {
+    use ConsoleIntegrationTestTrait;
+
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
-        parent::setUp();
-
-        $this->fixtureManager->shutDown();
+        static::$fixtureManager->shutDown();
 
         $this->exec('db_admin init -fs');
     }
@@ -44,7 +44,7 @@ class CheckSchemaTaskTest extends ConsoleIntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         ConnectionManager::get('default')
             ->transactional(function (Connection $connection) {
@@ -63,8 +63,6 @@ class CheckSchemaTaskTest extends ConsoleIntegrationTestCase
                     }
                 }
             });
-
-        parent::tearDownAfterClass();
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckTreeTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckTreeTaskTest.php
@@ -51,7 +51,7 @@ class CheckTreeTaskTest extends ConsoleIntegrationTestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -63,7 +63,7 @@ class CheckTreeTaskTest extends ConsoleIntegrationTestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Trees);
 

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/InitSchemaTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/InitSchemaTaskTest.php
@@ -30,17 +30,17 @@ class InitSchemaTaskTest extends ConsoleIntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
-        $this->fixtureManager->shutDown();
+        static::$fixtureManager->shutDown();
     }
 
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         ConnectionManager::get('default')
             ->transactional(function (Connection $connection) {

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/InitSchemaTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/InitSchemaTaskTest.php
@@ -34,7 +34,7 @@ class InitSchemaTaskTest extends ConsoleIntegrationTestCase
     {
         parent::setUp();
 
-        static::$fixtureManager->shutDown();
+        $this->fixtureManager->shutDown();
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/RecoverTreeTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/RecoverTreeTaskTest.php
@@ -48,7 +48,7 @@ class RecoverTreeTaskTest extends ConsoleIntegrationTestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -60,7 +60,7 @@ class RecoverTreeTaskTest extends ConsoleIntegrationTestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Trees);
 
@@ -81,6 +81,7 @@ class RecoverTreeTaskTest extends ConsoleIntegrationTestCase
          */
         $getTreeState = function () {
             return $this->Trees->find()
+                ->all()
                 ->combine('id', function (EntityInterface $node) {
                     return sprintf('%d / %d', $node['tree_left'], $node['tree_right']);
                 })

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/SetupAdminUserTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/SetupAdminUserTaskTest.php
@@ -50,7 +50,7 @@ class SetupAdminUserTaskTest extends ConsoleIntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -60,7 +60,7 @@ class SetupAdminUserTaskTest extends ConsoleIntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Users);
 

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/SetupConnectionTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/SetupConnectionTaskTest.php
@@ -44,7 +44,7 @@ class SetupConnectionTaskTest extends ConsoleIntegrationTestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         if (in_array(static::TEMP_CONNECTION, ConnectionManager::configured())) {
             ConnectionManager::drop(static::TEMP_CONNECTION);

--- a/plugins/BEdita/Core/tests/TestCase/State/CurrentApplicationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/State/CurrentApplicationTest.php
@@ -48,7 +48,7 @@ class CurrentApplicationTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -62,7 +62,7 @@ class CurrentApplicationTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->Applications);
 
@@ -182,10 +182,10 @@ class CurrentApplicationTest extends TestCase
      * @return void
      *
      * @covers ::setFromApiKey()
-     * @expectedException \Cake\Datasource\Exception\RecordNotFoundException
      */
     public function testSetFromApiKeyFailure()
     {
+        $this->expectException(\Cake\Datasource\Exception\RecordNotFoundException::class);
         CurrentApplication::setFromApiKey('INVALID_API_KEY');
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Utility/DatabaseTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/DatabaseTest.php
@@ -51,7 +51,7 @@ class DatabaseTest extends TestCase
      */
     public function testCurrentSchema()
     {
-        $this->fixtureManager->shutDown();
+        static::$fixtureManager->shutDown();
 
         $fixtures = ['Applications', 'Config', 'ObjectTypes', 'Roles'];
         $this->loadFixtures(...$fixtures);
@@ -77,11 +77,11 @@ class DatabaseTest extends TestCase
      *
      * @return void
      *
-     * @expectedException \Cake\Datasource\Exception\MissingDatasourceConfigException
      * @covers ::currentSchema()
      */
     public function testMissingDatasourceConfigException()
     {
+        $this->expectException(\Cake\Datasource\Exception\MissingDatasourceConfigException::class);
         Database::currentSchema('zzzzzzzz');
     }
 
@@ -95,7 +95,7 @@ class DatabaseTest extends TestCase
      */
     public function testSchemaCompare()
     {
-        $this->fixtureManager->shutDown();
+        static::$fixtureManager->shutDown();
 
         $fixtures1 = ['Applications', 'Config', 'ObjectTypes'];
         $this->loadFixtures(...$fixtures1);

--- a/plugins/BEdita/Core/tests/TestCase/Utility/DatabaseTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/DatabaseTest.php
@@ -51,7 +51,9 @@ class DatabaseTest extends TestCase
      */
     public function testCurrentSchema()
     {
-        static::$fixtureManager->shutDown();
+        parent::setUp();
+
+        $this->fixtureManager->shutDown();
 
         $fixtures = ['Applications', 'Config', 'ObjectTypes', 'Roles'];
         $this->loadFixtures(...$fixtures);
@@ -95,7 +97,7 @@ class DatabaseTest extends TestCase
      */
     public function testSchemaCompare()
     {
-        static::$fixtureManager->shutDown();
+        $this->fixtureManager->shutDown();
 
         $fixtures1 = ['Applications', 'Config', 'ObjectTypes'];
         $this->loadFixtures(...$fixtures1);

--- a/plugins/BEdita/Core/tests/TestCase/Utility/JsonSchemaTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/JsonSchemaTest.php
@@ -51,7 +51,7 @@ class JsonSchemaTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -264,7 +264,7 @@ class JsonSchemaTest extends TestCase
             'property_type_name' => 'string',
             'object_type_name' => 'documents',
         ];
-        $entity = $properties->newEntity();
+        $entity = $properties->newEntity([]);
         $entity = $properties->patchEntity($entity, $data);
         $entity = $properties->save($entity);
         $result = JsonSchema::generate($type, $url);

--- a/plugins/BEdita/Core/tests/TestCase/Utility/LoggedUserTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/LoggedUserTest.php
@@ -25,7 +25,7 @@ class LoggedUserTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         LoggedUser::resetUser();
     }

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHandlerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHandlerTest.php
@@ -46,7 +46,7 @@ class ObjectsHandlerTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -56,7 +56,7 @@ class ObjectsHandlerTest extends TestCase
     /**
      * {@inheritDoc}
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 
@@ -102,10 +102,10 @@ class ObjectsHandlerTest extends TestCase
      *
      * @return void
      * @covers ::save()
-     * @expectedException \Cake\ORM\Exception\PersistenceFailedException
      */
     public function testSaveException()
     {
+        $this->expectException(\Cake\ORM\Exception\PersistenceFailedException::class);
         $data = [];
         ObjectsHandler::save('users', $data);
     }
@@ -144,10 +144,10 @@ class ObjectsHandlerTest extends TestCase
      *
      * @return void
      * @covers ::remove()
-     * @expectedException \Cake\Datasource\Exception\RecordNotFoundException
      */
     public function testDeleteException()
     {
+        $this->expectException(\Cake\Datasource\Exception\RecordNotFoundException::class);
         ObjectsHandler::remove(123456);
     }
 
@@ -156,11 +156,11 @@ class ObjectsHandlerTest extends TestCase
      *
      * @return void
      * @covers ::checkEnvironment()
-     * @expectedException \Cake\Console\Exception\StopException
-     * @expectedExceptionMessage Operation avilable only in CLI environment
      */
     public function testEnvironment()
     {
+        $this->expectException(\Cake\Console\Exception\StopException::class);
+        $this->expectExceptionMessage('Operation avilable only in CLI environment');
         $testClass = new class extends ObjectsHandler {
             protected static function isCli(): bool
             {


### PR DESCRIPTION
This PR introduces some changes to simplify the migration to CakePHP4 

In this PR only changes to Unit tests have been considered.

*  `public function setUp()` and `public function tearDown()` now have the return type `: void` 
* `@expectedException` and `@expectedExceptionMessage` annotation have been moved to `$this->expectException###()` methods
* `$request` controller attribute is protected in Cake4 => use `getRequest()`
* `$response` controller attribute is protected in Cake4 => use `getResponse()`
* in `Table::newEntity()` signature is changed in Cake4, an array is required as argument => use `newEntity([])` instead `newEntity()` for empty new entities