### PR TITLE
Add `filter-components` reusable workflow

### DIFF
--- a/.github/workflows/components.yml
+++ b/.github/workflows/components.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - '**'
+      - '!5-salix'
+      - '!4-cactus'
     paths:
       - 'plugins/BEdita/**'
       - '.github/workflows/*'
@@ -12,32 +14,5 @@ on:
 
 jobs:
   filter-tree:
-    name: 'Filter components tree and push'
-    runs-on: 'ubuntu-latest'
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - repo: 'api'
-            path: 'plugins/BEdita/API'
-          - repo: 'core'
-            path: 'plugins/BEdita/Core'
-
-    steps:
-      - name: 'Checkout current revision'
-        uses: 'actions/checkout@v2'
-        with:
-          token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
-          fetch-depth: '0'
-
-      - name: 'Filter tree'
-        run: 'git filter-branch --prune-empty --subdirectory-filter "${{ matrix.path }}" --tag-name-filter cat -- --all'
-
-      - name: 'Output last 10 commits'
-        run: 'git log -n 10'
-
-      - name: 'Push to component repository'
-        env:
-          REMOTE: "${{ format('https://github.com/{0}/{1}.git', github.repository_owner, matrix.repo) }}"
-        run: 'git push --force --tags "${REMOTE}" HEAD'
+    uses: ./.github/workflows/filter-components.yml
+    secrets: inherit

--- a/.github/workflows/filter-components.yml
+++ b/.github/workflows/filter-components.yml
@@ -1,0 +1,36 @@
+name: 'Filter components'
+
+on:
+  workflow_call:
+
+jobs:
+  filter-tree:
+    name: 'Filter components tree and push'
+    runs-on: 'ubuntu-latest'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repo: 'api'
+            path: 'plugins/BEdita/API'
+          - repo: 'core'
+            path: 'plugins/BEdita/Core'
+
+    steps:
+      - name: 'Checkout current revision'
+        uses: 'actions/checkout@v2'
+        with:
+          token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
+          fetch-depth: '0'
+
+      - name: 'Filter tree'
+        run: 'git filter-branch --prune-empty --subdirectory-filter "${{ matrix.path }}" --tag-name-filter cat -- --all'
+
+      - name: 'Output last 10 commits'
+        run: 'git log -n 10'
+
+      - name: 'Push to component repository'
+        env:
+          REMOTE: "${{ format('https://github.com/{0}/{1}.git', github.repository_owner, matrix.repo) }}"
+        run: 'git push --force --tags "${REMOTE}" HEAD'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,12 @@ on:
     paths:
       - '**/*.php'
       - '.github/workflows/*'
+      - '**/composer.json'
   push:
     paths:
       - '**/*.php'
       - '.github/workflows/*'
+      - '**/composer.json'
 
 jobs:
   cs:


### PR DESCRIPTION
This PR fixes a workflow error introduced in #1949 where a (missing) `filter-components` reusable workflow was used
