### PR TITLE
Minor deprecations

### DIFF
--- a/plugins/BEdita/API/src/Controller/Component/UploadComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/UploadComponent.php
@@ -16,8 +16,8 @@ use BEdita\Core\Model\Action\GetEntityAction;
 use BEdita\Core\Model\Action\SaveEntityAction;
 use Cake\Controller\Component;
 use Cake\Datasource\EntityInterface;
-use Cake\Datasource\ModelAwareTrait;
 use Cake\Event\EventInterface;
+use Cake\ORM\Locator\LocatorAwareTrait;
 use Laminas\Diactoros\Stream;
 
 /**
@@ -28,7 +28,7 @@ use Laminas\Diactoros\Stream;
  */
 class UploadComponent extends Component
 {
-    use ModelAwareTrait;
+    use LocatorAwareTrait;
 
     /**
      * @inheritDoc
@@ -64,7 +64,7 @@ class UploadComponent extends Component
         $request = $this->getController()->getRequest();
         $request->allowMethod(['post']);
 
-        $this->loadModel('Streams');
+        $this->Streams = $this->fetchTable('Streams');
         // Add a new entity.
         $entity = $this->Streams->newEntity([]);
         $action = new SaveEntityAction(['table' => $this->Streams]);

--- a/plugins/BEdita/API/src/Controller/Model/SchemaController.php
+++ b/plugins/BEdita/API/src/Controller/Model/SchemaController.php
@@ -51,7 +51,7 @@ class SchemaController extends JsonBaseController
         $this->request->allowMethod(['get']);
 
         $response = $this->response->withEtag((string)JsonSchema::schemaRevision($typeName));
-        if ($response->checkNotModified($this->request)) {
+        if ($response->isNotModified($this->request)) {
             return $response;
         }
         $this->response = $response;

--- a/plugins/BEdita/API/src/Controller/Model/SchemaController.php
+++ b/plugins/BEdita/API/src/Controller/Model/SchemaController.php
@@ -51,8 +51,8 @@ class SchemaController extends JsonBaseController
         $this->request->allowMethod(['get']);
 
         $response = $this->response->withEtag((string)JsonSchema::schemaRevision($typeName));
-        if (!$response->isNotModified($this->request)) {
-            return $response;
+        if ($response->isNotModified($this->request)) {
+            return $response->withNotModified();
         }
         $this->response = $response;
 

--- a/plugins/BEdita/API/src/Controller/Model/SchemaController.php
+++ b/plugins/BEdita/API/src/Controller/Model/SchemaController.php
@@ -51,7 +51,7 @@ class SchemaController extends JsonBaseController
         $this->request->allowMethod(['get']);
 
         $response = $this->response->withEtag((string)JsonSchema::schemaRevision($typeName));
-        if ($response->isNotModified($this->request)) {
+        if (!$response->isNotModified($this->request)) {
             return $response;
         }
         $this->response = $response;

--- a/plugins/BEdita/Core/src/Configure/Engine/DatabaseConfig.php
+++ b/plugins/BEdita/Core/src/Configure/Engine/DatabaseConfig.php
@@ -14,7 +14,7 @@ namespace BEdita\Core\Configure\Engine;
 
 use Cake\Core\Configure\ConfigEngineInterface;
 use Cake\Database\Exception\DatabaseException;
-use Cake\Datasource\ModelAwareTrait;
+use Cake\ORM\Locator\LocatorAwareTrait;
 
 /**
  * BEdita database configuration engine.
@@ -34,7 +34,7 @@ use Cake\Datasource\ModelAwareTrait;
  */
 class DatabaseConfig implements ConfigEngineInterface
 {
-    use ModelAwareTrait;
+    use LocatorAwareTrait;
 
     /**
      * Application id
@@ -58,7 +58,7 @@ class DatabaseConfig implements ConfigEngineInterface
     public function __construct($applicationId = null)
     {
         $this->applicationId = $applicationId;
-        $this->loadModel('Config');
+        $this->Config = $this->fetchTable('Config');
     }
 
     /**

--- a/plugins/BEdita/Core/src/Mailer/Preview/UserMailerPreview.php
+++ b/plugins/BEdita/Core/src/Mailer/Preview/UserMailerPreview.php
@@ -90,7 +90,7 @@ class UserMailerPreview extends MailPreview
      */
     protected function getUser()
     {
-        $this->loadModel('Users');
+        $this->Users = $this->fetchTable('Users');
 
         $user = $this->Users->newEntity([
             'name' => 'Gustavo',

--- a/plugins/BEdita/Core/src/Shell/Task/CheckApiKeyTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/CheckApiKeyTask.php
@@ -47,7 +47,7 @@ class CheckApiKeyTask extends Shell
      */
     public function main()
     {
-        $this->loadModel('Applications');
+        $this->Applications = $this->fetchTable('Applications');
 
         try {
             $this->verbose('=====> Loading default application... ', 0);

--- a/plugins/BEdita/Core/src/Shell/Task/SetupAdminUserTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/SetupAdminUserTask.php
@@ -73,7 +73,7 @@ class SetupAdminUserTask extends Shell
      */
     public function main()
     {
-        $this->loadModel('Users');
+        $this->Users = $this->fetchTable('Users');
 
         try {
             $this->verbose('=====> Retrieving information for default administrator user... ', 0);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectModelBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectModelBehaviorTest.php
@@ -69,7 +69,7 @@ class ObjectModelBehaviorTest extends TestCase
      */
     public function testAddRelated(): void
     {
-        $this->loadModel('Documents');
+        $this->Documents = $this->fetchTable('Documents');
         $entity = $this->Documents->get(3);
         $related = $this->Documents->get(2);
         $this->Documents->addRelated($entity, 'test', [$related]);
@@ -87,7 +87,7 @@ class ObjectModelBehaviorTest extends TestCase
      */
     public function testReplaceRelated(): void
     {
-        $this->loadModel('Documents');
+        $this->Documents = $this->fetchTable('Documents');
         $entity = $this->Documents->get(3);
         $related = $this->Documents->get(2);
         $this->Documents->replaceRelated($entity, 'test', [$related]);
@@ -104,7 +104,7 @@ class ObjectModelBehaviorTest extends TestCase
      */
     public function testRemoveRelated(): void
     {
-        $this->loadModel('Documents');
+        $this->Documents = $this->fetchTable('Documents');
         $entity = $this->Documents->get(3);
         $related = $this->Documents->get(4);
         $this->Documents->removeRelated($entity, 'test', [$related]);

--- a/plugins/BEdita/Core/tests/TestCase/Utility/PropertiesTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/PropertiesTest.php
@@ -14,7 +14,6 @@
 namespace BEdita\Core\Test\TestCase\Utility;
 
 use BEdita\Core\Utility\Properties;
-use Cake\Datasource\ModelAwareTrait;
 use Cake\Http\Exception\BadRequestException;
 use Cake\TestSuite\TestCase;
 
@@ -26,8 +25,6 @@ use Cake\TestSuite\TestCase;
  */
 class PropertiesTest extends TestCase
 {
-    use ModelAwareTrait;
-
     /**
      * Fixtures
      *
@@ -71,7 +68,7 @@ class PropertiesTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->loadModel('Properties');
+        $this->Properties = $this->fetchTable('Properties');
     }
 
     /**


### PR DESCRIPTION
This PR a couple of minor CakePHP 4.x deprecations are solved.

* use `LocatorAwareTrait::fetchTable()` instead of `ModelAwareTrait::loadModel()`
* use `Response::isNotModified()` instead of `Response::checkModified()`
