### PR TITLE
Show `object_type_name` in `/model/categories`

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/TagsCategoriesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/TagsCategoriesTest.php
@@ -315,4 +315,66 @@ class TagsCategoriesTest extends IntegrationTestCase
         sort($ids);
         static::assertEquals($expected, $ids);
     }
+
+    /**
+     * Test `/model/categories` endpoint
+     *
+     * @return void
+     * @coversNothing
+     */
+    public function testCategoriesModel(): void
+    {
+        $this->configRequestHeaders();
+        $this->get('/model/categories');
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        $result = json_decode((string)$this->_response->getBody(), true);
+        $data = Hash::extract($result, 'data');
+        $expected = [
+            [
+                'id' => '1',
+                'type' => 'categories',
+                'attributes' => [
+                    'name' => 'first-cat',
+                    'label' => 'First category',
+                    'parent_id' => null,
+                    'tree_left' => 1,
+                    'tree_right' => 2,
+                    'enabled' => true,
+                    'object_type_name' => 'documents',
+                ],
+            ],
+            [
+                'id' => '2',
+                'type' => 'categories',
+                'attributes' => [
+                    'name' => 'second-cat',
+                    'label' => 'Second category',
+                    'parent_id' => null,
+                    'tree_left' => 3,
+                    'tree_right' => 4,
+                    'enabled' => true,
+                    'object_type_name' => 'documents',
+                ],
+            ],
+            [
+                'id' => '3',
+                'type' => 'categories',
+                'attributes' => [
+                    'name' => 'disabled-cat',
+                    'label' => 'Disabled category',
+                    'parent_id' => null,
+                    'tree_left' => 5,
+                    'tree_right' => 6,
+                    'enabled' => false,
+                    'object_type_name' => 'documents',
+                ],
+            ],
+        ];
+        $data = Hash::remove($data, '{n}.relationships');
+        $data = Hash::remove($data, '{n}.meta');
+        $data = Hash::remove($data, '{n}.links');
+
+        static::assertEquals($expected, $data);
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Entity/Category.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Category.php
@@ -57,7 +57,6 @@ class Category extends Entity implements JsonApiSerializable
         'object_type_id',
         'object_type',
         '_joinData',
-        'object_type_name',
         'object',
         'parent',
     ];

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CategoriesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CategoriesBehaviorTest.php
@@ -59,6 +59,7 @@ class CategoriesBehaviorTest extends TestCase
                         [
                             'name' => 'second-cat',
                             'id' => 2,
+                            'object_type_name' => null,
                         ],
                     ],
                 ],

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/CategoriesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/CategoriesTableTest.php
@@ -83,6 +83,7 @@ class CategoriesTableTest extends TestCase
             'tree_left' => 1,
             'tree_right' => 2,
             'enabled' => true,
+            'object_type_name' => 'documents',
         ];
         unset($category['created'], $category['modified']);
         static::assertEquals($expected, $category);


### PR DESCRIPTION
This PR fixes an unwanted side effect generated by #1965 - `object_type_name` virtual property of categories must not be hidden as default

This caused problems in apps using `/model/categories` endpoint
 