### PR TITLE
Fix migration CreateTagsTable

### DIFF
--- a/plugins/BEdita/Core/config/Migrations/20220316140137_CreateTagsTable.php
+++ b/plugins/BEdita/Core/config/Migrations/20220316140137_CreateTagsTable.php
@@ -190,6 +190,13 @@ class CreateTagsTable extends AbstractMigration
      */
     public function down()
     {
+        /**
+         * Drop foreign key categories_objecttypesid_fk, before updating
+         */
+        $this->table('categories')
+            ->dropForeignKey('object_type_id')
+            ->update();
+
         /*
          * Make `categories.object_type_id` nullable.
          */
@@ -202,6 +209,21 @@ class CreateTagsTable extends AbstractMigration
                 'signed' => false,
             ])
             ->update();
+
+        /**
+         * Add categories_objecttypesid_fk foreign key
+         */
+        $this->table('categories')->addForeignKey(
+            'object_type_id',
+            'object_types',
+            'id',
+            [
+                'constraint' => 'categories_objecttypesid_fk',
+                'update' => 'NO_ACTION',
+                'delete' => 'CASCADE',
+            ]
+        )
+        ->update();
 
         /*
          * Move tags from `tags` to `categories`.

--- a/plugins/BEdita/Core/config/Migrations/20220316140137_CreateTagsTable.php
+++ b/plugins/BEdita/Core/config/Migrations/20220316140137_CreateTagsTable.php
@@ -149,6 +149,13 @@ class CreateTagsTable extends AbstractMigration
                 ->execute();
         });
 
+        /**
+         * Drop foreign key categories_objecttypesid_fk, before updating
+         */
+        $this->table('categories')
+            ->dropForeignKey('object_type_id')
+            ->update();
+
         /*
          * Make `categories.object_type_id` not nullable.
          */
@@ -160,6 +167,21 @@ class CreateTagsTable extends AbstractMigration
                 'null' => false,
                 'signed' => false,
             ])
+            ->update();
+
+        /**
+         * Add categories_objecttypesid_fk foreign key
+         */
+        $this->table('categories')->addForeignKey(
+                'object_type_id',
+                'object_types',
+                'id',
+                [
+                    'constraint' => 'categories_objecttypesid_fk',
+                    'update' => 'NO_ACTION',
+                    'delete' => 'CASCADE',
+                ]
+            )
             ->update();
     }
 


### PR DESCRIPTION
This PR fixes a problem with migration `CreateTagsTable`: in some environments, migration fails with error:
```
PDOException: SQLSTATE[HY000]: General error: 1832 Cannot change column 'object_type_id': used in a foreign key constraint 'categories_objecttypesid_fk' in /var/www/bedita/_deploy/doorway_api/de04aa29/vendor/robmorgan/phinx/src/Phinx/Db/Adapter/PdoAdapter.php:184
```

This solves the problem, removing contraint `categories_objecttypesid_fk` before updating table `categories`, and adding again the constraint afterwards