### PR TITLE
Treat phpdbg SAPI as cli

### DIFF
--- a/plugins/BEdita/Core/config/bootstrap.php
+++ b/plugins/BEdita/Core/config/bootstrap.php
@@ -26,7 +26,7 @@ TableRegistry::setTableLocator(new TableLocator());
  * Load 'core' configuration parameters
  */
 Configure::config('database', new DatabaseConfig());
-if (!defined('UNIT_TEST_RUN') && (PHP_SAPI !== 'cli')) {
+if (!defined('UNIT_TEST_RUN') && !in_array(PHP_SAPI, ['cli', 'phpdbg'])) {
     Configure::load('core', 'database');
 }
 


### PR DESCRIPTION
This PR skips loading configuration from database when `PHP_SAPI` is equal to `phpdbg`, which is a coverage tool that can be used as an alternative to XDebug: their outputs are slightly different, but the performance gain is impressive.

Without this change, plugins cannot use PHPDBG to generate coverage for their unit tests, as it would break the bootstrap phase due to BEdita core attempting to load configuration from the database when fixtures have not yet been loaded. [This](https://github.com/bedita/placeholders/runs/5733746634) is an example failed run for this reason.