### PR TITLE
Authorize object locked by folder

### DIFF
--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -13,7 +13,6 @@
 namespace BEdita\API\Controller;
 
 use BEdita\API\Model\Action\UpdateRelatedAction;
-use BEdita\Core\Exception\LockedResourceException;
 use BEdita\Core\Model\Action\ActionTrait;
 use BEdita\Core\Model\Action\AddRelatedObjectsAction;
 use BEdita\Core\Model\Action\DeleteObjectAction;
@@ -335,7 +334,7 @@ class ObjectsController extends ResourcesController
                 }
 
                 if ($entity->get($field) !== Hash::get($data, $field)) {
-                    throw new LockedResourceException(
+                    throw new ForbiddenException(
                         __d(
                             'bedita',
                             'Cannot change "{0}" field since object {1} is locked by parent',

--- a/plugins/BEdita/API/src/Policy/ObjectPolicy.php
+++ b/plugins/BEdita/API/src/Policy/ObjectPolicy.php
@@ -87,6 +87,7 @@ class ObjectPolicy implements BeforePolicyInterface
 
         $parents = $this->fetchTable('Folders')
             ->find('available')
+            ->contain(['Permissions.Roles'])
             ->innerJoinWith('Children', function (Query $q) use ($object) {
                 return $q->where(['Children.id' => $object->id]);
             })

--- a/plugins/BEdita/API/src/Policy/ObjectPolicy.php
+++ b/plugins/BEdita/API/src/Policy/ObjectPolicy.php
@@ -88,9 +88,7 @@ class ObjectPolicy implements BeforePolicyInterface
         $parents = $this->fetchTable('Folders')
             ->find('available')
             ->contain(['Permissions.Roles'])
-            ->innerJoinWith('Children', function (Query $q) use ($object) {
-                return $q->where(['Children.id' => $object->id]);
-            })
+            ->innerJoinWith('Children', fn (Query $q) => $q->where(['Children.id' => $object->id]))
             ->toArray();
 
         foreach ($parents as $parent) {

--- a/plugins/BEdita/API/src/Policy/ObjectPolicy.php
+++ b/plugins/BEdita/API/src/Policy/ObjectPolicy.php
@@ -16,9 +16,11 @@ namespace BEdita\API\Policy;
 
 use Authorization\IdentityInterface;
 use Authorization\Policy\BeforePolicyInterface;
+use BEdita\Core\Model\Entity\Folder;
 use BEdita\Core\Model\Entity\ObjectEntity;
 use BEdita\Core\Model\Table\RolesTable;
 use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\ORM\Query;
 use Cake\Utility\Hash;
 
 /**
@@ -62,6 +64,41 @@ class ObjectPolicy implements BeforePolicyInterface
         }
 
         return !empty(array_intersect($permsRoles, $this->extractRolesNames($identity)));
+    }
+
+    /**
+     * Check if $identity can update parents of $object.
+     *
+     * @param \Authorization\IdentityInterface $identity The identity.
+     * @param \BEdita\Core\Model\Entity\ObjectEntity $object The object entity
+     * @return bool
+     */
+    public function canUpdateParents(IdentityInterface $identity, ObjectEntity $object): bool
+    {
+        /** @var \BEdita\Core\Model\Entity\ObjectType $folderObjectType */
+        $folderObjectType = $this->fetchTable('ObjectTypes')->get('folders');
+        if (!$folderObjectType->hasAssoc('Permissions')) {
+            return true;
+        }
+
+        if ($object instanceof Folder) {
+            return $this->canUpdate($identity, $object);
+        }
+
+        $parents = $this->fetchTable('Folders')
+            ->find('available')
+            ->innerJoinWith('Children', function (Query $q) use ($object) {
+                return $q->where(['Children.id' => $object->id]);
+            })
+            ->toArray();
+
+        foreach ($parents as $parent) {
+            if (!$this->canUpdate($identity, $parent)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -766,6 +766,7 @@ class ObjectsControllerTest extends IntegrationTestCase
      * @covers ::initialize()
      * @covers ::addCount()
      * @covers ::prepareInclude()
+     * @covers ::authorizeResource()
      */
     public function testSingle()
     {
@@ -865,6 +866,7 @@ class ObjectsControllerTest extends IntegrationTestCase
      * @return void
      * @covers ::resource()
      * @covers ::initialize()
+     * @covers ::authorizeResource()
      */
     public function testDeleted()
     {
@@ -966,6 +968,7 @@ class ObjectsControllerTest extends IntegrationTestCase
      * @return void
      * @covers ::resource()
      * @covers ::initialize()
+     * @covers ::authorizeResource()
      */
     public function testMissing()
     {

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -1315,7 +1315,7 @@ class ObjectsControllerTest extends IntegrationTestCase
                     ],
                 ],
             ],
-            'ok uname unchanged' => [
+            'ok status unchanged' => [
                 200,
                 [
                     'id' => '2',


### PR DESCRIPTION
This PR adds authorization check to see if resource is locked by folder i.e. if exists at least a parent of resource entity forbidden for authenticated user.

In this case:
* the resource can't be deleted
* the resource can be modified but `status` and `uname` fields
* the resource can't be removed from protected folder