### PR TITLE
Update major version on docker.com image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,4 +61,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: "${{ github.repository }}:${{ needs.release_job.outputs.version }}"
+          tags: "${{ github.repository }}:${{ needs.release_job.outputs.version }},${{ github.repository }}:${{ needs.release_job.outputs.major }}"


### PR DESCRIPTION
This PR updates a `4` major version of the `bedita/bedita` docker image on docker.com with the latest `4.x.x` created