### PR TITLE
Regex to validate internal resource names

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/ResourceNamesValidationTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ResourceNamesValidationTest.php
@@ -66,7 +66,7 @@ class ResourceNamesValidationTest extends IntegrationTestCase
                 400,
                 '/admin/applications',
                 [
-                    'name' => '1_app',
+                    'name' => '',
                 ],
                 'applications',
             ],

--- a/plugins/BEdita/API/tests/IntegrationTest/ResourceNamesValidationTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ResourceNamesValidationTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2022 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Test\IntegrationTest;
+
+use BEdita\API\TestSuite\IntegrationTestCase;
+
+/**
+ * Integration test for resource names validations.
+ */
+class ResourceNamesValidationTest extends IntegrationTestCase
+{
+    /**
+     * Data provider for `testValidate` method
+     *
+     * @return array
+     */
+    public function validateProvider(): array
+    {
+        return [
+            'bad ptype' => [
+                400,
+                '/model/property_types',
+                [
+                    'name' => '12345',
+                ],
+                'property_types',
+            ],
+            'good ptype' => [
+                201,
+                '/model/property_types',
+                [
+                    'name' => 'abc_de',
+                    'params' => null,
+                ],
+                'property_types',
+            ],
+            'bad otype' => [
+                400,
+                '/model/object_types',
+                [
+                    'name' => 'Foos',
+                    'singular' => 'Foo',
+                ],
+                'object_types',
+            ],
+            'good otype' => [
+                201,
+                '/model/object_types',
+                [
+                    'name' => 'foos',
+                    'singular' => 'foo',
+                ],
+                'object_types',
+            ],
+            'bad app' => [
+                400,
+                '/admin/applications',
+                [
+                    'name' => '1_app',
+                ],
+                'applications',
+            ],
+            'bad role' => [
+                400,
+                '/roles',
+                [
+                    'name' => 'first-role',
+                ],
+                'roles',
+            ],
+        ];
+    }
+
+    /**
+     * Test validation on resource creations
+     *
+     * @param int $expected Expected response code
+     * @param string $endpoint The test URL
+     * @param array $attributes Body data attributes
+     * @param string $type The resource type
+     * @return void
+     * @dataProvider validateProvider
+     * @coversNothing
+     */
+    public function testValidate(int $expected, string $endpoint, array $attributes, string $type): void
+    {
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $data = compact('type', 'attributes');
+
+        $this->post($endpoint, json_encode(compact('data')));
+        $this->assertResponseCode($expected);
+    }
+}

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
@@ -827,7 +827,7 @@ class ObjectTypesControllerTest extends IntegrationTestCase
             'id' => '2',
             'type' => 'object_types',
             'attributes' => [
-                'singular' => 'document new',
+                'singular' => 'document_new',
             ],
         ];
 
@@ -839,7 +839,7 @@ class ObjectTypesControllerTest extends IntegrationTestCase
 
         $ObjectTypes = TableRegistry::getTableLocator()->get('ObjectTypes');
         $entity = $ObjectTypes->get(2);
-        $this->assertEquals('document new', $entity->get('singular'));
+        $this->assertEquals('document_new', $entity->get('singular'));
 
         // restore previous values
         $entity = $ObjectTypes->patchEntity($entity, ['singular' => 'document']);

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
@@ -534,7 +534,7 @@ class PropertyTypesControllerTest extends IntegrationTestCase
         $data = [
             'type' => 'property_types',
             'attributes' => [
-                'name' => 'gustavo',
+                'name' => 'gustavo_type',
             ],
         ];
 
@@ -544,7 +544,7 @@ class PropertyTypesControllerTest extends IntegrationTestCase
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
         $this->assertHeader('Location', 'http://api.example.com/model/property_types/13');
-        static::assertTrue(TableRegistry::getTableLocator()->get('PropertyTypes')->exists(['name' => 'gustavo']));
+        static::assertTrue(TableRegistry::getTableLocator()->get('PropertyTypes')->exists(['name' => 'gustavo_type']));
         static::assertFalse(TableRegistry::getTableLocator()->get('PropertyTypes')->get(13)->get('core_type'));
     }
 

--- a/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
@@ -14,7 +14,6 @@
 namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Exception\ImmutableResourceException;
-use BEdita\Core\Model\Validation\Validation;
 use BEdita\Core\State\CurrentApplication;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;

--- a/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
@@ -91,7 +91,6 @@ class ApplicationsTable extends Table
 
             ->requirePresence('name', 'create')
             ->notEmptyString('name')
-            ->regex('name', Validation::RESOURCE_NAME_REGEX)
             ->add('name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table'])
 
             ->allowEmptyString('description')

--- a/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Exception\ImmutableResourceException;
+use BEdita\Core\Model\Validation\Validation;
 use BEdita\Core\State\CurrentApplication;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
@@ -90,6 +91,7 @@ class ApplicationsTable extends Table
 
             ->requirePresence('name', 'create')
             ->notEmptyString('name')
+            ->regex('name', Validation::RESOURCE_NAME_REGEX)
             ->add('name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table'])
 
             ->allowEmptyString('description')

--- a/plugins/BEdita/Core/src/Model/Table/AuthProvidersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/AuthProvidersTable.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Model\Table;
 
+use BEdita\Core\Model\Validation\Validation;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
@@ -69,6 +70,7 @@ class AuthProvidersTable extends Table
             ->add('name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table'])
             ->requirePresence('name', 'create')
             ->notEmptyString('name')
+            ->regex('name', Validation::RESOURCE_NAME_REGEX)
 
             // Use `add` instead of `urlWithProtocol` to preserve rule name.
             ->add('url', 'url', [

--- a/plugins/BEdita/Core/src/Model/Table/EndpointsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/EndpointsTable.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Model\Table;
 
+use BEdita\Core\Model\Validation\Validation;
 use Cake\Http\Exception\NotFoundException;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
@@ -70,6 +71,7 @@ class EndpointsTable extends Table
 
             ->requirePresence('name', 'create')
             ->notEmptyString('name')
+            ->regex('name', Validation::RESOURCE_NAME_REGEX)
             ->add('name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table'])
 
             ->allowEmptyString('description')

--- a/plugins/BEdita/Core/src/Model/Table/PropertiesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/PropertiesTable.php
@@ -16,6 +16,7 @@ namespace BEdita\Core\Model\Table;
 use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Model\Entity\Property;
 use BEdita\Core\Model\Entity\StaticProperty;
+use BEdita\Core\Model\Validation\Validation;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Query as DatabaseQuery;
 use Cake\Database\Schema\TableSchemaInterface;
@@ -25,7 +26,7 @@ use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
-use Cake\Validation\Validation;
+use Cake\Validation\Validation as CakeValidation;
 use Cake\Validation\Validator;
 
 /**
@@ -90,6 +91,7 @@ class PropertiesTable extends Table
 
             ->requirePresence('name')
             ->notEmptyString('name')
+            ->regex('name', Validation::RESOURCE_NAME_REGEX)
 
             ->allowEmptyString('description')
 
@@ -219,7 +221,7 @@ class PropertiesTable extends Table
             ->from([$this->getAlias() => $from], true)
             ->formatResults(function (ResultSetInterface $results) {
                 return $results->map(function ($row) {
-                    if (!($row instanceof Property) || empty($row->id) || !Validation::uuid($row->id)) {
+                    if (!($row instanceof Property) || empty($row->id) || !CakeValidation::uuid($row->id)) {
                         return $row;
                     }
 

--- a/plugins/BEdita/Core/src/Model/Table/PropertyTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/PropertyTypesTable.php
@@ -85,7 +85,7 @@ class PropertyTypesTable extends Table
 
             ->requirePresence('name', 'create')
             ->notEmptyString('name')
-            ->alphaNumeric('name')
+            ->regex('name', Validation::RESOURCE_NAME_REGEX)
 
             ->allowEmptyArray('params')
             ->add('params', 'valid', [

--- a/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
@@ -104,6 +104,7 @@ class RelationsTable extends Table
 
             ->requirePresence('name', 'create')
             ->notEmptyString('name')
+            ->regex('name', Validation::RESOURCE_NAME_REGEX)
             ->add('name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table'])
 
             ->allowEmptyString('label', null, 'create')
@@ -111,6 +112,7 @@ class RelationsTable extends Table
 
             ->requirePresence('inverse_name', 'create')
             ->notEmptyString('inverse_name')
+            ->regex('inverse_name', Validation::RESOURCE_NAME_REGEX)
             ->add('inverse_name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table'])
 
             ->allowEmptyString('inverse_label', null, 'create')

--- a/plugins/BEdita/Core/src/Model/Table/RolesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RolesTable.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Exception\ImmutableResourceException;
+use BEdita\Core\Model\Validation\Validation;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
@@ -86,6 +87,7 @@ class RolesTable extends Table
             ->add('name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table'])
             ->requirePresence('name')
             ->notEmptyString('name')
+            ->regex('name', Validation::RESOURCE_NAME_REGEX)
 
             ->allowEmptyString('description')
 

--- a/plugins/BEdita/Core/src/Model/Validation/ObjectTypesValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/ObjectTypesValidator.php
@@ -43,7 +43,7 @@ class ObjectTypesValidator extends Validator
             ->requirePresence('name', 'create')
             ->notEmptyString('name')
             // `name` must contain at least a letter (avoid conflicts with ids)
-            ->regex('name', '/^([a-zA-Z]+)/')
+            ->regex('name', Validation::RESOURCE_NAME_REGEX)
             ->add('name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table'])
             ->add('name', 'notReserved', ['rule' => 'notReserved', 'provider' => 'bedita']);
 
@@ -51,7 +51,7 @@ class ObjectTypesValidator extends Validator
             ->requirePresence('singular', 'create')
             ->notEmptyString('singular')
             // `singular` must contain at least a letter (avoid conflicts with ids)
-            ->regex('singular', '/^([a-zA-Z]+)/')
+            ->regex('singular', Validation::RESOURCE_NAME_REGEX)
             ->add('singular', 'notSameAs', [
                 'rule' => function ($value, $context) {
                     if (empty($context['data']['name'])) {

--- a/plugins/BEdita/Core/src/Model/Validation/Validation.php
+++ b/plugins/BEdita/Core/src/Model/Validation/Validation.php
@@ -30,7 +30,7 @@ class Validation
 {
     /**
      * Regular expression to validate resource names:
-     *  - starts with a lowercase latter
+     *  - starts with a lowercase letter
      *  - lowercase letters, numbers and underscores
      *  - length between 2 and 200 characters
      *

--- a/plugins/BEdita/Core/src/Model/Validation/Validation.php
+++ b/plugins/BEdita/Core/src/Model/Validation/Validation.php
@@ -29,6 +29,16 @@ use Swaggest\JsonSchema\Schema;
 class Validation
 {
     /**
+     * Regular expression to validate resource names:
+     *  - starts with a lowercase latter
+     *  - lowercase letters, numbers and underscores
+     *  - length between 2 and 200 characters
+     *
+     * @var string
+     */
+    public const RESOURCE_NAME_REGEX = '/^[a-z][a-z0-9_]{1,200}$/';
+
+    /**
      * The list of reserved names
      *
      * @var string[]|null

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -125,10 +125,8 @@ class ObjectTypeTest extends TestCase
      */
     public function testSetName()
     {
-        $data = [
-            'name' => 'FooBar',
-        ];
-        $objectType = $this->ObjectTypes->newEntity($data);
+        $objectType = $this->ObjectTypes->newEmptyEntity();
+        $objectType->set('name', 'FooBar');
 
         static::assertEquals('foo_bar', $objectType->name);
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/RelationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/RelationTest.php
@@ -92,13 +92,11 @@ class RelationTest extends TestCase
      */
     public function testSetName()
     {
-        $data = [
-            'name' => 'FooBar',
-        ];
-        $relation = $this->Relations->newEntity($data);
+        $relation = $this->Relations->newEmptyEntity();
         if (!($relation instanceof Relation)) {
             static::fail(sprintf('Unexpected entity class "%s"', get_class($relation)));
         }
+        $relation->set('name', 'FooBar');
 
         static::assertEquals('foo_bar', $relation->name);
         static::assertEquals('FooBar', $relation->alias);
@@ -113,13 +111,11 @@ class RelationTest extends TestCase
      */
     public function testSetInverseName()
     {
-        $data = [
-            'inverse_name' => 'bar-foo',
-        ];
-        $relation = $this->Relations->newEntity($data);
+        $relation = $this->Relations->newEmptyEntity();
         if (!($relation instanceof Relation)) {
             static::fail(sprintf('Unexpected entity class "%s"', get_class($relation)));
         }
+        $relation->set('inverse_name', 'bar-foo');
 
         static::assertEquals('bar_foo', $relation->inverse_name);
         static::assertEquals('BarFoo', $relation->inverse_alias);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertyTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertyTypesTableTest.php
@@ -108,7 +108,7 @@ class PropertyTypesTableTest extends TestCase
             'valid' => [
                 true,
                 [
-                    'name' => 'propName',
+                    'name' => 'prop_name',
                     'params' => [
                         'type' => 'string',
                     ],


### PR DESCRIPTION
This PR introduces a new regex to validate some internal resources names.

Regex is ```/^[a-z][a-z0-9_]{1,200}$/```
 * starts with a lowercase letter
 * composed by lowercase letters, numbers and underscores
 * length between 2 and 200 characters

This new validation regexp applies to: 
 * `auth_providers.name`
 * `endpoints.name`
 * `object_types.name`
 * `object_types.singular`
 * `properties.name`
 * `property_types.name`
 * `relations.name`
 * `relations.inverse_name`
 * `roles.name`
