### PR TITLE
Better coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   cs:
     name: 'Check coding style'
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-20.04'
 
     steps:
       - name: 'Checkout current revision'
@@ -51,7 +51,7 @@ jobs:
 
   stan:
     name: 'Static code analyzer'
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-20.04'
     continue-on-error: true
 
     steps:
@@ -88,7 +88,7 @@ jobs:
   unit:
     name: 'Run unit tests'
     if: "!contains(github.event.commits[0].message, '[skip ci]') && !contains(github.event.commits[0].message, '[ci skip]')"
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-20.04'
 
     strategy:
       fail-fast: false
@@ -182,7 +182,7 @@ jobs:
   unit-lowest:
     name: 'Run unit tests with lowest-matching dependencies versions'
     if: "!contains(github.event.commits[0].message, '[skip ci]') && !contains(github.event.commits[0].message, '[ci skip]')"
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-20.04'
 
     env:
       db_dsn: 'sqlite://tmp/test.sql'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,6 +160,9 @@ jobs:
       - name: 'Install dependencies with Composer'
         run: 'composer install --prefer-dist --no-interaction'
 
+      - name: 'Dump Composer autoloader'
+        run: 'composer dump-autoload --classmap-authoritative --no-cache'
+
       - name: 'Run PHPUnit with coverage'
         run: 'phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml'
 
@@ -213,6 +216,9 @@ jobs:
 
       - name: 'Update dependencies with Composer' # update again work
         run: 'composer update --prefer-lowest --prefer-dist --no-interaction'
+
+      - name: 'Dump Composer autoloader'
+        run: 'composer dump-autoload --classmap-authoritative --no-cache'
 
       - name: 'Run PHPUnit'
         run: 'vendor/bin/phpunit'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,8 +142,7 @@ jobs:
           php-version: '${{ matrix.php }}'
           tools: 'composer'
           extensions: 'mbstring, intl, pdo_${{ fromJson(matrix.db).pdo }}'
-          coverage: 'pcov'
-          ini-values: 'pcov.directory=., pcov.exclude="~vendor~"'
+          coverage: 'none' # Using `phpdbg`
 
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
@@ -161,11 +160,8 @@ jobs:
       - name: 'Install dependencies with Composer'
         run: 'composer install --prefer-dist --no-interaction'
 
-      - name: 'Setup PCOV clobber'
-        run: 'composer require pcov/clobber && vendor/bin/pcov clobber'
-
       - name: 'Run PHPUnit with coverage'
-        run: 'vendor/bin/phpunit --coverage-clover=clover.xml'
+        run: 'phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml'
 
       - name: 'Export coverage results'
         uses: 'codecov/codecov-action@v1'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+---
+codecov:
+  require_ci_to_pass: true
+  notify:
+    after_n_builds: 9
+
+coverage:
+  precision: 1
+  round: down
+  range: "85...100"
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no
+  after_n_builds: 2

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -132,7 +132,7 @@ ini_set('intl.default_locale', Configure::read('App.defaultLocale'));
 /*
  * Register application error and exception handlers.
  */
-$isCli = PHP_SAPI === 'cli';
+$isCli = in_array(PHP_SAPI, ['cli', 'phpdbg']);
 if ($isCli) {
     (new ConsoleErrorHandler(Configure::read('Error')))->register();
 } else {

--- a/plugins/BEdita/API/config/bootstrap.php
+++ b/plugins/BEdita/API/config/bootstrap.php
@@ -22,7 +22,7 @@ use Cake\Log\Log;
 /**
  * Load 'api' configuration parameters
  */
-if (!defined('UNIT_TEST_RUN') && (PHP_SAPI !== 'cli')) {
+if (!defined('UNIT_TEST_RUN') && !in_array(PHP_SAPI, ['cli', 'phpdbg'])) {
     Configure::load('api', 'database');
 }
 

--- a/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
+++ b/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
@@ -37,7 +37,7 @@ class ObjectsHandler
     protected static function checkEnvironment(): void
     {
         if (!static::isCli()) {
-            throw new StopException('Operation avilable only in CLI environment');
+            throw new StopException('Operation available only in CLI environment');
         }
     }
 
@@ -48,7 +48,7 @@ class ObjectsHandler
      */
     protected static function isCli(): bool
     {
-        return PHP_SAPI === 'cli';
+        return in_array(PHP_SAPI, ['cli', 'phpdbg']);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHandlerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHandlerTest.php
@@ -14,6 +14,7 @@ namespace BEdita\Core\Test\TestCase\Utility;
 
 use BEdita\Core\Utility\LoggedUser;
 use BEdita\Core\Utility\ObjectsHandler;
+use Cake\Console\Exception\StopException;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -161,8 +162,8 @@ class ObjectsHandlerTest extends TestCase
      */
     public function testEnvironment()
     {
-        $this->expectException(\Cake\Console\Exception\StopException::class);
-        $this->expectExceptionMessage('Operation avilable only in CLI environment');
+        $this->expectException(StopException::class);
+        $this->expectExceptionMessage('Operation available only in CLI environment');
         $testClass = new class extends ObjectsHandler {
             protected static function isCli(): bool
             {

--- a/src/Application.php
+++ b/src/Application.php
@@ -49,7 +49,7 @@ class Application extends BaseApplication
         // Call parent to load bootstrap from files.
         parent::bootstrap();
 
-        if (PHP_SAPI === 'cli') {
+        if (in_array(PHP_SAPI, ['cli', 'phpdbg'])) {
             $this->bootstrapCli();
         }
 


### PR DESCRIPTION
This PR uses `phpdbg` to generate coverage in place of PCov, which requires a clobber.

Additionally, Composer autoloader and authoritative classmap is dumped before running unit tests to catch usages of deprecated aliased classes, and Codecov will now wait for all jobs to complete before notifying about a coverage decrease.