### PR TITLE
Set `intervention/image` version to avoid error with lowest-matching dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,12 @@ on:
     paths:
       - '**/*.php'
       - '.github/workflows/*'
+      - '**/composer.json'
   push:
     paths:
       - '**/*.php'
       - '.github/workflows/*'
+      - '**/composer.json'
 
 jobs:
   cs:

--- a/plugins/BEdita/Core/composer.json
+++ b/plugins/BEdita/Core/composer.json
@@ -25,7 +25,8 @@
         "cakephp/cakephp": "~4.3.8",
         "cakephp/migrations": "^3.5.1",
         "league/flysystem": "^1.0.53",
-        "league/glide": "^1.5",
+        "league/glide": "^1.7.1",
+        "intervention/image": "^2.7.1",
         "robmorgan/phinx": "^0.12.10",
         "swaggest/json-schema": "~0.12.39"
     },


### PR DESCRIPTION
A more complete solution in #1905 
