### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - '**'
+      - '!5-salix'
+      - '!4-cactus'
     paths:
       - 'plugins/BEdita/**'
       - '.github/workflows/*'
@@ -12,32 +14,5 @@ on:
 
 jobs:
   filter-tree:
-    name: 'Filter components tree and push'
-    runs-on: 'ubuntu-latest'
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - repo: 'api'
-            path: 'plugins/BEdita/API'
-          - repo: 'core'
-            path: 'plugins/BEdita/Core'
-
-    steps:
-      - name: 'Checkout current revision'
-        uses: 'actions/checkout@v2'
-        with:
-          token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
-          fetch-depth: '0'
-
-      - name: 'Filter tree'
-        run: 'git filter-branch --prune-empty --subdirectory-filter "${{ matrix.path }}" --tag-name-filter cat -- --all'
-
-      - name: 'Output last 10 commits'
-        run: 'git log -n 10'
-
-      - name: 'Push to component repository'
-        env:
-          REMOTE: "${{ format('https://github.com/{0}/{1}.git', github.repository_owner, matrix.repo) }}"
-        run: 'git push --force --tags "${REMOTE}" HEAD'
+    uses: ./.github/workflows/filter-components.yml
+    secrets: inherit

--- a/.github/workflows/filter-components.yml
+++ b/.github/workflows/filter-components.yml
@@ -1,0 +1,36 @@
+name: 'Filter components'
+
+on:
+  workflow_call:
+
+jobs:
+  filter-tree:
+    name: 'Filter components tree and push'
+    runs-on: 'ubuntu-latest'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repo: 'api'
+            path: 'plugins/BEdita/API'
+          - repo: 'core'
+            path: 'plugins/BEdita/Core'
+
+    steps:
+      - name: 'Checkout current revision'
+        uses: 'actions/checkout@v2'
+        with:
+          token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
+          fetch-depth: '0'
+
+      - name: 'Filter tree'
+        run: 'git filter-branch --prune-empty --subdirectory-filter "${{ matrix.path }}" --tag-name-filter cat -- --all'
+
+      - name: 'Output last 10 commits'
+        run: 'git log -n 10'
+
+      - name: 'Push to component repository'
+        env:
+          REMOTE: "${{ format('https://github.com/{0}/{1}.git', github.repository_owner, matrix.repo) }}"
+        run: 'git push --force --tags "${REMOTE}" HEAD'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  release_job:
+    uses: bedita/github-workflows/.github/workflows/release.yml@feat/output-release
+    with:
+      main_branch: '5-salix'
+      dist_branches: '["5-salix","4-cactus"]'
+      version_ini_path: plugins/BEdita/Core/config/bedita.ini
+      version_ini_prefix: "[BEdita]\nversion = "
+
+  filter_tree:
+    needs: release_job
+    uses: ./.github/workflows/filter-components.yml
+    secrets: inherit
+
+  docker_push:
+    runs-on: 'ubuntu-latest'
+    needs: release_job
+    steps:
+
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Debug output version
+        run: |
+          echo version var ${{ needs.release_job.outputs.version }}
+
+      - name: Update version file
+        run: |
+          echo "[BEdita]\nversion = ${{ needs.release_job.outputs.version }}" > plugins/BEdita/Core/config/bedita.ini
+
+      - uses: mr-smithers-excellent/docker-build-push@v5
+        with:
+          image: '${{ github.repository }}'
+          registry: docker.io
+          tags: ${{ needs.release_job.outputs.version }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release_job:
-    uses: bedita/github-workflows/.github/workflows/release.yml@feat/output-release
+    uses: bedita/github-workflows/.github/workflows/release.yml@v1
     with:
       main_branch: '5-salix'
       dist_branches: '["5-salix","4-cactus"]'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+See https://github.com/bedita/bedita/releases for details on changes.
+
+*After `5.0.2` version this file is not maintained anymore!*
+
 ## Version 5.0.2 - Salix
 
 ### Integration changes (5.0.2)


### PR DESCRIPTION
This PR adds a release workflows to create releases and tags automatically after a PR merge:

* `components` workflow logic has been moved to a reusable workflow `filter-components` called by the `component` and by the `release` workflow 
* upon merge: 
  - a new release and tag is calculated and created looking ad `release:major`, `release:minor`, and `release:patch` PR labels
  - `plugins/BEdita/Core/config/bedita.ini` is updated with the new version and pushed to the repo 
  - `bedita/api` and `bedita/core` repo plugins are updated using `filter-components` 
  - a new docker image is pushed to docker.com 

In order to proceed with the docker image push on `docker.com` the following action secrets must be set in the repository:
 * `DOCKER_USERNAME` username on docker.com
 * `DOCKER_PASSWORD` password on docker.com