### PR TITLE
Fix error on multiple anonymizations

### DIFF
--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -413,7 +413,7 @@ class UsersTable extends Table
             }
         );
 
-        return $this->save($entity);
+        return $this->save($entity, ['checkRules' => false]);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -764,8 +764,28 @@ class UsersTableTest extends TestCase
         static::assertEquals('__deleted-5', $result->get('uname'));
         static::assertEquals(true, $result->get('locked'));
         static::assertNull($result->get('last_login'));
+        static::assertNull($result->get('email'));
         // verify external_auth records have been removed
         static::assertFalse($this->Users->ExternalAuth->exists(['user_id' => 5]));
+    }
+
+    /**
+     * Test anonymization when other anonymous
+     * users with `null` email exist
+     *
+     * @return void
+     * @covers ::delete()
+     * @covers ::anonymizeUser()
+     */
+    public function testMultiAnonymousDelete()
+    {
+        $user = $this->Users->get(1);
+        $user->set('email', null);
+        $this->Users->save($user);
+
+        $user = $this->Users->get(5);
+        $result = $this->Users->delete($user);
+        static::assertTrue($result);
     }
 
     /**


### PR DESCRIPTION
In case of multiple anonymizations we have now a failure with this error

```
[Cake\ORM\Exception\PersistenceFailedException] Entity delete failure. Found the following errors (email._isUnique: "This value is already in use").
```
This happens because multiple users will have a `NULL` email and validation fails in the anonymization save action.
To prevent this side effect validation has been skipped in anonymization.

A new test case has been added to highlight the current problem.
 