### PR TITLE
Remove deprecations and check via PHPStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,8 @@
         "dms/phpunit-arraysubset-asserts": "^0.4",
         "bedita/dev-tools": "^2.1",
         "phpstan/phpstan": "^1.7.1",
+        "phpstan/extension-installer": "^1.0",
+        "phpstan/phpstan-deprecation-rules": "^1.0",
         "dereuromark/cakephp-ide-helper": "^1.17"
     },
     "autoload": {
@@ -86,7 +88,8 @@
         "allow-plugins": {
             "cakephp/plugin-installer": true,
             "wikimedia/composer-merge-plugin": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "phpstan/extension-installer": true
         }
     }
 }

--- a/plugins/BEdita/API/src/Controller/Admin/ApplicationsController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/ApplicationsController.php
@@ -24,5 +24,5 @@ class ApplicationsController extends AdminController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'Applications';
+    public $defaultTable = 'Applications';
 }

--- a/plugins/BEdita/API/src/Controller/Admin/AsyncJobsController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/AsyncJobsController.php
@@ -24,5 +24,5 @@ class AsyncJobsController extends AdminController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'AsyncJobs';
+    public $defaultTable = 'AsyncJobs';
 }

--- a/plugins/BEdita/API/src/Controller/Admin/ConfigController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/ConfigController.php
@@ -36,5 +36,5 @@ class ConfigController extends AdminController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'Config';
+    public $defaultTable = 'Config';
 }

--- a/plugins/BEdita/API/src/Controller/Admin/EndpointPermissionsController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/EndpointPermissionsController.php
@@ -24,5 +24,5 @@ class EndpointPermissionsController extends AdminController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'EndpointPermissions';
+    public $defaultTable = 'EndpointPermissions';
 }

--- a/plugins/BEdita/API/src/Controller/Admin/EndpointsController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/EndpointsController.php
@@ -24,5 +24,5 @@ class EndpointsController extends AdminController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'Endpoints';
+    public $defaultTable = 'Endpoints';
 }

--- a/plugins/BEdita/API/src/Controller/AnnotationsController.php
+++ b/plugins/BEdita/API/src/Controller/AnnotationsController.php
@@ -27,7 +27,7 @@ class AnnotationsController extends ResourcesController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'Annotations';
+    public $defaultTable = 'Annotations';
 
     /**
      * @inheritDoc

--- a/plugins/BEdita/API/src/Controller/ApplicationsController.php
+++ b/plugins/BEdita/API/src/Controller/ApplicationsController.php
@@ -24,7 +24,7 @@ class ApplicationsController extends AppController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'Applications';
+    public $defaultTable = 'Applications';
 
     /**
      * Display available applications.

--- a/plugins/BEdita/API/src/Controller/ConfigController.php
+++ b/plugins/BEdita/API/src/Controller/ConfigController.php
@@ -24,5 +24,5 @@ class ConfigController extends ResourcesController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'AppConfig';
+    public $defaultTable = 'AppConfig';
 }

--- a/plugins/BEdita/API/src/Controller/FoldersController.php
+++ b/plugins/BEdita/API/src/Controller/FoldersController.php
@@ -31,7 +31,7 @@ class FoldersController extends ObjectsController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'Folders';
+    public $defaultTable = 'Folders';
 
     /**
      * @inheritDoc

--- a/plugins/BEdita/API/src/Controller/Model/CategoriesController.php
+++ b/plugins/BEdita/API/src/Controller/Model/CategoriesController.php
@@ -24,7 +24,7 @@ class CategoriesController extends ModelController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'Categories';
+    public $defaultTable = 'Categories';
 
     /**
      * @inheritDoc

--- a/plugins/BEdita/API/src/Controller/Model/ObjectTypesController.php
+++ b/plugins/BEdita/API/src/Controller/Model/ObjectTypesController.php
@@ -26,7 +26,7 @@ class ObjectTypesController extends ModelController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'ObjectTypes';
+    public $defaultTable = 'ObjectTypes';
 
     /**
      * @inheritDoc

--- a/plugins/BEdita/API/src/Controller/Model/PropertiesController.php
+++ b/plugins/BEdita/API/src/Controller/Model/PropertiesController.php
@@ -24,7 +24,7 @@ class PropertiesController extends ModelController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'Properties';
+    public $defaultTable = 'Properties';
 
     /**
      * @inheritDoc

--- a/plugins/BEdita/API/src/Controller/Model/PropertyTypesController.php
+++ b/plugins/BEdita/API/src/Controller/Model/PropertyTypesController.php
@@ -24,7 +24,7 @@ class PropertyTypesController extends ModelController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'PropertyTypes';
+    public $defaultTable = 'PropertyTypes';
 
     /**
      * @inheritDoc

--- a/plugins/BEdita/API/src/Controller/Model/RelationsController.php
+++ b/plugins/BEdita/API/src/Controller/Model/RelationsController.php
@@ -26,7 +26,7 @@ class RelationsController extends ModelController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'Relations';
+    public $defaultTable = 'Relations';
 
     /**
      * @inheritDoc

--- a/plugins/BEdita/API/src/Controller/Model/TagsController.php
+++ b/plugins/BEdita/API/src/Controller/Model/TagsController.php
@@ -24,7 +24,7 @@ class TagsController extends ModelController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'Tags';
+    public $defaultTable = 'Tags';
 
     /**
      * @inheritDoc

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -50,7 +50,7 @@ class ObjectsController extends ResourcesController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'Objects';
+    public $defaultTable = 'Objects';
 
     /**
      * The referred object type entity filled when `object_type` request param is set and valid
@@ -114,7 +114,7 @@ class ObjectsController extends ResourcesController
     /**
      * Init model related attributes:
      *  - $this->objectType
-     *  - $this->modelClass
+     *  - $this->defaultTable
      *  - $this->Table
      *
      * @return void
@@ -139,8 +139,8 @@ class ObjectsController extends ResourcesController
                     $this->objectType->name
                 ));
             }
-            $this->modelClass = $this->objectType->alias;
-            $this->Table = TableRegistry::getTableLocator()->get($this->modelClass);
+            $this->defaultTable = $this->objectType->alias;
+            $this->Table = $this->fetchTable();
         } catch (RecordNotFoundException $e) {
             $this->log(sprintf('Object type "%s" does not exist', $type), 'warning', ['request' => $this->request]);
 

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -84,8 +84,13 @@ abstract class ResourcesController extends AppController
                 $this->JsonApi->setConfig('clientGeneratedIds', true);
             }
         }
-
-        $this->Table = $this->fetchTable();
+        // backward compatibility: set $defaultTable if deprecated $modelClass attribute is used
+        if (empty($this->defaultTable) && !empty($this->modelClass)) { /* @phpstan-ignore-line */
+            $this->defaultTable = $this->modelClass; /* @phpstan-ignore-line */
+        }
+        if (empty($this->Table)) {
+            $this->Table = $this->fetchTable();
+        }
     }
 
     /**

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -33,7 +33,6 @@ use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Association\HasOne;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
-use Cake\ORM\TableRegistry;
 use Cake\Routing\Router;
 use Cake\Utility\Inflector;
 
@@ -86,7 +85,7 @@ abstract class ResourcesController extends AppController
             }
         }
 
-        $this->Table = TableRegistry::getTableLocator()->get($this->modelClass);
+        $this->Table = $this->fetchTable();
     }
 
     /**

--- a/plugins/BEdita/API/src/Controller/RolesController.php
+++ b/plugins/BEdita/API/src/Controller/RolesController.php
@@ -23,7 +23,7 @@ class RolesController extends ResourcesController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'Roles';
+    public $defaultTable = 'Roles';
 
     /**
      * @inheritDoc

--- a/plugins/BEdita/API/src/Controller/StreamsController.php
+++ b/plugins/BEdita/API/src/Controller/StreamsController.php
@@ -40,7 +40,7 @@ class StreamsController extends ResourcesController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'Streams';
+    public $defaultTable = 'Streams';
 
     /**
      * @inheritDoc

--- a/plugins/BEdita/API/src/Controller/TranslationsController.php
+++ b/plugins/BEdita/API/src/Controller/TranslationsController.php
@@ -27,7 +27,7 @@ class TranslationsController extends ResourcesController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'Translations';
+    public $defaultTable = 'Translations';
 
     /**
      * @inheritDoc

--- a/plugins/BEdita/API/src/Controller/TrashController.php
+++ b/plugins/BEdita/API/src/Controller/TrashController.php
@@ -30,7 +30,7 @@ class TrashController extends AppController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'Objects';
+    public $defaultTable = 'Objects';
 
     /**
      * Table.
@@ -51,8 +51,8 @@ class TrashController extends AppController
             /** @var \BEdita\Core\Model\Entity\ObjectType $objectType */
             $objectType = TableRegistry::getTableLocator()->get('ObjectTypes')->find('objectId', compact('id'))
                 ->firstOrFail();
-            $this->modelClass = $objectType->alias;
-            $this->Table = TableRegistry::getTableLocator()->get($this->modelClass);
+            $this->defaultTable = $objectType->alias;
+            $this->Table = $this->fetchTable();
         }
     }
 

--- a/plugins/BEdita/API/src/Controller/UsersController.php
+++ b/plugins/BEdita/API/src/Controller/UsersController.php
@@ -22,7 +22,7 @@ class UsersController extends ObjectsController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'Users';
+    public $defaultTable = 'Users';
 
     /**
      * Meta properties accessible for admins

--- a/plugins/BEdita/API/src/TestSuite/IntegrationTestCase.php
+++ b/plugins/BEdita/API/src/TestSuite/IntegrationTestCase.php
@@ -22,16 +22,21 @@ use Cake\Mailer\TransportFactory;
 use Cake\ORM\TableRegistry;
 use Cake\Routing\RouteCollection;
 use Cake\Routing\Router;
-use Cake\TestSuite\IntegrationTestCase as CakeIntegrationTestCase;
+use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\MiddlewareDispatcher;
+use Cake\TestSuite\TestCase;
 
 /**
  * Base class for API integration tests.
  *
  * @since 4.0.0
  */
-abstract class IntegrationTestCase extends CakeIntegrationTestCase
+abstract class IntegrationTestCase extends TestCase
 {
+    use IntegrationTestTrait {
+        _makeDispatcher as protected testMakeDispatcher;
+    }
+
     /**
      * Fixtures
      *
@@ -157,7 +162,7 @@ abstract class IntegrationTestCase extends CakeIntegrationTestCase
     {
         Router::setRouteCollection(new RouteCollection());
 
-        return parent::_makeDispatcher();
+        return $this->testMakeDispatcher();
     }
 
     /**

--- a/plugins/BEdita/API/src/View/JsonApiView.php
+++ b/plugins/BEdita/API/src/View/JsonApiView.php
@@ -30,7 +30,7 @@ class JsonApiView extends JsonView
     /**
      * @inheritDoc
      */
-    protected $_responseType = 'jsonapi';
+    protected static $contentType = 'application/vnd.api+json';
 
     /**
      * @inheritDoc
@@ -48,9 +48,17 @@ class JsonApiView extends JsonView
     ) {
         if ($request && $request->is('json')) {
             // change default response type if request is `json`
-            $this->_responseType = 'json';
+            static::$contentType = 'application/json';
         }
         parent::__construct($request, $response, $eventManager, $viewOptions);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function contentType(): string
+    {
+        return static::$contentType;
     }
 
     /**

--- a/plugins/BEdita/Core/src/Command/FixHistoryCommand.php
+++ b/plugins/BEdita/Core/src/Command/FixHistoryCommand.php
@@ -37,7 +37,7 @@ class FixHistoryCommand extends Command
     /**
      * @inheritDoc
      */
-    public $modelClass = 'Objects';
+    public $defaultTable = 'Objects';
 
     /**
      * History table

--- a/plugins/BEdita/Core/src/Command/TreeCheckCommand.php
+++ b/plugins/BEdita/Core/src/Command/TreeCheckCommand.php
@@ -35,7 +35,7 @@ class TreeCheckCommand extends Command
     /**
      * @inheritDoc
      */
-    public $modelClass = 'Objects';
+    public $defaultTable = 'Objects';
 
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/src/Command/TreeRecoverCommand.php
+++ b/plugins/BEdita/Core/src/Command/TreeRecoverCommand.php
@@ -29,7 +29,7 @@ class TreeRecoverCommand extends Command
     /**
      * @inheritDoc
      */
-    public $modelClass = 'Trees';
+    public $defaultTable = 'Trees';
 
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/src/Mailer/Email.php
+++ b/plugins/BEdita/Core/src/Mailer/Email.php
@@ -23,7 +23,7 @@ use Cake\Mailer\Email as CakeEmail;
  *
  * @since 4.0.0
  */
-class Email extends CakeEmail
+class Email extends CakeEmail /* @phpstan-ignore-line */
 {
     /**
      * Send a raw email.

--- a/plugins/BEdita/Core/src/Mailer/Preview/UserMailerPreview.php
+++ b/plugins/BEdita/Core/src/Mailer/Preview/UserMailerPreview.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Mailer\Preview;
 
+use Cake\Mailer\Mailer;
 use Cake\Utility\Text;
 use DebugKit\Mailer\MailPreview;
 
@@ -28,9 +29,9 @@ class UserMailerPreview extends MailPreview
     /**
      * Preview of Welcome message.
      *
-     * @return \Cake\Mailer\Email
+     * @return \Cake\Mailer\Mailer
      */
-    public function welcome()
+    public function welcome(): Mailer
     {
         $user = $this->getUser();
         $options = [
@@ -46,9 +47,9 @@ class UserMailerPreview extends MailPreview
     /**
      * Preview of Signup message.
      *
-     * @return \Cake\Mailer\Email
+     * @return \Cake\Mailer\Mailer
      */
-    public function signup()
+    public function signup(): Mailer
     {
         $options = [
             'params' => [
@@ -66,9 +67,9 @@ class UserMailerPreview extends MailPreview
     /**
      * Preview of Password recovery message.
      *
-     * @return \Cake\Mailer\Email
+     * @return \Cake\Mailer\Mailer
      */
-    public function changeRequest()
+    public function changeRequest(): Mailer
     {
         $options = [
             'params' => [

--- a/plugins/BEdita/Core/src/Model/Behavior/StatusBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/StatusBehavior.php
@@ -87,12 +87,12 @@ class StatusBehavior extends Behavior
         switch ($level) {
             case 'on':
                 return $query->where([
-                    $this->getTable()->aliasField($field) => 'on',
+                    $this->table()->aliasField($field) => 'on',
                 ]);
 
             case 'draft':
                 return $query->where(function (QueryExpression $exp) use ($field) {
-                    return $exp->in($this->getTable()->aliasField($field), ['on', 'draft']);
+                    return $exp->in($this->table()->aliasField($field), ['on', 'draft']);
                 });
 
             case 'off':

--- a/plugins/BEdita/Core/src/Shell/BeditaShell.php
+++ b/plugins/BEdita/Core/src/Shell/BeditaShell.php
@@ -32,7 +32,7 @@ use Cake\Datasource\ConnectionManager;
  * @property \BEdita\Core\Shell\Task\SetupAdminUserTask $SetupAdminUser
  * @property \BEdita\Core\Shell\Task\SetupConnectionTask $SetupConnection
  */
-class BeditaShell extends Shell
+class BeditaShell extends Shell /* @phpstan-ignore-line */
 {
     /**
      * @inheritDoc
@@ -53,7 +53,7 @@ class BeditaShell extends Shell
      */
     public function getOptionParser(): ConsoleOptionParser
     {
-        $parser = parent::getOptionParser();
+        $parser = parent::getOptionParser(); /* @phpstan-ignore-line */
 
         $parser->addSubcommand('setup', [
             'help' => 'Setup new instance.',

--- a/plugins/BEdita/Core/src/Shell/DbAdminShell.php
+++ b/plugins/BEdita/Core/src/Shell/DbAdminShell.php
@@ -27,7 +27,7 @@ use Cake\Datasource\ConnectionManager;
  * @property \BEdita\Core\Shell\Task\InitSchemaTask $Init
  * @property \BEdita\Core\Shell\Task\CheckSchemaTask $CheckSchema
  */
-class DbAdminShell extends Shell
+class DbAdminShell extends Shell /* @phpstan-ignore-line */
 {
     /**
      * @inheritDoc
@@ -46,7 +46,7 @@ class DbAdminShell extends Shell
     {
         Cache::disable();
 
-        parent::startup();
+        parent::startup(); /* @phpstan-ignore-line */
     }
 
     /**
@@ -56,7 +56,7 @@ class DbAdminShell extends Shell
      */
     protected function _welcome(): void
     {
-        parent::_welcome();
+        parent::_welcome(); /* @phpstan-ignore-line */
 
         if ($this->param('connection')) {
             $info = ConnectionManager::get($this->param('connection'))->config();
@@ -79,7 +79,7 @@ class DbAdminShell extends Shell
      */
     public function getOptionParser(): ConsoleOptionParser
     {
-        $parser = parent::getOptionParser();
+        $parser = parent::getOptionParser(); /* @phpstan-ignore-line */
         $parser
             ->addSubcommand('init', [
                 'help' => 'Initialize a new BEdita 4 database instance.',

--- a/plugins/BEdita/Core/src/Shell/JobsShell.php
+++ b/plugins/BEdita/Core/src/Shell/JobsShell.php
@@ -27,7 +27,7 @@ class JobsShell extends Shell
     /**
      * @inheritDoc
      */
-    public $modelClass = 'AsyncJobs';
+    public $defaultTable = 'AsyncJobs';
 
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/src/Shell/JobsShell.php
+++ b/plugins/BEdita/Core/src/Shell/JobsShell.php
@@ -22,7 +22,7 @@ use Cake\Datasource\Exception\RecordNotFoundException;
  * @since 4.0.0
  * @property \BEdita\Core\Model\Table\AsyncJobsTable $AsyncJobs
  */
-class JobsShell extends Shell
+class JobsShell extends Shell /* @phpstan-ignore-line */
 {
     /**
      * @inheritDoc
@@ -44,7 +44,7 @@ class JobsShell extends Shell
             ],
         ];
 
-        return parent::getOptionParser()
+        return parent::getOptionParser() /* @phpstan-ignore-line */
             ->addSubcommand('run', [
                 'help' => 'Process a job',
                 'parser' => [

--- a/plugins/BEdita/Core/src/Shell/JobsShell.php
+++ b/plugins/BEdita/Core/src/Shell/JobsShell.php
@@ -27,7 +27,7 @@ class JobsShell extends Shell /* @phpstan-ignore-line */
     /**
      * @inheritDoc
      */
-    public $defaultTable = 'AsyncJobs';
+    public $modelClass = 'AsyncJobs';
 
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/src/Shell/ResourcesShell.php
+++ b/plugins/BEdita/Core/src/Shell/ResourcesShell.php
@@ -26,7 +26,7 @@ use Cake\Utility\Inflector;
  *
  * @since 4.0.0
  */
-class ResourcesShell extends Shell
+class ResourcesShell extends Shell /* @phpstan-ignore-line */
 {
     /**
      * Accepted resource types
@@ -49,7 +49,7 @@ class ResourcesShell extends Shell
      */
     public function getOptionParser(): ConsoleOptionParser
     {
-        $parser = parent::getOptionParser();
+        $parser = parent::getOptionParser(); /* @phpstan-ignore-line */
 
         $options = [
             'type' => [

--- a/plugins/BEdita/Core/src/Shell/StreamsShell.php
+++ b/plugins/BEdita/Core/src/Shell/StreamsShell.php
@@ -24,7 +24,7 @@ use Cake\ORM\Query;
  * @since 4.0.0
  * @property \BEdita\Core\Model\Table\StreamsTable $Streams
  */
-class StreamsShell extends Shell
+class StreamsShell extends Shell /* @phpstan-ignore-line */
 {
     /**
      * @inheritDoc
@@ -38,7 +38,7 @@ class StreamsShell extends Shell
      */
     public function getOptionParser(): ConsoleOptionParser
     {
-        $parser = parent::getOptionParser();
+        $parser = parent::getOptionParser(); /* @phpstan-ignore-line */
         $parser->addSubcommand('removeOrphans', [
             'help' => 'remove obsolete/orphans streams and related files',
             'parser' => [

--- a/plugins/BEdita/Core/src/Shell/StreamsShell.php
+++ b/plugins/BEdita/Core/src/Shell/StreamsShell.php
@@ -29,7 +29,7 @@ class StreamsShell extends Shell
     /**
      * @inheritDoc
      */
-    public $modelClass = 'Streams';
+    public $defaultTable = 'Streams';
 
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/src/Shell/StreamsShell.php
+++ b/plugins/BEdita/Core/src/Shell/StreamsShell.php
@@ -29,7 +29,7 @@ class StreamsShell extends Shell /* @phpstan-ignore-line */
     /**
      * @inheritDoc
      */
-    public $defaultTable = 'Streams';
+    public $modelClass = 'Streams';
 
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/src/Shell/Task/CheckApiKeyTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/CheckApiKeyTask.php
@@ -24,7 +24,7 @@ use Cake\Datasource\Exception\RecordNotFoundException;
  * @since 4.0.0
  * @property \BEdita\Core\Model\Table\ApplicationsTable $Applications
  */
-class CheckApiKeyTask extends Shell
+class CheckApiKeyTask extends Shell /* @phpstan-ignore-line */
 {
     /**
      * {@inheritDoc}
@@ -33,7 +33,7 @@ class CheckApiKeyTask extends Shell
      */
     public function getOptionParser(): ConsoleOptionParser
     {
-        $parser = parent::getOptionParser();
+        $parser = parent::getOptionParser(); /* @phpstan-ignore-line */
         $parser
             ->setDescription([
                 'Setup API key.',

--- a/plugins/BEdita/Core/src/Shell/Task/CheckFilesystemTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/CheckFilesystemTask.php
@@ -21,7 +21,7 @@ use Cake\Console\Shell;
  *
  * @since 4.0.0
  */
-class CheckFilesystemTask extends Shell
+class CheckFilesystemTask extends Shell /* @phpstan-ignore-line */
 {
     /**
      * {@inheritDoc}
@@ -30,7 +30,7 @@ class CheckFilesystemTask extends Shell
      */
     public function getOptionParser(): ConsoleOptionParser
     {
-        $parser = parent::getOptionParser();
+        $parser = parent::getOptionParser(); /* @phpstan-ignore-line */
         $parser
             ->setDescription([
                 'Check filesystem permissions.',

--- a/plugins/BEdita/Core/src/Shell/Task/CheckSchemaTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/CheckSchemaTask.php
@@ -30,7 +30,7 @@ use Migrations\Migrations;
  *
  * @since 4.0.0
  */
-class CheckSchemaTask extends Shell
+class CheckSchemaTask extends Shell /* @phpstan-ignore-line */
 {
     /**
      * Registry of all issues found.
@@ -53,7 +53,7 @@ class CheckSchemaTask extends Shell
      */
     public function getOptionParser(): ConsoleOptionParser
     {
-        $parser = parent::getOptionParser();
+        $parser = parent::getOptionParser(); /* @phpstan-ignore-line */
         $parser
             ->setDescription([
                 'Current schema is compared with versioned schema dump to check if it is up to date.',

--- a/plugins/BEdita/Core/src/Shell/Task/InitSchemaTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/InitSchemaTask.php
@@ -24,7 +24,7 @@ use Migrations\Migrations;
  *
  * @since 4.0.0
  */
-class InitSchemaTask extends Shell
+class InitSchemaTask extends Shell /* @phpstan-ignore-line */
 {
     /**
      * {@inheritDoc}
@@ -33,7 +33,7 @@ class InitSchemaTask extends Shell
      */
     public function getOptionParser(): ConsoleOptionParser
     {
-        $parser = parent::getOptionParser();
+        $parser = parent::getOptionParser(); /* @phpstan-ignore-line */
         $parser
             ->setDescription([
                 'A new database schema is created using current DB connection.',

--- a/plugins/BEdita/Core/src/Shell/Task/SetupAdminUserTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/SetupAdminUserTask.php
@@ -25,7 +25,7 @@ use Cake\ORM\Exception\PersistenceFailedException;
  * @since 4.0.0
  * @property \BEdita\Core\Model\Table\UsersTable $Users
  */
-class SetupAdminUserTask extends Shell
+class SetupAdminUserTask extends Shell /* @phpstan-ignore-line */
 {
     /**
      * Default username of first user.
@@ -41,7 +41,7 @@ class SetupAdminUserTask extends Shell
      */
     public function getOptionParser(): ConsoleOptionParser
     {
-        $parser = parent::getOptionParser();
+        $parser = parent::getOptionParser(); /* @phpstan-ignore-line */
         $parser
             ->setDescription([
                 'Setup admin user.',

--- a/plugins/BEdita/Core/src/Shell/Task/SetupConnectionTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/SetupConnectionTask.php
@@ -27,7 +27,7 @@ use Cake\Utility\Hash;
  *
  * @since 4.0.0
  */
-class SetupConnectionTask extends Shell
+class SetupConnectionTask extends Shell /* @phpstan-ignore-line */
 {
     /**
      * {@inheritDoc}
@@ -36,7 +36,7 @@ class SetupConnectionTask extends Shell
      */
     public function getOptionParser(): ConsoleOptionParser
     {
-        $parser = parent::getOptionParser();
+        $parser = parent::getOptionParser(); /* @phpstan-ignore-line */
         $parser
             ->setDescription([
                 'Setup database connection.',
@@ -243,7 +243,7 @@ class SetupConnectionTask extends Shell
      */
     protected function saveConnectionConfig(Connection $connection)
     {
-        $file = new File($this->param('config-file'));
+        $file = new File($this->param('config-file')); /* @phpstan-ignore-line */
         if (!$file->exists() || !$file->readable() || !$file->writable()) {
             $this->abort('Unable to read from or write to configuration file');
         }

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/Transport/AsyncJobsTransportTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/Transport/AsyncJobsTransportTest.php
@@ -92,6 +92,7 @@ class AsyncJobsTransportTest extends TestCase
     {
         $before = $this->AsyncJobs->find()->count();
 
+         /* @phpstan-ignore-next-line */
         Email::deliver(
             ['evermannella@example.org' => 'Evermannella'],
             'Re Have you installed the latest version of Synapse?',
@@ -125,6 +126,7 @@ class AsyncJobsTransportTest extends TestCase
             'priority' => 1000,
         ]);
 
+        /* @phpstan-ignore-next-line */
         Email::deliver(
             ['evermannella@example.org' => 'Evermannella'],
             'Re: Have you installed the latest version of Synapse?',
@@ -161,6 +163,7 @@ class AsyncJobsTransportTest extends TestCase
             ],
         ];
 
+        /* @phpstan-ignore-next-line */
         Email::deliver(
             ['evermannella@example.org' => 'Evermannella'],
             'Re: Have you installed the latest version of Synapse?',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectModelBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectModelBehaviorTest.php
@@ -13,8 +13,7 @@
 
 namespace BEdita\Core\Test\TestCase\Model\Behavior;
 
-use Cake\Datasource\ModelAwareTrait;
-use Cake\ORM\TableRegistry;
+use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
 
@@ -26,7 +25,7 @@ use Cake\Utility\Hash;
  */
 class ObjectModelBehaviorTest extends TestCase
 {
-    use ModelAwareTrait;
+    use LocatorAwareTrait;
 
     /**
      * Fixtures
@@ -54,7 +53,7 @@ class ObjectModelBehaviorTest extends TestCase
      */
     public function testInitialize(): void
     {
-        $table = TableRegistry::getTableLocator()->get('FakeAnimals');
+        $table = $this->fetchTable('FakeAnimals');
         $count = $table->behaviors()->count();
         static::assertEquals(0, $count);
         $table->addBehavior('BEdita/Core.ObjectModel');

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectPermissionsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectPermissionsTableTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -37,8 +36,7 @@ class ObjectPermissionsTableTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $config = TableRegistry::exists('ObjectPermissions') ? [] : ['className' => 'BEdita\Core\Model\Table\ObjectPermissionsTable'];
-        $this->ObjectPermissions = TableRegistry::getTableLocator()->get('ObjectPermissions', $config);
+        $this->ObjectPermissions = $this->fetchTable('ObjectPermissions');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectPropertiesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectPropertiesTableTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -37,8 +36,7 @@ class ObjectPropertiesTableTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $config = TableRegistry::exists('ObjectProperties') ? [] : ['className' => 'BEdita\Core\Model\Table\ObjectPropertiesTable'];
-        $this->ObjectProperties = TableRegistry::getTableLocator()->get('ObjectProperties', $config);
+        $this->ObjectProperties = $this->fetchTable('ObjectProperties');
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Shell/BeditaShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/BeditaShellTest.php
@@ -14,7 +14,7 @@
 namespace BEdita\Core\Test\TestCase\Shell;
 
 use BEdita\Core\Shell\Task\InitSchemaTask;
-use Cake\Console\Shell;
+use Cake\Command\Command;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
@@ -143,7 +143,7 @@ class BeditaShellTest extends TestCase
             $returnValues
         );
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContains('Checking connection');
         $this->assertOutputContains('Initializing schema');
         $this->assertOutputContains('Checking filesystem permissions');
@@ -257,7 +257,7 @@ class BeditaShellTest extends TestCase
             )
         );
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContains('Checking connection');
         $this->assertOutputContains('Initializing schema');
         $this->assertOutputContains('Checking filesystem permissions');
@@ -278,7 +278,7 @@ class BeditaShellTest extends TestCase
         // Invoke task.
         $this->exec('bedita setup --admin-overwrite --admin-username gustavo --admin-password supporto');
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContains('Checking connection');
         $this->assertOutputContains('Checking schema');
         $this->assertOutputContains('Checking filesystem permissions');
@@ -299,7 +299,7 @@ class BeditaShellTest extends TestCase
         // Invoke task.
         $this->exec('bedita check');
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContains('Checking schema');
         $this->assertOutputContains('Checking filesystem permissions');
         $this->assertErrorEmpty();

--- a/plugins/BEdita/Core/tests/TestCase/Shell/JobsShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/JobsShellTest.php
@@ -15,8 +15,9 @@ namespace BEdita\Core\Test\TestCase\Shell;
 
 use BEdita\Core\Job\JobService;
 use BEdita\Core\Job\ServiceRegistry;
-use Cake\Console\Shell;
-use Cake\TestSuite\ConsoleIntegrationTestCase;
+use Cake\Command\Command;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
 use Cake\Utility\Text;
 
 /**
@@ -24,8 +25,10 @@ use Cake\Utility\Text;
  *
  * @coversDefaultClass \BEdita\Core\Shell\JobsShell
  */
-class JobsShellTest extends ConsoleIntegrationTestCase
+class JobsShellTest extends TestCase
 {
+    use ConsoleIntegrationTestTrait;
+
     /**
      * Fixtures
      *
@@ -78,7 +81,7 @@ class JobsShellTest extends ConsoleIntegrationTestCase
 
         $this->exec(sprintf('jobs run %s', $uuid));
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContains('completed successfully');
         $this->assertErrorEmpty();
     }
@@ -96,7 +99,7 @@ class JobsShellTest extends ConsoleIntegrationTestCase
 
         $this->exec(sprintf('jobs run %s', $uuid));
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContains('Could not obtain lock');
         $this->assertErrorEmpty();
     }
@@ -115,7 +118,7 @@ class JobsShellTest extends ConsoleIntegrationTestCase
 
         $this->exec(sprintf('jobs run %s', $uuid));
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertErrorContains('BadMethodCallException with message "example"');
         $this->assertErrorContains('failed');
     }
@@ -133,7 +136,7 @@ class JobsShellTest extends ConsoleIntegrationTestCase
 
         $this->exec(sprintf('jobs run %s', $uuid));
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertErrorContains('failed');
     }
 
@@ -150,7 +153,7 @@ class JobsShellTest extends ConsoleIntegrationTestCase
 
         $this->exec(sprintf('jobs run -F %s', $uuid));
 
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
         $this->assertErrorContains('failed');
     }
 
@@ -168,7 +171,7 @@ class JobsShellTest extends ConsoleIntegrationTestCase
 
         $this->exec('jobs pending');
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContains('completed successfully');
         $this->assertOutputContains('Operation complete');
         $this->assertErrorEmpty();
@@ -186,7 +189,7 @@ class JobsShellTest extends ConsoleIntegrationTestCase
 
         $this->exec('jobs pending --limit 0');
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContains('Nothing to do');
         $this->assertErrorEmpty();
     }
@@ -203,7 +206,7 @@ class JobsShellTest extends ConsoleIntegrationTestCase
 
         $this->exec('jobs pending -F');
 
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
         $this->assertErrorContains('failed');
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Shell/ResourcesShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/ResourcesShellTest.php
@@ -2,9 +2,10 @@
 namespace BEdita\Core\Test\TestCase\Shell;
 
 use BEdita\Core\Model\Entity\EndpointPermission;
-use Cake\Console\Shell;
+use Cake\Command\Command;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\ORM\TableRegistry;
-use Cake\TestSuite\ConsoleIntegrationTestCase;
+use Cake\TestSuite\TestCase;
 use Cake\Utility\Inflector;
 
 /**
@@ -12,8 +13,10 @@ use Cake\Utility\Inflector;
  *
  * @coversDefaultClass \BEdita\Core\Shell\ResourcesShell
  */
-class ResourcesShellTest extends ConsoleIntegrationTestCase
+class ResourcesShellTest extends TestCase
 {
+    use ConsoleIntegrationTestTrait;
+
     /**
      * Fixtures
      *
@@ -89,11 +92,11 @@ class ResourcesShellTest extends ConsoleIntegrationTestCase
         $exists = TableRegistry::getTableLocator()->get(Inflector::camelize($type))->exists(compact('name'));
         if ($expected === true) {
             static::assertTrue($exists);
-            $this->assertExitCode(Shell::CODE_SUCCESS);
+            $this->assertExitCode(Command::CODE_SUCCESS);
             $this->assertErrorEmpty();
         } else {
             static::assertFalse($exists);
-            $this->assertExitCode(Shell::CODE_ERROR);
+            $this->assertExitCode(Command::CODE_ERROR);
             $this->assertErrorContains($expected);
         }
     }
@@ -141,7 +144,7 @@ class ResourcesShellTest extends ConsoleIntegrationTestCase
     {
         $this->exec('resources add -t endpoint_permissions', [$application, $endpoint, $role, $read, $write]);
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertErrorEmpty();
 
         $endpointPermission = TableRegistry::getTableLocator()->get('EndpointPermissions')->find()->all()->last();
@@ -208,7 +211,7 @@ class ResourcesShellTest extends ConsoleIntegrationTestCase
 
         $newValue = $table->get($entity->id)->get($field);
         if ($value !== null) {
-            $this->assertExitCode(Shell::CODE_SUCCESS);
+            $this->assertExitCode(Command::CODE_SUCCESS);
             $this->assertErrorEmpty();
             static::assertEquals($value, $newValue);
         } else {
@@ -226,7 +229,7 @@ class ResourcesShellTest extends ConsoleIntegrationTestCase
     {
         $this->exec('resources edit -t applications -f description 1111');
         $this->assertErrorContains('Resource with id 1111 not found');
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
     }
 
     /**
@@ -265,7 +268,7 @@ class ResourcesShellTest extends ConsoleIntegrationTestCase
     {
         $this->exec(sprintf('resources ls -t %s', $type));
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertErrorEmpty();
         $this->assertOutputContains(sprintf('%d result(s) found', $expected));
     }
@@ -316,11 +319,11 @@ class ResourcesShellTest extends ConsoleIntegrationTestCase
         $countAfter = TableRegistry::getTableLocator()->get('Applications')->find()->count();
 
         if ($expected) {
-            $this->assertExitCode(Shell::CODE_SUCCESS);
+            $this->assertExitCode(Command::CODE_SUCCESS);
             $this->assertErrorEmpty();
             static::assertSame($countBefore - 1, $countAfter);
         } else {
-            $this->assertExitCode(Shell::CODE_ERROR);
+            $this->assertExitCode(Command::CODE_ERROR);
             static::assertSame($countBefore, $countAfter);
         }
     }

--- a/plugins/BEdita/Core/tests/TestCase/Shell/StreamsShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/StreamsShellTest.php
@@ -2,9 +2,10 @@
 namespace BEdita\Core\Test\TestCase\Shell;
 
 use BEdita\Core\Test\Utility\TestFilesystemTrait;
-use Cake\Console\Shell;
+use Cake\Command\Command;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\ORM\TableRegistry;
-use Cake\TestSuite\ConsoleIntegrationTestCase;
+use Cake\TestSuite\TestCase;
 
 /**
  * \BEdita\Core\Shell\StreamsShell Test Case
@@ -12,8 +13,9 @@ use Cake\TestSuite\ConsoleIntegrationTestCase;
  * @property \BEdita\Core\Model\Table\StreamsTable $Streams
  * @coversDefaultClass \BEdita\Core\Shell\StreamsShell
  */
-class StreamsShellTest extends ConsoleIntegrationTestCase
+class StreamsShellTest extends TestCase
 {
+    use ConsoleIntegrationTestTrait;
     use TestFilesystemTrait;
 
     /**
@@ -121,7 +123,7 @@ class StreamsShellTest extends ConsoleIntegrationTestCase
         $count = TableRegistry::getTableLocator()->get('Streams')->find()->count();
         $this->exec(sprintf('streams removeOrphans --days %d', $days));
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertErrorEmpty();
 
         $count -= TableRegistry::getTableLocator()->get('Streams')->find()->count();

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckApiKeyTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckApiKeyTaskTest.php
@@ -15,15 +15,18 @@ namespace BEdita\Core\Test\TestCase\Shell\Task;
 
 use BEdita\Core\Model\Table\ApplicationsTable;
 use BEdita\Core\Shell\Task\CheckApiKeyTask;
-use Cake\Console\Shell;
+use Cake\Command\Command;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\ORM\TableRegistry;
-use Cake\TestSuite\ConsoleIntegrationTestCase;
+use Cake\TestSuite\TestCase;
 
 /**
  * @coversDefaultClass \BEdita\Core\Shell\Task\CheckApiKeyTask
  */
-class CheckApiKeyTaskTest extends ConsoleIntegrationTestCase
+class CheckApiKeyTaskTest extends TestCase
 {
+    use ConsoleIntegrationTestTrait;
+
     /**
      * Applications table.
      *
@@ -72,7 +75,7 @@ class CheckApiKeyTaskTest extends ConsoleIntegrationTestCase
 
         $this->exec(CheckApiKeyTask::class);
 
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
         $this->assertErrorContains('Default application is missing, please check your installation');
     }
 
@@ -88,7 +91,7 @@ class CheckApiKeyTaskTest extends ConsoleIntegrationTestCase
 
         $this->exec(CheckApiKeyTask::class);
 
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
         $this->assertOutputContains('Default application has no API key');
     }
 
@@ -104,7 +107,7 @@ class CheckApiKeyTaskTest extends ConsoleIntegrationTestCase
 
         $this->exec(CheckApiKeyTask::class);
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContains(sprintf('Default API key is: <info>%s</info>', $apiKey));
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckFilesystemTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckFilesystemTaskTest.php
@@ -14,14 +14,17 @@
 namespace BEdita\Core\Test\TestCase\Shell\Task;
 
 use BEdita\Core\Shell\Task\CheckFilesystemTask;
-use Cake\Console\Shell;
-use Cake\TestSuite\ConsoleIntegrationTestCase;
+use Cake\Command\Command;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
 
 /**
  * @coversDefaultClass \BEdita\Core\Shell\Task\CheckFilesystemTask
  */
-class CheckFilesystemTaskTest extends ConsoleIntegrationTestCase
+class CheckFilesystemTaskTest extends TestCase
 {
+    use ConsoleIntegrationTestTrait;
+
     /**
      * Temporary directory for permissions tests.
      *
@@ -58,7 +61,7 @@ class CheckFilesystemTaskTest extends ConsoleIntegrationTestCase
 
         $this->exec(sprintf('%s --httpd-user %s %s', CheckFilesystemTask::class, exec('whoami'), static::TEMP_DIR));
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertErrorEmpty();
         $this->assertOutputContains('Filesystem permissions look alright. Time to write something in those shiny folders');
     }
@@ -82,7 +85,7 @@ class CheckFilesystemTaskTest extends ConsoleIntegrationTestCase
 
         $this->exec(sprintf('%s --verbose %s', CheckFilesystemTask::class, static::TEMP_DIR));
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContains(sprintf('Detected webserver user: <info>%s</info>', $user));
         $this->assertErrorEmpty();
     }
@@ -106,7 +109,7 @@ class CheckFilesystemTaskTest extends ConsoleIntegrationTestCase
 
         $this->exec(sprintf('%s %s', CheckFilesystemTask::class, static::TEMP_DIR));
 
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
         $this->assertOutputContains('Unable to detect webserver user');
         $this->assertErrorEmpty();
     }
@@ -122,7 +125,7 @@ class CheckFilesystemTaskTest extends ConsoleIntegrationTestCase
     {
         $this->exec(sprintf('%s --httpd-user %s %s', CheckFilesystemTask::class, exec('whoami'), static::TEMP_DIR));
 
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
         $this->assertErrorContains(sprintf('Path "%s" does not exist or is not a directory', static::TEMP_DIR));
     }
 
@@ -140,7 +143,7 @@ class CheckFilesystemTaskTest extends ConsoleIntegrationTestCase
 
         $this->exec(sprintf('%s --httpd-user nobody %s', CheckFilesystemTask::class, static::TEMP_DIR));
 
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
         $this->assertOutputContains(sprintf('Path "%s" might not be writable by CLI user', static::TEMP_DIR));
         $this->assertOutputContains('Potential issues were found, please check your installation');
         $this->assertErrorEmpty();
@@ -177,7 +180,7 @@ class CheckFilesystemTaskTest extends ConsoleIntegrationTestCase
 
         $this->exec(sprintf('%s --httpd-user nobody %s', CheckFilesystemTask::class, static::TEMP_DIR));
 
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
         $this->assertOutputContains(sprintf('Path "%s" might not be writable by webserver user', static::TEMP_DIR));
         $this->assertOutputContains('Potential issues were found, please check your installation');
         $this->assertErrorEmpty();
@@ -197,7 +200,7 @@ class CheckFilesystemTaskTest extends ConsoleIntegrationTestCase
 
         $this->exec(sprintf('%s --httpd-user nobody %s', CheckFilesystemTask::class, static::TEMP_DIR));
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContains(sprintf('Path "%s" is world writable!', static::TEMP_DIR));
         $this->assertOutputContains('Filesystem permissions look alright. Time to write something in those shiny folders');
         $this->assertErrorEmpty();

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckSchemaTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckSchemaTaskTest.php
@@ -14,7 +14,7 @@
 namespace BEdita\Core\Test\TestCase\Shell\Task;
 
 use BEdita\Core\Shell\Task\CheckSchemaTask;
-use Cake\Console\Shell;
+use Cake\Command\Command;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Core\Plugin;
 use Cake\Database\Connection;
@@ -98,7 +98,7 @@ class CheckSchemaTaskTest extends TestCase
 
         $this->exec(CheckSchemaTask::class);
 
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
         $this->assertErrorContains('Plugin "Migrations" must be loaded');
         // restore plugin
         $pluginCollection->add($migrationPlugin);
@@ -152,14 +152,14 @@ class CheckSchemaTaskTest extends TestCase
         $this->exec(CheckSchemaTask::class);
 
         if ($this->checkAvailable($connection)) {
-            static::assertExitCode(Shell::CODE_ERROR);
+            static::assertExitCode(Command::CODE_ERROR);
             $this->assertOutputContains('Column name "foo_bar" is not valid (same name as table)');
             $this->assertOutputContains('Column name "password" is not valid (reserved word)');
             $this->assertOutputContains('Column name "42gustavo__suppOrto_" is not valid');
             $this->assertOutputContains('Index name "mytestindex" is not valid');
             $this->assertOutputRegExp('/Constraint name "[a-zA-Z0-9_]+" is not valid/');
         } else {
-            static::assertExitCode(Shell::CODE_SUCCESS);
+            static::assertExitCode(Command::CODE_SUCCESS);
             $this->assertOutputContains('SQL conventions and schema differences can only be checked on MySQL');
         }
         $this->assertErrorEmpty();
@@ -178,7 +178,7 @@ class CheckSchemaTaskTest extends TestCase
 
         $this->exec(CheckSchemaTask::class);
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         if (!$this->checkAvailable($connection)) {
             $this->assertOutputContains('SQL conventions and schema differences can only be checked on MySQL');
         }
@@ -206,10 +206,10 @@ class CheckSchemaTaskTest extends TestCase
     //     $this->exec(CheckSchemaTask::class);
 
     //     if ($this->checkAvailable($connection)) {
-    //         $this->assertExitCode(Shell::CODE_ERROR);
+    //         $this->assertExitCode(Command::CODE_ERROR);
     //         $this->assertOutputContains('Table "foo_bar" has been added');
     //     } else {
-    //         $this->assertExitCode(Shell::CODE_SUCCESS);
+    //         $this->assertExitCode(Command::CODE_SUCCESS);
     //         $this->assertOutputContains('SQL conventions and schema differences can only be checked on MySQL');
     //     }
     //     $this->assertErrorEmpty();
@@ -236,10 +236,10 @@ class CheckSchemaTaskTest extends TestCase
     //     $this->exec(CheckSchemaTask::class);
 
     //     if ($this->checkAvailable($connection)) {
-    //         $this->assertExitCode(Shell::CODE_ERROR);
+    //         $this->assertExitCode(Command::CODE_ERROR);
     //         $this->assertOutputContains('Table "config" has been removed');
     //     } else {
-    //         $this->assertExitCode(Shell::CODE_SUCCESS);
+    //         $this->assertExitCode(Command::CODE_SUCCESS);
     //         $this->assertOutputContains('SQL conventions and schema differences can only be checked on MySQL');
     //     }
     //     $this->assertErrorEmpty();
@@ -267,7 +267,7 @@ class CheckSchemaTaskTest extends TestCase
     //     $this->exec(CheckSchemaTask::class);
 
     //     if ($this->checkAvailable($connection)) {
-    //         $this->assertExitCode(Shell::CODE_ERROR);
+    //         $this->assertExitCode(Command::CODE_ERROR);
     //         foreach ($constraints as $constraint) {
     //             $info = $table->getConstraint($constraint);
     //             if ($info && isset($info['type']) && $info['type'] !== TableSchema::CONSTRAINT_FOREIGN) {
@@ -277,7 +277,7 @@ class CheckSchemaTaskTest extends TestCase
     //             $this->assertOutputContains(sprintf('Constraint "%s" has been removed', $constraint));
     //         }
     //     } else {
-    //         $this->assertExitCode(Shell::CODE_SUCCESS);
+    //         $this->assertExitCode(Command::CODE_SUCCESS);
     //         $this->assertOutputContains('SQL conventions and schema differences can only be checked on MySQL');
     //     }
     //     $this->assertErrorEmpty();

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/InitSchemaTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/InitSchemaTaskTest.php
@@ -14,7 +14,7 @@
 namespace BEdita\Core\Test\TestCase\Shell\Task;
 
 use BEdita\Core\Shell\Task\InitSchemaTask;
-use Cake\Console\Shell;
+use Cake\Command\Command;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Core\Plugin;
 use Cake\Database\Connection;
@@ -85,7 +85,7 @@ class InitSchemaTaskTest extends TestCase
 
         $this->exec(sprintf('%s --no-force --no-seed', InitSchemaTask::class));
 
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
         $this->assertErrorContains('Database is not empty, no action has been performed');
     }
 
@@ -105,7 +105,7 @@ class InitSchemaTaskTest extends TestCase
 
         $schema = unserialize(file_get_contents(Plugin::configPath('BEdita/Core') . DS . 'Migrations' . DS . 'schema-dump-default.lock'));
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertErrorEmpty();
         static::assertCount(count($schema) + 1, $connection->getSchemaCollection()->listTables());
 
@@ -133,7 +133,7 @@ class InitSchemaTaskTest extends TestCase
 
         $schema = unserialize(file_get_contents(Plugin::configPath('BEdita/Core') . DS . 'Migrations' . DS . 'schema-dump-default.lock'));
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertErrorEmpty();
         static::assertCount(count($schema) + 1, $connection->getSchemaCollection()->listTables());
     }
@@ -155,7 +155,7 @@ class InitSchemaTaskTest extends TestCase
 
         $schema = unserialize(file_get_contents(Plugin::configPath('BEdita/Core') . DS . 'Migrations' . DS . 'schema-dump-default.lock'));
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertErrorEmpty();
         static::assertCount(count($schema) + 1, $connection->getSchemaCollection()->listTables());
     }
@@ -183,7 +183,7 @@ class InitSchemaTaskTest extends TestCase
 
         $schema = unserialize(file_get_contents(Plugin::configPath('BEdita/Core') . DS . 'Migrations' . DS . 'schema-dump-default.lock'));
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertErrorEmpty();
         static::assertCount(count($schema) + 1, $connection->getSchemaCollection()->listTables());
 

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/SetupAdminUserTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/SetupAdminUserTaskTest.php
@@ -15,15 +15,18 @@ namespace BEdita\Core\Test\TestCase\Shell\Task;
 
 use BEdita\Core\Model\Table\UsersTable;
 use BEdita\Core\Shell\Task\SetupAdminUserTask;
-use Cake\Console\Shell;
+use Cake\Command\Command;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\ORM\TableRegistry;
-use Cake\TestSuite\ConsoleIntegrationTestCase;
+use Cake\TestSuite\TestCase;
 
 /**
  * @coversDefaultClass \BEdita\Core\Shell\Task\SetupAdminUserTask
  */
-class SetupAdminUserTaskTest extends ConsoleIntegrationTestCase
+class SetupAdminUserTaskTest extends TestCase
 {
+    use ConsoleIntegrationTestTrait;
+
     /**
      * Users table.
      *
@@ -79,7 +82,7 @@ class SetupAdminUserTaskTest extends ConsoleIntegrationTestCase
 
         $this->exec(SetupAdminUserTask::class);
 
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
         $this->assertErrorContains(sprintf('Missing user %d!', UsersTable::ADMIN_USER));
     }
 
@@ -98,7 +101,7 @@ class SetupAdminUserTaskTest extends ConsoleIntegrationTestCase
         // Invoke task.
         $this->exec(SetupAdminUserTask::class, ['n']);
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContains(sprintf('Administrator user <comment>%s</comment> has already been configured', $username));
         $this->assertOutputContains('Do you want to overwrite current admin user?');
         $this->assertOutputContains('Existing administrator user has been preserved. Don\'t panic!');
@@ -123,7 +126,7 @@ class SetupAdminUserTaskTest extends ConsoleIntegrationTestCase
         // Invoke task.
         $this->exec(sprintf('%s --no-admin-overwrite', SetupAdminUserTask::class));
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $output = implode(PHP_EOL, $this->_out->messages());
         $this->assertOutputContains(sprintf('Administrator user <comment>%s</comment> has already been configured', $username));
         static::assertStringNotContainsString('Do you want to overwrite current admin user?', $output);
@@ -151,7 +154,7 @@ class SetupAdminUserTaskTest extends ConsoleIntegrationTestCase
         // Invoke task.
         $this->exec(SetupAdminUserTask::class, ['y', $newUsername, $newPassword]);
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContains(sprintf('Administrator user <comment>%s</comment> has already been configured', $username));
         $this->assertOutputContains('Do you want to overwrite current admin user?');
         $this->assertOutputContains('Enter new username for default admin user:');
@@ -180,7 +183,7 @@ class SetupAdminUserTaskTest extends ConsoleIntegrationTestCase
         // Invoke task.
         $this->exec(sprintf('%s --admin-overwrite --admin-username %s --admin-password %s', SetupAdminUserTask::class, $newUsername, $newPassword));
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $output = implode(PHP_EOL, $this->_out->messages());
         $this->assertOutputContains(sprintf('Administrator user <comment>%s</comment> has already been configured', $username));
         static::assertStringNotContainsString('Do you want to overwrite current admin user?', $output);
@@ -210,7 +213,7 @@ class SetupAdminUserTaskTest extends ConsoleIntegrationTestCase
         // Invoke task.
         $this->exec(sprintf('%s --admin-username %s --admin-password %s', SetupAdminUserTask::class, $newUsername, $newPassword));
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $output = implode(PHP_EOL, $this->_out->messages());
         static::assertStringNotContainsString('has already been configured', $output);
         static::assertStringNotContainsString('Do you want to overwrite current admin user?', $output);
@@ -240,7 +243,7 @@ class SetupAdminUserTaskTest extends ConsoleIntegrationTestCase
         // Invoke task.
         $this->exec(sprintf('%s --admin-username "%s" --admin-password %s', SetupAdminUserTask::class, $newUsername, $newPassword));
 
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
         $output = implode(PHP_EOL, $this->_out->messages());
         static::assertStringNotContainsString('has already been configured', $output);
         static::assertStringNotContainsString('Do you want to overwrite current admin user?', $output);

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/SetupConnectionTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/SetupConnectionTaskTest.php
@@ -14,7 +14,7 @@
 namespace BEdita\Core\Test\TestCase\Shell\Task;
 
 use BEdita\Core\Shell\Task\SetupConnectionTask;
-use Cake\Console\Shell;
+use Cake\Command\Command;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Database\Connection;
 use Cake\Datasource\ConnectionInterface;
@@ -76,7 +76,7 @@ class SetupConnectionTaskTest extends TestCase
 
         $this->exec(sprintf('%s --connection %s', SetupConnectionTask::class, static::TEMP_CONNECTION));
 
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
         $this->assertErrorContains('Invalid connection object');
     }
 
@@ -105,7 +105,7 @@ class SetupConnectionTaskTest extends TestCase
 
         $this->exec(sprintf('%s --connection %s', SetupConnectionTask::class, static::TEMP_CONNECTION));
 
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
         $this->assertOutputContains('Connection failed');
         $this->assertErrorContains(sprintf('Connection to %s could not be established', $driver));
     }
@@ -122,7 +122,7 @@ class SetupConnectionTaskTest extends TestCase
     {
         $this->exec(SetupConnectionTask::class);
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContains('Connection is still ok. Relax...');
         $this->assertErrorEmpty();
     }
@@ -173,7 +173,7 @@ class SetupConnectionTaskTest extends TestCase
         // Invoke task.
         $this->exec(sprintf('%s --connection %s', SetupConnectionTask::class, static::TEMP_CONNECTION), $returnValues);
 
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
         $this->assertOutputContains('Connection failed');
         $this->assertErrorContains(sprintf('Connection to %s could not be established', $driver));
     }
@@ -227,7 +227,7 @@ class SetupConnectionTaskTest extends TestCase
             $returnValues
         );
 
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
         $this->assertErrorContains('Unable to read from or write to configuration file');
     }
 
@@ -290,7 +290,7 @@ class SetupConnectionTaskTest extends TestCase
             $returnValues
         );
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertErrorEmpty();
         $this->assertOutputContains('Configuration saved');
         $this->assertOutputContains('Connection is ok. It\'s time to start using BEdita!');
@@ -401,7 +401,7 @@ class SetupConnectionTaskTest extends TestCase
             )
         );
 
-        $this->assertExitCode(Shell::CODE_SUCCESS);
+        $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertErrorEmpty();
         $this->assertOutputContains('Configuration saved');
         $this->assertOutputContains('Connection is ok. It\'s time to start using BEdita!');
@@ -510,7 +510,7 @@ class SetupConnectionTaskTest extends TestCase
             )
         );
 
-        $this->assertExitCode(Shell::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_ERROR);
         $this->assertErrorContains('Updated configuration file has invalid syntax');
 
         // Perform additional assertions on connection.

--- a/plugins/BEdita/Core/tests/TestCase/Utility/DatabaseTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/DatabaseTest.php
@@ -53,7 +53,7 @@ class DatabaseTest extends TestCase
         static::$fixtureManager->shutDown();
 
         $fixtures = ['Applications', 'Config', 'ObjectTypes', 'Roles'];
-        $this->loadFixtures(...$fixtures);
+        $this->loadFixtures(...$fixtures); /* @phpstan-ignore-line */
         $schema = Database::currentSchema();
 
         $this->assertCount(count($fixtures), $schema);
@@ -95,11 +95,11 @@ class DatabaseTest extends TestCase
         static::$fixtureManager->shutDown();
 
         $fixtures1 = ['Applications', 'Config', 'ObjectTypes'];
-        $this->loadFixtures(...$fixtures1);
+        $this->loadFixtures(...$fixtures1); /* @phpstan-ignore-line */
         $schema1 = Database::currentSchema();
 
         $fixtures2 = ['AsyncJobs', 'Roles'];
-        $this->loadFixtures(...$fixtures2);
+        $this->loadFixtures(...$fixtures2); /* @phpstan-ignore-line */
         $schema2 = Database::currentSchema();
 
         $fixtures2 = array_merge($fixtures1, $fixtures2);
@@ -153,10 +153,13 @@ class DatabaseTest extends TestCase
     public function testSupportedVersion()
     {
         $info = Database::basicInfo();
+        /* @phpstan-ignore-next-line */
         $result = Database::supportedVersion(['vendor' => $info['vendor'], 'version' => $info['version']]);
         static::assertTrue($result);
+        /* @phpstan-ignore-next-line */
         $result = Database::supportedVersion(['vendor' => $info['vendor'], 'version' => 'zzzzzzzzz']);
         static::assertFalse($result);
+        /* @phpstan-ignore-next-line */
         $result = Database::supportedVersion(['vendor' => 'mongodb']);
         static::assertFalse($result);
     }
@@ -214,7 +217,7 @@ class DatabaseTest extends TestCase
      */
     public function testExecuteTransaction($sql, $success, $rowCount, $queryCount, $dbConfig = 'test')
     {
-        $this->loadFixtures('Applications', 'Config', 'ObjectTypes', 'Roles');
+        $this->loadFixtures('Applications', 'Config', 'ObjectTypes', 'Roles'); /* @phpstan-ignore-line */
 
         $res = Database::executeTransaction($sql, $dbConfig);
         $this->assertNotEmpty($res);


### PR DESCRIPTION
This PR introduces `phpstan/phpstan-deprecation-rules` to highlight deprecations in PHPStan

Some deprecations have been removed and `@phpstan-ignore-line` or `@phpstan-ignore-next-line` annotations have been added in remaining cases.

Main changes:
* use `LocatorAwareTrait` instead of `ModelAwareTrait`
* use `IntegrationTestTrait` instead of `IntegrationTestCase` 
* use `LocatorAwareTrait::defaultTable` instead of `ModelAwareTrait::modelClass`
* use `Command` instead of `Shell` (when applicable)
