### PR TITLE
Update phpstan/phpstan to version 1.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
         uses: 'shivammathur/setup-php@v2'
         with:
           php-version: '7.4'
-          tools: 'composer, phpstan'
+          tools: 'composer'
           extensions: 'mbstring, intl'
           coverage: 'none'
 
@@ -83,8 +83,7 @@ jobs:
         run: 'composer install --prefer-dist --no-interaction'
 
       - name: 'Run PHP STAN'
-        run: |
-          phpstan analyse --no-progress src plugins/BEdita/API/src plugins/BEdita/Core/src
+        run: 'vendor/bin/phpstan analyse --no-progress --error-format=github'
 
   unit:
     name: 'Run unit tests'

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /index.html
 /logs/*
 !/logs/.gitkeep
+/phpstan.neon
 /phpunit.xml
 /provision/*
 /tmp/*

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "cakephp/cakephp-codesniffer": "~3.2.1",
         "psy/psysh": "@stable",
         "bedita/dev-tools": "1.5.*",
-        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan": "^1.5",
         "phpunit/phpunit": "^6.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
             ],
             "recurse": true,
             "replace": false,
-            "merge-dev": false,
+            "merge-dev": true,
             "merge-extra": false,
             "merge-extra-deep": false,
             "merge-scripts": false

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
             ],
             "recurse": true,
             "replace": false,
-            "merge-dev": true,
+            "merge-dev": false,
             "merge-extra": false,
             "merge-extra-deep": false,
             "merge-scripts": false

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,11 @@
+parameters:
+  bootstrapFiles:
+    - tests/bootstrap.php
+  paths:
+    - src
+    - tests
+    - plugins/BEdita/API/src
+    - plugins/BEdita/API/tests
+    - plugins/BEdita/Core/src
+    - plugins/BEdita/Core/tests
+  level: 0

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,4 +8,4 @@ parameters:
     - plugins/BEdita/API/tests
     - plugins/BEdita/Core/src
     - plugins/BEdita/Core/tests
-  level: 0
+  level: 1

--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -253,7 +253,7 @@ class LoginController extends AppController
         if (empty($this->request->getData('client_id')) && $grantType !== 'client_credentials') {
             return;
         }
-        /** @var \BEdita\Core\Model\Entity\Application $application */
+        /** @var \BEdita\Core\Model\Entity\Application|null $application */
         $application = TableRegistry::getTableLocator()->get('Applications')
             ->find('credentials', [
                 'client_id' => $this->request->getData('client_id'),
@@ -385,7 +385,7 @@ class LoginController extends AppController
         $contain = array_unique(array_merge($contain, ['Roles']));
         $conditions = ['id' => $userId];
 
-        /** @var \BEdita\Core\Model\Entity\User $user */
+        /** @var \BEdita\Core\Model\Entity\User|null $user */
         $user = $this->Users
             ->find('login', compact('conditions', 'contain'))
             ->first();

--- a/plugins/BEdita/API/src/Controller/TreesController.php
+++ b/plugins/BEdita/API/src/Controller/TreesController.php
@@ -223,7 +223,7 @@ class TreesController extends AppController
         $id = Hash::get($this->pathInfo['ids'], $count - 1);
         $parentId = Hash::get($this->pathInfo['ids'], $count - 2);
 
-        /** @var \BEdita\Core\Model\Entity\Tree $node */
+        /** @var \BEdita\Core\Model\Entity\Tree|null $node */
         $node = $this->Trees->find()
             ->where([
                 'object_id' => $id,

--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -300,7 +300,7 @@ class FilterQueryStringTest extends IntegrationTestCase
                    '1',
                 ],
             ],
-            'role name' => [
+            'role name (multiple)' => [
                 '/users?filter[roles]=first role,second role',
                 [
                    '1',

--- a/plugins/BEdita/API/tests/TestCase/Controller/TreesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TreesControllerTest.php
@@ -149,7 +149,7 @@ class TreesControllerTest extends IntegrationTestCase
                 compact('error'),
                 '/12/4',
             ],
-            'invalid 4' => [
+            'invalid 5' => [
                 compact('error'),
                 '/11/4',
             ],

--- a/plugins/BEdita/Core/src/Command/FixHistoryCommand.php
+++ b/plugins/BEdita/Core/src/Command/FixHistoryCommand.php
@@ -172,7 +172,7 @@ class FixHistoryCommand extends Command
      */
     protected function fixHistoryCreate(ObjectEntity $object): void
     {
-        /** @var \BEdita\Core\Model\Entity\History $history */
+        /** @var \BEdita\Core\Model\Entity\History|null $history */
         $history = $this->History
             ->find()->where([
                 $this->History->aliasField('resource_id') => $object->id,
@@ -180,7 +180,6 @@ class FixHistoryCommand extends Command
                 $this->History->aliasField('user_action') => 'create',
             ])
             ->first();
-
         if (empty($history)) {
             $history = $this->historyEntity($object);
             $history->user_action = 'create';
@@ -199,7 +198,7 @@ class FixHistoryCommand extends Command
      */
     protected function fixHistoryUpdate(ObjectEntity $object): void
     {
-        /** @var \BEdita\Core\Model\Entity\History $history */
+        /** @var \BEdita\Core\Model\Entity\History|null $history */
         $history = $this->History
             ->find()->where([
                 $this->History->aliasField('resource_id') => $object->id,
@@ -207,7 +206,6 @@ class FixHistoryCommand extends Command
                 sprintf("%s != 'create'", $this->History->aliasField('user_action')),
             ])
             ->first();
-
         if (empty($history)) {
             $history = $this->historyEntity($object);
             $history->user_action = 'update';

--- a/plugins/BEdita/Core/src/Filesystem/FilesystemRegistry.php
+++ b/plugins/BEdita/Core/src/Filesystem/FilesystemRegistry.php
@@ -69,7 +69,9 @@ class FilesystemRegistry extends ObjectRegistry
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
+     *
+     * @param string|object $class The class to build.
      */
     protected function _create($class, $alias, $config)
     {

--- a/plugins/BEdita/Core/src/Filesystem/ThumbnailRegistry.php
+++ b/plugins/BEdita/Core/src/Filesystem/ThumbnailRegistry.php
@@ -46,10 +46,13 @@ class ThumbnailRegistry extends ObjectRegistry
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
+     *
+     * @param string|object $class The class to build.
      */
     protected function _create($class, $alias, $config)
     {
+        $instance = null;
         if (is_object($class)) {
             $instance = $class;
         }

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -335,7 +335,7 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
      */
     protected function checkExternalAuth(array $data)
     {
-        /** @var \BEdita\Core\Model\Entity\AuthProvider $authProvider */
+        /** @var \BEdita\Core\Model\Entity\AuthProvider|null $authProvider */
         $authProvider = TableRegistry::getTableLocator()->get('AuthProviders')->find('enabled')
             ->where(['name' => $data['auth_provider']])
             ->first();

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -594,7 +594,7 @@ class SignupUserActionTest extends TestCase
                 ],
             ],
             // fail two not allowed roles
-            'failEmptyRoleWithAllowed' => [
+            'filMultipleRolesNotAllowed' => [
                 new BadRequestException([
                     'title' => 'Invalid data',
                     'detail' => [

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectModelBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectModelBehaviorTest.php
@@ -21,6 +21,8 @@ use Cake\Utility\Hash;
 /**
  * {@see \BEdita\Core\Model\Behavior\ObjectModelBehavior} Test Case
  *
+ * @property \BEdita\Core\Model\Table\ObjectsTable $Documents
+ *
  * @coversDefaultClass \BEdita\Core\Model\Behavior\ObjectModelBehavior
  */
 class ObjectModelBehaviorTest extends TestCase

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/QueryCacheBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/QueryCacheBehaviorTest.php
@@ -48,6 +48,7 @@ class QueryCacheBehaviorTest extends TestCase
     public function testAfterDelete(): void
     {
         $this->loadModel('Config');
+        $this->Config->fetchConfig(null, null)->toArray();
         $cacheConf = $this->Config->behaviors()->get('QueryCache')->getConfig('cacheConfig');
         $read = Cache::read('config_any_any', $cacheConf);
         static::assertNotEmpty($read);
@@ -68,6 +69,7 @@ class QueryCacheBehaviorTest extends TestCase
     public function testAfterSave(): void
     {
         $this->loadModel('Config');
+        $this->Config->fetchConfig(null, null)->toArray();
         $behavior = $this->Config->behaviors()->get('QueryCache');
         $read = Cache::read('config_any_any', $behavior->getConfig('cacheConfig'));
         static::assertNotEmpty($read);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/QueryCacheBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/QueryCacheBehaviorTest.php
@@ -20,6 +20,8 @@ use Cake\TestSuite\TestCase;
 /**
  * {@see \BEdita\Core\Model\Behavior\QueryCacheBehavior} Test Case
  *
+ * @property \BEdita\Core\Model\Table\ConfigTable $Config
+ *
  * @coversDefaultClass \BEdita\Core\Model\Behavior\QueryCacheBehavior
  */
 class QueryCacheBehaviorTest extends TestCase
@@ -46,7 +48,6 @@ class QueryCacheBehaviorTest extends TestCase
     public function testAfterDelete(): void
     {
         $this->loadModel('Config');
-        $config = $this->Config->fetchConfig(null, null)->toArray();
         $cacheConf = $this->Config->behaviors()->get('QueryCache')->getConfig('cacheConfig');
         $read = Cache::read('config_any_any', $cacheConf);
         static::assertNotEmpty($read);
@@ -67,7 +68,6 @@ class QueryCacheBehaviorTest extends TestCase
     public function testAfterSave(): void
     {
         $this->loadModel('Config');
-        $config = $this->Config->fetchConfig(null, null)->toArray();
         $behavior = $this->Config->behaviors()->get('QueryCache');
         $read = Cache::read('config_any_any', $behavior->getConfig('cacheConfig'));
         static::assertNotEmpty($read);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectEntityTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectEntityTest.php
@@ -569,7 +569,7 @@ class ObjectEntityTest extends TestCase
      * Test `hasProperty` method
      *
      * @covers ::hasProperty()
-     * @return bool
+     * @return void
      */
     public function testHasProperty()
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
@@ -246,6 +246,7 @@ class FoldersTableTest extends TestCase
     public function testSave($expected, $data)
     {
         $trees = TableRegistry::getTableLocator()->get('Trees');
+        $descendants = null;
         if (!empty($data['id'])) {
             $node = $trees->find()->where(['object_id' => $data['id']])->first();
             $descendants = $trees->childCount($node);
@@ -270,7 +271,7 @@ class FoldersTableTest extends TestCase
         if (!empty($data['id'])) {
             $node = $trees->find()->where(['object_id' => $data['id']])->first();
             $actual = $trees->childCount($node);
-            static::assertEquals($descendants, $actual);
+            static::assertSame($descendants, $actual);
         }
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Shell/StreamsShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/StreamsShellTest.php
@@ -9,6 +9,8 @@ use Cake\TestSuite\ConsoleIntegrationTestCase;
 /**
  * \BEdita\Core\Shell\StreamsShell Test Case
  *
+ * @property \BEdita\Core\Model\Table\StreamsTable $Streams
+ *
  * @coversDefaultClass \BEdita\Core\Shell\StreamsShell
  */
 class StreamsShellTest extends ConsoleIntegrationTestCase


### PR DESCRIPTION
This PR updates `phpstan/phpstan` to version 1.5. It also stores configuration in `/phpstan.neon.dist` rather than always passing it via CLI arguments, and enables inspection on test cases, which already caught a few issues.

Moreover, when PHPStan finds an issue in CI, the error will be marked using GitHub annotations.

Existing PHPStan issues (mostly duplicate array keys in test cases' data providers) have been fixed.