### PR TITLE
Folders children_order property and ListAssociatedAction custom sort for Children

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -100,6 +100,7 @@ class FoldersControllerTest extends IntegrationTestCase
                         'lang' => 'en',
                         'publish_start' => null,
                         'publish_end' => null,
+                        'children_order' => null,
                     ],
                     'meta' => [
                         'locked' => false,
@@ -147,6 +148,7 @@ class FoldersControllerTest extends IntegrationTestCase
                         'lang' => 'en',
                         'publish_start' => null,
                         'publish_end' => null,
+                        'children_order' => null,
                     ],
                     'meta' => [
                         'locked' => false,
@@ -194,6 +196,7 @@ class FoldersControllerTest extends IntegrationTestCase
                         'lang' => 'en',
                         'publish_start' => null,
                         'publish_end' => null,
+                        'children_order' => null,
                     ],
                     'meta' => [
                         'locked' => false,
@@ -307,6 +310,7 @@ class FoldersControllerTest extends IntegrationTestCase
                     'lang' => 'en',
                     'publish_start' => null,
                     'publish_end' => null,
+                    'children_order' => null,
                 ],
                 'meta' => [
                     'locked' => false,

--- a/plugins/BEdita/API/tests/TestCase/Controller/HistoryControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/HistoryControllerTest.php
@@ -365,6 +365,7 @@ class HistoryControllerTest extends IntegrationTestCase
      * Test `include` method.
      *
      * @return void
+     * @coversNothing
      */
     public function testInclude()
     {

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
@@ -306,6 +306,8 @@ class ProjectControllerTest extends IntegrationTestCase
                     'is_nullable' => true,
                     'property_type_name' => 'children_order',
                     'object_type_name' => 'folders',
+                    'object' => 'folders',
+                    'property' => 'children_order',
                 ],
             ],
         ];

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
@@ -304,8 +304,6 @@ class ProjectControllerTest extends IntegrationTestCase
                     'name' => 'children_order',
                     'description' => null,
                     'is_nullable' => true,
-                    'property_type_name' => 'children_order',
-                    'object_type_name' => 'folders',
                     'object' => 'folders',
                     'property' => 'children_order',
                 ],

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
@@ -300,6 +300,13 @@ class ProjectControllerTest extends IntegrationTestCase
                     'property' => 'integer',
                     'object' => 'profiles',
                 ],
+                [
+                    'name' => 'children_order',
+                    'description' => null,
+                    'is_nullable' => true,
+                    'property_type_name' => 'children_order',
+                    'object_type_name' => 'folders',
+                ],
             ],
         ];
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertiesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertiesControllerTest.php
@@ -56,10 +56,10 @@ class PropertiesControllerTest extends IntegrationTestCase
             ],
             'meta' => [
                 'pagination' => [
-                    'count' => 11,
+                    'count' => 12,
                     'page' => 1,
                     'page_count' => 1,
-                    'page_items' => 11,
+                    'page_items' => 12,
                     'page_size' => 20,
                 ],
             ],
@@ -284,6 +284,26 @@ class PropertiesControllerTest extends IntegrationTestCase
                         'self' => 'http://api.example.com/model/properties/11',
                     ],
                 ],
+                [
+                    'id' => '12',
+                    'type' => 'properties',
+                    'attributes' => [
+                        'name' => 'children_order',
+                        'description' => null,
+                        'property_type_name' => 'children_order',
+                        'object_type_name' => 'folders',
+                        'label' => null,
+                        'is_nullable' => true,
+                        'is_static' => false,
+                    ],
+                    'meta' => [
+                        'created' => '2022-12-01T15:26:00+00:00',
+                        'modified' => '2022-12-01T15:26:00+00:00',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/model/properties/12',
+                    ],
+                ],
             ],
         ];
 
@@ -438,7 +458,7 @@ class PropertiesControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertHeader('Location', 'http://api.example.com/model/properties/12');
+        $this->assertHeader('Location', 'http://api.example.com/model/properties/13');
         static::assertTrue(TableRegistry::getTableLocator()->get('Properties')->exists(['name' => 'yet_another_body']));
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
@@ -54,10 +54,10 @@ class PropertyTypesControllerTest extends IntegrationTestCase
             ],
             'meta' => [
                 'pagination' => [
-                    'count' => 12,
+                    'count' => 13,
                     'page' => 1,
                     'page_count' => 1,
-                    'page_items' => 12,
+                    'page_items' => 13,
                     'page_size' => 20,
                 ],
             ],
@@ -386,6 +386,40 @@ class PropertyTypesControllerTest extends IntegrationTestCase
                         ],
                     ],
                 ],
+                [
+                    'id' => '13',
+                    'type' => 'property_types',
+                    'attributes' => [
+                        'name' => 'children_order',
+                        'params' => [
+                            'type' => 'string',
+                            'enum' => [
+                                'position',
+                                '-position',
+                                'modified',
+                                '-modified',
+                                'title',
+                                '-title',
+                            ],
+                        ],
+                    ],
+                    'meta' => [
+                        'created' => '2022-12-01T15:35:21+00:00',
+                        'modified' => '2022-12-01T15:35:21+00:00',
+                        'core_type' => true,
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/model/property_types/13',
+                    ],
+                    'relationships' => [
+                        'properties' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/model/property_types/13/properties',
+                                'self' => 'http://api.example.com/model/property_types/13/relationships/properties',
+                            ],
+                        ],
+                    ],
+                ],
             ],
         ];
 
@@ -556,9 +590,9 @@ class PropertyTypesControllerTest extends IntegrationTestCase
 
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertHeader('Location', 'http://api.example.com/model/property_types/13');
+        $this->assertHeader('Location', 'http://api.example.com/model/property_types/14');
         static::assertTrue(TableRegistry::getTableLocator()->get('PropertyTypes')->exists(['name' => 'gustavo_type']));
-        static::assertFalse(TableRegistry::getTableLocator()->get('PropertyTypes')->get(13)->get('core_type'));
+        static::assertFalse(TableRegistry::getTableLocator()->get('PropertyTypes')->get(14)->get('core_type'));
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/TreesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TreesControllerTest.php
@@ -57,6 +57,7 @@ class TreesControllerTest extends IntegrationTestCase
                     'publish_start' => null,
                     'publish_end' => null,
                     'menu' => true,
+                    'children_order' => null,
                 ],
                 'meta' => [
                     'locked' => false,

--- a/plugins/BEdita/API/tests/TestConstants.php
+++ b/plugins/BEdita/API/tests/TestConstants.php
@@ -28,7 +28,7 @@ class TestConstants
         'documents' => '4059696127',
         'events' => '1528552691',
         'files' => '4129506705',
-        'folders' => '3223993640',
+        'folders' => '1494838194',
         'locations' => '2540919723',
         'profiles' => '951433151',
         'roles' => '2845943672',

--- a/plugins/BEdita/Core/config/Migrations/20221206063119_AddChildrenOrder.php
+++ b/plugins/BEdita/Core/config/Migrations/20221206063119_AddChildrenOrder.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2022 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+use BEdita\Core\Utility\Resources;
+use Migrations\AbstractMigration;
+
+class AddChildrenOrder extends AbstractMigration
+{
+    protected $create = [
+        'property_types' => [
+            [
+                'name' => 'children_order',
+                'params' => [
+                    'type' => 'string',
+                    'enum' => [
+                        'position',
+                        '-position',
+                        'title',
+                        '-title',
+                        'modified',
+                        '-modified',
+                    ],
+                ],
+                'core_type' => 1,
+            ],
+        ],
+        // this does not work in tests, for an issue with static_properties temporary table
+        // we instead use a sql insert/delete query
+        // 'properties' => [
+        //     [
+        //         'name' => 'children_order',
+        //         'object' => 'folders',
+        //         'property' => 'children_order',
+        //         'description' => 'Folders children order',
+        //         'enabled' => 1,
+        //         'is_nullable' => 1,
+        //     ],
+        // ],
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function up()
+    {
+        $connection = $this->getAdapter()->getCakeConnection();
+        Resources::save(
+            ['create' => $this->create],
+            ['connection' => $connection]
+        );
+        $objectTypeId = $connection
+            ->execute('SELECT id FROM object_types WHERE name = "folders"')
+            ->fetch(0)['id'];
+        $propertyTypeId = $connection
+            ->execute('SELECT id FROM property_types WHERE name = "children_order"')
+            ->fetch(0)['id'];
+        $d = new \DateTime();
+        $d = $d->format('Y-m-d\TH:i:s+00:00');
+        $fields = [
+            'name',
+            'object_type_id',
+            'property_type_id',
+            'created',
+            'modified',
+            'description',
+            'enabled',
+            'is_nullable',
+            'is_static',
+        ];
+        $values = [
+            "'children_order'",
+            $objectTypeId,
+            $propertyTypeId,
+            "'$d'",
+            "'$d'",
+            "'Folders children order'",
+            1,
+            1,
+            0,
+        ];
+        $connection
+            ->execute('INSERT INTO properties (' . implode(',', $fields) . ') VALUES (' . implode(',', $values) . ')');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function down()
+    {
+        $connection = $this->getAdapter()->getCakeConnection();
+        $connection
+            ->execute('DELETE FROM properties WHERE name = "children_order"');
+        Resources::save(
+            ['remove' => ['property_types' => $this->create['property_types']]],
+            ['connection' => $connection]
+        );
+    }
+}

--- a/plugins/BEdita/Core/config/Migrations/20221206063119_AddChildrenOrder.php
+++ b/plugins/BEdita/Core/config/Migrations/20221206063119_AddChildrenOrder.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
  */
 
 use BEdita\Core\Utility\Resources;
-use Cake\Database\Expression\FunctionExpression;
 use Migrations\AbstractMigration;
 
 class AddChildrenOrder extends AbstractMigration
@@ -60,6 +59,18 @@ class AddChildrenOrder extends AbstractMigration
             ['create' => $this->create],
             ['connection' => $this->getAdapter()->getCakeConnection()]
         );
+        $objectTypeId = (int)$this->getQueryBuilder()
+            ->select(['id'])
+            ->from(['object_types'])
+            ->where(['name' => 'folders'])
+            ->execute()
+            ->fetch()[0];
+        $propertyTypesId = (int)$this->getQueryBuilder()
+            ->select(['id'])
+            ->from(['property_types'])
+            ->where(['name' => 'children_order'])
+            ->execute()
+            ->fetch()[0];
         $fields = [
             'name' => 'string',
             'object_type_id' => 'int',
@@ -73,27 +84,16 @@ class AddChildrenOrder extends AbstractMigration
         $this->getQueryBuilder()
             ->insert(array_keys($fields), array_values($fields))
             ->into('properties')
-            ->values(
-                $this->getQueryBuilder()
-                    ->select([
-                        // Use a no-op expression to circumvent Cake query escaping issues
-                        // as the value would be interpreted as an identifier here.
-                        'name' => new FunctionExpression('COALESCE', ['children_order']),
-                        'object_types.id',
-                        'property_types.id',
-                        'created' => new FunctionExpression('CURRENT_TIMESTAMP'),
-                        'modified' => new FunctionExpression('CURRENT_TIMESTAMP'),
-                        'enabled' => 1,
-                        'is_nullable' => 1,
-                        'is_static' => 0,
-                    ])
-                    ->from(['object_types', 'property_types'])
-                    ->where([
-                        'object_types.name' => 'folders',
-                        'property_types.name' => 'children_order',
-                    ])
-                    ->limit(1)
-            )
+            ->values([
+                'name' => 'children_order',
+                'object_types_id' => $objectTypeId,
+                'property_types_id' => $propertyTypesId,
+                'created' => date('Y-m-d H:i:s'),
+                'modified' => date('Y-m-d H:i:s'),
+                'enabled' => 1,
+                'is_nullable' => 1,
+                'is_static' => 0,
+            ])
             ->execute();
     }
 

--- a/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
@@ -221,7 +221,8 @@ class ListAssociatedAction extends BaseAction
             $query = $query->select($this->Association->junction());
         }
         if ($this->Association instanceof BelongsToMany || $this->Association instanceof HasMany) {
-            $query = $query->order($this->Association->getSort());
+            $sort = $this->sort($this->Association, $primaryKey);
+            $query = $query->order($sort);
         }
 
         $primaryKeyConditions = $this->primaryKeyConditions($inverseAssociation->getTarget(), $primaryKey);

--- a/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
@@ -286,4 +286,21 @@ class ListAssociatedAction extends BaseAction
 
         return $query;
     }
+
+    /**
+     * Get association sort by association and primary key.
+     * When association name is "Children", use Folders.getSort($primaryKey).
+     *
+     * @param mixed $primaryKey Primary key
+     * @param \Cake\ORM\Association $association Association
+     * @return array
+     */
+    protected function sort(Association $association, $primaryKey): array
+    {
+        if ($association->getName() === 'Children') {
+            return (array)TableRegistry::getTableLocator()->get('Folders')->getSort($primaryKey);
+        }
+
+        return (array)$association->getSort();
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
@@ -309,4 +309,30 @@ class FoldersTable extends ObjectsTable
             ]
         );
     }
+
+    /**
+     * Get sort by object ID.
+     * Default 'Trees.tree_left' => 'asc'
+     *
+     * @param int $id The tree object ID
+     * @return array
+     */
+    public function getSort(int $id): array
+    {
+        /** @var \BEdita\Core\Model\Entity\Folder $entity */
+        $entity = $this->get($id);
+        $order = $entity->get('children_order');
+        if (empty($order) || $order === 'position') {
+            return ['Trees.tree_left' => 'asc'];
+        }
+        if ($order === '-position') {
+            return ['Trees.tree_left' => 'desc'];
+        }
+        $sign = substr($order, 0, 1);
+        $direction = $sign === '-' ? 'desc' : 'asc';
+        $field = $sign === '-' ? substr($order, 1) : $order;
+        $key = sprintf('Children.%s', $field);
+
+        return [$key => $direction];
+    }
 }

--- a/plugins/BEdita/Core/tests/Fixture/PropertiesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/PropertiesFixture.php
@@ -146,5 +146,17 @@ class PropertiesFixture extends TestFixture
             'is_nullable' => true,
             'is_static' => false,
         ],
+        [
+            'name' => 'children_order',
+            'property_type_id' => 13,
+            'object_type_id' => 10,
+            'created' => '2022-12-01 15:26:00',
+            'modified' => '2022-12-01 15:26:00',
+            'description' => null,
+            'enabled' => true,
+            'label' => null,
+            'is_nullable' => true,
+            'is_static' => false,
+        ],
     ];
 }

--- a/plugins/BEdita/Core/tests/Fixture/PropertyTypesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/PropertyTypesFixture.php
@@ -125,5 +125,13 @@ class PropertyTypesFixture extends TestFixture
             'modified' => '2019-11-02 09:23:43',
             'core_type' => false,
         ],
+        // 13
+        [
+            'name' => 'children_order',
+            'params' => '{"type":"string","enum":["position","-position","modified","-modified","title","-title"]}',
+            'created' => '2022-12-01 15:35:21',
+            'modified' => '2022-12-01 15:35:21',
+            'core_type' => true,
+        ],
     ];
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
@@ -22,7 +22,7 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
 /**
- * @covers \BEdita\Core\Model\Action\ListAssociatedAction
+ * @coversDefaultClass \BEdita\Core\Model\Action\ListAssociatedAction
  */
 class ListAssociatedActionTest extends TestCase
 {
@@ -192,6 +192,13 @@ class ListAssociatedActionTest extends TestCase
      * @param array $options Additional options for action.
      * @return void
      * @dataProvider invocationProvider()
+     * @covers ::initialize()
+     * @covers ::checkEntityExists()
+     * @covers ::primaryKeyConditions()
+     * @covers ::buildInverseAssociation()
+     * @covers ::clearInverseAssociation()
+     * @covers ::buildQuery()
+     * @covers ::execute()
      */
     public function testInvocation($expected, $table, $association, $id, ?array $options = null)
     {
@@ -241,6 +248,7 @@ class ListAssociatedActionTest extends TestCase
      * Test `sort` method
      *
      * @return void
+     * @covers ::sort()
      */
     public function testSort(): void
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
@@ -241,7 +241,6 @@ class ListAssociatedActionTest extends TestCase
      * Test `sort` method
      *
      * @return void
-     * @covers ::sort()
      */
     public function testSort(): void
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
@@ -37,6 +37,12 @@ class ListAssociatedActionTest extends TestCase
         'plugin.BEdita/Core.FakeMammals',
         'plugin.BEdita/Core.FakeTags',
         'plugin.BEdita/Core.FakeArticlesTags',
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.RelationTypes',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.ObjectRelations',
+        'plugin.BEdita/Core.Trees',
     ];
 
     /**
@@ -229,5 +235,21 @@ class ListAssociatedActionTest extends TestCase
 
         $action = new ListAssociatedAction(compact('association'));
         $action(['primaryKey' => 1]);
+    }
+
+    /**
+     * Test `sort` method
+     *
+     * @return void
+     * @covers ::sort()
+     */
+    public function testSort(): void
+    {
+        // association Children
+        $association = TableRegistry::getTableLocator()->get('Folders')->getAssociation('Children');
+        $action = new ListAssociatedAction(compact('association'));
+        $result = $action(['primaryKey' => 11]);
+        $result = json_decode(json_encode($result->toArray()), true);
+        static::assertEquals(2, count($result));
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
@@ -199,6 +199,7 @@ class ListAssociatedActionTest extends TestCase
      * @covers ::clearInverseAssociation()
      * @covers ::buildQuery()
      * @covers ::prepareJoinEntity()
+     * @covers ::sort()
      * @covers ::execute()
      */
     public function testInvocation($expected, $table, $association, $id, ?array $options = null)

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
@@ -198,6 +198,7 @@ class ListAssociatedActionTest extends TestCase
      * @covers ::buildInverseAssociation()
      * @covers ::clearInverseAssociation()
      * @covers ::buildQuery()
+     * @covers ::prepareJoinEntity()
      * @covers ::execute()
      */
     public function testInvocation($expected, $table, $association, $id, ?array $options = null)
@@ -229,6 +230,7 @@ class ListAssociatedActionTest extends TestCase
      * Test invocation of command with an unknown association type.
      *
      * @return void
+     * @covers ::execute()
      */
     public function testUnknownAssociationType()
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
@@ -510,4 +510,66 @@ class FoldersTableTest extends TestCase
         $childrenIds = Hash::extract($folder->children, '{*}.id');
         static::assertNotContains($firstChild->id, $childrenIds);
     }
+
+    /**
+     * Data provider for testGetSort()
+     *
+     * @return array
+     */
+    public function getSortProvider(): array
+    {
+        return [
+            'Order position Trees.tree_left asc' => [
+                11,
+                'position',
+                ['Trees.tree_left' => 'asc'],
+            ],
+            'Order -position Trees.tree_left desc' => [
+                11,
+                '-position',
+                ['Trees.tree_left' => 'desc'],
+            ],
+            'Order modified Children.modified asc' => [
+                11,
+                'modified',
+                ['Children.modified' => 'asc'],
+            ],
+            'Order -modified Children.modified desc' => [
+                11,
+                '-modified',
+                ['Children.modified' => 'desc'],
+            ],
+            'Order title Children.title asc' => [
+                11,
+                'title',
+                ['Children.title' => 'asc'],
+            ],
+            'Order -title Children.title desc' => [
+                11,
+                '-title',
+                ['Children.title' => 'desc'],
+            ],
+            'Default order Trees.tree_left asc' => [
+                11,
+                null,
+                ['Trees.tree_left' => 'asc'],
+            ],
+        ];
+    }
+
+    /**
+     * Test `getSort` method.
+     *
+     * @return void
+     * @dataProvider getSortProvider()
+     * @covers ::getSort()
+     */
+    public function testGetSort(int $id, ?string $order, array $expected): void
+    {
+        $folder = $this->Folders->get($id);
+        $folder = $this->Folders->patchEntity($folder, ['children_order' => $order]);
+        $this->Folders->save($folder);
+        $actual = $this->Folders->getSort($id);
+        static::assertSame($expected, $actual);
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -317,8 +317,6 @@ class ProjectModelTest extends TestCase
                 'name' => 'children_order',
                 'description' => null,
                 'is_nullable' => true,
-                'property_type_name' => 'children_order',
-                'object_type_name' => 'folders',
                 'object' => 'folders',
                 'property' => 'children_order',
             ],

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -313,6 +313,13 @@ class ProjectModelTest extends TestCase
                 'property' => 'integer',
                 'object' => 'profiles',
             ],
+            [
+                'name' => 'children_order',
+                'description' => null,
+                'is_nullable' => true,
+                'property_type_name' => 'children_order',
+                'object_type_name' => 'folders',
+            ],
         ],
     ];
 

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -319,6 +319,8 @@ class ProjectModelTest extends TestCase
                 'is_nullable' => true,
                 'property_type_name' => 'children_order',
                 'object_type_name' => 'folders',
+                'object' => 'folders',
+                'property' => 'children_order',
             ],
         ],
     ];


### PR DESCRIPTION
This PR fixes https://github.com/bedita/bedita/issues/1954 and https://github.com/bedita/bedita/issues/1956 (that becomes obsolete) using a new folders property "children_order".