### PR TITLE
Use server time when filtering published objects (4-🌵)

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/PublishStartEndTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/PublishStartEndTest.php
@@ -81,29 +81,29 @@ class PublishStartEndTest extends IntegrationTestCase
                 404,
                 true,
                 [
-                    'publish_start' => FrozenTime::parse(time() + DAY),
+                    'publish_start' => FrozenTime::now()->addDay(),
                 ],
             ],
             'no conf' => [
                 200,
                 false,
                 [
-                    'publish_start' => FrozenTime::parse(time() + DAY),
+                    'publish_start' => FrozenTime::now()->addDay(),
                 ],
             ],
             'ended' => [
                 404,
                 true,
                 [
-                    'publish_end' => FrozenTime::parse(time() - DAY),
+                    'publish_end' => FrozenTime::now()->subDay(),
                 ],
             ],
             'started' => [
                 200,
                 true,
                 [
-                    'publish_start' => FrozenTime::parse(time() - DAY),
-                    'publish_end' => FrozenTime::parse(time() + DAY),
+                    'publish_start' => FrozenTime::now()->subDay(),
+                    'publish_end' => FrozenTime::now()->addDay(),
                 ],
             ],
         ];

--- a/plugins/BEdita/Core/src/Model/Table/AsyncJobsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/AsyncJobsTable.php
@@ -176,7 +176,7 @@ class AsyncJobsTable extends Table
      */
     protected function findPending(Query $query)
     {
-        $now = $query->func()->now();
+        $now = FrozenTime::now();
 
         return $query
             ->where(function (QueryExpression $exp) use ($now) {
@@ -222,7 +222,7 @@ class AsyncJobsTable extends Table
      */
     protected function findFailed(Query $query)
     {
-        $now = $query->func()->now();
+        $now = FrozenTime::now();
 
         return $query->where(function (QueryExpression $exp) use ($now) {
             return $exp->and([

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -22,6 +22,7 @@ use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
+use Cake\I18n\FrozenTime;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
@@ -488,7 +489,7 @@ class ObjectsTable extends Table
      */
     protected function findPublishDateAllowed(Query $query): Query
     {
-        $now = $query->func()->now();
+        $now = FrozenTime::now();
 
         return $query->where(function (QueryExpression $exp) use ($now) {
             return $exp->and([

--- a/plugins/BEdita/Core/src/Model/Table/UserTokensTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UserTokensTable.php
@@ -15,6 +15,7 @@ namespace BEdita\Core\Model\Table;
 
 use Cake\Core\Configure;
 use Cake\Database\Expression\QueryExpression;
+use Cake\I18n\FrozenTime;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
@@ -147,7 +148,7 @@ class UserTokensTable extends Table
      */
     protected function findValid(Query $query)
     {
-        $now = $query->func()->now();
+        $now = FrozenTime::now();
 
         return $query
             ->where(function (QueryExpression $exp) use ($now) {


### PR DESCRIPTION
This PR replicates #2015 for branch `4-cactus`.

-----

This PR fixes an issue where database rows were filtered using database time rather than application time.

This caused inconsistent results when publishing or validity dates were set considering a different timezone than the one of the SQL server. This should be totally allowed and dealt with using a consistent date/time source.