### PR TITLE
Create and push major tag to docker registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,4 +61,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: "${{ github.repository }}:${{ needs.release_job.outputs.version }}"
+          tags: "${{ github.repository }}:${{ needs.release_job.outputs.version }},${{ github.repository }}:${{ needs.release_job.outputs.major }}"


### PR DESCRIPTION
In workflow release a major tag is also updated. 
This way you can `pull bedita/bedita:5` to get the latest `5.x.x` release

