### PR TITLE
Refactor: `LoggedUser::setUserAdmin` and `LoggedUser::getUserAdmin`

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -1318,7 +1318,7 @@ class FoldersControllerTest extends IntegrationTestCase
     protected function createDocument(array $data)
     {
         if (LoggedUser::id() === null) {
-            LoggedUser::setUser(['id' => 1]);
+            LoggedUser::setUserAdmin();
         }
 
         $documentsTable = TableRegistry::getTableLocator()->get('Documents');

--- a/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateRelatedActionTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateRelatedActionTest.php
@@ -156,7 +156,7 @@ class UpdateRelatedActionTest extends TestCase
             $this->expectExceptionMessage($expected->getMessage());
         }
 
-        LoggedUser::setUser(['id' => 1, 'roles' => [['id' => 1]]]);
+        LoggedUser::setUserAdmin();
         $request = new ServerRequest();
         $request = $request->withParsedBody($data);
         $association = $this->getTableLocator()->get($table)->getAssociation($association);

--- a/plugins/BEdita/API/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/plugins/BEdita/API/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -137,7 +137,7 @@ class IntegrationTestCaseTest extends IntegrationTestCase
         CurrentApplication::getInstance()->set(null);
         static::assertEquals([], LoggedUser::getUser());
         static::assertNull(CurrentApplication::getApplication());
-        LoggedUser::setUser(['id' => 1]);
+        LoggedUser::setUserAdmin();
 
         $this->setUp();
         static::assertEquals([], LoggedUser::getUser());

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -18,7 +18,6 @@ use BEdita\Core\Exception\UserExistsException;
 use BEdita\Core\Model\Entity\AsyncJob;
 use BEdita\Core\Model\Entity\User;
 use BEdita\Core\Model\Table\RolesTable;
-use BEdita\Core\Model\Table\UsersTable;
 use BEdita\Core\Model\Validation\Validation;
 use BEdita\Core\Utility\LoggedUser;
 use BEdita\Core\Utility\OAuth2;
@@ -273,7 +272,7 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
     {
         if (!LoggedUser::getUser()) {
             // use user 1 (admin) role 1 (admin / unchangeable)
-            LoggedUser::setUser(['id' => UsersTable::ADMIN_USER, 'roles' => [['id' => RolesTable::ADMIN_ROLE]]]);
+            LoggedUser::setUserAdmin();
         }
 
         $status = 'draft';

--- a/plugins/BEdita/Core/src/Utility/LoggedUser.php
+++ b/plugins/BEdita/Core/src/Utility/LoggedUser.php
@@ -94,7 +94,7 @@ class LoggedUser
      */
     public static function setUserAdmin()
     {
-        static::getInstance()->setUser(self::$userAdminData);
+        static::getInstance()->setUser(static::getInstance()->getUserAdmin());
     }
 
     /**

--- a/plugins/BEdita/Core/src/Utility/LoggedUser.php
+++ b/plugins/BEdita/Core/src/Utility/LoggedUser.php
@@ -45,7 +45,7 @@ class LoggedUser
      *
      * @var array
      */
-    protected $userAdminData = [
+    protected const ADMIN_DATA = [
         'id' => UsersTable::ADMIN_USER,
         'roles' => [
             [
@@ -94,7 +94,7 @@ class LoggedUser
      */
     public static function setUserAdmin()
     {
-        static::getInstance()->setUser(static::getInstance()->getUserAdmin());
+        static::getInstance()->setUser(static::ADMIN_DATA);
     }
 
     /**
@@ -104,7 +104,7 @@ class LoggedUser
      */
     public static function getUserAdmin(): array
     {
-        return static::getInstance()->userAdminData;
+        return static::ADMIN_DATA;
     }
 
     /**

--- a/plugins/BEdita/Core/src/Utility/LoggedUser.php
+++ b/plugins/BEdita/Core/src/Utility/LoggedUser.php
@@ -13,6 +13,8 @@
 
 namespace BEdita\Core\Utility;
 
+use BEdita\Core\Model\Table\RolesTable;
+use BEdita\Core\Model\Table\UsersTable;
 use BEdita\Core\SingletonTrait;
 use Cake\Utility\Hash;
 
@@ -37,6 +39,20 @@ class LoggedUser
      * @var array
      */
     private $userData = [];
+
+    /**
+     * User admin data: id and roles.
+     *
+     * @var array
+     */
+    protected $userAdminData = [
+        'id' => UsersTable::ADMIN_USER,
+        'roles' => [
+            [
+                'id' => RolesTable::ADMIN_ROLE,
+            ],
+        ],
+    ];
 
     /**
      * Read singleton current user data.
@@ -69,6 +85,26 @@ class LoggedUser
         if (!empty($userData['id'])) {
             static::getInstance()->userData = $userData;
         }
+    }
+
+    /**
+     * Set singleton admin user data.
+     *
+     * @return void
+     */
+    public static function setUserAdmin()
+    {
+        static::getInstance()->setUser(static::getInstance()->userAdminData);
+    }
+
+    /**
+     * Get user admin data.
+     *
+     * @return array
+     */
+    public static function getUserAdmin(): array
+    {
+        return static::getInstance()->userAdminData;
     }
 
     /**

--- a/plugins/BEdita/Core/src/Utility/LoggedUser.php
+++ b/plugins/BEdita/Core/src/Utility/LoggedUser.php
@@ -94,7 +94,7 @@ class LoggedUser
      */
     public static function setUserAdmin()
     {
-        static::getInstance()->setUser(static::getInstance()->userAdminData);
+        static::getInstance()->setUser(self::$userAdminData);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
+++ b/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
@@ -13,6 +13,9 @@
 
 namespace BEdita\Core\Utility;
 
+use BEdita\Core\Model\Entity\RolesUser;
+use BEdita\Core\Model\Table\RolesTable;
+use BEdita\Core\Model\Table\UsersTable;
 use Cake\Console\Exception\StopException;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
@@ -72,7 +75,7 @@ class ObjectsHandler
         static::checkEnvironment();
         $currentUser = LoggedUser::getUser();
         if (empty($user)) {
-            $user = empty($currentUser) ? ['id' => 1] : $currentUser;
+            $user = empty($currentUser) ? LoggedUser::getUserAdmin() : $currentUser;
         }
         LoggedUser::setUser($user);
 

--- a/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
+++ b/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
@@ -13,9 +13,6 @@
 
 namespace BEdita\Core\Utility;
 
-use BEdita\Core\Model\Entity\RolesUser;
-use BEdita\Core\Model\Table\RolesTable;
-use BEdita\Core\Model\Table\UsersTable;
 use Cake\Console\Exception\StopException;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
@@ -58,7 +58,7 @@ class AddRelatedObjectsActionTest extends TestCase
     {
         parent::setUp();
 
-        LoggedUser::setUser(['id' => 1]);
+        LoggedUser::setUserAdmin();
     }
 
     /**
@@ -248,7 +248,7 @@ class AddRelatedObjectsActionTest extends TestCase
         $association = TableRegistry::getTableLocator()->get('Users')->getAssociation('Roles');
         $entity = $association->getSource()->get(1);
         $relatedEntities = $association->getTarget()->find()->toArray();
-        LoggedUser::setUser(['id' => 1, 'roles' => [['id' => 1]]]);
+        LoggedUser::setUserAdmin();
         $action = new AddRelatedObjectsAction(compact('association'));
         $result = $action(compact('entity', 'relatedEntities'));
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteObjectActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteObjectActionTest.php
@@ -51,7 +51,7 @@ class DeleteObjectActionTest extends TestCase
     {
         parent::setUp();
 
-        LoggedUser::setUser(['id' => 1]);
+        LoggedUser::setUserAdmin();
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
@@ -56,7 +56,7 @@ class SetRelatedObjectsActionTest extends TestCase
     {
         parent::setUp();
 
-        LoggedUser::setUser(['id' => 1]);
+        LoggedUser::setUserAdmin();
     }
 
     /**
@@ -251,7 +251,7 @@ class SetRelatedObjectsActionTest extends TestCase
         $association = TableRegistry::getTableLocator()->get('Users')->getAssociation('Roles');
         $entity = $association->getSource()->get(1);
         $relatedEntities = $association->getTarget()->find()->toArray();
-        LoggedUser::setUser(['id' => 1, 'roles' => [['id' => 1]]]);
+        LoggedUser::setUserAdmin();
         $action = new SetRelatedObjectsAction(compact('association'));
         $result = $action(compact('entity', 'relatedEntities'));
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/HistoryBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/HistoryBehaviorTest.php
@@ -54,7 +54,7 @@ class HistoryBehaviorTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        LoggedUser::setUser(['id' => 1]);
+        LoggedUser::setUserAdmin();
     }
 
     /**
@@ -345,7 +345,7 @@ class HistoryBehaviorTest extends TestCase
      */
     public function testFindHistoryEditor(array $expected, array $options): void
     {
-        LoggedUser::setUser(['id' => 1]);
+        LoggedUser::setUserAdmin();
 
         $result = TableRegistry::getTableLocator()->get('Documents')
             ->find('historyEditor', $options)

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
@@ -54,7 +54,7 @@ class UniqueNameBehaviorTest extends TestCase
     {
         parent::setUp();
 
-        LoggedUser::setUser(['id' => 1]);
+        LoggedUser::setUserAdmin();
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UserModifiedBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UserModifiedBehaviorTest.php
@@ -58,7 +58,7 @@ class UserModifiedBehaviorTest extends TestCase
     {
         parent::setUp();
 
-        LoggedUser::setUser(['id' => 1]);
+        LoggedUser::setUserAdmin();
         $this->Objects = TableRegistry::getTableLocator()->get('Objects');
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/AnnotationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/AnnotationsTableTest.php
@@ -190,7 +190,7 @@ class AnnotationsTableTest extends TestCase
      */
     public function testBeforeDelete()
     {
-        LoggedUser::setUser(['id' => 1]);
+        LoggedUser::setUserAdmin();
         $annotation = $this->Annotations->get(1);
         $success = $this->Annotations->delete($annotation);
         static::assertTrue((bool)$success);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ExternalAuthTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ExternalAuthTableTest.php
@@ -185,7 +185,7 @@ class ExternalAuthTableTest extends TestCase
      */
     public function testBeforeSaveCreateUser()
     {
-        LoggedUser::setUser(['id' => 1, 'roles' => [['id' => 1]]]);
+        LoggedUser::setUserAdmin();
         Configure::write('Roles.BEdita/API.Uuid', ['first role']);
         $count = $this->ExternalAuth->Users->find()->count();
         $entity = $this->ExternalAuth->newEntity([

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
@@ -66,7 +66,7 @@ class FoldersTableTest extends TestCase
         parent::setUp();
 
         $this->Folders = TableRegistry::getTableLocator()->get('Folders');
-        LoggedUser::setUser(['id' => 1]);
+        LoggedUser::setUserAdmin();
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
@@ -59,7 +59,7 @@ class LocationsTableTest extends TestCase
         parent::setUp();
 
         $this->Locations = TableRegistry::getTableLocator()->get('Locations');
-        LoggedUser::setUser(['id' => 1]);
+        LoggedUser::setUserAdmin();
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/MediaTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/MediaTableTest.php
@@ -46,7 +46,7 @@ class MediaTableTest extends TestCase
         parent::setUp();
 
         $this->Media = TableRegistry::getTableLocator()->get('Media');
-        LoggedUser::setUser(['id' => 1]);
+        LoggedUser::setUserAdmin();
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -60,7 +60,7 @@ class ObjectsTableTest extends TestCase
         parent::setUp();
 
         $this->Objects = TableRegistry::getTableLocator()->get('Objects');
-        LoggedUser::setUser(['id' => 1]);
+        LoggedUser::setUserAdmin();
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
@@ -63,7 +63,7 @@ class ProfilesTableTest extends TestCase
         parent::setUp();
 
         $this->Profiles = TableRegistry::getTableLocator()->get('Profiles');
-        LoggedUser::setUser(['id' => 1]);
+        LoggedUser::setUserAdmin();
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
@@ -59,7 +59,7 @@ class RolesTableTest extends TestCase
         parent::setUp();
 
         $this->Roles = TableRegistry::getTableLocator()->get('Roles');
-        LoggedUser::setUser(['id' => 1]);
+        LoggedUser::setUserAdmin();
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesUsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesUsersTableTest.php
@@ -103,7 +103,7 @@ class RolesUsersTableTest extends TestCase
      */
     public function testValidation($expected, array $data)
     {
-        LoggedUser::setUser(['id' => 1, 'roles' => [['id' => 1]]]);
+        LoggedUser::setUserAdmin();
         $objectType = $this->RolesUsers->newEntity([]);
         $this->RolesUsers->patchEntity($objectType, $data);
 
@@ -148,7 +148,7 @@ class RolesUsersTableTest extends TestCase
      */
     public function testDeleteSecondRole()
     {
-        LoggedUser::setUser(['id' => 1, 'roles' => [['id' => 1]]]);
+        LoggedUser::setUserAdmin();
         $entity = $this->RolesUsers->get(2);
         $success = $this->RolesUsers->delete($entity);
         static::assertNotEmpty($success);
@@ -163,7 +163,7 @@ class RolesUsersTableTest extends TestCase
      */
     public function testModifyAdminRole()
     {
-        LoggedUser::setUser(['id' => 1, 'roles' => [['id' => 1]]]);
+        LoggedUser::setUserAdmin();
         $entity = $this->RolesUsers->newEntity([]);
         $this->RolesUsers->patchEntity($entity, [
             'role_id' => 2,

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/TreesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/TreesTableTest.php
@@ -281,7 +281,7 @@ class TreesTableTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
         // create new Folder
-        LoggedUser::setUser(['id' => 1]);
+        LoggedUser::setUserAdmin();
         $Folders = TableRegistry::getTableLocator()->get('Folders');
         $entity = $Folders->newEntity(['title' => 'subsub folder']);
         $entity->type = 'folders';

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -73,7 +73,7 @@ class UsersTableTest extends TestCase
         parent::setUp();
 
         $this->Users = TableRegistry::getTableLocator()->get('Users');
-        LoggedUser::setUser(['id' => 1]);
+        LoggedUser::setUserAdmin();
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Utility/LoggedUserTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/LoggedUserTest.php
@@ -47,5 +47,10 @@ class LoggedUserTest extends TestCase
         $this->assertEquals($userData['id'], LoggedUser::id());
 
         $this->assertEquals($userData, LoggedUser::getUser());
+
+        LoggedUser::setUserAdmin();
+        $expected = LoggedUser::getUserAdmin();
+        $actual = LoggedUser::getUser();
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHandlerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHandlerTest.php
@@ -52,7 +52,7 @@ class ObjectsHandlerTest extends TestCase
     {
         parent::setUp();
 
-        LoggedUser::setUser(['id' => 1]);
+        LoggedUser::setUserAdmin();
     }
 
     /**


### PR DESCRIPTION
This PR introduces new utility functions `LoggedUser::setUserAdmin()` and `LoggedUser::getUserAdmin()`.
This centralizes the logic into `LoggedUser` class, avoiding `setUser(['id' => 1])` et similia.