### PR TITLE
feat: introduce exact search

### DIFF
--- a/plugins/BEdita/Core/tests/Fixture/FakeSearchesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeSearchesFixture.php
@@ -42,5 +42,7 @@ class FakeSearchesFixture extends TestFixture
     public $records = [
         ['name' => 'hippo-tiger'],
         ['name' => 'lion_snake'],
+        ['name' => 'big mouse'],
+        ['name' => 'mouse big'],
     ];
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
@@ -170,13 +170,6 @@ class SearchableBehaviorTest extends TestCase
                 'eutheria cat',
                 'FakeMammals',
             ],
-            'bad type' => [
-                new BadFilterException([
-                    'title' => 'Invalid data',
-                    'detail' => 'query filter requires a non-empty query string',
-                ]),
-                ['not', 'a', 'string'],
-            ],
             'short words' => [
                 new BadFilterException([
                     'title' => 'Invalid data',
@@ -205,18 +198,48 @@ class SearchableBehaviorTest extends TestCase
                 'lion_snake',
                 'FakeSearches',
             ],
-             'search underscore 2' => [
-                 [
-                     2 => 'lion_snake',
-                 ],
-                 'li_n',
-                 'FakeSearches',
-             ],
-             'search case' => [
+            'search underscore 2' => [
+                [
+                   2 => 'lion_snake',
+                ],
+                'li_n',
+                'FakeSearches',
+            ],
+            'search case' => [
                 [
                     1 => 'hippo-tiger',
                 ],
                 'HIPPO',
+                'FakeSearches',
+            ],
+            'basic with "string" param' => [
+                [
+                   1 => 'hippo-tiger',
+                ],
+                [
+                    'string' => 'hippo',
+                ],
+                'FakeSearches',
+            ],
+            'exact false' => [
+                [
+                    3 => 'big mouse',
+                    4 => 'mouse big',
+                ],
+                [
+                    'string' => 'big mouse',
+                    'exact' => 0,
+                ],
+                'FakeSearches',
+            ],
+            'exact' => [
+                [
+                    3 => 'big mouse',
+                ],
+                [
+                    'string' => 'big mouse',
+                    'exact' => 1,
+                ],
                 'FakeSearches',
             ],
         ];
@@ -226,7 +249,7 @@ class SearchableBehaviorTest extends TestCase
      * Test finder for query string.
      *
      * @param array|\Exception $expected Expected result.
-     * @param string $query Query string.
+     * @param string|array $query Query string.
      * @param string $table Table.
      * @return void
      *
@@ -247,7 +270,7 @@ class SearchableBehaviorTest extends TestCase
         static::assertTrue($table->hasFinder('query'));
 
         $result = $table
-            ->find('query', [$query])
+            ->find('query', (array)$query)
             ->find('list')
             ->toArray();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
@@ -242,6 +242,16 @@ class SearchableBehaviorTest extends TestCase
                 ],
                 'FakeSearches',
             ],
+            'query with string param not a string' => [
+                new BadFilterException([
+                    'title' => 'Invalid data',
+                    'detail' => 'query filter requires a non-empty query string',
+                ]),
+                [
+                    'string' => 1,
+                ],
+                'FakeSearches',
+            ],
         ];
     }
 


### PR DESCRIPTION
Introduce exact search. 

From @fquffio : 

Just a quick note: from an API's perspective, the existing functionality is preserved and expanded.

The following requests are now possible:

- `GET /objects?filter[query]=foo+bar` — existing functionality
- `GET /objects?filter[query][string]=foo+bar&filter[query][exact]=0` — same as existing functionality (`exact` is off by default, and may be omitted)
- `GET /objects?filter[query][string]=foo+bar&filter[query][exact]=1` — expanded functionality: the query string is searched exactly as provided, without searching word by word

The "exact" search performs an exact match with the whole query string, rather than splitting words and searching them one by one.

For instance, when searching "foo bar", a document whose title is "some bar are foo" will not match.
