### PR TITLE
Fix docker entrypoint perms for sqlite db

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ARG DEBUG
 ENV DEBUG=${DEBUG:-false} \
     LOG_DEBUG_URL="console:///?stream=php://stdout" \
     LOG_ERROR_URL="console:///?stream=php://stderr" \
-    DATABASE_DIR="/var/www/html/" \
     DATABASE_URL="sqlite:////var/www/html/bedita.sqlite"
 
 # Install Wait-for-it, copy entrypoint, configure Apache and PHP

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ARG DEBUG
 ENV DEBUG=${DEBUG:-false} \
     LOG_DEBUG_URL="console:///?stream=php://stdout" \
     LOG_ERROR_URL="console:///?stream=php://stderr" \
+    DATABASE_DIR="/var/www/html/" \
     DATABASE_URL="sqlite:////var/www/html/bedita.sqlite"
 
 # Install Wait-for-it, copy entrypoint, configure Apache and PHP

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 COPY . /var/www/html
 WORKDIR /var/www/html
 RUN chown -R www-data:www-data /var/www/html
+RUN chmod g+w /var/www/html
 USER www-data:www-data
 VOLUME /var/www/html/webroot/_files
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -24,7 +24,8 @@ if [ ! -z "${DATABASE_URL}" ]; then
         DATABASE_PATH=$(php -r "echo substr(parse_url(preg_replace('/^([\\w\\\\\\]+)/', 'file', getenv('DATABASE_URL')), PHP_URL_PATH), 1);")
         echo "=====> Path: ${DATABASE_PATH}"
         chmod a+rwx ${DATABASE_PATH}
-        chown www-data:www-data ${DATABASE_PATH}
+        chown www-data:www-data ${DATABASE_PATH} ${DATABASE_DIR}
+        chmod g+w ${DATABASE_DIR}
     fi
 
     bin/cake cache clear_all

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -24,6 +24,7 @@ if [ ! -z "${DATABASE_URL}" ]; then
         DATABASE_PATH=$(php -r "echo substr(parse_url(preg_replace('/^([\\w\\\\\\]+)/', 'file', getenv('DATABASE_URL')), PHP_URL_PATH), 1);")
         echo "=====> Path: ${DATABASE_PATH}"
         chmod a+rwx ${DATABASE_PATH}
+        chown www-data:www-data ${DATABASE_PATH}
     fi
 
     bin/cake cache clear_all

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -24,6 +24,7 @@ if [ ! -z "${DATABASE_URL}" ]; then
         DATABASE_PATH=$(php -r "echo substr(parse_url(preg_replace('/^([\\w\\\\\\]+)/', 'file', getenv('DATABASE_URL')), PHP_URL_PATH), 1);")
         echo "=====> Path: ${DATABASE_PATH}"
         chmod a+rwx ${DATABASE_PATH}
+        DATABASE_DIR="$(dirname ${DATABASE_PATH})"
         chown www-data:www-data ${DATABASE_PATH} ${DATABASE_DIR}
         chmod g+w ${DATABASE_DIR}
     fi


### PR DESCRIPTION
This PR fixes a permissions problem on sqlite database by using `chown www-data:www-data` on sqlite database file.

The folder that houses the database file must be writeable (https://www.php.net/manual/en/ref.pdo-sqlite.php#57356), so this applies proper perms on database directory too.