### PR TITLE
Allow `filter[name]` query string on `/config` and `/admin/config`

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -547,6 +547,13 @@ class FilterQueryStringTest extends IntegrationTestCase
                     '4',
                  ],
             ],
+            'config name' => [
+                '/config',
+                'filter[name]=appVal',
+                [
+                    '11',
+                ],
+            ],
         ];
     }
 

--- a/plugins/BEdita/Core/src/Model/Table/ConfigTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ConfigTable.php
@@ -122,7 +122,9 @@ class ConfigTable extends Table
 
     /**
      * Finder for configuration by name and optional application name or id.
-     * Options array MUST have `name` and optionally `application` (application name) or `application_id`
+     * Options array MUST be:
+     *  - an associative array with `name` and optionally `application` (application name) or `application_id`
+     *  - a non empty indexed array, the first element is then used as `name`
      *
      * @param \Cake\ORM\Query $query Query object instance.
      * @param array $options Options array.

--- a/plugins/BEdita/Core/src/Model/Table/ConfigTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ConfigTable.php
@@ -19,6 +19,7 @@ use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
+use Cake\Utility\Hash;
 use Cake\Validation\Validator;
 
 /**
@@ -129,10 +130,11 @@ class ConfigTable extends Table
      */
     protected function findName(Query $query, array $options): Query
     {
-        if (empty($options['name'])) {
+        if (empty($options[0]) && empty($options['name'])) {
             throw new BadRequestException(__d('bedita', 'Missing mandatory option "name"'));
         }
-        $query = $query->where([$this->aliasField('name') => $options['name']]);
+        $name = (string)Hash::get($options, 'name', Hash::get($options, '0'));
+        $query = $query->where([$this->aliasField('name') => $name]);
         if (empty($options['application']) && empty($options['application_id'])) {
             return $query;
         }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
@@ -194,6 +194,12 @@ class ConfigTableTest extends TestCase
                     'name' => 'KeyName',
                 ],
             ],
+            'non assoc array' => [
+                1,
+                [
+                    'appVal',
+                ],
+            ],
             'bad' => [
                 new BadRequestException('Missing mandatory option "name"'),
                 [


### PR DESCRIPTION
This PR fixes a problem with `filter[name]` query string on `GET /config` and `GET /admin/config`.

Currently this filter is not working because the custom finder expects a different options structure (associative array) from the one provided by a query string on an attribute name via API (indexed array).

`ConfigTable::findName()` finder has been changed in order to accept both formats.
