### PR TITLE
Add methods to expand and compact priorities list

### DIFF
--- a/plugins/BEdita/Core/src/Model/Behavior/PriorityBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/PriorityBehavior.php
@@ -90,7 +90,7 @@ class PriorityBehavior extends Behavior
     /**
      * Compact entity field.
      *
-     * @param EntityInterface $entity The entity
+     * @param \Cake\Datasource\EntityInterface $entity The entity
      * @param string $field The field
      * @param array $config The config
      * @return bool
@@ -111,7 +111,7 @@ class PriorityBehavior extends Behavior
      * Update entity priorities.
      * Return true if data is updated, false otherwise.
      *
-     * @param EntityInterface $entity The entity
+     * @param \Cake\Datasource\EntityInterface $entity The entity
      * @param string $field The field
      * @param array $config the config
      * @return bool

--- a/plugins/BEdita/Core/src/Model/Behavior/PriorityBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/PriorityBehavior.php
@@ -15,6 +15,7 @@ namespace BEdita\Core\Model\Behavior;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\ORM\Behavior;
+use Cake\ORM\Entity;
 use Cake\Utility\Hash;
 
 /**
@@ -57,6 +58,7 @@ class PriorityBehavior extends Behavior
      * Set up priorities before an entity is saved.
      * Use current max value + 1 if not set.
      * New values will start at 1.
+     * Other priorities are shifted on priority change.
      *
      * @param \Cake\Event\EventInterface $event Dispatched event.
      * @param \Cake\Datasource\EntityInterface $entity Entity instance.
@@ -65,51 +67,156 @@ class PriorityBehavior extends Behavior
     public function beforeSave(EventInterface $event, EntityInterface $entity)
     {
         $fields = $this->getConfig('fields');
-
         foreach ($fields as $field => $config) {
-            if (!empty($entity->get($field)) || empty($config['scope'])) {
-                continue;
-            }
-
-            $maxValue = $this->maxValue($entity, $field, (array)$config['scope']);
-            $entity->set($field, $maxValue + 1);
+            $this->updateEntityPriorities($entity, $field, $config);
         }
     }
 
     /**
-     * Get current max priority on an object relation
+     * Compact other priorities before the entity is deleted.
      *
-     * @param \Cake\Datasource\EntityInterface $entity Entity being saved
-     * @param string $field Priority field name.
-     * @param array $scope Priority scope.
-     * @return int
+     * @param \Cake\Event\EventInterface $event Dispatched event.
+     * @param \Cake\Datasource\EntityInterface $entity Entity instance.
+     * @return void
      */
-    protected function maxValue(EntityInterface $entity, string $field, array $scope): int
+    public function beforeDelete(EventInterface $event, EntityInterface $entity)
+    {
+        $fields = $this->getConfig('fields');
+        foreach ($fields as $field => $config) {
+            $this->compactEntityField($entity, $field, $config);
+        }
+    }
+
+    /**
+     * Compact entity field.
+     *
+     * @param EntityInterface $entity The entity
+     * @param string $field The field
+     * @param array $config The config
+     * @return bool
+     */
+    public function compactEntityField(EntityInterface $entity, string $field, array $config): bool
+    {
+        if (empty($entity->get($field)) || empty($config['scope'])) {
+            return false;
+        }
+
+        $conditions = $this->_getConditions($entity, $config['scope']);
+        $this->compact($field, $entity->get($field), null, $conditions);
+
+        return true;
+    }
+
+    /**
+     * Update entity priorities.
+     * Return true if data is updated, false otherwise.
+     *
+     * @param EntityInterface $entity The entity
+     * @param string $field The field
+     * @param array $config the config
+     * @return bool
+     */
+    public function updateEntityPriorities(EntityInterface $entity, string $field, array $config): bool
+    {
+        if (empty($config['scope'])) {
+            return false;
+        }
+
+        $conditions = $this->_getConditions($entity, $config['scope']);
+        if (!empty($entity->get($field)) && $entity instanceof Entity) {
+            $actualValue = $entity->get($field);
+            $previousValue = $entity->getOriginal($field);
+            if ($previousValue === $actualValue) {
+                return false;
+            }
+
+            if ($previousValue < $actualValue) {
+                $this->compact($field, $previousValue, $actualValue, $conditions);
+
+                return true;
+            }
+            // $previousValue > $actualValue
+            $this->expand($field, $actualValue, $previousValue, $conditions);
+
+            return true;
+        }
+
+        $maxValue = $this->maxValue($field, $conditions);
+        $entity->set($field, $maxValue + 1);
+
+        return true;
+    }
+
+    /**
+     * Get scope conditions from entity.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity Entity instance.
+     * @param string[] $scope A list of scope fields.
+     * @return array A list of conditions.
+     */
+    protected function _getConditions(EntityInterface $entity, array $scope): array
     {
         $conditions = [];
         foreach ($scope as $item) {
             $keyField = sprintf('%s IS', $this->table()->aliasField($item));
             $conditions[$keyField] = $entity->get($item);
         }
+
+        return $conditions;
+    }
+
+    /**
+     * Create a gap in the priority list where an item can be inserted or moved.
+     *
+     * @param string $field Field name.
+     * @param int $from The initial priority value to update.
+     * @param int|null $to The final priority value to update.
+     * @param array $conditions A list of scope conditions.
+     * @return void
+     */
+    protected function expand(string $field, int $from, ?int $to = null, array $conditions = []): void
+    {
+        $conditions = $conditions + ["{$field} >=" => $from];
+        if ($to !== null) {
+            $conditions["{$field} <"] = $to;
+        }
+
+        $this->table()->updateAll([sprintf('%s = %1$s + 1', $field)], $conditions);
+    }
+
+    /**
+     * Compact priority values.
+     *
+     * @param string $field Field name.
+     * @param int $from The initial priority value to update.
+     * @param int|null $to The final priority value to update.
+     * @param array $conditions A list of scope conditions.
+     * @return void
+     */
+    protected function compact(string $field, int $from, ?int $to = null, array $conditions = []): void
+    {
+        $conditions = $conditions + ["{$field} >" => $from];
+        if ($to !== null) {
+            $conditions["{$field} <="] = $to;
+        }
+
+        $this->table()->updateAll([sprintf('%s = %1$s - 1', $field)], $conditions);
+    }
+
+    /**
+     * Get current max priority on an object relation
+     *
+     * @param string $field Priority field name.
+     * @param array $conditions Scope conditions.
+     * @return int
+     */
+    protected function maxValue(string $field, array $conditions): int
+    {
         $query = $this->table()->find()->where($conditions);
         $query->select([
             'max_value' => $query->func()->max($this->table()->aliasField($field)),
         ]);
 
         return (int)Hash::get($query->toArray(), '0.max_value');
-    }
-
-    /**
-     * Compact other priorities before the entity is deleted.
-     *
-     * @todo Implement this method.
-     * @param \Cake\Event\EventInterface $event Dispatched event.
-     * @param \Cake\Datasource\EntityInterface $entity Entity instance.
-     * @return void
-     * @codeCoverageIgnore
-     */
-    public function beforeDelete(EventInterface $event, EntityInterface $entity)
-    {
-        return;
     }
 }

--- a/plugins/BEdita/Core/tests/Fixture/ObjectRelationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ObjectRelationsFixture.php
@@ -57,5 +57,13 @@ class ObjectRelationsFixture extends TestFixture
             'inv_priority' => 1,
             'params' => null,
         ],
+        [
+            'left_id' => 2,
+            'relation_id' => 1,
+            'right_id' => 7,
+            'priority' => 3,
+            'inv_priority' => 1,
+            'params' => null,
+        ],
     ];
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/CountRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/CountRelatedObjectsActionTest.php
@@ -174,7 +174,7 @@ class CountRelatedObjectsActionTest extends TestCase
                         'id' => 7,
                         'count' => [
                             'test' => 0,
-                            'inverse_test' => 0,
+                            'inverse_test' => 1,
                         ],
                     ],
                     [
@@ -215,7 +215,7 @@ class CountRelatedObjectsActionTest extends TestCase
                         'id' => 7,
                         'count' => [
                             'test' => 0,
-                            'inverse_test' => 0,
+                            'inverse_test' => 1,
                         ],
                     ],
                     [
@@ -321,7 +321,7 @@ class CountRelatedObjectsActionTest extends TestCase
                         'id' => 7,
                         'count' => [
                             'test' => 0,
-                            'inverse_test' => 0,
+                            'inverse_test' => 1,
                             'another_test' => 0,
                             'inverse_another_test' => 0,
                             'test_abstract' => 0,


### PR DESCRIPTION
This PR introduces `expand` and `compact` methods to the `PriorityBehavior`. They are used to shift relation's priorities when an item is moved or deleted.

* [x] Implementation
* [x] Add tests