### PR TITLE
fix: avoid changing results cardinality when using `?filter[ancestors]`

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -689,9 +689,9 @@ class FilterQueryStringTest extends IntegrationTestCase
                 '/objects',
                 'filter[ancestor]=root-folder',
                 [
-                    '12',
-                    '4',
                     '2',
+                    '4',
+                    '12',
                 ],
             ],
             'documents' => [

--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -946,6 +946,7 @@ class FoldersControllerTest extends IntegrationTestCase
         $getDescendants = function () use ($folderId, $foldersTable) {
             return $foldersTable
                 ->find('ancestor', [$folderId])
+                ->order([$foldersTable->aliasField('id') => 'ASC'])
                 ->find('list')
                 ->toArray();
         };

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -429,7 +429,7 @@ class ObjectsTable extends Table
                         return $exp
                             ->gt($this->TreeNodes->aliasField('tree_left'), $parentNode->get('tree_left'))
                             ->lt($this->TreeNodes->aliasField('tree_right'), $parentNode->get('tree_right'));
-                    }),
+                    })
             );
         });
     }

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -420,15 +420,18 @@ class ObjectsTable extends Table
             ])
             ->firstOrFail();
 
-        return $query
-            ->innerJoinWith('TreeNodes', function (Query $query) use ($parentNode) {
-                return $query->where(function (QueryExpression $exp) use ($parentNode) {
-                    return $exp
-                        ->gt($this->TreeNodes->aliasField('tree_left'), $parentNode->get('tree_left'))
-                        ->lt($this->TreeNodes->aliasField('tree_right'), $parentNode->get('tree_right'));
-                });
-            })
-            ->order($this->TreeNodes->aliasField('tree_left'));
+        return $query->where(function (QueryExpression $exp) use ($parentNode): QueryExpression {
+            return $exp->in(
+                $this->aliasField('id'),
+                $this->TreeNodes->find()
+                    ->select(['object_id'])
+                    ->where(function (QueryExpression $exp) use ($parentNode) {
+                        return $exp
+                            ->gt($this->TreeNodes->aliasField('tree_left'), $parentNode->get('tree_left'))
+                            ->lt($this->TreeNodes->aliasField('tree_right'), $parentNode->get('tree_right'));
+                    }),
+            );
+        });
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
@@ -311,6 +311,7 @@ class FoldersTableTest extends TestCase
         $root = $this->Folders->get(13);
         $startDeletedInfo = $this->Folders
             ->find('ancestor', [$root->id])
+            ->order([$this->Folders->aliasField('id') => 'ASC'])
             ->find('list', [
                 'keyField' => 'id',
                 'valueField' => 'deleted',
@@ -320,7 +321,9 @@ class FoldersTableTest extends TestCase
         $root->deleted = true;
         $this->Folders->save($root);
 
-        $children = $this->Folders->find('ancestor', [$root->id]);
+        $children = $this->Folders
+            ->find('ancestor', [$root->id])
+            ->order([$this->Folders->aliasField('id') => 'ASC']);
         foreach ($children as $child) {
             if ($child->type === 'folders') {
                 // folders should have deleted field set to true
@@ -337,6 +340,7 @@ class FoldersTableTest extends TestCase
 
         $restoredDeletedInfo = $this->Folders
             ->find('ancestor', [$root->id])
+            ->order([$this->Folders->aliasField('id') => 'ASC'])
             ->find('list', [
                 'keyField' => 'id',
                 'valueField' => 'deleted',
@@ -372,6 +376,7 @@ class FoldersTableTest extends TestCase
         // get descendants not folders
         $notFoldersIds = $this->Folders
             ->find('ancestor', [$parentFolder->id])
+            ->order([$this->Folders->aliasField('id') => 'ASC'])
             ->find('list', [
                 'keyField' => 'id',
                 'valueField' => 'id',
@@ -467,6 +472,7 @@ class FoldersTableTest extends TestCase
 
         $children = $this->Folders
             ->find('ancestor', [11])
+            ->order([$this->Folders->aliasField('id') => 'ASC'])
             ->where(['object_type_id' => $this->Folders->objectType()->id])
             ->toArray();
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -537,10 +537,12 @@ class ObjectsTableTest extends TestCase
      */
     public function testFindAncestor()
     {
-        $objects = $this->Objects->find('ancestor', [11])->toArray();
+        $objects = $this->Objects->find('ancestor', [11])
+            ->sortAsc($this->Objects->aliasField('id'))
+            ->toArray();
         static::assertNotEmpty($objects);
         $ids = Hash::extract($objects, '{n}.id');
-        static::assertEquals([12, 2, 4], $ids);
+        static::assertEquals([2, 4, 12], $ids);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -540,7 +540,7 @@ class ObjectsTableTest extends TestCase
         $objects = $this->Objects->find('ancestor', [11])->toArray();
         static::assertNotEmpty($objects);
         $ids = Hash::extract($objects, '{n}.id');
-        static::assertEquals([2, 4, 12], $ids);
+        static::assertEquals([12, 2, 4], $ids);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -538,7 +538,7 @@ class ObjectsTableTest extends TestCase
     public function testFindAncestor()
     {
         $objects = $this->Objects->find('ancestor', [11])
-            ->sortAsc($this->Objects->aliasField('id'))
+            ->order([$this->Objects->aliasField('id') => 'ASC'])
             ->toArray();
         static::assertNotEmpty($objects);
         $ids = Hash::extract($objects, '{n}.id');

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -540,7 +540,7 @@ class ObjectsTableTest extends TestCase
         $objects = $this->Objects->find('ancestor', [11])->toArray();
         static::assertNotEmpty($objects);
         $ids = Hash::extract($objects, '{n}.id');
-        static::assertEquals([12, 4, 2], $ids);
+        static::assertEquals([2, 4, 12], $ids);
     }
 
     /**


### PR DESCRIPTION
This PR fixes a problem when using `?filter[ancestors]`: results cardinality is affected by multiple positions of the object on a specific tree (e.g. object is on three, different position of the tree, the API call shows the object three times on results data instead of one).