### PR TITLE
Add endpoint to clone an existing stream

### DIFF
--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -109,6 +109,11 @@ return function (RouteBuilder $routes) {
             ['_name' => 'streams:upload', 'pass' => ['fileName']]
         );
         $routes->connect(
+            '/streams/clone/{uuid}',
+            ['controller' => 'Streams', 'action' => 'clone'],
+            ['_name' => 'streams:clone']
+        )->setPass(['uuid']);
+        $routes->connect(
             '/media/thumbs/{id}',
             ['controller' => 'Media', 'action' => 'thumbs'],
             ['_name' => 'media:thumbs', 'pass' => ['id']]

--- a/plugins/BEdita/API/src/Controller/Component/UploadComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/UploadComponent.php
@@ -66,7 +66,7 @@ class UploadComponent extends Component
 
         $this->Streams = $this->fetchTable('Streams');
         // Add a new entity.
-        $entity = $this->Streams->newEntity([]);
+        $entity = $this->Streams->newEmptyEntity();
         $action = new SaveEntityAction(['table' => $this->Streams]);
 
         $data = [

--- a/plugins/BEdita/API/src/Controller/StreamsController.php
+++ b/plugins/BEdita/API/src/Controller/StreamsController.php
@@ -114,7 +114,6 @@ class StreamsController extends ResourcesController
      */
     public function download(string $uuid): Response
     {
-        /** @var \BEdita\Core\Model\Entity\Stream $stream */
         $stream = $this->Table->get($uuid);
         $filename = Hash::get($stream, 'file_name', sprintf('stream-%s', $uuid));
 

--- a/plugins/BEdita/API/src/Controller/StreamsController.php
+++ b/plugins/BEdita/API/src/Controller/StreamsController.php
@@ -106,6 +106,34 @@ class StreamsController extends ResourcesController
     }
 
     /**
+     * Clone a Stream by its UUID.
+     *
+     * @param string $uuid ID of the Stream to clone.
+     * @return void
+     */
+    public function clone(string $uuid): void
+    {
+        $data = $this->Table->clone($this->Table->get($uuid));
+
+        $this->set(compact('data'));
+        $this->setSerialize(['data']);
+
+        $this->response = $this->response
+            ->withStatus(201)
+            ->withHeader(
+                'Location',
+                Router::url(
+                    [
+                        '_name' => 'api:resources:resource',
+                        'controller' => $this->name,
+                        'id' => $data->get('uuid'),
+                    ],
+                    true
+                )
+            );
+    }
+
+    /**
      * Download a stream.
      *
      * @param string $uuid Stream UUID.

--- a/plugins/BEdita/Core/src/Model/Behavior/UploadableBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UploadableBehavior.php
@@ -37,6 +37,9 @@ class UploadableBehavior extends Behavior
                 'contents' => 'contents',
             ],
         ],
+        'implementedMethods' => [
+            'copyFiles' => 'copyFiles',
+        ],
     ];
 
     /**
@@ -72,12 +75,15 @@ class UploadableBehavior extends Behavior
      */
     protected function processUpload(Entity $entity, string $pathField, string $contentsField): void
     {
-        if (!$entity->isDirty($pathField) && !$entity->isDirty($contentsField)) {
+        $manager = FilesystemRegistry::getMountManager();
+        if (
+            (!$entity->isDirty($pathField) || !$manager->fileExists($entity->getOriginal($pathField)))
+            && !$entity->isDirty($contentsField)
+        ) {
             // Nothing to do.
             return;
         }
 
-        $manager = FilesystemRegistry::getMountManager();
         $path = $entity->get($pathField);
         $originalPath = $entity->getOriginal($pathField);
         if ($entity->isDirty($pathField) && $originalPath !== $path) {
@@ -156,6 +162,25 @@ class UploadableBehavior extends Behavior
     {
         foreach ($this->getConfig('files') as $file) {
             $this->processDelete($entity, $file['path']);
+        }
+    }
+
+    /**
+     * Copy files from an entity to another.
+     *
+     * @param \Cake\ORM\Entity $src Source entity. It must have path fields set and referenced files must exist.
+     * @param \Cake\ORM\Entity $dest Destination entity. It must have path fields set.
+     * @return void
+     * @throws \League\Flysystem\FilesystemException
+     */
+    public function copyFiles(Entity $src, Entity $dest): void
+    {
+        $manager = FilesystemRegistry::getMountManager();
+        foreach ($this->getConfig('files') as $file) {
+            $srcPath = $src->get($file['path']);
+            $destPath = $dest->get($file['path']);
+
+            $manager->copy($srcPath, $destPath);
         }
     }
 }

--- a/plugins/BEdita/Core/src/Model/Behavior/UploadableBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UploadableBehavior.php
@@ -47,7 +47,7 @@ class UploadableBehavior extends Behavior
      * @param mixed $contents File contents.
      * @return void
      */
-    protected function write(MountManager $manager, $path, $contents): void
+    protected function write(MountManager $manager, string $path, $contents): void
     {
         if ($contents instanceof StreamInterface) {
             $contents = $contents->detach();
@@ -70,7 +70,7 @@ class UploadableBehavior extends Behavior
      * @param string $contentsField Name of field in which contents are stored.
      * @return void
      */
-    protected function processUpload(Entity $entity, $pathField, $contentsField): void
+    protected function processUpload(Entity $entity, string $pathField, string $contentsField): void
     {
         if (!$entity->isDirty($pathField) && !$entity->isDirty($contentsField)) {
             // Nothing to do.
@@ -105,7 +105,7 @@ class UploadableBehavior extends Behavior
      * @param string $pathField Name of field in which path is stored.
      * @return void
      */
-    protected function setVisibility(Entity $entity, $pathField): void
+    protected function setVisibility(Entity $entity, string $pathField): void
     {
         if (!$entity->get('private_url')) {
             return;
@@ -137,7 +137,7 @@ class UploadableBehavior extends Behavior
      * @param \Cake\ORM\Entity $entity Entity.
      * @return void
      */
-    public function afterSave(EventInterface $event, Entity $entity)
+    public function afterSave(EventInterface $event, Entity $entity): void
     {
         foreach ($this->getConfig('files') as $file) {
             $this->processUpload($entity, $file['path'], $file['contents']);
@@ -152,7 +152,7 @@ class UploadableBehavior extends Behavior
      * @param \Cake\ORM\Entity $entity Entity.
      * @return void
      */
-    public function afterDelete(EventInterface $event, Entity $entity)
+    public function afterDelete(EventInterface $event, Entity $entity): void
     {
         foreach ($this->getConfig('files') as $file) {
             $this->processDelete($entity, $file['path']);

--- a/plugins/BEdita/Core/src/Model/Entity/Stream.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Stream.php
@@ -54,6 +54,19 @@ class Stream extends Entity implements JsonApiSerializable
     use JsonApiTrait;
     use LogTrait;
 
+    public const FILE_PROPERTIES = [
+        'file_name',
+        'mime_type',
+        'file_size',
+        'hash_md5',
+        'hash_sha1',
+        'width',
+        'height',
+        'duration',
+        'file_metadata',
+        'private_url',
+    ];
+
     /**
      * @inheritDoc
      */

--- a/plugins/BEdita/Core/src/Model/Table/StreamsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/StreamsTable.php
@@ -151,7 +151,7 @@ class StreamsTable extends Table
      * @param \BEdita\Core\Model\Entity\Stream $entity Entity.
      * @return void
      */
-    public function beforeSave(EventInterface $event, Stream $entity)
+    public function beforeSave(EventInterface $event, Stream $entity): void
     {
         if (!$entity->isNew()) {
             return;
@@ -170,7 +170,7 @@ class StreamsTable extends Table
      * @param \BEdita\Core\Model\Entity\Stream $stream Entity.
      * @return void
      */
-    public function afterDelete(EventInterface $event, Stream $stream)
+    public function afterDelete(EventInterface $event, Stream $stream): void
     {
         Thumbnail::delete($stream);
     }

--- a/plugins/BEdita/Core/src/Model/Table/StreamsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/StreamsTable.php
@@ -127,6 +127,7 @@ class StreamsTable extends Table
      *
      * @param \Cake\Validation\Validator $validator Validator instance.
      * @return \Cake\Validation\Validator
+     * @codeCoverageIgnore
      */
     public function validationClone(Validator $validator): Validator
     {

--- a/plugins/BEdita/Core/src/Model/Table/StreamsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/StreamsTable.php
@@ -33,6 +33,7 @@ use Cake\Validation\Validator;
  * @method \BEdita\Core\Model\Entity\Stream[] patchEntities($entities, array $data, array $options = [])
  * @method \BEdita\Core\Model\Entity\Stream findOrCreate($search, callable $callback = null, $options = [])
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \BEdita\Core\Model\Behavior\UploadableBehavior
  * @since 4.0.0
  */
 class StreamsTable extends Table
@@ -122,6 +123,18 @@ class StreamsTable extends Table
     }
 
     /**
+     * Validator for cloning streams.
+     *
+     * @param \Cake\Validation\Validator $validator Validator instance.
+     * @return \Cake\Validation\Validator
+     */
+    public function validationClone(Validator $validator): Validator
+    {
+        return $this->validationDefault($validator)
+            ->requirePresence('contents', false);
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @codeCoverageIgnore
@@ -173,5 +186,27 @@ class StreamsTable extends Table
     public function afterDelete(EventInterface $event, Stream $stream): void
     {
         Thumbnail::delete($stream);
+    }
+
+    /**
+     * Clone a stream.
+     *
+     * @param \BEdita\Core\Model\Entity\Stream $stream Stream to clone.
+     * @return \BEdita\Core\Model\Entity\Stream
+     */
+    public function clone(Stream $stream): Stream
+    {
+        $clone = $this->newEntity($stream->extract(Stream::FILE_PROPERTIES), [
+            'accessibleFields' => array_fill_keys(Stream::FILE_PROPERTIES, true),
+            'validate' => 'clone',
+        ]);
+        $clone->uri = $clone->filesystemPath();
+
+        return $this->getConnection()->transactional(function () use ($clone, $stream): Stream {
+            $clone = $this->saveOrFail($clone, ['atomic' => false]);
+            $this->copyFiles($stream, $clone);
+
+            return $this->get($clone->get('uuid'));
+        });
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
@@ -30,7 +30,7 @@ class UploadableBehaviorTest extends TestCase
      *
      * @var \BEdita\Core\Model\Table\StreamsTable
      */
-    public $Streams;
+    protected $Streams;
 
     /**
      * Fixtures
@@ -70,7 +70,7 @@ class UploadableBehaviorTest extends TestCase
      *
      * @return array
      */
-    public function afterSaveProvider()
+    public function afterSaveProvider(): array
     {
         $originalContents = "Sample uploaded file.\n";
         $newContents = 'Modified contents.';
@@ -136,7 +136,7 @@ class UploadableBehaviorTest extends TestCase
      * @covers ::setVisibility()
      * @covers ::write()
      */
-    public function testAfterSave(array $expected, array $data)
+    public function testAfterSave(array $expected, array $data): void
     {
         $manager = FilesystemRegistry::getMountManager();
 
@@ -167,7 +167,7 @@ class UploadableBehaviorTest extends TestCase
      * @covers ::afterDelete()
      * @covers ::processDelete()
      */
-    public function testAfterDelete()
+    public function testAfterDelete(): void
     {
         $manager = FilesystemRegistry::getMountManager();
 
@@ -177,5 +177,25 @@ class UploadableBehaviorTest extends TestCase
         $this->Streams->deleteOrFail($stream);
 
         static::assertFalse($manager->fileExists($path));
+    }
+
+    /**
+     * Test [@see \BEdita\Core\Model\Behavior\UploadableBehavior::copyFiles()} method..
+     *
+     * @return void
+     * @covers ::copyFiles()
+     */
+    public function testCopyFiles(): void
+    {
+        $manager = FilesystemRegistry::getMountManager();
+
+        $stream = $this->Streams->get('9e58fa47-db64-4479-a0ab-88a706180d59');
+        $copy = $this->Streams->newEmptyEntity();
+        $copy->uri = $copy->filesystemPath();
+
+        $this->Streams->copyFiles($stream, $copy);
+
+        static::assertTrue($manager->fileExists($copy->uri));
+        static::assertSame($manager->read($stream->uri), $manager->read($copy->uri));
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/StreamsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/StreamsTableTest.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
+use BEdita\Core\Model\Entity\Stream;
 use BEdita\Core\Model\Table\ObjectsTable;
 use BEdita\Core\Test\Utility\TestFilesystemTrait;
 use Cake\ORM\Association\BelongsTo;
@@ -252,5 +253,31 @@ class StreamsTableTest extends TestCase
         $result = $stream->extract(array_keys($expected));
 
         static::assertSame($expected, $result);
+    }
+
+    /**
+     * Test {@see \BEdita\Core\Model\Table\StreamsTable::clone()} method.
+     *
+     * @param string $uuid UUID of the Stream to clone.
+     * @return void
+     * @testWith    ["e5afe167-7341-458d-a1e6-042e8791b0fe"]
+     *              ["9e58fa47-db64-4479-a0ab-88a706180d59"]
+     *              ["6aceb0eb-bd30-4f60-ac74-273083b921b6"]
+     * @covers ::clone()
+     */
+    public function testClone(string $uuid): void
+    {
+        $src = $this->Streams->get($uuid);
+        $expected = $src->extract(Stream::FILE_PROPERTIES);
+
+        $clone = $this->Streams->clone($src);
+        $actual = $clone->extract(Stream::FILE_PROPERTIES);
+
+        static::assertNotSame($src, $clone, 'Cloned stream is the same entity as the source stream');
+        static::assertTrue($this->Streams->exists(['uuid' => $clone->uuid]), 'Cloned stream has not been persisted');
+        static::assertNotSame($src->uuid, $clone->uuid, 'Cloned stream has the same UUID as the source stream');
+        static::assertNull($clone->object_id, 'Cloned stream must not be linked to any object');
+        static::assertSame($src->contents->getContents(), $clone->contents->getContents(), 'Cloned stream must have the same file contents');
+        static::assertSame($expected, $actual, 'Cloned stream must preserve property values');
     }
 }


### PR DESCRIPTION
This PR adds an endpoint `POST /streams/clone/{uuid}` (with empty body) to clone an existing Stream. The response headers and body is analogous to `POST /streams/upload/{fileName}`.

This may be useful to clone a whole Media object by first cloning the underlying Stream, then cloning the object itself referencing the cloned Stream.