### PR TITLE
Add Categories to Project Model definition

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
@@ -326,21 +326,21 @@ class ProjectControllerTest extends IntegrationTestCase
                     'label' => 'Disabled category',
                     'parent' => null,
                     'enabled' => false,
-                    'object' => 'documents'
+                    'object' => 'documents',
                 ],
                 [
                     'name' => 'first-cat',
                     'label' => 'First category',
                     'parent' => null,
                     'enabled' => true,
-                    'object' => 'documents'
+                    'object' => 'documents',
                 ],
                 [
                     'name' => 'second-cat',
                     'label' => 'Second category',
                     'parent' => null,
                     'enabled' => true,
-                    'object' => 'documents'
+                    'object' => 'documents',
                 ],
             ],
         ];

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
@@ -322,13 +322,6 @@ class ProjectControllerTest extends IntegrationTestCase
             ],
             'categories' => [
                 [
-                    'name' => 'disabled-cat',
-                    'label' => 'Disabled category',
-                    'parent' => null,
-                    'enabled' => false,
-                    'object' => 'documents',
-                ],
-                [
                     'name' => 'first-cat',
                     'label' => 'First category',
                     'parent' => null,
@@ -340,6 +333,13 @@ class ProjectControllerTest extends IntegrationTestCase
                     'label' => 'Second category',
                     'parent' => null,
                     'enabled' => true,
+                    'object' => 'documents',
+                ],
+                [
+                    'name' => 'disabled-cat',
+                    'label' => 'Disabled category',
+                    'parent' => null,
+                    'enabled' => false,
                     'object' => 'documents',
                 ],
             ],

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
@@ -320,6 +320,29 @@ class ProjectControllerTest extends IntegrationTestCase
                     'read_only' => false,
                 ],
             ],
+            'categories' => [
+                [
+                    'name' => 'disabled-cat',
+                    'label' => 'Disabled category',
+                    'parent' => null,
+                    'enabled' => false,
+                    'object' => 'documents'
+                ],
+                [
+                    'name' => 'first-cat',
+                    'label' => 'First category',
+                    'parent' => null,
+                    'enabled' => true,
+                    'object' => 'documents'
+                ],
+                [
+                    'name' => 'second-cat',
+                    'label' => 'Second category',
+                    'parent' => null,
+                    'enabled' => true,
+                    'object' => 'documents'
+                ],
+            ],
         ];
 
         $this->configRequestHeaders('GET', ['Accept' => 'application/json']);

--- a/plugins/BEdita/Core/src/Model/Entity/Category.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Category.php
@@ -14,7 +14,6 @@
 namespace BEdita\Core\Model\Entity;
 
 use BEdita\Core\Utility\JsonApiSerializable;
-use Cake\Datasource\Exception\InvalidPrimaryKeyException;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\ORM\Entity;
 

--- a/plugins/BEdita/Core/src/Model/Entity/Category.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Category.php
@@ -58,6 +58,8 @@ class Category extends Entity implements JsonApiSerializable
         'object_type_id',
         'object_type',
         '_joinData',
+        'object',
+        'parent',
     ];
 
     /**

--- a/plugins/BEdita/Core/src/Model/Entity/Category.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Category.php
@@ -108,8 +108,6 @@ class Category extends Entity implements JsonApiSerializable
                 $this->parent_category = $this->getTable()->get($this->parent_id);
             } catch (RecordNotFoundException $e) {
                 return null;
-            } catch (InvalidPrimaryKeyException $e) {
-                return null;
             }
         }
 

--- a/plugins/BEdita/Core/src/Model/Entity/Category.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Category.php
@@ -58,6 +58,7 @@ class Category extends Entity implements JsonApiSerializable
         'object_type_id',
         'object_type',
         '_joinData',
+        'object_type_name',
         'object',
         'parent',
     ];

--- a/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
@@ -173,6 +173,7 @@ class CategoriesTable extends Table
                     [
                         'id', 'enabled', 'created', 'modified',
                         'object_type_id', 'object_type_name',
+                        'parent', 'object',
                         'parent_id', 'tree_left', 'tree_right',
                     ],
                     true

--- a/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
@@ -22,6 +22,7 @@ use Cake\Event\EventInterface;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
+use Cake\Utility\Hash;
 use Cake\Validation\Validator;
 
 /**
@@ -252,11 +253,12 @@ class CategoriesTable extends Table
         if (empty($options['name'])) {
             throw new BadFilterException(__d('bedita', 'Missing required parameter "{0}"', 'name'));
         }
-        if (empty($options['object_type_name'])) {
+        $object = Hash::get($options, 'object_type_name', Hash::get($options, 'object'));
+        if (empty($object)) {
             throw new BadFilterException(__d('bedita', 'Missing required parameter "{0}"', 'object_type_name'));
         }
 
-        return $query->find('type', [$options['object_type_name']])
+        return $query->find('type', [$object])
             ->where([$this->aliasField('name') => $options['name']]);
     }
 }

--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -188,16 +188,16 @@ class ProjectModel
             ->order(['tree_left' => 'ASC'])
             ->all()
             ->each(function (EntityInterface $row) {
-                $hidden = [
+                $row->setHidden([
                     'id',
-                    'parent_id',
                     'created',
                     'modified',
+                    'object_type_id',
+                    'object_type_name',
+                    'parent_id',
                     'tree_left',
                     'tree_right',
-                    'object_type_name',
-                ];
-                $row->setHidden($hidden, true);
+                ]);
             })
             ->toArray();
     }
@@ -217,7 +217,7 @@ class ProjectModel
         $create = $update = $remove = [];
         $currentModel = json_decode(json_encode(static::generate()), true);
         foreach ($currentModel as $key => $items) {
-            if ($key === 'properties' || $key === 'categoriesw') {
+            if ($key === 'properties' || $key === 'categories') {
                 $diff = static::propertiesDiff((array)$items, (array)Hash::get($project, $key));
                 $create[$key] = $diff['create'];
                 $remove[$key] = $diff['remove'];

--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -218,7 +218,7 @@ class ProjectModel
         $currentModel = json_decode(json_encode(static::generate()), true);
         foreach ($currentModel as $key => $items) {
             if ($key === 'properties' || $key === 'categories') {
-                $diff = static::propertiesDiff((array)$items, (array)Hash::get($project, $key));
+                $diff = static::byObjectDiff((array)$items, (array)Hash::get($project, $key));
                 $create[$key] = $diff['create'];
                 $remove[$key] = $diff['remove'];
                 $update[$key] = $diff['update'];
@@ -237,13 +237,16 @@ class ProjectModel
     }
 
     /**
-     * Calculate diff between current and project model properties.
+     * Calculate diff between current and project model resources
+     * grouping by `object`.
+     * Needed for `properties` and `categories` resources that may
+     * have duplicate `name` fields, but still unique by object.
      *
-     * @param array $items Current properties items.
-     * @param array $projectItems Project properties items.
+     * @param array $items Current items.
+     * @param array $projectItems Project items.
      * @return array
      */
-    protected static function propertiesDiff(array $items, array $projectItems): array
+    protected static function byObjectDiff(array $items, array $projectItems): array
     {
         $create = $update = $remove = [];
         $current = Hash::combine($items, '{n}.name', '{n}', '{n}.object');

--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -185,7 +185,7 @@ class ProjectModel
     {
         return TableRegistry::getTableLocator()->get('Categories')
             ->find()
-            ->order(['name' => 'ASC'])
+            ->order(['tree_left' => 'ASC'])
             ->all()
             ->each(function (EntityInterface $row) {
                 $hidden = [
@@ -197,28 +197,9 @@ class ProjectModel
                     'tree_right',
                     'object_type_name',
                 ];
-                $row->set('object', $row->get('object_type_name'));
-                $parent = static::parentCategory($row->get('parent_id'), $row->get('object_type_id'));
-                $row->set('parent', $parent);
                 $row->setHidden($hidden, true);
             })
             ->toArray();
-    }
-
-    /**
-     * Get parent category name.
-     *
-     * @return string|null
-     */
-    protected static function parentCategory(?int $id, int $typeId): ?string
-    {
-        return TableRegistry::getTableLocator()->get('Categories')
-            ->find('list', ['valueField' => 'name'])
-            ->where([
-                'id IS' => $id,
-                'object_type_id' => $typeId,
-            ])
-            ->first();
     }
 
     /**

--- a/plugins/BEdita/Core/src/Utility/Resources.php
+++ b/plugins/BEdita/Core/src/Utility/Resources.php
@@ -69,6 +69,9 @@ class Resources extends ResourcesBase
         'property_types' => [
             'core_type' => 0,
         ],
+        'categories' => [
+            'enabled' => 1,
+        ],
     ];
 
     /**
@@ -112,7 +115,7 @@ class Resources extends ResourcesBase
         $result = [];
 
         foreach ($data as $item) {
-            $resource = $Table->newEntity([]);
+            $resource = $Table->newEmptyEntity();
             $defaults = (array)Hash::get(static::$defaults, $type);
             $item = array_merge($defaults, $item);
             foreach ($item as $k => $v) {

--- a/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
@@ -36,6 +36,7 @@ class ProjectModelCommandTest extends TestCase
         'plugin.BEdita/Core.Applications',
         'plugin.BEdita/Core.Roles',
         'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.Categories',
         'plugin.BEdita/Core.PropertyTypes',
         'plugin.BEdita/Core.Properties',
         'plugin.BEdita/Core.Relations',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CategoriesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CategoriesBehaviorTest.php
@@ -59,7 +59,6 @@ class CategoriesBehaviorTest extends TestCase
                         [
                             'name' => 'second-cat',
                             'id' => 2,
-                            'object_type_name' => null,
                         ],
                     ],
                 ],
@@ -190,6 +189,7 @@ class CategoriesBehaviorTest extends TestCase
         $entity = $table->patchEntity($entity, $data);
         $entity = $table->save($entity);
         static::assertNotFalse($entity);
+ //       $entity->setHidden(['object', 'object_type_name', 'parent']);
 
         foreach (array_keys($expected) as $key) {
             $result = (array)$entity->get($key);
@@ -200,7 +200,7 @@ class CategoriesBehaviorTest extends TestCase
                     $res = $res->toArray();
                 }
                 ksort($res);
-                unset($res['modified']);
+                unset($res['modified'], $res['object'], $res['object_type_name']);
                 static::assertSame($expected[$key][$k], $res);
             }
         }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CategoriesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CategoriesBehaviorTest.php
@@ -189,7 +189,6 @@ class CategoriesBehaviorTest extends TestCase
         $entity = $table->patchEntity($entity, $data);
         $entity = $table->save($entity);
         static::assertNotFalse($entity);
- //       $entity->setHidden(['object', 'object_type_name', 'parent']);
 
         foreach (array_keys($expected) as $key) {
             $result = (array)$entity->get($key);
@@ -200,7 +199,7 @@ class CategoriesBehaviorTest extends TestCase
                     $res = $res->toArray();
                 }
                 ksort($res);
-                unset($res['modified'], $res['object'], $res['object_type_name']);
+                unset($res['modified']);
                 static::assertSame($expected[$key][$k], $res);
             }
         }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/CategoryTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/CategoryTest.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Entity;
+
+use BEdita\Core\Model\Entity\Category;
+use Cake\TestSuite\TestCase;
+
+/**
+ *  {@see \BEdita\Core\Model\Entity\Category} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Model\Entity\Category
+ */
+class CategoryTest extends TestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        // 'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.Categories',
+        // 'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.RelationTypes',
+    ];
+
+    /**
+     * Test `_getObject` method.
+     *
+     * @return void
+     * @covers ::_getObject()
+     */
+    public function testGetObject(): void
+    {
+        $category = $this->fetchTable('Categories')->get(1);
+        static::assertEquals('documents', $category->get('object'));
+    }
+
+    /**
+     * Test `_setObject` method.
+     *
+     * @return void
+     * @covers ::_setObject()
+     */
+    public function testSetObject(): void
+    {
+        $category = $this->fetchTable('Categories')->newEmptyEntity();
+        $category->set('object', 'documents');
+        static::assertEquals(2, $category->get('object_type_id'));
+    }
+
+    /**
+     * Data provider for `testGetParent` test case.
+     *
+     * @return array
+     */
+    public function getParentProvider()
+    {
+        return [
+            'no parent' => [
+                null,
+                null,
+            ],
+            'first parent' => [
+                'first-cat',
+                1,
+            ],
+            'not found' => [
+                null,
+                99,
+            ],
+        ];
+    }
+
+    /**
+     * Test `_getParent` method.
+     *
+     * @param string|null $expected Expected parent name.
+     * @param int|null $parentId Parent ID.
+     * @return void
+     * @covers ::_getParent()
+     * @dataProvider getParentProvider()
+     */
+    public function testGetParent(?string $expected, ?int $parentId): void
+    {
+        $entity = new Category();
+        $entity->setSource('Categories');
+        $entity->parent_id = $parentId;
+        static::assertSame($expected, $entity->get('parent'));
+    }
+
+    /**
+     * Data provider for `testSetParent` test case.
+     *
+     * @return array
+     */
+    public function setParentProvider()
+    {
+        return [
+            'no parent' => [
+                null,
+                null,
+            ],
+            'first parent' => [
+                1,
+                'first-cat',
+            ],
+            'not found' => [
+                null,
+                'some-cat',
+            ],
+        ];
+    }
+
+    /**
+     * Test `_setParent` method.
+     *
+     * @param int|null $expected Expected parent ID.
+     * @param ?string $parent Parent name.
+     * @return void
+     * @covers ::_setParent()
+     * @dataProvider setParentProvider()
+     */
+    public function testSetParent(?int $expected, ?string $parent): void
+    {
+        $entity = new Category();
+        $entity->setSource('Categories');
+        $entity->object_type_id = 2;
+        $entity->set('parent', $parent);
+        static::assertSame($expected, $entity->parent_id);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/CategoryTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/CategoryTest.php
@@ -29,10 +29,8 @@ class CategoryTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        // 'plugin.BEdita/Core.PropertyTypes',
         'plugin.BEdita/Core.ObjectTypes',
         'plugin.BEdita/Core.Categories',
-        // 'plugin.BEdita/Core.Properties',
         'plugin.BEdita/Core.Relations',
         'plugin.BEdita/Core.RelationTypes',
     ];

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/CategoriesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/CategoriesTableTest.php
@@ -77,7 +77,6 @@ class CategoriesTableTest extends TestCase
         $category = $this->Categories->get(1)->toArray();
         $expected = [
             'id' => 1,
-            'object_type_name' => 'documents',
             'name' => 'first-cat',
             'label' => 'First category',
             'parent_id' => null,

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -32,6 +32,7 @@ class ProjectModelTest extends TestCase
         'plugin.BEdita/Core.Applications',
         'plugin.BEdita/Core.Roles',
         'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.Categories',
         'plugin.BEdita/Core.PropertyTypes',
         'plugin.BEdita/Core.Properties',
         'plugin.BEdita/Core.Relations',
@@ -331,6 +332,29 @@ class ProjectModelTest extends TestCase
                 'property' => 'string',
                 'object' => 'profiles',
                 'read_only' => false,
+            ],
+        ],
+        'categories' => [
+            [
+                'name' => 'disabled-cat',
+                'label' => 'Disabled category',
+                'parent' => null,
+                'enabled' => false,
+                'object' => 'documents'
+            ],
+            [
+                'name' => 'first-cat',
+                'label' => 'First category',
+                'parent' => null,
+                'enabled' => true,
+                'object' => 'documents'
+            ],
+            [
+                'name' => 'second-cat',
+                'label' => 'Second category',
+                'parent' => null,
+                'enabled' => true,
+                'object' => 'documents'
             ],
         ],
     ];

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -370,6 +370,7 @@ class ProjectModelTest extends TestCase
      * @covers ::objectTypes()
      * @covers ::relations()
      * @covers ::properties()
+     * @covers ::categories()
      */
     public function testGenerate(): void
     {
@@ -384,7 +385,7 @@ class ProjectModelTest extends TestCase
      *
      * @return void
      * @covers ::diff()
-     * @covers ::propertiesDiff()
+     * @covers ::byObjectDiff()
      * @covers ::itemsToUpdate()
      */
     public function testDiffAdd(): void
@@ -420,7 +421,7 @@ class ProjectModelTest extends TestCase
      *
      * @return void
      * @covers ::diff()
-     * @covers ::propertiesDiff()
+     * @covers ::byObjectDiff()
      */
     public function testDiffRemove(): void
     {
@@ -458,7 +459,7 @@ class ProjectModelTest extends TestCase
      *
      * @return void
      * @covers ::diff()
-     * @covers ::propertiesDiff()
+     * @covers ::byObjectDiff()
      * @covers ::itemsToUpdate()
      */
     public function testDiffUpdate(): void

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -336,13 +336,6 @@ class ProjectModelTest extends TestCase
         ],
         'categories' => [
             [
-                'name' => 'disabled-cat',
-                'label' => 'Disabled category',
-                'parent' => null,
-                'enabled' => false,
-                'object' => 'documents',
-            ],
-            [
                 'name' => 'first-cat',
                 'label' => 'First category',
                 'parent' => null,
@@ -354,6 +347,13 @@ class ProjectModelTest extends TestCase
                 'label' => 'Second category',
                 'parent' => null,
                 'enabled' => true,
+                'object' => 'documents',
+            ],
+            [
+                'name' => 'disabled-cat',
+                'label' => 'Disabled category',
+                'parent' => null,
+                'enabled' => false,
                 'object' => 'documents',
             ],
         ],

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -340,21 +340,21 @@ class ProjectModelTest extends TestCase
                 'label' => 'Disabled category',
                 'parent' => null,
                 'enabled' => false,
-                'object' => 'documents'
+                'object' => 'documents',
             ],
             [
                 'name' => 'first-cat',
                 'label' => 'First category',
                 'parent' => null,
                 'enabled' => true,
-                'object' => 'documents'
+                'object' => 'documents',
             ],
             [
                 'name' => 'second-cat',
                 'label' => 'Second category',
                 'parent' => null,
                 'enabled' => true,
-                'object' => 'documents'
+                'object' => 'documents',
             ],
         ],
     ];


### PR DESCRIPTION
This PR adds `categories` data to `project_model` JSON output, enabling export/import on categories definition.

This is the output format: 
``` 
            'categories' => [
                [
                    'name' => 'parent-cat',
                    'label' => 'Parent category',
                    'parent' => null,
                    'enabled' => true,
                    'object' => 'documents',
                ],
                [
                    'name' => 'child-cat',
                    'label' => 'Child category',
                    'parent' => 'parent-cat',
                    'enabled' => true,
                    'object' => 'documents',
                ],
```  

The items order is not alphabetical like for other model resources, instead `cateogires.tree_left` is used to make sure parent nodes are created before children. 

Main changes:

* New virtual and hidden getters/setters have been added to `Category` entity:
  *  ´object` - an alias for `object_type_name` 
  *  `parent` to get/set parent category via its unique name 
*  category and project model related test cases have been updated accordingly 
