### PR TITLE
Fix docker perms for sqlite db and folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 COPY . /var/www/html
 WORKDIR /var/www/html
 RUN chown -R www-data:www-data /var/www/html
+RUN chmod g+w /var/www/html
 USER www-data:www-data
 VOLUME /var/www/html/webroot/_files
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -24,6 +24,9 @@ if [ ! -z "${DATABASE_URL}" ]; then
         DATABASE_PATH=$(php -r "echo substr(parse_url(preg_replace('/^([\\w\\\\\\]+)/', 'file', getenv('DATABASE_URL')), PHP_URL_PATH), 1);")
         echo "=====> Path: ${DATABASE_PATH}"
         chmod a+rwx ${DATABASE_PATH}
+        DATABASE_DIR="$(dirname ${DATABASE_PATH})"
+        chown www-data:www-data ${DATABASE_PATH} ${DATABASE_DIR}
+        chmod g+w ${DATABASE_DIR}
     fi
 
     bin/cake cache clearAll


### PR DESCRIPTION
This PR fixes a permissions problem on sqlite database by using `chown www-data:www-data` on sqlite database file.

The folder that houses the database file must be writeable (https://www.php.net/manual/en/ref.pdo-sqlite.php#57356), so this applies proper perms on database directory too.

V4 version of https://github.com/bedita/bedita/pull/2001