### PR TITLE
Allow dot separated strings in username

### DIFF
--- a/plugins/BEdita/Core/src/Model/Validation/UsersValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/UsersValidator.php
@@ -24,6 +24,17 @@ use Cake\Validation\Validation as CakeValidation;
 class UsersValidator extends ProfilesValidator
 {
     /**
+     * Regular expression to allow dot separated strings without spaces.
+     * For example:
+     * - `first.second.third` valid
+     * - `first.second..third` not valid
+     * - `first.second third` not valid
+     *
+     * @var string
+     */
+    public const DOT_SEPARATED_STRING_REGEX = '/^[^\s.]+(\.[^\s.]+)*$/';
+
+    /**
      * {@inheritDoc}
      *
      * @codeCoverageIgnore
@@ -60,14 +71,20 @@ class UsersValidator extends ProfilesValidator
      */
     public static function validUsername($value): bool
     {
-        if (CakeValidation::email($value)) {
-            return true;
-        }
-
         if (!is_string($value)) {
             return false;
         }
 
-        return parent::validName($value);
+        if (CakeValidation::email($value)) {
+            return true;
+        }
+
+        // check for not valid dot separated strings
+        if (strpos($value, '.') !== false && !preg_match(static::DOT_SEPARATED_STRING_REGEX, $value)) {
+            return false;
+        }
+
+        // check for invalid characters presence
+        return preg_match(static::NAME_REGEX, $value);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Validation/UsersValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/UsersValidator.php
@@ -85,6 +85,6 @@ class UsersValidator extends ProfilesValidator
         }
 
         // check for invalid characters presence
-        return preg_match(static::NAME_REGEX, $value);
+        return CakeValidation::custom($value, static::NAME_REGEX);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/UsersValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/UsersValidatorTest.php
@@ -138,12 +138,32 @@ class UsersValidatorTest extends TestCase
                     'username' => 'http://www',
                 ],
             ],
-            'invalid username domain' => [
+            'invalid username with dot and space' => [
                 [
                     'username.validUsername',
                 ],
                 [
                     'username' => 'click on domain.name',
+                ],
+            ],
+            'valid dot separated username' => [
+                [],
+                [
+                    'username' => 'name.surname',
+                ],
+            ],
+            'invalid double dot separated username' => [
+                [
+                    'username.validUsername',
+                ],
+                [
+                    'username' => 'name..surname',
+                ],
+            ],
+            'valid username with space' => [
+                [],
+                [
+                    'username' => 'name surname',
                 ],
             ],
         ];

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/UsersValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/UsersValidatorTest.php
@@ -152,6 +152,12 @@ class UsersValidatorTest extends TestCase
                     'username' => 'name.surname',
                 ],
             ],
+            'valid dot separated username with three strings' => [
+                [],
+                [
+                    'username' => 'first.second.third',
+                ],
+            ],
             'invalid double dot separated username' => [
                 [
                     'username.validUsername',


### PR DESCRIPTION
This PR fixes a wrong invalidation pattern for username like `name.surname` introduced in #1973.

