### PR TITLE
Fix POST relation types

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
@@ -534,4 +534,104 @@ class RelationsControllerTest extends IntegrationTestCase
         $this->assertContentType('application/vnd.api+json');
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * Test adding object types to the left and to the right side of a relation
+     *
+     * @codeCoverageIgnore
+     * @return void
+     */
+    public function testPostLeftRightObjectTypes(): void
+    {
+        // `locations` and `events` to the left
+        $payload = json_encode([
+            'data' => [
+                [
+                    'type' => 'object_types',
+                    'id' => 6,
+                ],
+                [
+                    'type' => 'object_types',
+                    'id' => 7,
+                ],
+            ],
+        ]);
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $this->post('/model/relations/1/relationships/left_object_types', $payload);
+        $this->assertResponseCode(200);
+
+        // add only `users` to the right
+        $payload = json_encode([
+            'data' => [
+                'type' => 'object_types',
+                'id' => 4,
+            ],
+        ]);
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $this->post('/model/relations/1/relationships/right_object_types', $payload);
+        $this->assertResponseCode(200);
+
+        $this->configRequestHeaders();
+        $this->get('/model/relations/1?include=left_object_types,right_object_types');
+        $this->assertResponseCode(200);
+
+        $result = json_decode((string)$this->_response->getBody(), true);
+        $left = Hash::extract($result, 'data.relationships.left_object_types.data.{n}.id');
+        $right = Hash::extract($result, 'data.relationships.right_object_types.data.{n}.id');
+
+        static::assertTrue(in_array(6, $left));
+        static::assertTrue(in_array(7, $left));
+        static::assertTrue(in_array(4, $right));
+    }
+
+    /**
+     * Test replacing object types to the left and to the right side of a relation
+     *
+     * @codeCoverageIgnore
+     * @return void
+     */
+    public function testPatchLeftRightObjectTypes(): void
+    {
+        // `locations` and `events` to the left
+        $payload = json_encode([
+            'data' => [
+                [
+                    'type' => 'object_types',
+                    'id' => 6,
+                ],
+                [
+                    'type' => 'object_types',
+                    'id' => 7,
+                ],
+            ],
+        ]);
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $this->patch('/model/relations/1/relationships/left_object_types', $payload);
+        $this->assertResponseCode(200);
+
+        // `users` to the right
+        $payload = json_encode([
+            'data' => [
+                [
+                    'type' => 'object_types',
+                    'id' => 4,
+                ],
+            ],
+        ]);
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $this->patch('/model/relations/1/relationships/right_object_types', $payload);
+        $this->assertResponseCode(200);
+
+        $this->configRequestHeaders();
+        $this->get('/model/relations/1?include=left_object_types,right_object_types');
+        $this->assertResponseCode(200);
+        $result = json_decode((string)$this->_response->getBody(), true);
+        $left = Hash::extract($result, 'data.relationships.left_object_types.data.{n}.id');
+        $right = Hash::extract($result, 'data.relationships.right_object_types.data.{n}.id');
+
+        sort($left);
+        sort($right);
+        static::assertEquals([6, 7], $left);
+        static::assertEquals([4], $right);
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Action/AssociatedTrait.php
+++ b/plugins/BEdita/Core/src/Model/Action/AssociatedTrait.php
@@ -200,7 +200,9 @@ trait AssociatedTrait
             $joinData->setNew(true);
         }
 
-        $this->Association->junction()->patchEntity($joinData, $data ?: []);
+        if (!empty($data)) {
+            $this->Association->junction()->patchEntity($joinData, $data);
+        }
         $errors = $joinData->getErrors();
         if (!empty($errors)) {
             throw new InvalidDataException(__d('bedita', 'Invalid data'), $errors);

--- a/plugins/BEdita/Core/src/ORM/Inheritance/Query.php
+++ b/plugins/BEdita/Core/src/ORM/Inheritance/Query.php
@@ -92,7 +92,9 @@ class Query extends CakeQuery
      */
     public function getInheritanceSubQuery()
     {
+        // @codingStandardsIgnoreStart
         $subQuery = new parent($this->getConnection(), $this->_repository);
+        // @codingStandardsIgnoreEnd
 
         // Current table.
         $subQuery

--- a/plugins/BEdita/Core/src/TestSuite/Fixture/TestFixture.php
+++ b/plugins/BEdita/Core/src/TestSuite/Fixture/TestFixture.php
@@ -14,7 +14,7 @@
 namespace BEdita\Core\TestSuite\Fixture;
 
 use Cake\Core\Plugin;
-use Cake\Database\Schema\Table as Schema;
+use Cake\Database\Schema\TableSchema;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventListenerInterface;
@@ -96,7 +96,7 @@ class TestFixture extends CakeFixture implements EventListenerInterface, EventDi
     protected function fieldsFromConf()
     {
         $table = $this->getTableSchemaFromConf();
-        if (!($table instanceof Schema)) {
+        if (!($table instanceof TableSchema)) {
             return [];
         }
 


### PR DESCRIPTION
This PR fixes a problem found in #1912

The API call `POST /model/relations/{id}/relationships/{left|right}_object_types` fails with this error output

```json
    "error": {
        "status": "400",
        "title": "Invalid data",
        "detail": "[side._required]: This field is required"
    }
```
Also the similar `PATCH` call fails with the same error. 

New unit tests have been added for `POST /model/relations/{id}/relationships/{left|right}_object_types` and `PATCH /model/relations/{id}/relationships/{left|right}_object_types` API calls.

