### PR TITLE
Fix ObjectHanlders save with custom properties

### DIFF
--- a/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
+++ b/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
@@ -62,12 +62,12 @@ class ObjectsHandler
      * If $data['id'] is set, corresponding object is updated.
      * On missing $data['id'] a new object is created.
      *
-     * @param string $type Object type name
+     * @param string|int $type Object type name or id
      * @param array $data Input data array
      * @param array $user User performing action data
      * @return \Cake\Datasource\EntityInterface Entity saved
      */
-    public static function save(string $type, array $data, array $user = []): EntityInterface
+    public static function save($type, $data, $user = []): EntityInterface
     {
         static::checkEnvironment();
         $currentUser = LoggedUser::getUser();
@@ -77,7 +77,7 @@ class ObjectsHandler
         LoggedUser::setUser($user);
 
         $objectType = TableRegistry::getTableLocator()->get('ObjectTypes')->get($type);
-        $table = TableRegistry::getTableLocator()->get($type);
+        $table = TableRegistry::getTableLocator()->get($objectType->name);
         if (!empty($data['id'])) {
             $entity = $table->get($data['id']);
         } else {

--- a/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
+++ b/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
@@ -62,12 +62,12 @@ class ObjectsHandler
      * If $data['id'] is set, corresponding object is updated.
      * On missing $data['id'] a new object is created.
      *
-     * @param string|int $type Object type name or id
+     * @param string $type Object type name
      * @param array $data Input data array
      * @param array $user User performing action data
      * @return \Cake\Datasource\EntityInterface Entity saved
      */
-    public static function save($type, $data, $user = []): EntityInterface
+    public static function save(string $type, array $data, array $user = []): EntityInterface
     {
         static::checkEnvironment();
         $currentUser = LoggedUser::getUser();
@@ -77,11 +77,11 @@ class ObjectsHandler
         LoggedUser::setUser($user);
 
         $objectType = TableRegistry::getTableLocator()->get('ObjectTypes')->get($type);
-        $table = TableRegistry::getTableLocator()->get($objectType->model);
+        $table = TableRegistry::getTableLocator()->get($type);
         if (!empty($data['id'])) {
             $entity = $table->get($data['id']);
         } else {
-            $entity = $table->newEntity([]);
+            $entity = $table->newEmptyEntity();
         }
         $options = ['accessibleFields' => ['locked' => true]];
         $entity = $table->patchEntity($entity, $data, $options);

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHandlerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHandlerTest.php
@@ -171,4 +171,21 @@ class ObjectsHandlerTest extends TestCase
         };
         $testClass::save('documents', []);
     }
+
+    /**
+     * Test save custom properties
+     *
+     * @return void
+     * @coversNothing
+     */
+    public function testCustomPropsSave()
+    {
+        $data = [
+            'title' => 'a pragmatic title',
+            'another_title' => 'an agile title',
+        ];
+        $result = ObjectsHandler::save('documents', $data);
+        $document = $this->fetchTable('documents')->get($result->id);
+        static::assertEquals($data['another_title'], $document->get('another_title'));
+    }
 }


### PR DESCRIPTION
This PR fixes a problem with `ObjectsHandler::save()` method currently not saving custom properties.
 A new test case have been added to highlight the issue.