### PR TITLE
Dirty props consistency in inheritance

### DIFF
--- a/plugins/BEdita/Core/src/ORM/Inheritance/InheritanceEventHandler.php
+++ b/plugins/BEdita/Core/src/ORM/Inheritance/InheritanceEventHandler.php
@@ -235,7 +235,13 @@ class InheritanceEventHandler implements EventListenerInterface
     protected function toDescendant(EntityInterface $entity, EntityInterface $parent, CakeTable $table, CakeTable $inheritedTable)
     {
         $properties = array_merge(array_keys($parent->toArray()), $parent->getHidden()); // All properties.
-        $entity->set(array_filter($parent->extract($properties)), ['guard' => false]); // Copy properties.
+        // Copy properties.
+        foreach (array_filter($parent->extract($properties)) as $prop => $val) {
+            if ($entity->get($prop) !== $val) {
+                $entity->set($prop, $val);
+            }
+        }
+
         if ($entity->isNew()) {
             $entity->set(
                 array_combine(

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/InheritanceEventHandlerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/InheritanceEventHandlerTest.php
@@ -509,7 +509,7 @@ class InheritanceEventHandlerTest extends TestCase
         $feline = $this->fakeFelines->get(1);
         $data = [
             'name' => 'Big cat',
-            'family' => 'The big cat familiy',
+            'family' => 'The big cat family',
         ];
         $feline = $this->fakeFelines->patchEntity($feline, $data);
 

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/InheritanceEventHandlerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/InheritanceEventHandlerTest.php
@@ -525,16 +525,19 @@ class InheritanceEventHandlerTest extends TestCase
         }
 
         $eventDispatched = 0;
-        $this->fakeFelines->getEventManager()->on('Model.afterSave', function () use (&$eventDispatched, $feline, $dirtyProps, $cleanProps) {
-            $eventDispatched++;
+        $this->fakeFelines->getEventManager()->on(
+            'Model.afterSave',
+            function (Event $event, EntityInterface $entity) use (&$eventDispatched, $dirtyProps, $cleanProps) {
+                $eventDispatched++;
 
-            foreach ($dirtyProps as $prop) {
-                static::assertTrue($feline->isDirty($prop));
+                foreach ($dirtyProps as $prop) {
+                    static::assertTrue($entity->isDirty($prop));
+                }
+                foreach ($cleanProps as $prop) {
+                    static::assertFalse($entity->isDirty($prop));
+                }
             }
-            foreach ($cleanProps as $prop) {
-                static::assertFalse($feline->isDirty($prop));
-            }
-        });
+        );
 
         $feline = $this->fakeFelines->save($feline);
 

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/InheritanceEventHandlerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/InheritanceEventHandlerTest.php
@@ -496,4 +496,49 @@ class InheritanceEventHandlerTest extends TestCase
         static::assertSame($expectedMammals, $this->fakeMammals->find()->count());
         static::assertSame($expectedAnimals, $this->fakeAnimals->find()->count());
     }
+
+    /**
+     * Test dirty properties consistency during save process.
+     *
+     * @return void
+     * @covers ::beforeSave()
+     * @covers ::toDescendant()
+     */
+    public function testDirtyPropertiesSaving(): void
+    {
+        $feline = $this->fakeFelines->get(1);
+        $data = [
+            'name' => 'Big cat',
+            'family' => 'The big cat familiy',
+        ];
+        $feline = $this->fakeFelines->patchEntity($feline, $data);
+
+        $properties = array_keys($feline->toArray());
+        $dirtyProps = array_keys($data);
+        $cleanProps = array_diff($properties, $dirtyProps);
+
+        foreach ($dirtyProps as $prop) {
+            static::assertTrue($feline->isDirty($prop));
+        }
+        foreach ($cleanProps as $prop) {
+            static::assertFalse($feline->isDirty($prop));
+        }
+
+        $eventDispatched = 0;
+        $this->fakeFelines->getEventManager()->on('Model.afterSave', function () use (&$eventDispatched, $feline, $dirtyProps, $cleanProps) {
+            $eventDispatched++;
+
+            foreach ($dirtyProps as $prop) {
+                static::assertTrue($feline->isDirty($prop));
+            }
+            foreach ($cleanProps as $prop) {
+                static::assertFalse($feline->isDirty($prop));
+            }
+        });
+
+        $feline = $this->fakeFelines->save($feline);
+
+        static::assertEquals(1, $eventDispatched);
+        static::assertFalse($feline->isDirty()); // after save is committed the entity must be clean
+    }
 }


### PR DESCRIPTION
This PR fixes a bug in inheritance that marked entity properties as dirty before saving data.

Setting up a listener on `Model.AfterSave` event the inherited entity properties were marked as dirty. For example the `ObjectEntity`properties were marked as dirty in `Profile` and `User` entities also when there weren't changes.

A test was added to verify the consistency of dirty props in the save process.