### PR TITLE
Allow `null` parent name in object types

### DIFF
--- a/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
@@ -317,11 +317,17 @@ class ObjectType extends Entity implements JsonApiSerializable, EventDispatcherI
     /**
      * Setter for virtual property `parent_name`.
      *
-     * @param string $parentName Parent object type name.
+     * @param string|null $parentName Parent object type name.
      * @return string
      */
-    protected function _setParentName(string $parentName): ?string
+    protected function _setParentName(?string $parentName): ?string
     {
+        if ($parentName === null) {
+            $this->parent = null;
+            $this->parent_id = null;
+
+            return null;
+        }
         try {
             /** @var \BEdita\Core\Model\Table\ObjectTypesTable $table */
             $table = $this->getTableLocator()->get($this->getSource());

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -389,6 +389,12 @@ class ObjectTypeTest extends TestCase
                 'not_found',
                 null,
             ],
+            'objects' => [
+                'objects',
+                null,
+                null,
+                null,
+            ],
             'documents' => [
                 'documents',
                 'objects',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -389,7 +389,7 @@ class ObjectTypeTest extends TestCase
                 'not_found',
                 null,
             ],
-            'objects' => [
+            'objects null' => [
                 'objects',
                 null,
                 null,


### PR DESCRIPTION
In this PR we allow `null` as possible value for the virtual `parent_name` of an object type. 
This can generally happen for the type `object` and not for other types.
