### PR TITLE
Handle `num_login_err` and `last_login_err` on authentication failure

### DIFF
--- a/plugins/BEdita/API/src/Middleware/LoggedUserMiddleware.php
+++ b/plugins/BEdita/API/src/Middleware/LoggedUserMiddleware.php
@@ -19,6 +19,7 @@ use Authentication\Authenticator\AuthenticatorInterface;
 use Authentication\Authenticator\JwtAuthenticator;
 use BEdita\Core\Model\Entity\User;
 use BEdita\Core\Utility\LoggedUser;
+use Cake\Event\EventDispatcherTrait;
 use Cake\Http\Exception\UnauthorizedException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -30,6 +31,8 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 class LoggedUserMiddleware implements MiddlewareInterface
 {
+    use EventDispatcherTrait;
+
     /**
      * @inheritDoc
      */
@@ -41,6 +44,7 @@ class LoggedUserMiddleware implements MiddlewareInterface
             empty($service->getIdentity())
         ) {
             if (in_array($request->getUri()->getPath(), ['/auth', '/auth/optout'])) {
+                $this->dispatchEvent('Authentication.failure', compact('request'));
                 throw new UnauthorizedException(__d('bedita', 'Login request not successful'));
             }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
@@ -199,8 +199,12 @@ class LoginControllerTest extends IntegrationTestCase
             'grant_type' => 'password',
         ];
         $this->post('/auth', json_encode($body));
-
         $this->assertResponseCode(401);
+
+        $user = $this->fetchTable('Users')->get(1);
+        static::assertNotNull($user->last_login_err);
+        static::assertEqualsWithDelta(FrozenTime::now()->timestamp, $user->last_login_err->timestamp, 1, '');
+        static::assertEquals(2, $user->num_login_err);
     }
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20160930083942_Alpha.php
+++ b/plugins/BEdita/Core/config/Migrations/20160930083942_Alpha.php
@@ -1480,7 +1480,7 @@ class Alpha extends AbstractMigration
                 'null' => true,
             ])
             ->addColumn('last_login_err', 'datetime', [
-                'comment' => 'last login filaure datetime',
+                'comment' => 'last login failure datetime',
                 'default' => null,
                 'limit' => null,
                 'null' => true,

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -236,9 +236,8 @@ class UsersTable extends Table
         /** @var \Cake\Http\ServerRequest|null $request */
         $request = $event->getData('request');
         if (
-            empty($request) ||
-            (string)$request->getData('grant_type') !== 'password' ||
-            !$request instanceof ServerRequest
+            !$request instanceof ServerRequest ||
+            (string)$request->getData('grant_type') !== 'password'
         ) {
             return;
         }

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -111,7 +111,7 @@ class UsersTable extends Table
         ]);
 
         EventManager::instance()->on('Authentication.afterIdentify', [$this, 'login']);
-        EventManager::instance()->on('Authentication.failure', [$this, 'failure']);
+        EventManager::instance()->on('Authentication.failure', [$this, 'authFailure']);
     }
 
     /**
@@ -194,8 +194,6 @@ class UsersTable extends Table
         $implementedEvents = parent::implementedEvents();
         $implementedEvents += [
             'Auth.externalAuth' => 'externalAuthLogin',
-            'Authentication.afterIdentify' => 'login',
-            'Authentication.failure' => 'failure',
         ];
 
         return $implementedEvents;
@@ -227,12 +225,12 @@ class UsersTable extends Table
     }
 
     /**
-     * Update login failure.
+     * Update fields on authentication failure.
      *
      * @param \Cake\Event\EventInterface $event Dispatched event.
      * @return void
      */
-    public function failure(EventInterface $event): void
+    public function authFailure(EventInterface $event): void
     {
         /** @var \Cake\Http\ServerRequest|null $request */
         $request = $event->getData('request');

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -26,6 +26,7 @@ use Cake\Event\Event;
 use Cake\Event\EventInterface;
 use Cake\Event\EventManager;
 use Cake\Http\Exception\BadRequestException;
+use Cake\Http\ServerRequest;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
@@ -234,7 +235,11 @@ class UsersTable extends Table
     {
         /** @var \Cake\Http\ServerRequest|null $request */
         $request = $event->getData('request');
-        if (empty($request) || (string)$request->getData('grant_type') !== 'password') {
+        if (
+            empty($request) ||
+            (string)$request->getData('grant_type') !== 'password' ||
+            !$request instanceof ServerRequest
+        ) {
             return;
         }
 

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -243,7 +243,7 @@ class UsersTable extends Table
         $this->updateAll(
             [
                 'last_login_err' => $this->timestamp(),
-                'num_login_err' => 1,
+                new QueryExpression('num_login_err = num_login_err + 1'),
             ],
             [
                 'username' => (string)$request->getData('username'),


### PR DESCRIPTION
In this PR `users.num_login_err` (consecutive number of login failures) and `users.last_login_err` (last login failure timestamp) fields are updated upon authentication failure with `grant_type` password.

A new event `Authentication.failure` has been introduced for this use case.

`'Authentication.afterIdentify' => 'login'` item has been removed from `implementedEvents()` because the method was called twice (there is also an explicit `EventManager::instance()->on(..)` call)   