### PR TITLE
Use v3 codecov-action and upload-artifact, replace set-output with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
-        run: 'echo "::set-output name=path::$(composer global config cache-dir)"'
+        run: echo "{name}={path::$(composer global config cache-dir)}" >> $GITHUB_OUTPUT
 
       - name: 'Share Composer cache across runs'
         uses: 'actions/cache@v3'
@@ -70,7 +70,7 @@ jobs:
 
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
-        run: 'echo "::set-output name=path::$(composer global config cache-dir)"'
+        run: echo "{name}={path::$(composer global config cache-dir)}" >> $GITHUB_OUTPUT
 
       - name: 'Share Composer cache across runs'
         uses: 'actions/cache@v3'
@@ -153,7 +153,7 @@ jobs:
 
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
-        run: 'echo "::set-output name=path::$(composer global config cache-dir)"'
+        run: echo "{name}={path::$(composer global config cache-dir)}" >> $GITHUB_OUTPUT
 
       - name: 'Share Composer cache across runs'
         uses: 'actions/cache@v3'
@@ -171,13 +171,13 @@ jobs:
         run: 'vendor/bin/phpunit --coverage-clover=clover.xml'
 
       - name: 'Export coverage results'
-        uses: 'codecov/codecov-action@v1'
+        uses: 'codecov/codecov-action@v3'
         with:
-          file: './clover.xml'
+          files: './clover.xml'
           env_vars: PHP_VERSION,DB_VENDOR
 
       - name: 'Archive code coverage results'
-        uses: 'actions/upload-artifact@v2'
+        uses: 'actions/upload-artifact@v3'
         with:
           name: 'PHP ${{ matrix.php }} with ${{ fromJson(matrix.db).vendor }}'
           path: 'clover.xml'
@@ -203,7 +203,7 @@ jobs:
 
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
-        run: 'echo "::set-output name=path::$(composer global config cache-dir)"'
+        run: echo "{name}={path::$(composer global config cache-dir)}" >> $GITHUB_OUTPUT
 
       - name: 'Share Composer cache across runs'
         uses: 'actions/cache@v3'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
-        run: echo "{name}={path::$(composer global config cache-dir)}" >> $GITHUB_OUTPUT
+        run: echo "path=$(composer global config cache-dir)" >> $GITHUB_OUTPUT
 
       - name: 'Share Composer cache across runs'
         uses: 'actions/cache@v3'
@@ -70,7 +70,7 @@ jobs:
 
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
-        run: echo "{name}={path::$(composer global config cache-dir)}" >> $GITHUB_OUTPUT
+        run: echo "path=$(composer global config cache-dir)" >> $GITHUB_OUTPUT
 
       - name: 'Share Composer cache across runs'
         uses: 'actions/cache@v3'
@@ -153,7 +153,7 @@ jobs:
 
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
-        run: echo "{name}={path::$(composer global config cache-dir)}" >> $GITHUB_OUTPUT
+        run: echo "path=$(composer global config cache-dir)" >> $GITHUB_OUTPUT
 
       - name: 'Share Composer cache across runs'
         uses: 'actions/cache@v3'
@@ -203,7 +203,7 @@ jobs:
 
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
-        run: echo "{name}={path::$(composer global config cache-dir)}" >> $GITHUB_OUTPUT
+        run: echo "path=$(composer global config cache-dir)" >> $GITHUB_OUTPUT
 
       - name: 'Share Composer cache across runs'
         uses: 'actions/cache@v3'


### PR DESCRIPTION
This PR fixes some deprecations in test github workflow, by updating the following:

 - codecov/codecov-action@v3
 - actions/upload-artifact@v3

Furthermore `set-output` is replaced with `GITHUB_OUTPUT`

Refs
====

Check coding style
-------------------------
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Static code analyzer
---------------------------
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Run unit tests (8.1, {"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image...
--------------------------------------------------------------------------------------------------------------------------
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: codecov/codecov-action@v1, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
