### PR TITLE
Add name validation regex for category and tag

### DIFF
--- a/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
@@ -15,6 +15,7 @@ namespace BEdita\Core\Model\Table;
 
 use ArrayObject;
 use BEdita\Core\Exception\BadFilterException;
+use BEdita\Core\Model\Validation\Validation;
 use Cake\Collection\CollectionInterface;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
@@ -113,6 +114,7 @@ class CategoriesTable extends Table
             ->maxLength('name', 50)
             ->requirePresence('name', 'create')
             ->notEmptyString('name')
+            ->regex('name', Validation::CATEGORY_NAME_REGEX)
 
             ->scalar('label')
             ->maxLength('label', 255)

--- a/plugins/BEdita/Core/src/Model/Table/TagsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TagsTable.php
@@ -15,6 +15,7 @@ namespace BEdita\Core\Model\Table;
 
 use ArrayObject;
 use BEdita\Core\Exception\BadFilterException;
+use BEdita\Core\Model\Validation\Validation;
 use Cake\Collection\CollectionInterface;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
@@ -92,6 +93,7 @@ class TagsTable extends Table
             ->maxLength('name', 50)
             ->requirePresence('name', 'create')
             ->notEmptyString('name')
+            ->regex('name', Validation::CATEGORY_NAME_REGEX)
 
             ->scalar('label')
             ->maxLength('label', 255)

--- a/plugins/BEdita/Core/src/Model/Validation/Validation.php
+++ b/plugins/BEdita/Core/src/Model/Validation/Validation.php
@@ -29,6 +29,17 @@ use Swaggest\JsonSchema\Schema;
 class Validation
 {
     /**
+     * Regular expression to validate category names:
+     *  - starts with a lowercase letter
+     *  - lowercase letters, numbers and hyphens
+     *  - length between 2 and 50 characters
+     *  - no spaces
+     *
+     * @var string
+     */
+    public const CATEGORY_NAME_REGEX = '/^[a-z][a-z0-9-]{1,50}$/';
+
+    /**
      * Regular expression to validate resource names:
      *  - starts with a lowercase letter
      *  - lowercase letters, numbers and underscores


### PR DESCRIPTION
This PR fixes https://github.com/bedita/bedita/issues/1860

A validation regex is added to category and tag name.
