### PR TITLE
Bedita Shell CleanupData task

### DIFF
--- a/bedita-app/vendors/shells/bedita.php
+++ b/bedita-app/vendors/shells/bedita.php
@@ -46,7 +46,7 @@ class BeditaShell extends BeditaBaseShell {
 	const DEFAULT_TAR_FILE 	= 'bedita-export.tar' ;
 	const DEFAULT_ARCHIVE_FILE 	= 'bedita-export.tar.gz' ;
 
-	var $tasks = array('Cleanup');
+	var $tasks = array('Cleanup', 'CleanupData');
 	
 	/**
 	 * Overrides base startup(), don't call initConfig...

--- a/bedita-app/vendors/shells/tasks/cleanup_data.php
+++ b/bedita-app/vendors/shells/tasks/cleanup_data.php
@@ -1,0 +1,134 @@
+<?php
+/*-----8<--------------------------------------------------------------------
+ *
+ * BEdita - a semantic content management framework
+ *
+ * Copyright 2022 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * BEdita is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * version 3 along with BEdita (see LICENSE.LGPL).
+ * If not, see <http://gnu.org/licenses/lgpl-3.0.html>.
+ *
+ *------------------------------------------------------------------->8-----
+ */
+
+/**
+ * Cleanup data task
+ * 
+ * @property \BEobject $BEobject
+ */
+class CleanupDataTask extends BeditaBaseShell {
+    
+    /**
+     * @inheritDoc
+     */
+    public $uses = ['BEObject'];
+
+    protected $truncateTables = ['event_logs', 'mail_jobs', 'mail_logs'];
+
+    protected $cleanupTables = ['history', 'versions'];
+
+    public function help() {
+        $this->hr();
+        $this->out('cleanup data script shell usage:');
+        $this->out('');
+        $this->out('./cake.sh cleanupData // truncate event_logs, mail_jobs, mail_logs, clean old data from history and versions');
+        $this->out('./cake.sh cleanupData -ld <limit date yyyy-MM-dd> // use custom limit date for clean');
+        $this->out('./cake.sh cleanupData -ni // no interactive mode');
+        $this->out('./cake.sh cleanupData -tt <comma separated table names> // truncate event_logs, mail_jobs, mail_logs + more tables');
+        $this->out('./cake.sh cleanupData help // show this help');
+        $this->out('');
+    }
+
+    /**
+     * Tables to clean (truncate or delete data):
+     * - event_logs (truncate)
+     * - mail_jobs (truncate, if no messages pending)
+     * - mail_logs (truncate)
+     * - history (cleanup: mantain only "CY-1 / CY" data (CY is the Current Year))
+     * - versions (cleanup: mantain only "CY-1 / CY" data (CY is the Current Year))
+     *
+     * @return void
+     */
+    public function execute()
+    {
+        $this->hr();
+        $this->out('BEdita Data Cleanup');
+        $this->out('--- count data before cleaning ---');
+        $tables = $this->truncateTables;
+        if (isset($this->params['tt'])) {
+            $tables = array_merge($tables, explode(',', $this->params['tt']));
+        }
+        $countTables = array_merge($this->cleanupTables, $tables);
+        sort($countTables);
+        $limitDate = date('Y')-2 . '-12-31 23:59:59';
+		if (isset($this->params['ld'])) {
+			$limitDate = $this->params['ld'] . ' 23:59:59';
+        }
+        $limitWhere = sprintf('WHERE created < \'%s\'', $limitDate);
+        foreach ($countTables as $tableName) {
+            $this->countRecords($tableName);
+            $this->countRecords($tableName, $limitWhere);
+        }
+        // check if mail_jobs can be truncated
+        $query = 'SELECT COUNT(*) AS n FROM mail_jobs WHERE status NOT IN (\'sent\', \'failed\')';
+        $result = $this->BEObject->query($query);
+        $pending = $result[0][0]['n'];
+        $this->out(sprintf('%s => %s', $query, $pending));
+        if ($pending > 0) {
+            $this->out('mail_jobs won\'t be truncated, because there are pending jobs. cleanup instead');
+            if (($key = array_search('mail_jobs', $tables)) !== false) {
+                unset($tables[$key]);
+            }
+            $this->cleanupTables[] = 'mail_jobs';
+        }
+
+        $this->out(sprintf('Truncate tables "%s"', implode(',', $tables)));
+        $this->out(sprintf('Remove from tables "%s" records created before date limit: %s', implode(',', $this->cleanupTables), $limitDate));
+        if (!isset($this->params['ni'])) { // no interactive
+            $res = $this->in('Continue? [y/n]');
+            if ($res != 'y') {
+                $this->out('Bye');
+
+                return;
+            }    
+        }
+        $this->out('--- clean data ---');
+        foreach ($this->cleanupTables as $tableName) {
+            $this->cleanupTable($tableName, $limitDate);
+        }
+        foreach ($tables as $tableName) {
+            $this->truncateTable($tableName);
+        }
+        $this->hr();
+        $this->out('Done');        
+    }
+
+    protected function countRecords($tableName, $where = '')
+    {
+        $query = trim(sprintf('SELECT COUNT(*) AS n FROM %s %s', $tableName, $where));
+        $result = $this->BEObject->query($query);
+        $this->out(sprintf('%s => %s', $query, $result[0][0]['n']));
+    }
+
+    protected function truncateTable($tableName)
+    {
+        $query = sprintf('TRUNCATE table %s', $tableName);
+        $this->out($query);
+        $this->BEObject->query($query);
+    }
+
+    protected function cleanupTable($tableName, $limitDate)
+    {
+        $query = sprintf('DELETE FROM %s WHERE created < \'%s\'', $tableName, $limitDate);
+        $this->out($query);
+        $this->BEObject->query($query);
+    }
+}

--- a/bedita-app/vendors/shells/tasks/cleanup_data.php
+++ b/bedita-app/vendors/shells/tasks/cleanup_data.php
@@ -72,6 +72,7 @@ class CleanupDataTask extends BeditaBaseShell {
 		if (isset($this->params['ld'])) {
 			$limitDate = $this->params['ld'] . ' 23:59:59';
         }
+        $counts = [];
         foreach ($countTables as $tableName) {
             if (in_array($tableName, $this->cleanupTables)) {
                 $counts[$tableName] = $this->countRecords($tableName, $limitDate);
@@ -105,6 +106,9 @@ class CleanupDataTask extends BeditaBaseShell {
         }
         $this->out('--- clean data ---');
         foreach ($this->cleanupTables as $tableName) {
+            if ($counts[$tableName] === 0) {
+                $this->out(sprintf('table %s clean, skip', $tableName));
+            }
             $this->cleanupTable($tableName, $limitDate);
         }
         foreach ($tables as $tableName) {

--- a/bedita-app/vendors/shells/tasks/cleanup_data.php
+++ b/bedita-app/vendors/shells/tasks/cleanup_data.php
@@ -108,6 +108,7 @@ class CleanupDataTask extends BeditaBaseShell {
         foreach ($this->cleanupTables as $tableName) {
             if ($counts[$tableName] === 0) {
                 $this->out(sprintf('table %s clean, skip', $tableName));
+                continue;
             }
             $this->cleanupTable($tableName, $limitDate);
         }

--- a/bedita-app/vendors/shells/tasks/cleanup_data.php
+++ b/bedita-app/vendors/shells/tasks/cleanup_data.php
@@ -69,8 +69,8 @@ class CleanupDataTask extends BeditaBaseShell {
         $countTables = array_merge($this->cleanupTables, $tables);
         sort($countTables);
         $limitDate = date('Y')-2 . '-12-31 23:59:59';
-		if (isset($this->params['ld'])) {
-			$limitDate = $this->params['ld'] . ' 23:59:59';
+        if (isset($this->params['ld'])) {
+            $limitDate = $this->params['ld'] . ' 23:59:59';
         }
         $counts = [];
         foreach ($countTables as $tableName) {

--- a/bedita-app/vendors/shells/tasks/cleanup_data.php
+++ b/bedita-app/vendors/shells/tasks/cleanup_data.php
@@ -94,7 +94,7 @@ class CleanupDataTask extends BeditaBaseShell {
         $this->out(sprintf('Remove from tables "%s" records created before date limit: %s', implode(',', $this->cleanupTables), $limitDate));
         if (!isset($this->params['ni'])) { // no interactive
             $res = $this->in('Continue? [y/n]');
-            if ($res != 'y') {
+            if (strtolower($res) !== 'y') {
                 $this->out('Bye');
 
                 return;


### PR DESCRIPTION
This PR provides a CleanupData task to truncate jobs and logs tables and remove old records from history and versions.

Truncate tables event_logs, mail_jobs (if no "pending" jobs), mail_logs.
More table can be truncated, using paramenter `-tt <comma separated table names>`.
Remove from `history` and `versions` records created after "limitDate" (limitDate can be passed as parameter to shell, or default date limit is 31/12 of 2 years ago, to preserve 1 year of data).

Usage:
```
$ ./cake.sh bedita cleanupData help
---------------------------------------------------------------
cleanup data script shell usage:

./cake.sh bedita cleanupData // truncate event_logs, mail_jobs, mail_logs, clean old data from history and versions
./cake.sh bedita cleanupData -ld <limit date yyyy-MM-dd> // use custom limit date for clean
./cake.sh bedita cleanupData -ni // no interactive mode
./cake.sh bedita cleanupData -tt <comma separated table names> // truncate event_logs, mail_jobs, mail_logs + more tables
./cake.sh bedita cleanupData help // show this help
```

