### PR TITLE
Bug in POST /model/relations/:relationId/relationships/left_object_types and right_object_types

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
@@ -534,4 +534,47 @@ class RelationsControllerTest extends IntegrationTestCase
         $this->assertContentType('application/vnd.api+json');
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * Test POST /model/relations/:id/relationships/left_object_types and POST /model/relations/:id/relationships/right_object_types
+     *
+     * @return void
+     */
+    public function testPostLeftRightObjectTypes(): void
+    {
+        $payload = json_encode([
+            'data' => [
+                [
+                    'type' => 'object_types',
+                    'id' => 6,
+                ], // locations
+            ],
+        ]);
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $this->post('/model/relations/1/relationships/left_object_types', $payload);
+        // $result = json_decode((string)$this->_response->getBody(), true);
+        // $result contains aerror 400 Invalid data / [side._required]: This field is required]
+        // the following fails
+        $this->assertResponseCode(200);
+
+        $payload = json_encode([
+            'data' => [
+                ['type' => 'object_types', 'id' => 4], // users
+            ],
+        ]);
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $this->post('/model/relations/1/relationships/right_object_types', $payload);
+        $this->assertResponseCode(200);
+
+        $this->configRequestHeaders();
+        $this->get('/model/relations/1/left_object_types');
+        $this->assertResponseCode(200);
+
+        $result = json_decode((string)$this->_response->getBody(), true);
+        $left = Hash::extract($result, 'data.{n}.relationships.left_relations.data');
+        $right = Hash::extract($result, 'data.{n}.relationships.right_relations.data');
+
+        static::assertTrue(in_array(6, $left));
+        static::assertTrue(in_array(4, $right));
+    }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
@@ -553,7 +553,7 @@ class RelationsControllerTest extends IntegrationTestCase
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
         $this->post('/model/relations/1/relationships/left_object_types', $payload);
         // $result = json_decode((string)$this->_response->getBody(), true);
-        // $result contains aerror 400 Invalid data / [side._required]: This field is required]
+        // $result contains error 400 Invalid data / [side._required]: This field is required]
         // the following fails
         $this->assertResponseCode(200);
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
@@ -544,10 +544,7 @@ class RelationsControllerTest extends IntegrationTestCase
     {
         $payload = json_encode([
             'data' => [
-                [
-                    'type' => 'object_types',
-                    'id' => 6,
-                ], // locations
+                ['type' => 'object_types', 'id' => 6], // locations
             ],
         ]);
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());


### PR DESCRIPTION
This PR adds a test to show a buggy behaviour on `POST /model/relations/:relationId/relationships/left_object_types` and `POST /model/relations/:relationId/relationships/right_object_types`

## Expected behaviour

`POST /model/relations/:relationId/relationships/left_object_types` returns a 200, and adds the desired object type to left objects for relation.

## Actual behaviour

`POST /model/relations/:relationId/relationships/left_object_types` returns an error 400 Invalid data / [side._required]: This field is required].