### PR TITLE
New `additionalHeaders` configuration for OAuth2 API requests

### DIFF
--- a/plugins/BEdita/Core/src/Utility/OAuth2.php
+++ b/plugins/BEdita/Core/src/Utility/OAuth2.php
@@ -36,6 +36,8 @@ class OAuth2
         'header' => 'Authorization',
         'headerPrefix' => 'Bearer',
         'queryParam' => 'access_token',
+        // Additional headers required by OAuth2 provider
+        'additionalHeaders' => [],
         // mode can be 'header' (default) or 'query'
         'mode' => 'header',
     ];
@@ -53,7 +55,7 @@ class OAuth2
         $this->setConfig($options);
         $client = new Client((array)$this->getConfig('client'));
         $query = $this->getQuery($accessToken);
-        $headers = $this->getHeaders($accessToken);
+        $headers = $this->getHeaders($accessToken) + (array)$this->getConfig('additionalHeaders');
         $response = $client->get($url, $query, compact('headers'));
 
         return (array)$response->getJson();


### PR DESCRIPTION
This PR introduces a configurable set of `additionalHeaders` to be used in OAuth2 API requests.
