### PR TITLE
Ensure left and right fields are update when removing a tree entity

### DIFF
--- a/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
@@ -18,6 +18,7 @@ use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Query;
 use Cake\Datasource\EntityInterface;
+use Cake\Event\Event;
 use Cake\ORM\Behavior\TreeBehavior as CakeTreeBehavior;
 use Cake\ORM\Table;
 
@@ -42,6 +43,19 @@ class TreeBehavior extends CakeTreeBehavior
         ];
 
         parent::__construct($table, $config);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function beforeDelete(Event $event, EntityInterface $entity)
+    {
+        // ensure to use actual left and right fields
+        unset($entity[$this->getConfig('left')]);
+        unset($entity[$this->getConfig('right')]);
+        $this->_ensureFields($entity);
+
+        parent::beforeDelete($event, $entity);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
@@ -46,7 +46,7 @@ class TreeBehavior extends CakeTreeBehavior
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function beforeDelete(Event $event, EntityInterface $entity)
     {

--- a/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
@@ -51,8 +51,7 @@ class TreeBehavior extends CakeTreeBehavior
     public function beforeDelete(Event $event, EntityInterface $entity)
     {
         // ensure to use actual left and right fields
-        unset($entity[$this->getConfig('left')]);
-        unset($entity[$this->getConfig('right')]);
+        unset($entity[$this->getConfig('left')], $entity[$this->getConfig('right')]);
         $this->_ensureFields($entity);
 
         parent::beforeDelete($event, $entity);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -374,7 +374,6 @@ class TreeBehaviorTest extends TestCase
      * @return void
      *
      * @covers ::beforeDelete()
-     * @covers ::reloadPosition()
      */
     public function testUnorderedDelete()
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -34,6 +34,12 @@ class TreeBehaviorTest extends TestCase
         parent::setUp();
 
         $this->Table = TableRegistry::getTableLocator()->get('FakeCategories');
+        $this->Table->belongsToMany('ChildCategories', [
+            'className' => 'FakeCategories',
+            'joinTable' => 'fake_categories',
+            'foreignKey' => 'parent_id',
+            'targetForeignKey' => 'id',
+        ]);
         $this->Table->addBehavior('BEdita/Core.Tree', [
             'left' => 'left_idx',
             'right' => 'right_idx',
@@ -360,5 +366,30 @@ class TreeBehaviorTest extends TestCase
         $errors = $this->Table->checkIntegrity();
 
         static::assertSame($expected, $errors);
+    }
+
+    /**
+     * Test {@see TreeBehavior::beforeDelete()} method with two siblings nodes.
+     *
+     * @return void
+     *
+     * @covers ::beforeDelete()
+     * @covers ::reloadPosition()
+     */
+    public function testUnorderedDelete()
+    {
+        $parentNode = $this->Table->find()
+            ->where(['name' => 'Mathematics'])
+            ->contain(['ChildCategories'])
+            ->firstOrFail();
+
+        $this->Table->ChildCategories->unlink($parentNode, [
+            $parentNode->child_categories[0],
+            $parentNode->child_categories[2],
+        ]);
+
+        $errors = $this->Table->checkIntegrity();
+
+        $this->assertEmpty($errors);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -389,6 +389,6 @@ class TreeBehaviorTest extends TestCase
 
         $errors = $this->Table->checkIntegrity();
 
-        $this->assertEmpty($errors);
+        static::assertEmpty($errors);
     }
 }


### PR DESCRIPTION
When deleting two (or more) child nodes from a folder, BEdita performs the deletion by removing the nodes from the parent/children association.

These nodes are already hydrated at the time of removal, with a `tree_left` and a `tree_right` that correspond to the position of the nodes in the tree. However, when the first node association is deleted, Cake does not take into account the new shifted position of the subsequent nodes, and performs updates using the outdated `tree_left` and `tree_right`. This may lead to corrupted tree state.

This PR introduces a change in the `beforeDelete` hook of the TreeBehavior to make sure that that position is up to date before the delete is performed.