### PR TITLE
Skip docker image creation on missing release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,18 @@ jobs:
         run: |
           echo version var ${{ needs.release_job.outputs.version }}
 
+      - name: Print message if no semantic version was created
+        if: contains(needs.release_job.outputs.version, 'undefined')
+        run: |
+          echo Skip version file update and docker image creation
+
       - name: Update version file
+        if: ${{ !contains(needs.release_job.outputs.version, 'undefined') }}
         run: |
           echo "[BEdita]\nversion = ${{ needs.release_job.outputs.version }}" > plugins/BEdita/Core/config/bedita.ini
 
       - uses: mr-smithers-excellent/docker-build-push@v5
+        if: ${{ !contains(needs.release_job.outputs.version, 'undefined') }}
         with:
           image: '${{ github.repository }}'
           registry: docker.io


### PR DESCRIPTION
This PR avoids error message and skips docker image creation if no semantic release version was defined
