### PR TITLE
Add endpoint to clone an existing stream - BEdita 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "cakephp/cakephp-codesniffer": "~3.2.1",
         "psy/psysh": "@stable",
         "bedita/dev-tools": "1.5.*",
-        "phpstan/phpstan": "^1.5",
+        "phpstan/phpstan": "^1.5, < 1.10.12 || ^1.11",
         "phpunit/phpunit": "^6.5"
     },
     "autoload": {

--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -119,6 +119,11 @@ Router::plugin(
             ['_name' => 'streams:upload', 'pass' => ['fileName']]
         );
         $routes->connect(
+            '/streams/clone/{uuid}',
+            ['controller' => 'Streams', 'action' => 'clone'],
+            ['_name' => 'streams:clone']
+        )->setPass(['uuid']);
+        $routes->connect(
             '/media/thumbs/{id}',
             ['controller' => 'Media', 'action' => 'thumbs'],
             ['_name' => 'media:thumbs', 'pass' => ['id']]

--- a/plugins/BEdita/API/src/Controller/StreamsController.php
+++ b/plugins/BEdita/API/src/Controller/StreamsController.php
@@ -106,6 +106,34 @@ class StreamsController extends ResourcesController
     }
 
     /**
+     * Clone a Stream by its UUID.
+     *
+     * @param string $uuid ID of the Stream to clone.
+     * @return void
+     */
+    public function clone(string $uuid): void
+    {
+        $data = $this->Table->clone($this->Table->get($uuid));
+
+        $this->set(compact('data'));
+        $this->setSerialize(['data']);
+
+        $this->response = $this->response
+            ->withStatus(201)
+            ->withHeader(
+                'Location',
+                Router::url(
+                    [
+                        '_name' => 'api:resources:resource',
+                        'controller' => $this->name,
+                        'id' => $data->get('uuid'),
+                    ],
+                    true
+                )
+            );
+    }
+
+    /**
      * Download a stream.
      *
      * @param string $uuid Stream UUID.

--- a/plugins/BEdita/API/tests/TestCase/Controller/StreamsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/StreamsControllerTest.php
@@ -242,4 +242,43 @@ class StreamsControllerTest extends IntegrationTestCase
         $response = (string)$this->_response->getBody();
         static::assertEquals(trim($response), 'Sample uploaded file.');
     }
+
+    /**
+     * Test {@see \BEdita\API\Controller\StreamsController::clone()} action.
+     *
+     * @return void
+     * @covers ::clone()
+     */
+    public function testClone(): void
+    {
+        $attributes = [
+            'file_name' => 'bedita-logo-gray.gif',
+            'mime_type' => 'image/gif',
+        ];
+        $meta = [
+            'version' => 1,
+            'file_size' => 927,
+            'hash_md5' => 'a714dbb31ca89d5b1257245dfa5c5153',
+            'hash_sha1' => '444b2b42b48b0b815d70f6648f8a7a23d5faf54b',
+        ];
+
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $this->post('/streams/clone/6aceb0eb-bd30-4f60-ac74-273083b921b6');
+
+        $this->assertResponseCode(201);
+        $this->assertContentType('application/vnd.api+json');
+
+        $response = json_decode((string)$this->_response->getBody(), true);
+        static::assertArrayHasKey('data', $response);
+
+        $id = $response['data']['id'];
+        $url = sprintf('http://api.example.com/streams/%s', $id);
+        static::assertTrue(Validation::uuid($id));
+        static::assertSame('streams', $response['data']['type']);
+        static::assertEquals($attributes, $response['data']['attributes']);
+        static::assertArraySubset($meta, $response['data']['meta']);
+        static::assertSame(sprintf('https://static.example.org/files/%s-%s', $id, $attributes['file_name']), $response['data']['meta']['url']);
+
+        $this->assertHeader('Location', $url);
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Behavior/UploadableBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UploadableBehavior.php
@@ -37,6 +37,9 @@ class UploadableBehavior extends Behavior
                 'contents' => 'contents',
             ],
         ],
+        'implementedMethods' => [
+            'copyFiles' => 'copyFiles',
+        ],
     ];
 
     /**
@@ -70,12 +73,15 @@ class UploadableBehavior extends Behavior
      */
     protected function processUpload(Entity $entity, $pathField, $contentsField)
     {
-        if (!$entity->isDirty($pathField) && !$entity->isDirty($contentsField)) {
+        $manager = FilesystemRegistry::getMountManager();
+        if (
+            (!$entity->isDirty($pathField) || !$manager->fileExists($entity->getOriginal($pathField)))
+            && !$entity->isDirty($contentsField)
+        ) {
             // Nothing to do.
             return true;
         }
 
-        $manager = FilesystemRegistry::getMountManager();
         $path = $entity->get($pathField);
         $originalPath = $entity->getOriginal($pathField);
         if ($entity->isDirty($pathField) && $originalPath !== $path) {
@@ -150,6 +156,25 @@ class UploadableBehavior extends Behavior
     {
         foreach ($this->getConfig('files') as $file) {
             $this->processDelete($entity, $file['path']);
+        }
+    }
+
+    /**
+     * Copy files from an entity to another.
+     *
+     * @param \Cake\ORM\Entity $src Source entity. It must have path fields set and referenced files must exist.
+     * @param \Cake\ORM\Entity $dest Destination entity. It must have path fields set.
+     * @return void
+     * @throws \League\Flysystem\FilesystemException
+     */
+    public function copyFiles(Entity $src, Entity $dest): void
+    {
+        $manager = FilesystemRegistry::getMountManager();
+        foreach ($this->getConfig('files') as $file) {
+            $srcPath = $src->get($file['path']);
+            $destPath = $dest->get($file['path']);
+
+            $manager->copy($srcPath, $destPath);
         }
     }
 }

--- a/plugins/BEdita/Core/src/Model/Behavior/UploadableBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UploadableBehavior.php
@@ -75,7 +75,7 @@ class UploadableBehavior extends Behavior
     {
         $manager = FilesystemRegistry::getMountManager();
         if (
-            (!$entity->isDirty($pathField) || !$manager->fileExists($entity->getOriginal($pathField)))
+            (!$entity->isDirty($pathField) || !$manager->has($entity->getOriginal($pathField)))
             && !$entity->isDirty($contentsField)
         ) {
             // Nothing to do.

--- a/plugins/BEdita/Core/src/Model/Entity/Stream.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Stream.php
@@ -55,6 +55,19 @@ class Stream extends Entity implements JsonApiSerializable
     use JsonApiTrait;
     use LogTrait;
 
+    public const FILE_PROPERTIES = [
+        'file_name',
+        'mime_type',
+        'file_size',
+        'hash_md5',
+        'hash_sha1',
+        'width',
+        'height',
+        'duration',
+        'file_metadata',
+        'private_url',
+    ];
+
     /**
      * @inheritDoc
      */

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
@@ -30,7 +30,7 @@ class UploadableBehaviorTest extends TestCase
      *
      * @var \BEdita\Core\Model\Table\StreamsTable
      */
-    public $Streams;
+    protected $Streams;
 
     /**
      * Fixtures
@@ -70,7 +70,7 @@ class UploadableBehaviorTest extends TestCase
      *
      * @return array
      */
-    public function afterSaveProvider()
+    public function afterSaveProvider(): array
     {
         $originalContents = "Sample uploaded file.\n";
         $newContents = 'Modified contents.';
@@ -136,7 +136,7 @@ class UploadableBehaviorTest extends TestCase
      * @covers ::setVisibility()
      * @covers ::write()
      */
-    public function testAfterSave(array $expected, array $data)
+    public function testAfterSave(array $expected, array $data): void
     {
         $manager = FilesystemRegistry::getMountManager();
 
@@ -167,7 +167,7 @@ class UploadableBehaviorTest extends TestCase
      * @covers ::afterDelete()
      * @covers ::processDelete()
      */
-    public function testAfterDelete()
+    public function testAfterDelete(): void
     {
         $manager = FilesystemRegistry::getMountManager();
 
@@ -177,5 +177,25 @@ class UploadableBehaviorTest extends TestCase
         $this->Streams->deleteOrFail($stream);
 
         static::assertFalse($manager->has($path));
+    }
+
+    /**
+     * Test [@see \BEdita\Core\Model\Behavior\UploadableBehavior::copyFiles()} method..
+     *
+     * @return void
+     * @covers ::copyFiles()
+     */
+    public function testCopyFiles(): void
+    {
+        $manager = FilesystemRegistry::getMountManager();
+
+        $stream = $this->Streams->get('9e58fa47-db64-4479-a0ab-88a706180d59');
+        $copy = $this->Streams->newEntity([]);
+        $copy->uri = $copy->filesystemPath();
+
+        $this->Streams->copyFiles($stream, $copy);
+
+        static::assertTrue($manager->has($copy->uri));
+        static::assertSame($manager->read($stream->uri), $manager->read($copy->uri));
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/StreamsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/StreamsTableTest.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
+use BEdita\Core\Model\Entity\Stream;
 use BEdita\Core\Model\Table\ObjectsTable;
 use BEdita\Core\Test\Utility\TestFilesystemTrait;
 use Cake\ORM\Association\BelongsTo;
@@ -250,5 +251,31 @@ class StreamsTableTest extends TestCase
         $result = $stream->extract(array_keys($expected));
 
         static::assertSame($expected, $result);
+    }
+
+    /**
+     * Test {@see \BEdita\Core\Model\Table\StreamsTable::clone()} method.
+     *
+     * @param string $uuid UUID of the Stream to clone.
+     * @return void
+     * @testWith    ["e5afe167-7341-458d-a1e6-042e8791b0fe"]
+     *              ["9e58fa47-db64-4479-a0ab-88a706180d59"]
+     *              ["6aceb0eb-bd30-4f60-ac74-273083b921b6"]
+     * @covers ::clone()
+     */
+    public function testClone(string $uuid): void
+    {
+        $src = $this->Streams->get($uuid);
+        $expected = $src->extract(Stream::FILE_PROPERTIES);
+
+        $clone = $this->Streams->clone($src);
+        $actual = $clone->extract(Stream::FILE_PROPERTIES);
+
+        static::assertNotSame($src, $clone, 'Cloned stream is the same entity as the source stream');
+        static::assertTrue($this->Streams->exists(['uuid' => $clone->uuid]), 'Cloned stream has not been persisted');
+        static::assertNotSame($src->uuid, $clone->uuid, 'Cloned stream has the same UUID as the source stream');
+        static::assertNull($clone->object_id, 'Cloned stream must not be linked to any object');
+        static::assertSame($src->contents->getContents(), $clone->contents->getContents(), 'Cloned stream must have the same file contents');
+        static::assertSame($expected, $actual, 'Cloned stream must preserve property values');
     }
 }


### PR DESCRIPTION
This PR mirrors #2006 for branch `4-cactus`.

---

This PR adds an endpoint `POST /streams/clone/{uuid}` (with empty body) to clone an existing Stream. The response headers and body is analogous to POST `/streams/upload/{fileName}`.

This may be useful to clone a whole Media object by first cloning the underlying Stream, then cloning the object itself referencing the cloned Stream.