### PR TITLE
Fix signup: create user with role admin

### DIFF
--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -18,6 +18,7 @@ use BEdita\Core\Exception\UserExistsException;
 use BEdita\Core\Model\Entity\AsyncJob;
 use BEdita\Core\Model\Entity\User;
 use BEdita\Core\Model\Table\RolesTable;
+use BEdita\Core\Model\Table\UsersTable;
 use BEdita\Core\Model\Validation\Validation;
 use BEdita\Core\Utility\LoggedUser;
 use BEdita\Core\Utility\OAuth2;
@@ -264,7 +265,8 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
     protected function createUser(array $data)
     {
         if (!LoggedUser::getUser()) {
-            LoggedUser::setUser(['id' => 1]);
+            // use user 1 (admin) role 1 (admin / unchangeable)
+            LoggedUser::setUser(['id' => UsersTable::ADMIN_USER, 'roles' => [['id' => RolesTable::ADMIN_ROLE]]]);
         }
 
         $status = 'draft';

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -630,7 +630,6 @@ class SignupUserActionTest extends TestCase
      */
     public function testRoles($expected, array $data, array $config = [])
     {
-        LoggedUser::setUser(['id' => 1, 'roles' => [['id' => 1]]]);
         Configure::write('Signup', $config);
         if ($expected instanceof \Exception) {
             $this->expectException(get_class($expected));

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -18,7 +18,6 @@ use BEdita\Core\Exception\UserExistsException;
 use BEdita\Core\Model\Action\SignupUserAction;
 use BEdita\Core\Model\Entity\AsyncJob;
 use BEdita\Core\Model\Entity\User;
-use BEdita\Core\Utility\LoggedUser;
 use Cake\Core\Configure;
 use Cake\Core\Exception\Exception as CakeException;
 use Cake\Event\Event;


### PR DESCRIPTION
This PR fixes a problem generated by recent introduction of `roles.priority`.

During signup process, `admin` user creates the new user. Admin role is necessary to provide a `roles.priority` change.