### PR TITLE
Fix release action and generated docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,13 +38,27 @@ jobs:
       - name: Update version file
         if: ${{ !contains(needs.release_job.outputs.version, 'undefined') }}
         run: |
-          echo "[BEdita]\nversion = ${{ needs.release_job.outputs.version }}" > plugins/BEdita/Core/config/bedita.ini
+          echo -e "[BEdita]\nversion = ${{ needs.release_job.outputs.version }}" > plugins/BEdita/Core/config/bedita.ini
 
-      - uses: mr-smithers-excellent/docker-build-push@v5
+      - name: Set up QEMU
+        if: ${{ !contains(needs.release_job.outputs.version, 'undefined') }}
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        if: ${{ !contains(needs.release_job.outputs.version, 'undefined') }}
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
         if: ${{ !contains(needs.release_job.outputs.version, 'undefined') }}
         with:
-          image: '${{ github.repository }}'
-          registry: docker.io
-          tags: ${{ needs.release_job.outputs.version }}
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        if: ${{ !contains(needs.release_job.outputs.version, 'undefined') }}
+        with:
+          context: .
+          push: true
+          tags: "${{ github.repository }}:${{ needs.release_job.outputs.version }}"

--- a/plugins/BEdita/API/src/Controller/AppController.php
+++ b/plugins/BEdita/API/src/Controller/AppController.php
@@ -51,7 +51,7 @@ class AppController extends Controller
     {
         parent::initialize();
 
-        $this->response = $this->response->withHeader('X-BEdita-Version', Configure::read('BEdita.version'));
+        $this->response = $this->response->withHeader('X-BEdita-Version', (string)Configure::read('BEdita.version'));
 
         $this->paginate = (array)Configure::read('Pagination') + $this->paginate;
         $this->loadComponent('RequestHandler');


### PR DESCRIPTION
This PR fixes a problem in the generated docker images via gh actions.

Problem:

 * `plugins/BEdita/Core/config/bedita.ini` file containing version number was wrongly formatted, one line instead of two
 * a `null` `'X-BEdita-Version'` header caused a systematic error as a consequence
 
Solution:

* use `-e` option in `echo` to enable interpretation of backslash escapes
* avoid `null` as generated header


Bonus track: official build and push docker actions has been introduced
