### PR TITLE
Category and tag name validation: allow name starts with a lowercase letter or a number

### DIFF
--- a/plugins/BEdita/Core/src/Model/Validation/Validation.php
+++ b/plugins/BEdita/Core/src/Model/Validation/Validation.php
@@ -30,14 +30,14 @@ class Validation
 {
     /**
      * Regular expression to validate category names:
-     *  - starts with a lowercase letter
+     *  - starts with a lowercase letter or a number
      *  - lowercase letters, numbers and hyphens
      *  - length between 2 and 50 characters
      *  - no spaces
      *
      * @var string
      */
-    public const CATEGORY_NAME_REGEX = '/^[a-z][a-z0-9-]{1,50}$/';
+    public const CATEGORY_NAME_REGEX = '/^[a-z0-9][a-z0-9-_]{1,50}$/';
 
     /**
      * The list of reserved names

--- a/plugins/BEdita/Core/src/Model/Validation/Validation.php
+++ b/plugins/BEdita/Core/src/Model/Validation/Validation.php
@@ -31,7 +31,7 @@ class Validation
     /**
      * Regular expression to validate category names:
      *  - starts with a lowercase letter or a number
-     *  - lowercase letters, numbers and hyphens
+     *  - lowercase letters, numbers, hyphens and underscores as accepted characters
      *  - length between 2 and 50 characters
      *  - no spaces
      *


### PR DESCRIPTION
This PR updates `CATEGORY_NAME_REGEX` used in `tags` and `categories` save, to allow "starts with a lowercase letter or a number".
