### PR TITLE
Add `async_jobs` endpoint for get and post

### DIFF
--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -223,6 +223,13 @@ return function (RouteBuilder $routes) {
             ['_name' => 'applications:index']
         );
 
+        // Async jobs.
+        $routes->connect(
+            '/async_jobs',
+            ['controller' => 'AsyncJobs', 'action' => 'index'],
+            ['_name' => 'async_jobs:index']
+        );
+
         // Trees.
         $routes->connect(
             '/trees/**',

--- a/plugins/BEdita/API/src/Controller/AsyncJobsController.php
+++ b/plugins/BEdita/API/src/Controller/AsyncJobsController.php
@@ -34,10 +34,9 @@ class AsyncJobsController extends ResourcesController
      */
     public function initialize(): void
     {
-        parent::initialize();
-
         if (!in_array($this->request->getMethod(), ['GET', 'POST'])) {
             throw new MethodNotAllowedException();
         }
+        parent::initialize();
     }
 }

--- a/plugins/BEdita/API/src/Controller/AsyncJobsController.php
+++ b/plugins/BEdita/API/src/Controller/AsyncJobsController.php
@@ -1,7 +1,9 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
- * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ * Copyright 2023 Atlas Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published

--- a/plugins/BEdita/API/src/Controller/AsyncJobsController.php
+++ b/plugins/BEdita/API/src/Controller/AsyncJobsController.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2021 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\API\Controller;
+
+/**
+ * Controller for `/async_jobs` endpoint.
+ *
+ * @property \BEdita\Core\Model\Table\AsyncJobsTable $AsyncJobs
+ */
+class AsyncJobsController extends AppController
+{
+    /**
+     * @inheritDoc
+     */
+    public $defaultTable = 'AsyncJobs';
+
+    /**
+     * Handle async_jobs endpoint.
+     *
+     * @return void
+     */
+    public function index(): void
+    {
+        $this->getRequest()->allowMethod(['GET', 'POST']);
+        if ($this->getRequest()->is('GET')) {
+            $query = $this->AsyncJobs->find();
+            $data = $this->paginate($query);
+            $this->set(compact('data'));
+            $this->setSerialize(['data']);
+
+            return;
+        }
+        $data = $this->getRequest()->getData();
+        $asyncJob = $this->AsyncJobs->newEntity($data);
+        $this->AsyncJobs->save($asyncJob);
+        $this->set(compact('asyncJob'));
+        $this->setSerialize(['asyncJob']);
+    }
+}

--- a/plugins/BEdita/API/src/Controller/AsyncJobsController.php
+++ b/plugins/BEdita/API/src/Controller/AsyncJobsController.php
@@ -15,12 +15,14 @@ declare(strict_types=1);
 
 namespace BEdita\API\Controller;
 
+use Cake\Http\Exception\MethodNotAllowedException;
+
 /**
  * Controller for `/async_jobs` endpoint.
  *
  * @property \BEdita\Core\Model\Table\AsyncJobsTable $AsyncJobs
  */
-class AsyncJobsController extends AppController
+class AsyncJobsController extends ResourcesController
 {
     /**
      * @inheritDoc
@@ -28,25 +30,14 @@ class AsyncJobsController extends AppController
     public $defaultTable = 'AsyncJobs';
 
     /**
-     * Handle async_jobs endpoint.
-     *
-     * @return void
+     * @inheritDoc
      */
-    public function index(): void
+    public function initialize(): void
     {
-        $this->getRequest()->allowMethod(['GET', 'POST']);
-        if ($this->getRequest()->is('GET')) {
-            $query = $this->AsyncJobs->find();
-            $data = $this->paginate($query);
-            $this->set(compact('data'));
-            $this->setSerialize(['data']);
+        parent::initialize();
 
-            return;
+        if (!in_array($this->request->getMethod(), ['GET', 'POST'])) {
+            throw new MethodNotAllowedException();
         }
-        $data = $this->getRequest()->getData();
-        $asyncJob = $this->AsyncJobs->newEntity($data);
-        $this->AsyncJobs->save($asyncJob);
-        $this->set(compact('asyncJob'));
-        $this->setSerialize(['asyncJob']);
     }
 }

--- a/plugins/BEdita/API/src/Controller/HomeController.php
+++ b/plugins/BEdita/API/src/Controller/HomeController.php
@@ -47,6 +47,10 @@ class HomeController extends AppController
             'methods' => 'ALL',
             'multiple_types' => true,
         ],
+        '/async_jobs' => [
+            'methods' => ['GET', 'POST'],
+            'multiple_types' => false,
+        ],
         '/model' => [
             'methods' => 'ALL',
             'multiple_types' => true,

--- a/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
@@ -29,7 +29,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
      * Test index method on GET.
      *
      * @return void
-     * @coversNothing
+     * @covers ::initialize()
      */
     public function testIndex(): void
     {
@@ -269,7 +269,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
      * Test index method on POST.
      *
      * @return void
-     * @coversNothing
+     * @covers ::initialize()
      */
     public function testAdd(): void
     {

--- a/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
@@ -333,11 +333,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
     public function testDelete(): void
     {
         $this->configRequestHeaders('DELETE', $this->getUserAuthHeader());
-        $data = [
-            'id' => '6407afa6-96a3-4aeb-90c1-1541756efdef', // 'whatever
-            'type' => 'async_jobs',
-        ];
-        $this->delete('/async_jobs', json_encode(compact('data')));
+        $this->delete('/async_jobs');
         $actual = json_decode((string)$this->_response->getBody(), true);
         $expected = [
             'error' => [

--- a/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2023 Atlas Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
@@ -281,7 +281,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
         ];
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());
         $this->post('/async_jobs', json_encode(compact('data')));
-        $this->assertResponseCode(200);
+        $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
         $asyncJob = TableRegistry::getTableLocator()->get('AsyncJobs')
             ->find()

--- a/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\ORM\TableRegistry;
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
@@ -289,5 +290,68 @@ class AsyncJobsControllerTest extends IntegrationTestCase
             ->first();
         $expected = array_merge(['uuid' => $asyncJob->get('uuid')], $data['attributes']);
         static::assertArraySubset($expected, $asyncJob->toArray());
+    }
+
+    /**
+     * Test method not allowed exception on patch
+     *
+     * @return void
+     * @covers ::initialize()
+     */
+    public function testPatch(): void
+    {
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $data = [
+            'id' => '6407afa6-96a3-4aeb-90c1-1541756efdef', // 'whatever
+            'type' => 'async_jobs',
+            'attributes' => [
+                'service' => 'whatever',
+            ],
+        ];
+        $this->patch('/async_jobs', json_encode(compact('data')));
+        $actual = json_decode((string)$this->_response->getBody(), true);
+        $expected = [
+            'error' => [
+                'status' => '405',
+                'title' => 'Method Not Allowed',
+            ],
+            'links' => [
+                'self' => '/async_jobs',
+                'home' => '/home',
+            ],
+        ];
+        $this->assertSame($expected['error']['status'], $actual['error']['status']);
+        $this->assertSame($expected['error']['title'], $actual['error']['title']);
+        $this->assertSame($expected['links'], $actual['links']);
+    }
+
+    /**
+     * Test method not allowed exception on delete
+     *
+     * @return void
+     * @covers ::initialize()
+     */
+    public function testDelete(): void
+    {
+        $this->configRequestHeaders('DELETE', $this->getUserAuthHeader());
+        $data = [
+            'id' => '6407afa6-96a3-4aeb-90c1-1541756efdef', // 'whatever
+            'type' => 'async_jobs',
+        ];
+        $this->delete('/async_jobs', json_encode(compact('data')));
+        $actual = json_decode((string)$this->_response->getBody(), true);
+        $expected = [
+            'error' => [
+                'status' => '405',
+                'title' => 'Method Not Allowed',
+            ],
+            'links' => [
+                'self' => '/async_jobs',
+                'home' => '/home',
+            ],
+        ];
+        $this->assertSame($expected['error']['status'], $actual['error']['status']);
+        $this->assertSame($expected['error']['title'], $actual['error']['title']);
+        $this->assertSame($expected['links'], $actual['links']);
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
@@ -29,9 +29,9 @@ class AsyncJobsControllerTest extends IntegrationTestCase
      * Test index method on GET.
      *
      * @return void
-     * @covers ::index()
+     * @coversNothing
      */
-    public function testIndexGet(): void
+    public function testIndex(): void
     {
         $AsyncJobs = TableRegistry::getTableLocator()->get('AsyncJobs');
         $expected = [
@@ -269,9 +269,9 @@ class AsyncJobsControllerTest extends IntegrationTestCase
      * Test index method on POST.
      *
      * @return void
-     * @covers ::index()
+     * @coversNothing
      */
-    public function testIndexPost(): void
+    public function testAdd(): void
     {
         $data = [
             'type' => 'async_jobs',

--- a/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
@@ -1,0 +1,291 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Test\TestCase\Controller;
+
+use BEdita\API\TestSuite\IntegrationTestCase;
+use Cake\ORM\TableRegistry;
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+
+/**
+ * @coversDefaultClass \BEdita\API\Controller\AsyncJobsController
+ */
+class AsyncJobsControllerTest extends IntegrationTestCase
+{
+    use ArraySubsetAsserts;
+
+    /**
+     * Test index method on GET.
+     *
+     * @return void
+     * @covers ::index()
+     */
+    public function testIndexGet(): void
+    {
+        $AsyncJobs = TableRegistry::getTableLocator()->get('AsyncJobs');
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/async_jobs?sort=uuid',
+                'first' => 'http://api.example.com/async_jobs?sort=uuid',
+                'last' => 'http://api.example.com/async_jobs?sort=uuid',
+                'prev' => null,
+                'next' => null,
+                'home' => 'http://api.example.com/home',
+            ],
+            'meta' => [
+                'pagination' => [
+                    'count' => 8,
+                    'page' => 1,
+                    'page_count' => 1,
+                    'page_items' => 8,
+                    'page_size' => 20,
+                ],
+            ],
+            'data' => [
+                [
+                    'id' => '0c833458-dff1-4fbb-bbf6-a30818b60616',
+                    'type' => 'async_jobs',
+                    'attributes' => [
+                        'service' => 'example',
+                        'priority' => 1,
+                        'payload' => [
+                            'key' => 'value',
+                        ],
+                        'scheduled_from' => null,
+                        'expires' => '1992-08-17T19:29:31+00:00',
+                        'max_attempts' => 1,
+                        'results' => null,
+                    ],
+                    'meta' => [
+                        'locked_until' => null,
+                        'created' => '2017-04-28T19:29:31+00:00',
+                        'modified' => '2017-04-28T19:29:31+00:00',
+                        'completed' => null,
+                        'status' => 'failed',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/admin/async_jobs/0c833458-dff1-4fbb-bbf6-a30818b60616',
+                    ],
+                ],
+                [
+                    'id' => '1e2d1c66-c0bb-47d7-be5a-5bc92202333e',
+                    'type' => 'async_jobs',
+                    'attributes' => [
+                        'service' => 'example',
+                        'priority' => 1,
+                        'payload' => [
+                            'key' => 'value',
+                        ],
+                        'scheduled_from' => null,
+                        'expires' => null,
+                        'max_attempts' => 1,
+                        'results' => null,
+                    ],
+                    'meta' => [
+                        'locked_until' => null,
+                        'created' => '2017-04-28T19:29:31+00:00',
+                        'modified' => '2017-04-28T19:29:31+00:00',
+                        'completed' => '2017-04-28T19:29:31+00:00',
+                        'status' => 'completed',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/admin/async_jobs/1e2d1c66-c0bb-47d7-be5a-5bc92202333e',
+                    ],
+                ],
+                [
+                    'id' => '40e22034-213f-4028-9930-81c0ed79c5a6',
+                    'type' => 'async_jobs',
+                    'attributes' => [
+                        'service' => 'example',
+                        'priority' => 1,
+                        'payload' => [
+                            'key' => 'value',
+                        ],
+                        'scheduled_from' => null,
+                        'expires' => null,
+                        'max_attempts' => 0,
+                        'results' => null,
+                    ],
+                    'meta' => [
+                        'locked_until' => null,
+                        'created' => '2017-04-28T19:29:31+00:00',
+                        'modified' => '2017-04-28T19:29:31+00:00',
+                        'completed' => null,
+                        'status' => 'failed',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/admin/async_jobs/40e22034-213f-4028-9930-81c0ed79c5a6',
+                    ],
+                ],
+                [
+                    'id' => '427ece75-71fb-4aca-bfab-1214cd98495a',
+                    'type' => 'async_jobs',
+                    'attributes' => [
+                        'service' => 'signup',
+                        'priority' => 20,
+                        'payload' => [
+                            'user_id' => '99999',
+                        ],
+                        'scheduled_from' => null,
+                        'expires' => null,
+                        'max_attempts' => 1,
+                        'results' => null,
+                    ],
+                    'meta' => [
+                        'locked_until' => null,
+                        'created' => '2017-04-28T19:29:31+00:00',
+                        'modified' => '2017-04-28T19:29:31+00:00',
+                        'completed' => null,
+                        'status' => 'pending',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/admin/async_jobs/427ece75-71fb-4aca-bfab-1214cd98495a',
+                    ],
+                ],
+                [
+                    'id' => '6407afa6-96a3-4aeb-90c1-1541756efdef',
+                    'type' => 'async_jobs',
+                    'attributes' => [
+                        'service' => 'example',
+                        'priority' => 1,
+                        'payload' => [
+                            'key' => 'value',
+                        ],
+                        'scheduled_from' => null,
+                        'expires' => null,
+                        'max_attempts' => 1,
+                        'results' => null,
+                    ],
+                    'meta' => [
+                        'locked_until' => json_decode(json_encode($AsyncJobs->get('6407afa6-96a3-4aeb-90c1-1541756efdef')->get('locked_until')), true),
+                        'created' => '2017-04-28T19:29:31+00:00',
+                        'modified' => '2017-04-28T19:29:31+00:00',
+                        'completed' => null,
+                        'status' => 'locked',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/admin/async_jobs/6407afa6-96a3-4aeb-90c1-1541756efdef',
+                    ],
+                ],
+                [
+                    'id' => '66594f3c-995f-49d2-9192-382baf1a12b3',
+                    'type' => 'async_jobs',
+                    'attributes' => [
+                        'service' => 'example',
+                        'priority' => 1,
+                        'payload' => [
+                            'key' => 'value',
+                        ],
+                        'scheduled_from' => json_decode(json_encode($AsyncJobs->get('66594f3c-995f-49d2-9192-382baf1a12b3')->get('scheduled_from')), true),
+                        'expires' => null,
+                        'max_attempts' => 1,
+                        'results' => null,
+                    ],
+                    'meta' => [
+                        'locked_until' => null,
+                        'created' => '2017-04-28T19:29:31+00:00',
+                        'modified' => '2017-04-28T19:29:31+00:00',
+                        'completed' => null,
+                        'status' => 'planned',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/admin/async_jobs/66594f3c-995f-49d2-9192-382baf1a12b3',
+                    ],
+                ],
+                [
+                    'id' => 'd6bb8c84-6b29-432e-bb84-c3c4b2c1b99c',
+                    'type' => 'async_jobs',
+                    'attributes' => [
+                        'service' => 'example',
+                        'priority' => 1,
+                        'payload' => [
+                            'key' => 'value',
+                        ],
+                        'scheduled_from' => null,
+                        'expires' => null,
+                        'max_attempts' => 1,
+                        'results' => null,
+                    ],
+                    'meta' => [
+                        'locked_until' => null,
+                        'created' => '2017-04-28T19:29:31+00:00',
+                        'modified' => '2017-04-28T19:29:31+00:00',
+                        'completed' => null,
+                        'status' => 'pending',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/admin/async_jobs/d6bb8c84-6b29-432e-bb84-c3c4b2c1b99c',
+                    ],
+                ],
+                [
+                    'id' => 'e533e1cf-b12c-4dbe-8fb7-b25fafbd2f76',
+                    'type' => 'async_jobs',
+                    'attributes' => [
+                        'service' => 'example2',
+                        'priority' => 10,
+                        'payload' => [
+                            'key' => 'value',
+                        ],
+                        'scheduled_from' => null,
+                        'expires' => null,
+                        'max_attempts' => 1,
+                        'results' => null,
+                    ],
+                    'meta' => [
+                        'locked_until' => null,
+                        'created' => '2017-04-28T19:29:31+00:00',
+                        'modified' => '2017-04-28T19:29:31+00:00',
+                        'completed' => null,
+                        'status' => 'pending',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/admin/async_jobs/e533e1cf-b12c-4dbe-8fb7-b25fafbd2f76',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->configRequestHeaders();
+        $this->get('/async_jobs?sort=uuid');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test index method on POST.
+     *
+     * @return void
+     * @covers ::index()
+     */
+    public function testIndexPost(): void
+    {
+        $data = [
+            'type' => 'async_jobs',
+            'attributes' => [
+                'service' => 'whatever',
+            ],
+        ];
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $this->post('/async_jobs', json_encode(compact('data')));
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        $asyncJob = TableRegistry::getTableLocator()->get('AsyncJobs')
+            ->find()
+            ->order(['created' => 'DESC'])
+            ->first();
+        $expected = array_merge(['uuid' => $asyncJob->get('uuid')], $data['attributes']);
+        static::assertArraySubset($expected, $asyncJob->toArray());
+    }
+}

--- a/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 /**
  * BEdita, API-first content management framework
- * Copyright 2023 Atlas Srl, Chialab Srl
+ * Copyright 2023 Channelweb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
-use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\ORM\TableRegistry;
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
@@ -334,6 +334,23 @@ class HomeControllerTest extends IntegrationTestCase
                             'multiple_types' => false,
                         ],
                     ],
+                    '/async_jobs' => [
+                        'href' => 'http://api.example.com/async_jobs',
+                        'hints' => [
+                            'allow' => [
+                                'GET', 'POST',
+                            ],
+                            'formats' => [
+                                'application/json',
+                                'application/vnd.api+json',
+                            ],
+                            'display' => [
+                                'label' => 'AsyncJobs',
+                            ],
+                            'object_type' => false,
+                            'multiple_types' => false,
+                        ],
+                    ],
                 ],
                 'project' => $project,
                 'version' => $version,

--- a/plugins/BEdita/Core/config/Migrations/20230519093954_AsyncJobsEndpointAdminOnly.php
+++ b/plugins/BEdita/Core/config/Migrations/20230519093954_AsyncJobsEndpointAdminOnly.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+use BEdita\Core\Model\Table\RolesTable;
+use Migrations\AbstractMigration;
+
+class AsyncJobsEndpointAdminOnly extends AbstractMigration
+{
+    /**
+     * @inheritDoc
+     */
+    public function up(): void
+    {
+        $this->table('endpoints')
+            ->insert([
+                [
+                    'name' => 'async_jobs',
+                    'description' => 'Async jobs endpoint',
+                    'created' => '2023-05-19 12:06:03',
+                    'modified' => '2023-05-19 12:06:03',
+                ],
+            ])
+            ->save();
+        $endpointId = (int)$this->getQueryBuilder()
+            ->select(['id'])
+            ->from(['endpoints'])
+            ->where(['name' => 'async_jobs'])
+            ->execute()
+            ->fetch()[0];
+        $this->table('endpoint_permissions')
+            ->insert([
+                [
+                    'endpoint_id' => $endpointId,
+                    'role_id' => RolesTable::ADMIN_ROLE,
+                    'application_id' => null,
+                    'permission' => 15, // 1111
+                ],
+            ])
+            ->save();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function down(): void
+    {
+        $endpointId = (int)$this->getQueryBuilder()
+            ->select(['id'])
+            ->from(['endpoints'])
+            ->where(['name' => 'async_jobs'])
+            ->execute()
+            ->fetch()[0];
+        $endpointPermissionId = (int)$this->getQueryBuilder()
+            ->select(['id'])
+            ->from(['endpoint_permissions'])
+            ->where([
+                'endpoint_id' => $endpointId,
+                'role_id' => RolesTable::ADMIN_ROLE,
+                'application_id IS NULL',
+                'permission' => 15,
+            ])
+            ->execute()
+            ->fetch()[0];
+        $this->getQueryBuilder()
+            ->delete('endpoint_permissions')
+            ->where(['id' => $endpointPermissionId])
+            ->execute();
+        $this->getQueryBuilder()
+            ->delete('endpoints')
+            ->where(['id' => $endpointId])
+            ->execute();
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Command/TreeCheckCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/TreeCheckCommandTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2022 Atlas Srl, Chialab Srl
+ * Copyright 2022 Channelweb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published

--- a/plugins/BEdita/Core/tests/TestCase/Command/TreeRecoverCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/TreeRecoverCommandTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * BEdita, API-first content management framework
- * Copyright 2022 Atlas Srl, Chialab Srl
+ * Copyright 2022 Channelweb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published


### PR DESCRIPTION
This PR provides a new `/async_jobs` endpoint for `GET` and `POST`.

This endpoint will be available for "non admin" users.
Admins can use `/admin/async_jobs` for `GET`, `PATCH`, `POST`, `DELETE`.