### PR TITLE
Folders children_order property and ListAssociatedAction custom sort for Children

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -97,6 +97,7 @@ class FoldersControllerTest extends IntegrationTestCase
                         'lang' => 'en',
                         'publish_start' => null,
                         'publish_end' => null,
+                        'children_order' => null
                     ],
                     'meta' => [
                         'locked' => false,
@@ -144,6 +145,7 @@ class FoldersControllerTest extends IntegrationTestCase
                         'lang' => 'en',
                         'publish_start' => null,
                         'publish_end' => null,
+                        'children_order' => null
                     ],
                     'meta' => [
                         'locked' => false,
@@ -191,6 +193,7 @@ class FoldersControllerTest extends IntegrationTestCase
                         'lang' => 'en',
                         'publish_start' => null,
                         'publish_end' => null,
+                        'children_order' => null
                     ],
                     'meta' => [
                         'locked' => false,

--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -307,6 +307,7 @@ class FoldersControllerTest extends IntegrationTestCase
                     'lang' => 'en',
                     'publish_start' => null,
                     'publish_end' => null,
+                    'children_order' => null
                 ],
                 'meta' => [
                     'locked' => false,

--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -97,7 +97,7 @@ class FoldersControllerTest extends IntegrationTestCase
                         'lang' => 'en',
                         'publish_start' => null,
                         'publish_end' => null,
-                        'children_order' => null
+                        'children_order' => null,
                     ],
                     'meta' => [
                         'locked' => false,
@@ -145,7 +145,7 @@ class FoldersControllerTest extends IntegrationTestCase
                         'lang' => 'en',
                         'publish_start' => null,
                         'publish_end' => null,
-                        'children_order' => null
+                        'children_order' => null,
                     ],
                     'meta' => [
                         'locked' => false,
@@ -193,7 +193,7 @@ class FoldersControllerTest extends IntegrationTestCase
                         'lang' => 'en',
                         'publish_start' => null,
                         'publish_end' => null,
-                        'children_order' => null
+                        'children_order' => null,
                     ],
                     'meta' => [
                         'locked' => false,
@@ -307,7 +307,7 @@ class FoldersControllerTest extends IntegrationTestCase
                     'lang' => 'en',
                     'publish_start' => null,
                     'publish_end' => null,
-                    'children_order' => null
+                    'children_order' => null,
                 ],
                 'meta' => [
                     'locked' => false,

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
@@ -302,6 +302,13 @@ class ProjectControllerTest extends IntegrationTestCase
                     'property_type_name' => 'integer',
                     'object_type_name' => 'profiles',
                 ],
+                [
+                    'name' => 'children_order',
+                    'description' => null,
+                    'is_nullable' => true,
+                    'property_type_name' => 'children_order',
+                    'object_type_name' => 'folders',
+                ],
             ],
         ];
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertiesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertiesControllerTest.php
@@ -455,7 +455,7 @@ class PropertiesControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertHeader('Location', 'http://api.example.com/model/properties/12');
+        $this->assertHeader('Location', 'http://api.example.com/model/properties/13');
         static::assertTrue(TableRegistry::getTableLocator()->get('Properties')->exists(['name' => 'yet_another_body']));
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertiesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertiesControllerTest.php
@@ -53,10 +53,10 @@ class PropertiesControllerTest extends IntegrationTestCase
             ],
             'meta' => [
                 'pagination' => [
-                    'count' => 11,
+                    'count' => 12,
                     'page' => 1,
                     'page_count' => 1,
-                    'page_items' => 11,
+                    'page_items' => 12,
                     'page_size' => 20,
                 ],
             ],
@@ -279,6 +279,26 @@ class PropertiesControllerTest extends IntegrationTestCase
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/model/properties/11',
+                    ],
+                ],
+                [
+                    'id' => '12',
+                    'type' => 'properties',
+                    'attributes' => [
+                        'name' => 'children_order',
+                        'description' => null,
+                        'property_type_name' => 'children_order',
+                        'object_type_name' => 'folders',
+                        'label' => null,
+                        'is_nullable' => true,
+                        'is_static' => false,
+                    ],
+                    'meta' => [
+                        'created' => '2022-12-01T15:26:00+00:00',
+                        'modified' => '2022-12-01T15:26:00+00:00',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/model/properties/12',
                     ],
                 ],
             ],

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
@@ -574,9 +574,9 @@ class PropertyTypesControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertHeader('Location', 'http://api.example.com/model/property_types/13');
+        $this->assertHeader('Location', 'http://api.example.com/model/property_types/14');
         static::assertTrue(TableRegistry::getTableLocator()->get('PropertyTypes')->exists(['name' => 'gustavo']));
-        static::assertFalse(TableRegistry::getTableLocator()->get('PropertyTypes')->get(13)->get('core_type'));
+        static::assertFalse(TableRegistry::getTableLocator()->get('PropertyTypes')->get(14)->get('core_type'));
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
@@ -51,10 +51,10 @@ class PropertyTypesControllerTest extends IntegrationTestCase
             ],
             'meta' => [
                 'pagination' => [
-                    'count' => 12,
+                    'count' => 13,
                     'page' => 1,
                     'page_count' => 1,
-                    'page_items' => 12,
+                    'page_items' => 13,
                     'page_size' => 20,
                 ],
             ],
@@ -379,6 +379,40 @@ class PropertyTypesControllerTest extends IntegrationTestCase
                             'links' => [
                                 'related' => 'http://api.example.com/model/property_types/12/properties',
                                 'self' => 'http://api.example.com/model/property_types/12/relationships/properties',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'id' => '13',
+                    'type' => 'property_types',
+                    'attributes' => [
+                        'name' => 'children_order',
+                        'params' => [
+                            'type' => 'string',
+                            'enum' => [
+                                'position',
+                                '-position',
+                                'modified',
+                                '-modified',
+                                'title',
+                                '-title',
+                            ],
+                        ],
+                    ],
+                    'meta' => [
+                        'created' => '2022-12-01T15:35:21+00:00',
+                        'modified' => '2022-12-01T15:35:21+00:00',
+                        'core_type' => true,
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/model/property_types/13',
+                    ],
+                    'relationships' => [
+                        'properties' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/model/property_types/13/properties',
+                                'self' => 'http://api.example.com/model/property_types/13/relationships/properties',
                             ],
                         ],
                     ],

--- a/plugins/BEdita/API/tests/TestCase/Controller/TreesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TreesControllerTest.php
@@ -57,6 +57,7 @@ class TreesControllerTest extends IntegrationTestCase
                     'publish_start' => null,
                     'publish_end' => null,
                     'menu' => true,
+                    'children_order' => null,
                 ],
                 'meta' => [
                     'locked' => false,

--- a/plugins/BEdita/API/tests/TestConstants.php
+++ b/plugins/BEdita/API/tests/TestConstants.php
@@ -28,7 +28,7 @@ class TestConstants
         'documents' => '4059696127',
         'events' => '1528552691',
         'files' => '4129506705',
-        'folders' => '3223993640',
+        'folders' => '1494838194',
         'locations' => '2540919723',
         'profiles' => '951433151',
         'roles' => '2845943672',

--- a/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
+++ b/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
@@ -54,17 +54,15 @@ class AddChildrenOrder extends AbstractMigration
      */
     public function up()
     {
+        $connection = $this->getAdapter()->getCakeConnection();
         Resources::save(
             ['create' => $this->create],
-            ['connection' => $this->getAdapter()->getCakeConnection()]
+            ['connection' => $connection]
         );
-        $objectTypeId = TableRegistry::getTableLocator()->get('ObjectTypes')->get('folders')->id;
-        $propertyTypeId = TableRegistry::getTableLocator()->get('PropertyTypes')
-            ->find()
-            ->select(['id'])
-            ->where(['name' => 'children_order'])
-            ->firstOrFail()
-            ->id;
+        $sql = 'SELECT id FROM object_types WHERE name = "folders"';
+        $objectTypeId = $connection->execute($sql)->fetch(0)['id'];
+        $sql = 'SELECT id FROM property_types WHERE name = "children_order"';
+        $propertyTypeId = $connection->execute($sql)->fetch(0)['id'];
         $d = new \DateTime();
         $d = $d->format('Y-m-d\TH:i:s+00:00');
         $sql = 'INSERT INTO properties (';
@@ -78,7 +76,7 @@ class AddChildrenOrder extends AbstractMigration
             $d,
             $d
         );
-        $this->query($sql);
+        $connection->execute($sql);
     }
 
     /**
@@ -90,11 +88,12 @@ class AddChildrenOrder extends AbstractMigration
         //     ['remove' => ['properties' => $this->create['properties']]],
         //     ['connection' => $this->getAdapter()->getCakeConnection()]
         // );
+        $connection = $this->getAdapter()->getCakeConnection();
         $sql = 'DELETE FROM properties WHERE name = "children_order"';
-        $this->query($sql);
+        $connection->execute($sql);
         Resources::save(
             ['remove' => ['property_types' => $this->create['property_types']]],
-            ['connection' => $this->getAdapter()->getCakeConnection()]
+            ['connection' => $connection]
         );
     }
 }

--- a/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
+++ b/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
@@ -53,19 +53,22 @@ class AddChildrenOrder extends AbstractMigration
      */
     public function up()
     {
-        $connection = $this->getAdapter()->getCakeConnection();
         Resources::save(
             ['create' => $this->create],
-            ['connection' => $connection]
+            ['connection' => $this->getAdapter()->getCakeConnection()]
         );
-        $objectTypeId = $connection
-            ->execute('SELECT id FROM object_types WHERE name = "folders"')
+        $objectTypeId = (int)$this->getQueryBuilder()
+            ->select(['id'])
+            ->from(['object_types'])
+            ->where(['name' => 'folders'])
+            ->execute()
             ->fetch(0)['id'];
-        $propertyTypeId = $connection
-            ->execute('SELECT id FROM property_types WHERE name = "children_order"')
+        $propertyTypeId = (int)$this->getQueryBuilder()
+            ->select(['id'])
+            ->from(['property_types'])
+            ->where(['name' => 'children_order'])
+            ->execute()
             ->fetch(0)['id'];
-        $d = new \DateTime();
-        $d = $d->format('Y-m-d H:i:s');
         $fields = [
             'name' => 'string',
             'object_type_id' => 'int',
@@ -77,21 +80,20 @@ class AddChildrenOrder extends AbstractMigration
             'is_nullable' => 'boolean',
             'is_static' => 'boolean',
         ];
-        $values = [
-            'name' => 'children_order',
-            'object_type_id' => $objectTypeId,
-            'property_type_id' => $propertyTypeId,
-            'created' => $d,
-            'modified' => $d,
-            'description' => 'Folders children order',
-            'enabled' => 1,
-            'is_nullable' => 1,
-            'is_static' => 0,
-        ];
         $this->getQueryBuilder()
             ->insert(array_keys($fields), array_values($fields))
             ->into('properties')
-            ->values($values)
+            ->values([
+                'name' => 'children_order',
+                'object_type_id' => $objectTypeId,
+                'property_type_id' => $propertyTypeId,
+                'created' => date('Y-m-d H:i:s'),
+                'modified' => date('Y-m-d H:i:s'),
+                'description' => 'Folders children order',
+                'enabled' => 1,
+                'is_nullable' => 1,
+                'is_static' => 0,
+            ])
             ->execute();
     }
 

--- a/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
+++ b/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
@@ -11,8 +11,8 @@
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
 
-use BEdita\Core\Utility\Resources;
 use Migrations\AbstractMigration;
+use Phinx\Db\Adapter\MysqlAdapter;
 
 class AddChildrenOrder extends AbstractMigration
 {
@@ -21,67 +21,68 @@ class AddChildrenOrder extends AbstractMigration
      */
     public function up()
     {
-        $fields = [
-            'name' => 'string',
-            'params' => 'string',
-            'core_type' => 'boolean',
-        ];
-        $this->getQueryBuilder()
-            ->insert(array_keys($fields), array_values($fields))
-            ->into('property_types')
-            ->values([
-                'name' => 'children_order',
-                'params' => json_encode([
-                    'type' => 'string',
-                    'enum' => [
-                        'position',
-                        '-position',
-                        'title',
-                        '-title',
-                        'modified',
-                        '-modified',
-                    ],
-                ]),
-                'core_type' => 1,
-            ])
-            ->execute();
-
-        $objectTypeId = (int)$this->getQueryBuilder()
-            ->select(['id'])
-            ->from(['object_types'])
-            ->where(['name' => 'folders'])
-            ->execute()
-            ->fetch()[0];
-        $propertyTypesId = (int)$this->getQueryBuilder()
-            ->select(['id'])
-            ->from(['property_types'])
-            ->where(['name' => 'children_order'])
-            ->execute()
-            ->fetch()[0];
-        $fields = [
-            'name' => 'string',
-            'object_type_id' => 'int',
-            'property_type_id' => 'int',
-            'created' => 'datetime',
-            'modified' => 'datetime',
-            'enabled' => 'boolean',
-            'is_nullable' => 'boolean',
-            'is_static' => 'boolean',
-        ];
-        $this->getQueryBuilder()
-            ->insert(array_keys($fields), array_values($fields))
-            ->into('properties')
-            ->values([
-                'name' => 'children_order',
-                'object_types_id' => $objectTypeId,
-                'property_type_id' => $propertyTypesId,
-                'created' => date('Y-m-d H:i:s'),
-                'modified' => date('Y-m-d H:i:s'),
-                'enabled' => 1,
-                'is_nullable' => 1,
-                'is_static' => 0,
-            ])
-            ->execute();
+        $this->transactional(function () {
+            $fields = [
+                'name' => 'string',
+                'params' => 'string',
+                'core_type' => 'boolean',
+            ];
+            $this->getQueryBuilder()
+                ->insert(array_keys($fields), array_values($fields))
+                ->into('property_types')
+                ->values([
+                    'name' => 'children_order',
+                    'params' => json_encode([
+                        'type' => 'string',
+                        'enum' => [
+                            'position',
+                            '-position',
+                            'title',
+                            '-title',
+                            'modified',
+                            '-modified',
+                        ],
+                    ]),
+                    'core_type' => 1,
+                ])
+                ->execute();
+            $objectTypeId = (int)$this->getQueryBuilder()
+                ->select(['id'])
+                ->from(['object_types'])
+                ->where(['name' => 'folders'])
+                ->execute()
+                ->fetch()[0];
+            $propertyTypeId = (int)$this->getQueryBuilder()
+                ->select(['id'])
+                ->from(['property_types'])
+                ->where(['name' => 'children_order'])
+                ->execute()
+                ->fetch()[0];
+            $fields = [
+                'name' => 'string',
+                'object_type_id' => 'int',
+                'property_type_id' => 'int',
+                'created' => 'datetime',
+                'modified' => 'datetime',
+                'enabled' => 'boolean',
+                'is_nullable' => 'boolean',
+                'is_static' => 'boolean',
+            ];
+            $this->getQueryBuilder()
+                ->insert(array_keys($fields), array_values($fields))
+                ->into('properties')
+                ->values([
+                    'name' => 'children_order',
+                    'object_type_id' => $objectTypeId,
+                    'property_type_id' => $propertyTypeId,
+                    'created' => date('Y-m-d H:i:s'),
+                    'modified' => date('Y-m-d H:i:s'),
+                    'enabled' => 1,
+                    'is_nullable' => 1,
+                    'is_static' => 0,
+                ])
+                ->execute();
+        });
     }
 
     /**
@@ -100,5 +101,31 @@ class AddChildrenOrder extends AbstractMigration
             ->where(['name' => 'children_order'])
             ->limit(1)
             ->execute();
+    }
+
+    /**
+     * Execute multiple queries wrapped within a transaction, if needed.
+     *
+     * @param callable $cb Callable.
+     * @return void
+     */
+    protected function transactional(callable $cb): void
+    {
+        $adapter = $this->getAdapter();
+        if (!$adapter instanceof MysqlAdapter) {
+            // Only in MySQL DDL statements cause an implicit commit.
+            // For other drivers, just work with the currently active transaction.
+            $cb();
+
+            return;
+        }
+
+        $adapter->beginTransaction();
+        try {
+            $cb();
+            $adapter->commitTransaction();
+        } catch (Throwable $e) {
+            $adapter->rollbackTransaction();
+        }
     }
 }

--- a/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
+++ b/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
@@ -19,7 +19,7 @@ class AddChildrenOrder extends AbstractMigration
     protected $create = [
         'property_types' => [
             [
-                'name' => 'objects_order',
+                'name' => 'children_order',
                 'params' => [
                     'type' => 'string',
                     'enum' => [
@@ -38,7 +38,7 @@ class AddChildrenOrder extends AbstractMigration
             [
                 'name' => 'children_order',
                 'object' => 'folders',
-                'property' => 'objects_order',
+                'property' => 'children_order',
                 'description' => 'Folders children order',
                 'enabled' => 1,
                 'is_nullable' => 1,

--- a/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
+++ b/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
@@ -12,6 +12,7 @@
  */
 
 use BEdita\Core\Utility\Resources;
+use Cake\ORM\TableRegistry;
 use Migrations\AbstractMigration;
 
 class AddChildrenOrder extends AbstractMigration
@@ -34,16 +35,18 @@ class AddChildrenOrder extends AbstractMigration
                 'core_type' => 1,
             ],
         ],
-        'properties' => [
-            [
-                'name' => 'children_order',
-                'object' => 'folders',
-                'property' => 'children_order',
-                'description' => 'Folders children order',
-                'enabled' => 1,
-                'is_nullable' => 1,
-            ],
-        ],
+        // this does not work in tests, for an issue with static_properties temporary table
+        // we instead use a sql insert/delete query
+        // 'properties' => [
+        //     [
+        //         'name' => 'children_order',
+        //         'object' => 'folders',
+        //         'property' => 'children_order',
+        //         'description' => 'Folders children order',
+        //         'enabled' => 1,
+        //         'is_nullable' => 1,
+        //     ],
+        // ],
     ];
 
     /**
@@ -55,6 +58,27 @@ class AddChildrenOrder extends AbstractMigration
             ['create' => $this->create],
             ['connection' => $this->getAdapter()->getCakeConnection()]
         );
+        $objectTypeId = TableRegistry::getTableLocator()->get('ObjectTypes')->get('folders')->id;
+        $propertyTypeId = TableRegistry::getTableLocator()->get('PropertyTypes')
+            ->find()
+            ->select(['id'])
+            ->where(['name' => 'children_order'])
+            ->firstOrFail()
+            ->id;
+        $d = new \DateTime();
+        $d = $d->format('Y-m-d\TH:i:s+00:00');
+        $sql = 'INSERT INTO properties (';
+        $sql .= 'name, object_type_id, property_type_id, created, modified,';
+        $sql .= 'description, enabled, is_nullable, is_static';
+        $sql .= ') VALUES (';
+        $sql .= sprintf(
+            '"children_order", %d, %d, "%s", "%s", "Folders children order", 1, 1, 0)',
+            $objectTypeId,
+            $propertyTypeId,
+            $d,
+            $d
+        );
+        $this->query($sql);
     }
 
     /**
@@ -62,10 +86,12 @@ class AddChildrenOrder extends AbstractMigration
      */
     public function down()
     {
-        Resources::save(
-            ['remove' => ['properties' => $this->create['properties']]],
-            ['connection' => $this->getAdapter()->getCakeConnection()]
-        );
+        // Resources::save(
+        //     ['remove' => ['properties' => $this->create['properties']]],
+        //     ['connection' => $this->getAdapter()->getCakeConnection()]
+        // );
+        $sql = 'DELETE FROM properties WHERE name = "children_order"';
+        $this->query($sql);
         Resources::save(
             ['remove' => ['property_types' => $this->create['property_types']]],
             ['connection' => $this->getAdapter()->getCakeConnection()]

--- a/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
+++ b/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
@@ -20,15 +20,8 @@ class AddChildrenOrder extends AbstractMigration
      */
     public function up()
     {
-        $fields = [
-            'name' => 'string',
-            'params' => 'string',
-            'core_type' => 'boolean',
-        ];
-        $this->getQueryBuilder()
-            ->insert(array_keys($fields), array_values($fields))
-            ->into('property_types')
-            ->values([
+        $this->table('property_types')
+            ->insert([
                 'name' => 'children_order',
                 'params' => json_encode([
                     'type' => 'string',
@@ -43,7 +36,7 @@ class AddChildrenOrder extends AbstractMigration
                 ]),
                 'core_type' => 1,
             ])
-            ->execute();
+            ->save();
         $objectTypeId = (int)$this->getQueryBuilder()
             ->select(['id'])
             ->from(['object_types'])
@@ -56,20 +49,8 @@ class AddChildrenOrder extends AbstractMigration
             ->where(['name' => 'children_order'])
             ->execute()
             ->fetch()[0];
-        $fields = [
-            'name' => 'string',
-            'object_type_id' => 'integer',
-            'property_type_id' => 'integer',
-            'created' => 'datetime',
-            'modified' => 'datetime',
-            'enabled' => 'boolean',
-            'is_nullable' => 'boolean',
-            'is_static' => 'boolean',
-        ];
-        $this->getQueryBuilder()
-            ->insert(array_keys($fields), array_values($fields))
-            ->into('properties')
-            ->values([
+        $this->table('properties')
+            ->insert([
                 'name' => 'children_order',
                 'object_type_id' => $objectTypeId,
                 'property_type_id' => $propertyTypeId,
@@ -79,7 +60,7 @@ class AddChildrenOrder extends AbstractMigration
                 'is_nullable' => 1,
                 'is_static' => 0,
             ])
-            ->execute();
+            ->save();
     }
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
+++ b/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
@@ -12,7 +12,6 @@
  */
 
 use Migrations\AbstractMigration;
-use Phinx\Db\Adapter\MysqlAdapter;
 
 class AddChildrenOrder extends AbstractMigration
 {
@@ -21,68 +20,66 @@ class AddChildrenOrder extends AbstractMigration
      */
     public function up()
     {
-        $this->transactional(function () {
-            $fields = [
-                'name' => 'string',
-                'params' => 'string',
-                'core_type' => 'boolean',
-            ];
-            $this->getQueryBuilder()
-                ->insert(array_keys($fields), array_values($fields))
-                ->into('property_types')
-                ->values([
-                    'name' => 'children_order',
-                    'params' => json_encode([
-                        'type' => 'string',
-                        'enum' => [
-                            'position',
-                            '-position',
-                            'title',
-                            '-title',
-                            'modified',
-                            '-modified',
-                        ],
-                    ]),
-                    'core_type' => 1,
-                ])
-                ->execute();
-            $objectTypeId = (int)$this->getQueryBuilder()
-                ->select(['id'])
-                ->from(['object_types'])
-                ->where(['name' => 'folders'])
-                ->execute()
-                ->fetch()[0];
-            $propertyTypeId = (int)$this->getQueryBuilder()
-                ->select(['id'])
-                ->from(['property_types'])
-                ->where(['name' => 'children_order'])
-                ->execute()
-                ->fetch()[0];
-            $fields = [
-                'name' => 'string',
-                'object_type_id' => 'int',
-                'property_type_id' => 'int',
-                'created' => 'datetime',
-                'modified' => 'datetime',
-                'enabled' => 'boolean',
-                'is_nullable' => 'boolean',
-                'is_static' => 'boolean',
-            ];
-            $this->getQueryBuilder()
-                ->insert(array_keys($fields), array_values($fields))
-                ->into('properties')
-                ->values([
-                    'name' => 'children_order',
-                    'object_type_id' => $objectTypeId,
-                    'property_type_id' => $propertyTypeId,
-                    'created' => date('Y-m-d H:i:s'),
-                    'modified' => date('Y-m-d H:i:s'),
-                    'enabled' => 1,
-                    'is_nullable' => 1,
-                    'is_static' => 0,
-                ])
-                ->execute();
-        });
+        $fields = [
+            'name' => 'string',
+            'params' => 'string',
+            'core_type' => 'boolean',
+        ];
+        $this->getQueryBuilder()
+            ->insert(array_keys($fields), array_values($fields))
+            ->into('property_types')
+            ->values([
+                'name' => 'children_order',
+                'params' => json_encode([
+                    'type' => 'string',
+                    'enum' => [
+                        'position',
+                        '-position',
+                        'title',
+                        '-title',
+                        'modified',
+                        '-modified',
+                    ],
+                ]),
+                'core_type' => 1,
+            ])
+            ->execute();
+        $objectTypeId = (int)$this->getQueryBuilder()
+            ->select(['id'])
+            ->from(['object_types'])
+            ->where(['name' => 'folders'])
+            ->execute()
+            ->fetch()[0];
+        $propertyTypeId = (int)$this->getQueryBuilder()
+            ->select(['id'])
+            ->from(['property_types'])
+            ->where(['name' => 'children_order'])
+            ->execute()
+            ->fetch()[0];
+        $fields = [
+            'name' => 'string',
+            'object_type_id' => 'integer',
+            'property_type_id' => 'integer',
+            'created' => 'datetime',
+            'modified' => 'datetime',
+            'enabled' => 'boolean',
+            'is_nullable' => 'boolean',
+            'is_static' => 'boolean',
+        ];
+        $this->getQueryBuilder()
+            ->insert(array_keys($fields), array_values($fields))
+            ->into('properties')
+            ->values([
+                'name' => 'children_order',
+                'object_type_id' => $objectTypeId,
+                'property_type_id' => $propertyTypeId,
+                'created' => date('Y-m-d H:i:s'),
+                'modified' => date('Y-m-d H:i:s'),
+                'enabled' => 1,
+                'is_nullable' => 1,
+                'is_static' => 0,
+            ])
+            ->execute();
     }
 
     /**
@@ -101,31 +98,5 @@ class AddChildrenOrder extends AbstractMigration
             ->where(['name' => 'children_order'])
             ->limit(1)
             ->execute();
-    }
-
-    /**
-     * Execute multiple queries wrapped within a transaction, if needed.
-     *
-     * @param callable $cb Callable.
-     * @return void
-     */
-    protected function transactional(callable $cb): void
-    {
-        $adapter = $this->getAdapter();
-        if (!$adapter instanceof MysqlAdapter) {
-            // Only in MySQL DDL statements cause an implicit commit.
-            // For other drivers, just work with the currently active transaction.
-            $cb();
-
-            return;
-        }
-
-        $adapter->beginTransaction();
-        try {
-            $cb();
-            $adapter->commitTransaction();
-        } catch (Throwable $e) {
-            $adapter->rollbackTransaction();
-        }
     }
 }

--- a/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
+++ b/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
@@ -65,31 +65,34 @@ class AddChildrenOrder extends AbstractMigration
             ->execute('SELECT id FROM property_types WHERE name = "children_order"')
             ->fetch(0)['id'];
         $d = new \DateTime();
-        $d = $d->format('Y-m-d\TH:i:s+00:00');
+        $d = $d->format('Y-m-d H:i:s');
         $fields = [
-            'name',
-            'object_type_id',
-            'property_type_id',
-            'created',
-            'modified',
-            'description',
-            'enabled',
-            'is_nullable',
-            'is_static',
+            'name' => 'string',
+            'object_type_id' => 'int',
+            'property_type_id' => 'int',
+            'created' => 'datetime',
+            'modified' => 'datetime',
+            'description' => 'string',
+            'enabled' => 'boolean',
+            'is_nullable' => 'boolean',
+            'is_static' => 'boolean',
         ];
         $values = [
-            "'children_order'",
-            $objectTypeId,
-            $propertyTypeId,
-            "'$d'",
-            "'$d'",
-            "'Folders children order'",
-            1,
-            1,
-            0,
+            'name' => 'children_order',
+            'object_type_id' => $objectTypeId,
+            'property_type_id' => $propertyTypeId,
+            'created' => $d,
+            'modified' => $d,
+            'description' => 'Folders children order',
+            'enabled' => 1,
+            'is_nullable' => 1,
+            'is_static' => 0,
         ];
-        $connection
-            ->execute('INSERT INTO properties (' . implode(',', $fields) . ') VALUES (' . implode(',', $values) . ')');
+        $this->getQueryBuilder()
+            ->insert(array_keys($fields), array_values($fields))
+            ->into('properties')
+            ->values($values)
+            ->execute();
     }
 
     /**
@@ -97,12 +100,18 @@ class AddChildrenOrder extends AbstractMigration
      */
     public function down()
     {
-        $connection = $this->getAdapter()->getCakeConnection();
-        $connection
-            ->execute('DELETE FROM properties WHERE name = "children_order"');
+        $this->getQueryBuilder()
+            ->delete('properties')
+            ->innerJoin('object_types', [
+                'object_types.id = objects.object_type_id',
+                'object_types.name' => 'folders',
+            ])
+            ->where(['name' => 'children_order'])
+            ->limit(1)
+            ->execute();
         Resources::save(
             ['remove' => ['property_types' => $this->create['property_types']]],
-            ['connection' => $connection]
+            ['connection' => $this->getAdapter()->getCakeConnection()]
         );
     }
 }

--- a/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
+++ b/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
@@ -12,7 +12,6 @@
  */
 
 use BEdita\Core\Utility\Resources;
-use Cake\ORM\TableRegistry;
 use Migrations\AbstractMigration;
 
 class AddChildrenOrder extends AbstractMigration
@@ -84,10 +83,6 @@ class AddChildrenOrder extends AbstractMigration
      */
     public function down()
     {
-        // Resources::save(
-        //     ['remove' => ['properties' => $this->create['properties']]],
-        //     ['connection' => $this->getAdapter()->getCakeConnection()]
-        // );
         $connection = $this->getAdapter()->getCakeConnection();
         $sql = 'DELETE FROM properties WHERE name = "children_order"';
         $connection->execute($sql);

--- a/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
+++ b/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
@@ -58,24 +58,38 @@ class AddChildrenOrder extends AbstractMigration
             ['create' => $this->create],
             ['connection' => $connection]
         );
-        $sql = 'SELECT id FROM object_types WHERE name = "folders"';
-        $objectTypeId = $connection->execute($sql)->fetch(0)['id'];
-        $sql = 'SELECT id FROM property_types WHERE name = "children_order"';
-        $propertyTypeId = $connection->execute($sql)->fetch(0)['id'];
+        $objectTypeId = $connection
+            ->execute('SELECT id FROM object_types WHERE name = "folders"')
+            ->fetch(0)['id'];
+        $propertyTypeId = $connection
+            ->execute('SELECT id FROM property_types WHERE name = "children_order"')
+            ->fetch(0)['id'];
         $d = new \DateTime();
         $d = $d->format('Y-m-d\TH:i:s+00:00');
-        $sql = 'INSERT INTO properties (';
-        $sql .= 'name, object_type_id, property_type_id, created, modified,';
-        $sql .= 'description, enabled, is_nullable, is_static';
-        $sql .= ') VALUES (';
-        $sql .= sprintf(
-            '"children_order", %d, %d, "%s", "%s", "Folders children order", 1, 1, 0)',
+        $fields = [
+            'name',
+            'object_type_id',
+            'property_type_id',
+            'created',
+            'modified',
+            'description',
+            'enabled',
+            'is_nullable',
+            'is_static',
+        ];
+        $values = [
+            "'children_order'",
             $objectTypeId,
             $propertyTypeId,
-            $d,
-            $d
-        );
-        $connection->execute($sql);
+            "'$d'",
+            "'$d'",
+            "'Folders children order'",
+            1,
+            1,
+            0,
+        ];
+        $connection
+            ->execute('INSERT INTO properties (' . implode(',', $fields) . ') VALUES (' . implode(',', $values) . ')');
     }
 
     /**
@@ -84,8 +98,8 @@ class AddChildrenOrder extends AbstractMigration
     public function down()
     {
         $connection = $this->getAdapter()->getCakeConnection();
-        $sql = 'DELETE FROM properties WHERE name = "children_order"';
-        $connection->execute($sql);
+        $connection
+            ->execute('DELETE FROM properties WHERE name = "children_order"');
         Resources::save(
             ['remove' => ['property_types' => $this->create['property_types']]],
             ['connection' => $connection]

--- a/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
+++ b/plugins/BEdita/Core/config/Migrations/20221201092959_AddChildrenOrder.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2022 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+use BEdita\Core\Utility\Resources;
+use Migrations\AbstractMigration;
+
+class AddChildrenOrder extends AbstractMigration
+{
+    protected $create = [
+        'property_types' => [
+            [
+                'name' => 'objects_order',
+                'params' => [
+                    'type' => 'string',
+                    'enum' => [
+                        'position',
+                        '-position',
+                        'title',
+                        '-title',
+                        'modified',
+                        '-modified',
+                    ],
+                ],
+                'core_type' => 1,
+            ],
+        ],
+        'properties' => [
+            [
+                'name' => 'children_order',
+                'object' => 'folders',
+                'property' => 'objects_order',
+                'description' => 'Folders children order',
+                'enabled' => 1,
+                'is_nullable' => 1,
+            ],
+        ],
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function up()
+    {
+        Resources::save(
+            ['create' => $this->create],
+            ['connection' => $this->getAdapter()->getCakeConnection()]
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function down()
+    {
+        Resources::save(
+            ['remove' => ['properties' => $this->create['properties']]],
+            ['connection' => $this->getAdapter()->getCakeConnection()]
+        );
+        Resources::save(
+            ['remove' => ['property_types' => $this->create['property_types']]],
+            ['connection' => $this->getAdapter()->getCakeConnection()]
+        );
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
@@ -249,7 +249,8 @@ class ListAssociatedAction extends BaseAction
     }
 
     /**
-     * Get association sort by association and primary key
+     * Get association sort by association and primary key.
+     * When association name is "Children", use Folders.getSort($primaryKey).
      *
      * @param mixed $primaryKey Primary key
      * @param \Cake\ORM\Association $association Association

--- a/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
@@ -205,7 +205,8 @@ class ListAssociatedAction extends BaseAction
             $query = $query->select($this->Association->junction());
         }
         if ($this->Association instanceof BelongsToMany || $this->Association instanceof HasMany) {
-            $query = $query->order($this->Association->getSort());
+            $sort = $this->sort($this->Association, $primaryKey);
+            $query = $query->order($sort);
         }
 
         $primaryKeyConditions = $this->primaryKeyConditions($inverseAssociation->getTarget(), $primaryKey);
@@ -245,6 +246,22 @@ class ListAssociatedAction extends BaseAction
      */
     protected function prepareJoinEntity(EntityInterface $joinData): void
     {
+    }
+
+    /**
+     * Get association sort by association and primary key
+     *
+     * @param mixed $primaryKey Primary key
+     * @param \Cake\ORM\Association $association Association
+     * @return array
+     */
+    protected function sort(Association $association, $primaryKey): array
+    {
+        if ($association->getName() === 'Children') {
+            return (array)TableRegistry::getTableLocator()->get('Folders')->getSort($primaryKey);
+        }
+
+        return (array)$association->getSort();
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
@@ -309,4 +309,29 @@ class FoldersTable extends ObjectsTable
             ]
         );
     }
+
+    /**
+     * Get sort by object ID.
+     * Default 'Trees.tree_left' => 'asc'
+     *
+     * @param int $id The tree object ID
+     * @return array
+     */
+    public function getSort(int $id): array
+    {
+        /** @var \BEdita\Core\Model\Entity\Folder $entity */
+        $entity = $this->find()->where(['id' => $id])->first();
+        if (empty($entity->children_order) || $entity->children_order === 'position') {
+            return ['Trees.tree_left' => 'asc'];
+        }
+        if ($entity->children_order === '-position') {
+            return ['Trees.tree_left' => 'desc'];
+        }
+        $sign = substr($entity->children_order, 0, 1);
+        $direction = $sign === '-' ? 'desc' : 'asc';
+        $field = $sign === '-' ? substr($entity->children_order, 1) : $entity->children_order;
+        $key = sprintf('Children.%s', $field);
+
+        return [$key => $direction];
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
@@ -320,16 +320,17 @@ class FoldersTable extends ObjectsTable
     public function getSort(int $id): array
     {
         /** @var \BEdita\Core\Model\Entity\Folder $entity */
-        $entity = $this->find()->where(['id' => $id])->first();
-        if (empty($entity->children_order) || $entity->children_order === 'position') {
+        $entity = $this->get($id);
+        $order = $entity->get('children_order');
+        if (empty($order) || $order === 'position') {
             return ['Trees.tree_left' => 'asc'];
         }
-        if ($entity->children_order === '-position') {
+        if ($order === '-position') {
             return ['Trees.tree_left' => 'desc'];
         }
-        $sign = substr($entity->children_order, 0, 1);
+        $sign = substr($order, 0, 1);
         $direction = $sign === '-' ? 'desc' : 'asc';
-        $field = $sign === '-' ? substr($entity->children_order, 1) : $entity->children_order;
+        $field = $sign === '-' ? substr($order, 1) : $order;
         $key = sprintf('Children.%s', $field);
 
         return [$key => $direction];

--- a/plugins/BEdita/Core/tests/Fixture/PropertiesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/PropertiesFixture.php
@@ -146,5 +146,17 @@ class PropertiesFixture extends TestFixture
             'is_nullable' => true,
             'is_static' => false,
         ],
+        [
+            'name' => 'children_order',
+            'property_type_id' => 13,
+            'object_type_id' => 10,
+            'created' => '2022-12-01 15:26:00',
+            'modified' => '2022-12-01 15:26:00',
+            'description' => null,
+            'enabled' => true,
+            'label' => null,
+            'is_nullable' => true,
+            'is_static' => false,
+        ],
     ];
 }

--- a/plugins/BEdita/Core/tests/Fixture/PropertyTypesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/PropertyTypesFixture.php
@@ -125,5 +125,13 @@ class PropertyTypesFixture extends TestFixture
             'modified' => '2019-11-02 09:23:43',
             'core_type' => false,
         ],
+        // 13
+        [
+            'name' => 'children_order',
+            'params' => '{"type":"string","enum":["position","-position","modified","-modified","title","-title"]}',
+            'created' => '2022-12-01 15:35:21',
+            'modified' => '2022-12-01 15:35:21',
+            'core_type' => true,
+        ],
     ];
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
@@ -37,6 +37,12 @@ class ListAssociatedActionTest extends TestCase
         'plugin.BEdita/Core.FakeMammals',
         'plugin.BEdita/Core.FakeTags',
         'plugin.BEdita/Core.FakeArticlesTags',
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.RelationTypes',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.ObjectRelations',
+        'plugin.BEdita/Core.Trees',
     ];
 
     /**
@@ -229,5 +235,21 @@ class ListAssociatedActionTest extends TestCase
 
         $action = new ListAssociatedAction(compact('association'));
         $action(['primaryKey' => 1]);
+    }
+
+    /**
+     * Test `sort` method
+     *
+     * @return void
+     * @covers ::sort()
+     */
+    public function testSort(): void
+    {
+        // association Children
+        $association = TableRegistry::getTableLocator()->get('Folders')->getAssociation('Children');
+        $action = new ListAssociatedAction(compact('association'));
+        $result = $action(['primaryKey' => 11]);
+        $result = json_decode(json_encode($result->toArray()), true);
+        static::assertEquals(2, count($result));
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
@@ -510,4 +510,66 @@ class FoldersTableTest extends TestCase
         $childrenIds = Hash::extract($folder->children, '{*}.id');
         static::assertNotContains($firstChild->id, $childrenIds);
     }
+
+    /**
+     * Data provider for testGetSort()
+     *
+     * @return array
+     */
+    public function getSortProvider(): array
+    {
+        return [
+            'Order position Trees.tree_left asc' => [
+                11,
+                'position',
+                ['Trees.tree_left' => 'asc'],
+            ],
+            'Order -position Trees.tree_left desc' => [
+                11,
+                '-position',
+                ['Trees.tree_left' => 'desc'],
+            ],
+            'Order modified Children.modified asc' => [
+                11,
+                'modified',
+                ['Children.modified' => 'asc'],
+            ],
+            'Order -modified Children.modified desc' => [
+                11,
+                '-modified',
+                ['Children.modified' => 'desc'],
+            ],
+            'Order title Children.title asc' => [
+                11,
+                'title',
+                ['Children.title' => 'asc'],
+            ],
+            'Order -title Children.title desc' => [
+                11,
+                '-title',
+                ['Children.title' => 'desc'],
+            ],
+            'Default order Trees.tree_left asc' => [
+                11,
+                null,
+                ['Trees.tree_left' => 'asc'],
+            ],
+        ];
+    }
+
+    /**
+     * Test `getSort` method.
+     *
+     * @return void
+     * @dataProvider getSortProvider()
+     * @covers ::getSort()
+     */
+    public function testGetSort(int $id, ?string $order, array $expected): void
+    {
+        $folder = $this->Folders->get($id);
+        $folder = $this->Folders->patchEntity($folder, ['children_order' => $order]);
+        $this->Folders->save($folder);
+        $actual = $this->Folders->getSort($id);
+        static::assertSame($expected, $actual);
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Shell/BeditaShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/BeditaShellTest.php
@@ -48,7 +48,7 @@ class BeditaShellTest extends TestCase
      */
     public function setUp(): void
     {
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             return;
         }
 
@@ -67,7 +67,7 @@ class BeditaShellTest extends TestCase
      */
     public function tearDown(): void
     {
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             return;
         }
         ConnectionManager::alias('test', 'default'); // Restore alias which is dropped by `BeditaShell`.
@@ -104,7 +104,7 @@ class BeditaShellTest extends TestCase
      */
     public function testSetupNewInteractive()
     {
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             $this->markTestSkipped('Skip this test on sqlite.');
 
             return;
@@ -173,7 +173,7 @@ class BeditaShellTest extends TestCase
      */
     public function testSetupNewNonInteractive()
     {
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             $this->markTestSkipped('Skip this test on sqlite.');
 
             return;
@@ -293,7 +293,7 @@ class BeditaShellTest extends TestCase
      */
     public function testSetupExistingNonInteractive()
     {
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             $this->markTestSkipped('Skip this test on sqlite.');
 
             return;
@@ -319,7 +319,7 @@ class BeditaShellTest extends TestCase
      */
     public function testCheck()
     {
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             $this->markTestSkipped('Skip this test on sqlite.');
 
             return;

--- a/plugins/BEdita/Core/tests/TestCase/Shell/BeditaShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/BeditaShellTest.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Test\TestCase\Shell;
 
 use BEdita\Core\Shell\Task\InitSchemaTask;
+use BEdita\Core\Test\Utility\CheckDriver;
 use Cake\Console\Shell;
 use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
@@ -47,11 +48,7 @@ class BeditaShellTest extends TestCase
      */
     public function setUp(): void
     {
-        $cfg = ConnectionManager::get('default')->config();
-        $driver = substr($cfg['driver'], strrpos($cfg['driver'], '\\') + 1);
-        if ($driver === 'Sqlite') {
-            $this->markTestSkipped('Skip this test, on sqlite.');
-
+        if (CheckDriver::is('Sqlite')) {
             return;
         }
 
@@ -70,6 +67,9 @@ class BeditaShellTest extends TestCase
      */
     public function tearDown(): void
     {
+        if (CheckDriver::is('Sqlite')) {
+            return;
+        }
         ConnectionManager::alias('test', 'default'); // Restore alias which is dropped by `BeditaShell`.
         ConnectionManager::get('default')->getDriver()->disconnect();
         ConnectionManager::get('default')
@@ -104,6 +104,12 @@ class BeditaShellTest extends TestCase
      */
     public function testSetupNewInteractive()
     {
+        if (CheckDriver::is('Sqlite')) {
+            $this->markTestSkipped('Skip this test on sqlite.');
+
+            return;
+        }
+
         // Setup configuration file.
         file_put_contents(
             static::TEMP_FILE,
@@ -167,6 +173,12 @@ class BeditaShellTest extends TestCase
      */
     public function testSetupNewNonInteractive()
     {
+        if (CheckDriver::is('Sqlite')) {
+            $this->markTestSkipped('Skip this test on sqlite.');
+
+            return;
+        }
+
         // Setup configuration file.
         file_put_contents(
             static::TEMP_FILE,
@@ -281,6 +293,11 @@ class BeditaShellTest extends TestCase
      */
     public function testSetupExistingNonInteractive()
     {
+        if (CheckDriver::is('Sqlite')) {
+            $this->markTestSkipped('Skip this test on sqlite.');
+
+            return;
+        }
         $this->exec(sprintf('%s --force --seed', InitSchemaTask::class));
 
         // Invoke task.
@@ -302,6 +319,11 @@ class BeditaShellTest extends TestCase
      */
     public function testCheck()
     {
+        if (CheckDriver::is('Sqlite')) {
+            $this->markTestSkipped('Skip this test on sqlite.');
+
+            return;
+        }
         $this->exec(sprintf('%s --force --seed', InitSchemaTask::class));
 
         // Invoke task.

--- a/plugins/BEdita/Core/tests/TestCase/Shell/BeditaShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/BeditaShellTest.php
@@ -47,6 +47,14 @@ class BeditaShellTest extends TestCase
      */
     public function setUp(): void
     {
+        $cfg = ConnectionManager::get('default')->config();
+        $driver = substr($cfg['driver'], strrpos($cfg['driver'], '\\') + 1);
+        if ($driver === 'Sqlite') {
+            $this->markTestSkipped('Skip this test, on sqlite.');
+
+            return;
+        }
+
         $this->fixtureManager->shutDown();
 
         // Try to avoid "database schema has changed" error on SQLite.

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckSchemaTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckSchemaTaskTest.php
@@ -38,7 +38,7 @@ class CheckSchemaTaskTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             return;
         }
         $this->fixtureManager->shutDown();
@@ -51,7 +51,7 @@ class CheckSchemaTaskTest extends TestCase
      */
     public static function tearDownAfterClass(): void
     {
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             return;
         }
         ConnectionManager::get('default')
@@ -100,7 +100,7 @@ class CheckSchemaTaskTest extends TestCase
      */
     public function testMissingMigrationsPlugin()
     {
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             $this->markTestSkipped('Skip this test on sqlite.');
 
             return;
@@ -127,7 +127,7 @@ class CheckSchemaTaskTest extends TestCase
      */
     public function testOffendedConventions()
     {
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             $this->markTestSkipped('Skip this test on sqlite.');
 
             return;
@@ -191,7 +191,7 @@ class CheckSchemaTaskTest extends TestCase
      */
     public function testCheckSchema()
     {
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             $this->markTestSkipped('Skip this test on sqlite.');
 
             return;
@@ -217,7 +217,7 @@ class CheckSchemaTaskTest extends TestCase
      */
     public function testAddTable()
     {
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             $this->markTestSkipped('Skip this test on sqlite.');
 
             return;
@@ -251,7 +251,7 @@ class CheckSchemaTaskTest extends TestCase
      */
     public function testRemoveTable()
     {
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             $this->markTestSkipped('Skip this test on sqlite.');
 
             return;
@@ -285,7 +285,7 @@ class CheckSchemaTaskTest extends TestCase
      */
     public function testUpdateConstraints()
     {
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             $this->markTestSkipped('Skip this test on sqlite.');
 
             return;

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckSchemaTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckSchemaTaskTest.php
@@ -14,27 +14,33 @@
 namespace BEdita\Core\Test\TestCase\Shell\Task;
 
 use BEdita\Core\Shell\Task\CheckSchemaTask;
+use BEdita\Core\Test\Utility\CheckDriver;
 use Cake\Console\Shell;
 use Cake\Core\Plugin;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
-use Cake\TestSuite\ConsoleIntegrationTestCase;
+use Cake\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
 
 /**
  * @coversDefaultClass \BEdita\Core\Shell\Task\CheckSchemaTask
  */
-class CheckSchemaTaskTest extends ConsoleIntegrationTestCase
+class CheckSchemaTaskTest extends TestCase
 {
+    use ConsoleIntegrationTestTrait;
+
     /**
      * @inheritDoc
      */
     public function setUp(): void
     {
         parent::setUp();
-
+        if (CheckDriver::is('Sqlite')) {
+            return;
+        }
         $this->fixtureManager->shutDown();
 
         $this->exec('db_admin init -fs');
@@ -45,6 +51,9 @@ class CheckSchemaTaskTest extends ConsoleIntegrationTestCase
      */
     public static function tearDownAfterClass(): void
     {
+        if (CheckDriver::is('Sqlite')) {
+            return;
+        }
         ConnectionManager::get('default')
             ->transactional(function (Connection $connection) {
                 $tables = $connection->getSchemaCollection()->listTables();
@@ -91,6 +100,11 @@ class CheckSchemaTaskTest extends ConsoleIntegrationTestCase
      */
     public function testMissingMigrationsPlugin()
     {
+        if (CheckDriver::is('Sqlite')) {
+            $this->markTestSkipped('Skip this test on sqlite.');
+
+            return;
+        }
         $pluginCollection = Plugin::getCollection();
         $migrationPlugin = $pluginCollection->get('Migrations');
         $pluginCollection->remove('Migrations');
@@ -113,6 +127,11 @@ class CheckSchemaTaskTest extends ConsoleIntegrationTestCase
      */
     public function testOffendedConventions()
     {
+        if (CheckDriver::is('Sqlite')) {
+            $this->markTestSkipped('Skip this test on sqlite.');
+
+            return;
+        }
         /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get('default');
 
@@ -172,6 +191,11 @@ class CheckSchemaTaskTest extends ConsoleIntegrationTestCase
      */
     public function testCheckSchema()
     {
+        if (CheckDriver::is('Sqlite')) {
+            $this->markTestSkipped('Skip this test on sqlite.');
+
+            return;
+        }
         /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get('default');
 
@@ -193,6 +217,11 @@ class CheckSchemaTaskTest extends ConsoleIntegrationTestCase
      */
     public function testAddTable()
     {
+        if (CheckDriver::is('Sqlite')) {
+            $this->markTestSkipped('Skip this test on sqlite.');
+
+            return;
+        }
         /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get('default');
 
@@ -222,6 +251,11 @@ class CheckSchemaTaskTest extends ConsoleIntegrationTestCase
      */
     public function testRemoveTable()
     {
+        if (CheckDriver::is('Sqlite')) {
+            $this->markTestSkipped('Skip this test on sqlite.');
+
+            return;
+        }
         /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get('default');
 
@@ -251,6 +285,11 @@ class CheckSchemaTaskTest extends ConsoleIntegrationTestCase
      */
     public function testUpdateConstraints()
     {
+        if (CheckDriver::is('Sqlite')) {
+            $this->markTestSkipped('Skip this test on sqlite.');
+
+            return;
+        }
         /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get('default');
 

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/InitSchemaTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/InitSchemaTaskTest.php
@@ -37,7 +37,7 @@ class InitSchemaTaskTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             return;
         }
         $this->fixtureManager->shutDown();
@@ -48,7 +48,7 @@ class InitSchemaTaskTest extends TestCase
      */
     public function tearDown(): void
     {
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             return;
         }
         ConnectionManager::get('default')
@@ -79,7 +79,7 @@ class InitSchemaTaskTest extends TestCase
      */
     public function testDatabaseNotEmpty()
     {
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             $this->markTestSkipped('Skip this test on sqlite.');
 
             return;
@@ -107,7 +107,7 @@ class InitSchemaTaskTest extends TestCase
      */
     public function testDatabaseEmpty()
     {
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             $this->markTestSkipped('Skip this test on sqlite.');
 
             return;
@@ -135,7 +135,7 @@ class InitSchemaTaskTest extends TestCase
      */
     public function testDatabaseCleanup()
     {
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             $this->markTestSkipped('Skip this test on sqlite.');
 
             return;
@@ -167,7 +167,7 @@ class InitSchemaTaskTest extends TestCase
      */
     public function testDatabaseSeed()
     {
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             $this->markTestSkipped('Skip this test on sqlite.');
 
             return;
@@ -195,7 +195,7 @@ class InitSchemaTaskTest extends TestCase
      */
     public function testInteractive($notSeededCount)
     {
-        if (CheckDriver::is('Sqlite')) {
+        if (CheckDriver::is(\Cake\Database\Driver\Sqlite::class)) {
             $this->markTestSkipped('Skip this test on sqlite.');
 
             return;

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/InitSchemaTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/InitSchemaTaskTest.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Test\TestCase\Shell\Task;
 
 use BEdita\Core\Shell\Task\InitSchemaTask;
+use BEdita\Core\Test\Utility\CheckDriver;
 use Cake\Console\Shell;
 use Cake\Core\Plugin;
 use Cake\Database\Connection;
@@ -36,7 +37,9 @@ class InitSchemaTaskTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-
+        if (CheckDriver::is('Sqlite')) {
+            return;
+        }
         $this->fixtureManager->shutDown();
     }
 
@@ -45,6 +48,9 @@ class InitSchemaTaskTest extends TestCase
      */
     public function tearDown(): void
     {
+        if (CheckDriver::is('Sqlite')) {
+            return;
+        }
         ConnectionManager::get('default')
             ->transactional(function (Connection $connection) {
                 $tables = $connection->getSchemaCollection()->listTables();
@@ -73,6 +79,11 @@ class InitSchemaTaskTest extends TestCase
      */
     public function testDatabaseNotEmpty()
     {
+        if (CheckDriver::is('Sqlite')) {
+            $this->markTestSkipped('Skip this test on sqlite.');
+
+            return;
+        }
         $connection = ConnectionManager::get('default');
         if (!($connection instanceof Connection)) {
             throw new \RuntimeException('Unable to use database connection');
@@ -96,6 +107,11 @@ class InitSchemaTaskTest extends TestCase
      */
     public function testDatabaseEmpty()
     {
+        if (CheckDriver::is('Sqlite')) {
+            $this->markTestSkipped('Skip this test on sqlite.');
+
+            return;
+        }
         $connection = ConnectionManager::get('default');
         if (!($connection instanceof Connection)) {
             throw new \RuntimeException('Unable to use database connection');
@@ -119,6 +135,11 @@ class InitSchemaTaskTest extends TestCase
      */
     public function testDatabaseCleanup()
     {
+        if (CheckDriver::is('Sqlite')) {
+            $this->markTestSkipped('Skip this test on sqlite.');
+
+            return;
+        }
         $connection = ConnectionManager::get('default');
         if (!($connection instanceof Connection)) {
             throw new \RuntimeException('Unable to use database connection');
@@ -146,6 +167,11 @@ class InitSchemaTaskTest extends TestCase
      */
     public function testDatabaseSeed()
     {
+        if (CheckDriver::is('Sqlite')) {
+            $this->markTestSkipped('Skip this test on sqlite.');
+
+            return;
+        }
         $connection = ConnectionManager::get('default');
         if (!($connection instanceof Connection)) {
             throw new \RuntimeException('Unable to use database connection');
@@ -169,6 +195,11 @@ class InitSchemaTaskTest extends TestCase
      */
     public function testInteractive($notSeededCount)
     {
+        if (CheckDriver::is('Sqlite')) {
+            $this->markTestSkipped('Skip this test on sqlite.');
+
+            return;
+        }
         $connection = ConnectionManager::get('default');
         if (!($connection instanceof Connection)) {
             throw new \RuntimeException('Unable to use database connection');

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -315,6 +315,13 @@ class ProjectModelTest extends TestCase
                 'property_type_name' => 'integer',
                 'object_type_name' => 'profiles',
             ],
+            [
+                'name' => 'children_order',
+                'description' => null,
+                'is_nullable' => true,
+                'property_type_name' => 'children_order',
+                'object_type_name' => 'folders',
+            ],
         ],
     ];
 

--- a/plugins/BEdita/Core/tests/Utility/CheckDriver.php
+++ b/plugins/BEdita/Core/tests/Utility/CheckDriver.php
@@ -23,13 +23,13 @@ class CheckDriver
     /**
      * Check if a specific driver is used (like 'Sqlite' or 'Mysql')
      *
+     * @param string $className The full name of class, i.e. \Cake\Database\Driver\Mysql::class
      * @return bool
      */
-    public static function is(string $name): bool
+    public static function is(string $className): bool
     {
-        $cfg = ConnectionManager::get('default')->config();
-        $driver = substr($cfg['driver'], strrpos($cfg['driver'], '\\') + 1);
+        $driver = ConnectionManager::get('default')->getDriver();
 
-        return $driver === $name;
+        return $driver instanceof $className;
     }
 }

--- a/plugins/BEdita/Core/tests/Utility/CheckDriver.php
+++ b/plugins/BEdita/Core/tests/Utility/CheckDriver.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\Utility;
+
+use Cake\Datasource\ConnectionManager;
+
+/**
+ * Utility with methods to check connection drivers
+ */
+class CheckDriver
+{
+    /**
+     * Check if a specific driver is used (like 'Sqlite' or 'Mysql')
+     *
+     * @return bool
+     */
+    public static function is(string $name): bool
+    {
+        $cfg = ConnectionManager::get('default')->config();
+        $driver = substr($cfg['driver'], strrpos($cfg['driver'], '\\') + 1);
+
+        return $driver === $name;
+    }
+}


### PR DESCRIPTION
This PR fixes #1954 and https://github.com/bedita/bedita/issues/1956 (that becomes obsolete) using a new folders property "children_order".
