### PR TITLE
Avoid injection of URLs or tags in `name`, `surname` or `username`

### DIFF
--- a/plugins/BEdita/Core/src/Model/Validation/ProfilesValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/ProfilesValidator.php
@@ -21,6 +21,22 @@ namespace BEdita\Core\Model\Validation;
 class ProfilesValidator extends ObjectsValidator
 {
     /**
+     * Regular expression to validate names and surnames.
+     * Do not allow special chars like <, >, :, /, = to avoid
+     * malicious links or markup insertion.
+     *
+     * @var string
+     */
+    public const NAME_REGEX = '/^[^<>:\/=]*$/';
+
+    /**
+     * Regular expression to avoid presence of a valid domain name.
+     *
+     * @var string
+     */
+    public const NO_DOMAIN_REGEX = '/^(?!.*\.[a-z]{2,}).*$/';
+
+    /**
      * {@inheritDoc}
      *
      * @codeCoverageIgnore
@@ -31,8 +47,10 @@ class ProfilesValidator extends ObjectsValidator
 
         $this
             ->allowEmptyString('name')
+            ->add('name', 'validName', ['rule' => [ProfilesValidator::class, 'validName']])
 
             ->allowEmptyString('surname')
+            ->add('surname', 'validName', ['rule' => [ProfilesValidator::class, 'validName']])
 
             ->email('email')
             ->allowEmptyString('email')
@@ -75,5 +93,28 @@ class ProfilesValidator extends ObjectsValidator
             ->allowEmptyString('national_id_number')
 
             ->allowEmptyString('vat_number');
+    }
+
+    /**
+     * Checks that a value does not contain malicious elements like:
+     *  * URL, code or markup related characters
+     *  * domain names
+     *
+     * @param string $value The string to check
+     * @return bool
+     */
+    public static function validName(string $value)
+    {
+        // check for invalid characters
+        if (!preg_match(static::NAME_REGEX, $value, $matches)) {
+            return false;
+        }
+
+        // check for domain name
+        if (!preg_match(static::NO_DOMAIN_REGEX, $value, $matches)) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/plugins/BEdita/Core/src/Model/Validation/ProfilesValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/ProfilesValidator.php
@@ -103,14 +103,14 @@ class ProfilesValidator extends ObjectsValidator
      * @param string $value The string to check
      * @return bool
      */
-    public static function validName(string $value)
+    public static function validName(string $value): bool
     {
-        // check for invalid characters
+        // check for invalid characters presence
         if (!preg_match(static::NAME_REGEX, $value, $matches)) {
             return false;
         }
 
-        // check for domain name
+        // check for domain name presence
         if (!preg_match(static::NO_DOMAIN_REGEX, $value, $matches)) {
             return false;
         }

--- a/plugins/BEdita/Core/src/Model/Validation/UsersValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/UsersValidator.php
@@ -14,7 +14,7 @@
 namespace BEdita\Core\Model\Validation;
 
 use Cake\ORM\TableRegistry;
-use Cake\Validation\Validation;
+use Cake\Validation\Validation as CakeValidation;
 
 /**
  * Validator for users.
@@ -60,7 +60,7 @@ class UsersValidator extends ProfilesValidator
      */
     public static function validUsername($value): bool
     {
-        if (Validation::email($value)) {
+        if (CakeValidation::email($value)) {
             return true;
         }
 

--- a/plugins/BEdita/Core/src/Model/Validation/UsersValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/UsersValidator.php
@@ -68,16 +68,6 @@ class UsersValidator extends ProfilesValidator
             return false;
         }
 
-        // check for invalid characters presence
-        if (!preg_match(ProfilesValidator::NAME_REGEX, $value, $matches)) {
-            return false;
-        }
-
-        // check for domain name presence
-        if (!preg_match(ProfilesValidator::NO_DOMAIN_REGEX, $value, $matches)) {
-            return false;
-        }
-
-        return true;
+        return parent::validName($value);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Validation/UsersValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/UsersValidator.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Model\Validation;
 
 use Cake\ORM\TableRegistry;
+use Cake\Validation\Validation;
 
 /**
  * Validator for users.
@@ -37,6 +38,7 @@ class UsersValidator extends ProfilesValidator
             ->add('username', 'unique', ['rule' => 'validateUnique', 'provider' => 'usersTable'])
             ->requirePresence('username', 'create')
             ->notEmptyString('username')
+            ->add('username', 'validUsername', ['rule' => [UsersValidator::class, 'validUsername']])
 
             ->add('email', 'unique', ['rule' => 'validateUnique', 'provider' => 'usersTable'])
 
@@ -44,5 +46,38 @@ class UsersValidator extends ProfilesValidator
 
             ->boolean('blocked')
             ->allowEmptyString('blocked');
+    }
+
+    /**
+     * Checks that a value is a correct username.
+     * It is ok with a valid email format, otherwise it must not contain
+     * malicious elements like:
+     *  * URL, code or markup related characters
+     *  * domain names
+     *
+     * @param mixed $value The value to check
+     * @return bool
+     */
+    public static function validUsername($value): bool
+    {
+        if (Validation::email($value)) {
+            return true;
+        }
+
+        if (!is_string($value)) {
+            return false;
+        }
+
+        // check for invalid characters presence
+        if (!preg_match(ProfilesValidator::NAME_REGEX, $value, $matches)) {
+            return false;
+        }
+
+        // check for domain name presence
+        if (!preg_match(ProfilesValidator::NO_DOMAIN_REGEX, $value, $matches)) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/plugins/BEdita/Core/src/Model/Validation/Validation.php
+++ b/plugins/BEdita/Core/src/Model/Validation/Validation.php
@@ -37,7 +37,7 @@ class Validation
      *
      * @var string
      */
-    public const CATEGORY_NAME_REGEX = '/^[a-z][a-z0-9-]{1,50}$/';
+    public const CATEGORY_NAME_REGEX = '/^[a-z][a-z0-9-_]{1,50}$/';
 
     /**
      * Regular expression to validate resource names:

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/ProfilesValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/ProfilesValidatorTest.php
@@ -18,7 +18,7 @@ use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
 
 /**
- * @coversNothing
+ * @covers \BEdita\Core\Model\Validation\ProfilesValidator
  */
 class ProfilesValidatorTest extends TestCase
 {
@@ -100,6 +100,29 @@ class ProfilesValidatorTest extends TestCase
                 ],
                 [
                     'website' => 'www.example.com/without/protocol.txt?shouldBeValid=no',
+                ],
+            ],
+            'invalid name' => [
+                [
+                    'name.validName',
+                ],
+                [
+                    'name' => 'http://someurl',
+                ],
+            ],
+            'invalid surname' => [
+                [
+                    'surname.validName',
+                ],
+                [
+                    'surname' => 'gustavo.com',
+                ],
+            ],
+            'valid surname' => [
+                [
+                ],
+                [
+                    'surname' => 'Support Jr.',
                 ],
             ],
         ];

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/UsersValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/UsersValidatorTest.php
@@ -18,7 +18,7 @@ use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
 
 /**
- * @coversNothing
+ * @covers \BEdita\Core\Model\Validation\UsersValidator
  */
 class UsersValidatorTest extends TestCase
 {
@@ -60,6 +60,7 @@ class UsersValidatorTest extends TestCase
             'empty fields' => [
                 [
                     'status._empty',
+                    'username.validUsername',
                 ],
                 [
                     'status' => '',
@@ -119,6 +120,22 @@ class UsersValidatorTest extends TestCase
                 [
                     'email' => 'gustavo.supporto@channelweb.it',
                     'username' => 'first user',
+                ],
+            ],
+            'invalid username characters' => [
+                [
+                    'username.validUsername',
+                ],
+                [
+                    'username' => 'http://www',
+                ],
+            ],
+            'invalid username domain' => [
+                [
+                    'username.validUsername',
+                ],
+                [
+                    'username' => 'click on domain.name',
                 ],
             ],
         ];

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/UsersValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/UsersValidatorTest.php
@@ -122,6 +122,14 @@ class UsersValidatorTest extends TestCase
                     'username' => 'first user',
                 ],
             ],
+            'username email' => [
+                [
+                ],
+                [
+                    'email' => 'some.user@example.com',
+                    'username' => 'some.user@example.com',
+                ],
+            ],
             'invalid username characters' => [
                 [
                     'username.validUsername',


### PR DESCRIPTION
This PR contains a security fix on users/profiles data to avoid insertion of possible malicious elements like tags, scripts or URLs in fields like `username`, `name` or `surname` of Profiles and Users. 

* in `ProfilesValidator` a new rule has been added to avoid insertion of tags or urls in `name` and `username` 
* in `UsersValidator` a new rule has been added to allow the use of email format as `surname`, but to avoid insertion of possible tags/urls 
* (bonus) allow `_` usage in category names
