### PR TITLE
Anonymize users on delete if an annotation exists

### DIFF
--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -26,9 +26,9 @@ use Cake\Event\Event;
 use Cake\Event\EventInterface;
 use Cake\Event\EventManager;
 use Cake\Http\Exception\BadRequestException;
+use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
-use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 use Cake\Validation\Validator;
 
@@ -49,6 +49,8 @@ use Cake\Validation\Validator;
  */
 class UsersTable extends Table
 {
+    use LocatorAwareTrait;
+
     /**
      * Administrator user id
      *
@@ -443,10 +445,11 @@ class UsersTable extends Table
      */
     public function delete(EntityInterface $entity, $options = []): bool
     {
-        $exists = TableRegistry::getTableLocator()->get('Objects')->exists([
+        $existsObject = $this->fetchTable('Objects')->exists([
             'OR' => ['created_by' => $entity->get('id'), 'modified_by' => $entity->get('id')],
         ]);
-        if (!$exists) {
+        $existsAnnotation = $this->fetchTable('Annotations')->exists(['user_id' => $entity->get('id')]);
+        if (!$existsObject && !$existsAnnotation) {
             return parent::delete($entity, $options);
         }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -62,6 +62,7 @@ class JsonApiTraitTest extends TestCase
         'plugin.BEdita/Core.ObjectCategories',
         'plugin.BEdita/Core.Tags',
         'plugin.BEdita/Core.ObjectTags',
+        'plugin.BEdita/Core.Annotations',
     ];
 
     /**
@@ -320,14 +321,15 @@ class JsonApiTraitTest extends TestCase
     public function testGetRelationshipsIncludedEmpty()
     {
         // This is needed in order to permanently remove user with id 5
-        $usersTable = TableRegistry::getTableLocator()->get('Users');
+        $usersTable = $this->fetchTable('Users');
         $user = $usersTable->get(5);
         $user->created_by = 1;
         $user->modified_by = 1;
         $user = $usersTable->saveOrFail($user);
-        $doc = TableRegistry::getTableLocator()->get('Objects')->get(3);
+        $doc = $this->fetchTable('Objects')->get(3);
         $doc->modified_by = 1;
-        $doc = TableRegistry::getTableLocator()->get('Objects')->saveOrFail($doc);
+        $doc = $this->fetchTable('Objects')->saveOrFail($doc);
+        $this->fetchTable('Annotations')->deleteAll([]);
 
         $usersTable->delete($usersTable->get(5));
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -59,6 +59,7 @@ class UsersTableTest extends TestCase
         'plugin.BEdita/Core.Trees',
         'plugin.BEdita/Core.Categories',
         'plugin.BEdita/Core.ObjectCategories',
+        'plugin.BEdita/Core.ObjectTags',
         'plugin.BEdita/Core.History',
     ];
 
@@ -786,6 +787,7 @@ class UsersTableTest extends TestCase
         $user = $this->Users->get(5);
         $result = $this->Users->delete($user);
         static::assertTrue($result);
+        static::assertTrue($this->Users->exists(['id' => 5]));
     }
 
     /**
@@ -836,6 +838,30 @@ class UsersTableTest extends TestCase
         $result = $this->Users->delete($user);
         static::assertTrue($result);
         static::assertFalse($this->Users->exists(['id' => 5]));
+    }
+
+    /**
+     * Test `delete` method when an annotation
+     * from the user being removed exist
+     *
+     * @return void
+     * @covers ::delete()
+     */
+    public function testAnnotationsDelete()
+    {
+        // remove object modified by user 5
+        $doc = $this->fetchTable('Objects')->get(3);
+        $this->fetchTable('Objects')->delete($doc);
+        // change created_by and modifed_by on user 5
+        $user = $this->Users->get(5);
+        $user->created_by = 1;
+        $user->modified_by = 1;
+        $user = $this->Users->saveOrFail($user);
+
+        $user = $this->Users->get(5);
+        $result = $this->Users->delete($user);
+        static::assertTrue($result);
+        static::assertTrue($this->Users->exists(['id' => 5]));
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -61,6 +61,7 @@ class UsersTableTest extends TestCase
         'plugin.BEdita/Core.ObjectCategories',
         'plugin.BEdita/Core.ObjectTags',
         'plugin.BEdita/Core.History',
+        'plugin.BEdita/Core.Annotations',
     ];
 
     /**
@@ -829,8 +830,9 @@ class UsersTableTest extends TestCase
         $user->created_by = 1;
         $user->modified_by = 1;
         $user = $this->Users->saveOrFail($user);
+        $this->fetchTable('Annotations')->deleteAll([]);
 
-        $table = TableRegistry::getTableLocator()->get('Objects');
+        $table = $this->fetchTable('Objects');
         $doc = $table->get(3);
         $doc->modified_by = 1;
         $doc = $table->saveOrFail($doc);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -853,8 +853,10 @@ class UsersTableTest extends TestCase
     {
         // remove object modified by user 5
         $doc = $this->fetchTable('Objects')->get(3);
-        $this->fetchTable('Objects')->delete($doc);
-        // change created_by and modifed_by on user 5
+        $doc->created_by = 1;
+        $doc->modified_by = 1;
+        $this->fetchTable('Objects')->saveOrFail($doc);
+        // change created_by and modifed_by attributes linked to user 5
         $user = $this->Users->get(5);
         $user->created_by = 1;
         $user->modified_by = 1;


### PR DESCRIPTION
This PR fixes a problem removing a user permanently if an annotation from the same user exists.
In this case a user anonymization has to be performed.

Currently user removal fails with an SQL error like:

```
PDOException] SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails (`#####`.`annotations`, CONSTRAINT `annotations_userid_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)) 
```

 