### PR TITLE
Fix: full path name for service get

### DIFF
--- a/plugins/BEdita/Core/src/Job/ServiceRegistry.php
+++ b/plugins/BEdita/Core/src/Job/ServiceRegistry.php
@@ -56,7 +56,7 @@ class ServiceRegistry
 
         $className = $plugin . Inflector::camelize($name);
         if (strpos($name, '\\') === 0) {
-            $className = Inflector::camelize($name);
+            $className = $name;
         }
         $fullClassName = App::className($className, 'Job/Service', 'Service');
 

--- a/plugins/BEdita/Core/src/Job/ServiceRegistry.php
+++ b/plugins/BEdita/Core/src/Job/ServiceRegistry.php
@@ -55,6 +55,9 @@ class ServiceRegistry
         }
 
         $className = $plugin . Inflector::camelize($name);
+        if (strpos($name, '\\') === 0) {
+            $className = Inflector::camelize($name);
+        }
         $fullClassName = App::className($className, 'Job/Service', 'Service');
 
         if ($fullClassName === null) {

--- a/plugins/BEdita/Core/tests/TestCase/Job/ServiceRegistryTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/ServiceRegistryTest.php
@@ -73,6 +73,12 @@ class ServiceRegistryTest extends TestCase
 
         static::assertNotEmpty($result);
         static::assertInstanceOf(JobService::class, $result);
+
+        // test full path notation
+        $result = ServiceRegistry::get('\\BEdita\\Core\\Job\\Service\\MailService');
+
+        static::assertNotEmpty($result);
+        static::assertInstanceOf(JobService::class, $result);
     }
 
     /**


### PR DESCRIPTION
This fixes `ServiceRegistry::get(string $name)` when `$name` is a fullpath, i.e. `\\MyService\Full\Path\ClassName`.