### PR TITLE
Fix signup error for `draft` users

### DIFF
--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -154,7 +154,7 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
 
         $user = (new GetObjectAction(['table' => $this->Users]))->execute(['primaryKey' => $user->id, 'contain' => 'Roles']);
         Configure::write('Status.level', $statusLevel);
-        
+
         return $user;
     }
 

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -104,6 +104,7 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
     /**
      * {@inheritDoc}
      *
+     * @param array $data Action data.
      * @return \BEdita\Core\Model\Entity\User
      * @throws \Cake\Http\Exception\BadRequestException When validation of URL options fails
      * @throws \Cake\Http\Exception\UnauthorizedException Upon external authorization check failure.
@@ -147,6 +148,8 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
 
             throw $e;
         }
+        // set Status.level to `draft` to allow `draft` user object load
+        Configure::write('Status.level', 'draft');
 
         return (new GetObjectAction(['table' => $this->Users]))->execute(['primaryKey' => $user->id, 'contain' => 'Roles']);
     }

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -149,9 +149,13 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
             throw $e;
         }
         // Remove `Status.level` filter here to allow user object with `draft` or any other status
+        $statusLevel = Configure::read('Status.level');
         Configure::delete('Status.level');
 
-        return (new GetObjectAction(['table' => $this->Users]))->execute(['primaryKey' => $user->id, 'contain' => 'Roles']);
+        $user = (new GetObjectAction(['table' => $this->Users]))->execute(['primaryKey' => $user->id, 'contain' => 'Roles']);
+        Configure::write('Status.level', $statusLevel);
+        
+        return $user;
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -148,8 +148,8 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
 
             throw $e;
         }
-        // set Status.level to `draft` to allow `draft` user object load
-        Configure::write('Status.level', 'draft');
+        // Remove `Status.level` filter here to allow user object with `draft` or any other status
+        Configure::delete('Status.level');
 
         return (new GetObjectAction(['table' => $this->Users]))->execute(['primaryKey' => $user->id, 'contain' => 'Roles']);
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -286,6 +286,32 @@ class SignupUserActionTest extends TestCase
     }
 
     /**
+     * Test command execution with `Status.level` set to `on`.
+     *
+     * @return void
+     */
+    public function testStatusLevelExecute(): void
+    {
+        Configure::write('Status.level', 'on');
+        $data = [
+            'username' => 'testsignup',
+            'password' => 'testsignup',
+            'email' => 'test.signup@example.com',
+            'activation_url' => 'http://sample.com?confirm=true',
+            'redirect_url' => 'http://sample.com/ok',
+        ];
+
+        $action = new SignupUserAction();
+        $result = $action(compact('data'));
+
+        static::assertTrue((bool)$result);
+        static::assertInstanceOf(User::class, $result);
+        static::assertSame('draft', $result->status);
+        static::assertSame($data['username'], $result->username);
+        Configure::delete('Status.level');
+    }
+
+    /**
      * Test command execution with external auth
      *
      * @param array|\Exception $expected Expected result.


### PR DESCRIPTION
This PR solves a problem in `/signup` logic when a status level filter is active, namely with `'Status.level' configuration is `on`.

Upon successful signup, at the end of `SignupUserAction` the newly created user is returned via `GetObjectAction`. If a user requires a validation (email verification usually) its user object can be `draft` and a 404 Not Found error will be raised if `'Status.level' conf is `on`. Solution: get rid of status level filter in this particular case.
