### PR TITLE
Do not fail saving objects with relation priority as empty string

### DIFF
--- a/bedita-app/models/objects/b_e_object.php
+++ b/bedita-app/models/objects/b_e_object.php
@@ -392,9 +392,13 @@ class BEObject extends BEAppModel {
             foreach ($this->data['BEObject']['RelatedObject'] as $switch => $values) {
 
                 foreach ($values as $key => $val) {
-                    $obj_id	= isset($val['id'])? Sanitize::escape($val['id']) : false;
-                    $priority = isset($val['priority'])? Sanitize::escape($val['priority']) : 'NULL';
+                    $obj_id	= isset($val['id'])? Sanitize::escape(trim($val['id'])) : false;
+                    $priority = isset($val['priority'])? Sanitize::escape(trim($val['priority'])) : 'NULL';
                     $params = isset($val['params'])? "'" . Sanitize::escape(json_encode($val['params'])) . "'" : 'NULL';
+
+                    if (empty($priority)) {
+                        $priority = 'NULL';
+                    }
 
                     $inverseSwitch = $switch;
                     if (!empty($allRelations[$switch]) && !empty($allRelations[$switch]["inverse"])) {


### PR DESCRIPTION
This PR avoids to build wrong SQL INSERT statement if the array of `RelatedObject` contains some `priority` field equal to empty string. 