### PR TITLE
History include filter and related endpoints

### DIFF
--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -24,6 +24,7 @@ Router::plugin(
     function (RouteBuilder $routes) {
         $resourcesControllers = [
             'roles',
+            'history',
             'streams',
             'users',
             'media',
@@ -231,13 +232,6 @@ Router::plugin(
             '/config',
             ['controller' => 'Config', 'action' => 'index', '_method' => 'GET'],
             ['_name' => 'config:index']
-        );
-
-        // History.
-        $routes->connect(
-            '/history',
-            ['controller' => 'History', 'action' => 'index', '_method' => 'GET'],
-            ['_name' => 'history:index']
         );
 
         // Trees.

--- a/plugins/BEdita/API/src/Controller/HistoryController.php
+++ b/plugins/BEdita/API/src/Controller/HistoryController.php
@@ -12,10 +12,7 @@
  */
 namespace BEdita\API\Controller;
 
-use Cake\Http\Exception\NotFoundException;
 use Cake\ORM\Association;
-use Cake\ORM\Table;
-use Cake\Utility\Inflector;
 
 /**
  * Controller for `/history` endpoint.
@@ -35,23 +32,9 @@ class HistoryController extends ResourcesController
      */
     protected $_defaultConfig = [
         'allowedAssociations' => [
-            'users' => ['users'],
+            'user' => ['users'],
         ],
     ];
-
-    /**
-     * @inheritDoc
-     */
-    protected function findAssociation(string $relationship, ?Table $table = null): Association
-    {
-        $relationship = Inflector::underscore($relationship);
-        $association = $this->Table->associations()->getByProperty($relationship);
-        if (empty($association)) {
-            throw new NotFoundException(__d('bedita', 'Relationship "{0}" does not exist', $relationship));
-        }
-
-        return $association;
-    }
 
     /**
      * @inheritDoc

--- a/plugins/BEdita/API/src/Controller/HistoryController.php
+++ b/plugins/BEdita/API/src/Controller/HistoryController.php
@@ -12,6 +12,7 @@
  */
 namespace BEdita\API\Controller;
 
+use Cake\Core\Configure;
 use Cake\ORM\Association;
 
 /**
@@ -25,16 +26,21 @@ class HistoryController extends ResourcesController
     /**
      * @inheritDoc
      */
-    public $modelClass = 'History';
-
-    /**
-     * @inheritDoc
-     */
     protected $_defaultConfig = [
         'allowedAssociations' => [
             'user' => ['users'],
         ],
     ];
+
+    /**
+     * @inheritDoc
+     */
+    public function initialize(): void
+    {
+        $this->modelClass = (string)Configure::read('History.table', 'History');
+
+        parent::initialize();
+    }
 
     /**
      * @inheritDoc

--- a/plugins/BEdita/API/tests/TestCase/Controller/HistoryControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/HistoryControllerTest.php
@@ -12,8 +12,8 @@
  */
 namespace BEdita\API\Test\TestCase\Controller;
 
-use BEdita\API\Test\TestConstants;
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\API\Test\TestConstants;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\HistoryController

--- a/plugins/BEdita/API/tests/TestCase/Controller/HistoryControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/HistoryControllerTest.php
@@ -12,6 +12,7 @@
  */
 namespace BEdita\API\Test\TestCase\Controller;
 
+use BEdita\API\Test\TestConstants;
 use BEdita\API\TestSuite\IntegrationTestCase;
 
 /**
@@ -170,5 +171,142 @@ class HistoryControllerTest extends IntegrationTestCase
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
         $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test `related` method.
+     *
+     * @return void
+     * @covers ::initialize()
+     * @covers ::related()
+     * @covers ::findAssociation()
+     * @covers ::getAvailableUrl()
+     */
+    public function testRelated()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/history/1/user',
+                'home' => 'http://api.example.com/home',
+                'available' => null,
+            ],
+            'meta' => [
+                'schema' => [
+                    'users' => [
+                        '$id' => 'http://api.example.com/model/schema/users',
+                        'revision' => TestConstants::SCHEMA_REVISIONS['users'],
+                    ],
+                ],
+            ],
+            'data' => [
+                'id' => '1',
+                'type' => 'users',
+                'attributes' => [
+                    'status' => 'on',
+                    'uname' => 'first-user',
+                    'title' => 'Mr. First User',
+                    'description' => null,
+                    'body' => null,
+                    'extra' => null,
+                    'lang' => 'en',
+                    'name' => 'First',
+                    'surname' => 'User',
+                    'email' => 'first.user@example.com',
+                    'person_title' => 'Mr.',
+                    'gender' => null,
+                    'birthdate' => '1945-04-25',
+                    'deathdate' => null,
+                    'company' => false,
+                    'company_name' => null,
+                    'company_kind' => null,
+                    'street_address' => null,
+                    'city' => null,
+                    'zipcode' => null,
+                    'country' => null,
+                    'state_name' => null,
+                    'phone' => null,
+                    'website' => null,
+                    'national_id_number' => null,
+                    'vat_number' => null,
+                    'publish_start' => null,
+                    'publish_end' => null,
+                    'username' => 'first user',
+                    'another_username' => null, // custom property
+                    'another_email' => null, // custom property
+                    'pseudonym' => null,
+                    'user_preferences' => null,
+                ],
+                'meta' => [
+                    'locked' => true,
+                    'created' => '2016-05-13T07:09:23+00:00',
+                    'modified' => '2016-05-13T07:09:23+00:00',
+                    'published' => null,
+                    'created_by' => 1,
+                    'modified_by' => 1,
+                    'blocked' => false,
+                    'last_login' => null,
+                    'last_login_err' => null,
+                    'num_login_err' => 1,
+                    'verified' => '2017-05-29T11:36:00+00:00',
+                    'password_modified' => '2017-05-29T11:36:00+00:00',
+                    'external_auth' => [
+                        [
+                            'provider' => 'example',
+                            'username' => 'first_user',
+                        ],
+                    ],
+                ],
+                'relationships' => [
+                    'roles' => [
+                        'links' => [
+                            'related' => 'http://api.example.com/users/1/roles',
+                            'self' => 'http://api.example.com/users/1/relationships/roles',
+                        ],
+                    ],
+                    'another_test' => [
+                        'links' => [
+                            'related' => 'http://api.example.com/users/1/another_test',
+                            'self' => 'http://api.example.com/users/1/relationships/another_test',
+                        ],
+                    ],
+                    'parents' => [
+                        'links' => [
+                            'related' => 'http://api.example.com/users/1/parents',
+                            'self' => 'http://api.example.com/users/1/relationships/parents',
+                        ],
+                    ],
+                    'translations' => [
+                        'links' => [
+                            'related' => 'http://api.example.com/users/1/translations',
+                            'self' => 'http://api.example.com/users/1/relationships/translations',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->configRequestHeaders();
+        $this->get('/history/1/user');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test `setRelationshipsAllowedMethods` method.
+     *
+     * @return void
+     * @covers ::setRelationshipsAllowedMethods()
+     */
+    public function testSetRelationshipsAllowedMethods()
+    {
+        $authHeader = $this->getUserAuthHeader();
+        $this->configRequestHeaders('POST', $authHeader);
+        $this->post('/history/1/relationships/user', [
+            'id' => 5,
+        ]);
+        $this->assertResponseCode(405);
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/HistoryControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/HistoryControllerTest.php
@@ -230,7 +230,6 @@ class HistoryControllerTest extends IntegrationTestCase
      * @return void
      * @covers ::initialize()
      * @covers ::related()
-     * @covers ::findAssociation()
      * @covers ::getAvailableUrl()
      */
     public function testRelated()
@@ -357,6 +356,7 @@ class HistoryControllerTest extends IntegrationTestCase
         $this->configRequestHeaders('POST', $authHeader);
         $this->post('/history/1/relationships/user', [
             'id' => 5,
+            'type' => 'users',
         ]);
         $this->assertResponseCode(405);
     }
@@ -365,7 +365,6 @@ class HistoryControllerTest extends IntegrationTestCase
      * Test `include` method.
      *
      * @return void
-     * @covers ::findAssociation()
      */
     public function testInclude()
     {

--- a/plugins/BEdita/API/tests/TestCase/Controller/HistoryControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/HistoryControllerTest.php
@@ -51,6 +51,23 @@ class HistoryControllerTest extends IntegrationTestCase
                         'user_action' => 'create',
                         'changed' => '{"title":"title one","description":"description here"}',
                     ],
+                    'relationships' => [
+                        'user' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/history/1/user',
+                                'self' => 'http://api.example.com/history/1/relationships/user',
+                            ],
+                        ],
+                        'application' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/history/1/application',
+                                'self' => 'http://api.example.com/history/1/relationships/application',
+                            ],
+                        ],
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/history/1',
+                    ],
                 ],
                 [
                     'id' => '2',
@@ -63,6 +80,23 @@ class HistoryControllerTest extends IntegrationTestCase
                         'application_id' => 1,
                         'user_action' => 'update',
                         'changed' => '{"body":"body here","extra":{"abstract":"abstract here","list": ["one", "two", "three"]}}',
+                    ],
+                    'relationships' => [
+                        'user' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/history/2/user',
+                                'self' => 'http://api.example.com/history/2/relationships/user',
+                            ],
+                        ],
+                        'application' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/history/2/application',
+                                'self' => 'http://api.example.com/history/2/relationships/application',
+                            ],
+                        ],
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/history/2',
                     ],
                 ],
             ],
@@ -151,6 +185,23 @@ class HistoryControllerTest extends IntegrationTestCase
                         'application_id' => 1,
                         'user_action' => 'update',
                         'changed' => '{"body":"body here","extra":{"abstract":"abstract here","list": ["one", "two", "three"]}}',
+                    ],
+                    'relationships' => [
+                        'user' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/history/2/user',
+                                'self' => 'http://api.example.com/history/2/relationships/user',
+                            ],
+                        ],
+                        'application' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/history/2/application',
+                                'self' => 'http://api.example.com/history/2/relationships/application',
+                            ],
+                        ],
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/history/2',
                     ],
                 ],
             ],
@@ -308,5 +359,295 @@ class HistoryControllerTest extends IntegrationTestCase
             'id' => 5,
         ]);
         $this->assertResponseCode(405);
+    }
+
+    /**
+     * Test `include` method.
+     *
+     * @return void
+     * @covers ::findAssociation()
+     */
+    public function testInclude()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/history?include=user',
+                'home' => 'http://api.example.com/home',
+                'first' => 'http://api.example.com/history?include=user',
+                'last' => 'http://api.example.com/history?include=user',
+                'prev' => null,
+                'next' => null,
+            ],
+            'data' => [
+                [
+                    'id' => '1',
+                    'type' => 'history',
+                    'meta' => [
+                        'resource_id' => 2,
+                        'resource_type' => 'objects',
+                        'created' => '2016-05-13T07:09:22+00:00',
+                        'user_id' => 1,
+                        'application_id' => 1,
+                        'user_action' => 'create',
+                        'changed' => '{"title":"title one","description":"description here"}',
+                    ],
+                    'relationships' => [
+                        'user' => [
+                            'data' => [
+                                'id' => '1',
+                                'type' => 'users',
+                            ],
+                            'links' => [
+                                'related' => 'http://api.example.com/history/1/user',
+                                'self' => 'http://api.example.com/history/1/relationships/user',
+                            ],
+                        ],
+                        'application' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/history/1/application',
+                                'self' => 'http://api.example.com/history/1/relationships/application',
+                            ],
+                        ],
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/history/1',
+                    ],
+                ],
+                [
+                    'id' => '2',
+                    'type' => 'history',
+                    'meta' => [
+                        'resource_id' => 2,
+                        'resource_type' => 'objects',
+                        'created' => '2016-05-13T07:09:23+00:00',
+                        'user_id' => 5,
+                        'application_id' => 1,
+                        'user_action' => 'update',
+                        'changed' => '{"body":"body here","extra":{"abstract":"abstract here","list": ["one", "two", "three"]}}',
+                    ],
+                    'relationships' => [
+                        'user' => [
+                            'data' => [
+                                'id' => '5',
+                                'type' => 'users',
+                            ],
+                            'links' => [
+                                'related' => 'http://api.example.com/history/2/user',
+                                'self' => 'http://api.example.com/history/2/relationships/user',
+                            ],
+                        ],
+                        'application' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/history/2/application',
+                                'self' => 'http://api.example.com/history/2/relationships/application',
+                            ],
+                        ],
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/history/2',
+                    ],
+                ],
+            ],
+            'meta' => [
+                'pagination' => [
+                    'count' => 2,
+                    'page' => 1,
+                    'page_count' => 1,
+                    'page_items' => 2,
+                    'page_size' => 20,
+                ],
+                'schema' => [
+                    'users' => [
+                        '$id' => 'http://api.example.com/model/schema/users',
+                        'revision' => '1833541891',
+                    ],
+                ],
+            ],
+            'included' => [
+                [
+                    'id' => '1',
+                    'type' => 'users',
+                    'attributes' => [
+                        'status' => 'on',
+                        'uname' => 'first-user',
+                        'title' => 'Mr. First User',
+                        'description' => null,
+                        'body' => null,
+                        'extra' => null,
+                        'lang' => 'en',
+                        'name' => 'First',
+                        'surname' => 'User',
+                        'email' => 'first.user@example.com',
+                        'person_title' => 'Mr.',
+                        'gender' => null,
+                        'birthdate' => '1945-04-25',
+                        'deathdate' => null,
+                        'company' => false,
+                        'company_name' => null,
+                        'company_kind' => null,
+                        'street_address' => null,
+                        'city' => null,
+                        'zipcode' => null,
+                        'country' => null,
+                        'state_name' => null,
+                        'phone' => null,
+                        'website' => null,
+                        'national_id_number' => null,
+                        'vat_number' => null,
+                        'publish_start' => null,
+                        'publish_end' => null,
+                        'username' => 'first user',
+                        'another_username' => null, // custom property
+                        'another_email' => null, // custom property
+                        'pseudonym' => null,
+                        'user_preferences' => null,
+                    ],
+                    'relationships' => [
+                        'roles' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/users/1/roles',
+                                'self' => 'http://api.example.com/users/1/relationships/roles',
+                            ],
+                        ],
+                        'another_test' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/users/1/another_test',
+                                'self' => 'http://api.example.com/users/1/relationships/another_test',
+                            ],
+                        ],
+                        'parents' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/users/1/parents',
+                                'self' => 'http://api.example.com/users/1/relationships/parents',
+                            ],
+                        ],
+                        'translations' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/users/1/translations',
+                                'self' => 'http://api.example.com/users/1/relationships/translations',
+                            ],
+                        ],
+                    ],
+                    'meta' => [
+                        'blocked' => false,
+                        'last_login' => null,
+                        'last_login_err' => null,
+                        'num_login_err' => 1,
+                        'verified' => '2017-05-29T11:36:00+00:00',
+                        'password_modified' => '2017-05-29T11:36:00+00:00',
+                        'external_auth' => [
+                            [
+                                'provider' => 'example',
+                                'username' => 'first_user',
+                            ],
+                        ],
+                        'locked' => true,
+                        'created' => '2016-05-13T07:09:23+00:00',
+                        'modified' => '2016-05-13T07:09:23+00:00',
+                        'published' => null,
+                        'created_by' => 1,
+                        'modified_by' => 1,
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/users/1',
+                    ],
+                ],
+                [
+                    'id' => '5',
+                    'type' => 'users',
+                    'attributes' => [
+                        'status' => 'on',
+                        'uname' => 'second-user',
+                        'title' => 'Miss Second User',
+                        'description' => null,
+                        'body' => null,
+                        'extra' => null,
+                        'lang' => 'en',
+                        'name' => 'Second',
+                        'surname' => 'User',
+                        'email' => 'second.user@example.com',
+                        'person_title' => 'Miss',
+                        'gender' => null,
+                        'birthdate' => null,
+                        'deathdate' => null,
+                        'company' => false,
+                        'company_name' => null,
+                        'company_kind' => null,
+                        'street_address' => null,
+                        'city' => null,
+                        'zipcode' => null,
+                        'country' => null,
+                        'state_name' => null,
+                        'phone' => null,
+                        'website' => null,
+                        'national_id_number' => null,
+                        'vat_number' => null,
+                        'publish_start' => null,
+                        'publish_end' => null,
+                        'username' => 'second user',
+                        'another_username' => 'synapse', // custom property
+                        'another_email' => 'synapse@example.org', // custom property
+                        'pseudonym' => null,
+                        'user_preferences' => null,
+                    ],
+                    'relationships' => [
+                        'roles' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/users/5/roles',
+                                'self' => 'http://api.example.com/users/5/relationships/roles',
+                            ],
+                        ],
+                        'another_test' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/users/5/another_test',
+                                'self' => 'http://api.example.com/users/5/relationships/another_test',
+                            ],
+                        ],
+                        'parents' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/users/5/parents',
+                                'self' => 'http://api.example.com/users/5/relationships/parents',
+                            ],
+                        ],
+                        'translations' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/users/5/translations',
+                                'self' => 'http://api.example.com/users/5/relationships/translations',
+                            ],
+                        ],
+                    ],
+                    'meta' => [
+                        'blocked' => false,
+                        'last_login' => '2016-03-15T09:57:38+00:00',
+                        'last_login_err' => '2016-03-15T09:57:38+00:00',
+                        'num_login_err' => 0,
+                        'verified' => null,
+                        'password_modified' => '2016-03-15T09:57:38+00:00',
+                        'external_auth' => [
+                            [
+                                'provider' => 'uuid',
+                                'username' => '17fec0fa-068a-4d7c-8283-da91d47cef7d',
+                            ],
+                        ],
+                        'locked' => false,
+                        'created' => '2016-05-13T07:09:23+00:00',
+                        'modified' => '2016-05-13T07:09:23+00:00',
+                        'published' => null,
+                        'created_by' => 5,
+                        'modified_by' => 5,
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/users/5',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->configRequestHeaders();
+        $this->get('/history?include=user');
+        $result = json_decode((string)$this->_response->getBody(), true);
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertEquals($expected, $result);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/HistoryTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/HistoryTable.php
@@ -52,6 +52,7 @@ class HistoryTable extends Table
             'foreignKey' => 'user_id',
             'joinType' => 'INNER',
             'className' => 'BEdita/Core.Users',
+            'strategy' => 'select',
         ]);
         $this->belongsTo('Applications', [
             'foreignKey' => 'application_id',


### PR DESCRIPTION
This PR introduces related endpoints for history entities: `/history/{id}/user`. It also fixes `include=user` filter for index method.