### PR TITLE
Avoid to execute the entire middleware queue for OPTIONS requests

### DIFF
--- a/plugins/BEdita/API/src/Middleware/CorsMiddleware.php
+++ b/plugins/BEdita/API/src/Middleware/CorsMiddleware.php
@@ -86,6 +86,10 @@ class CorsMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
+        if ($request->getMethod() === 'OPTIONS') {
+            return $this->buildCors($request, (new Response())->withStatus(200));
+        }
+
         return $this->buildCors($request, $handler->handle($request));
     }
 


### PR DESCRIPTION
This PR restores a behavior of `CorsMiddleware` presents in 4.* versions returning early the response for preflight requests without executing the entire middleware queue.