### PR TITLE
Use search adapters in SearchableBehavior

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -485,4 +485,19 @@ return [
             ],
         ],
     ],
+
+    /**
+     * Search configuration.
+     *
+     * - `use`: the search adapter to use on search
+     * - `adapters`: configured search adapters
+     */
+    'Search' => [
+        'use' => 'default',
+        'adapters' => [
+            'default' => [
+                'className' => 'BEdita/Core.Simple',
+            ],
+        ],
+    ],
 ];

--- a/config/app.php
+++ b/config/app.php
@@ -489,7 +489,7 @@ return [
     /**
      * Search configuration.
      *
-     * - `use`: the search adapter to use on search
+     * - `use`: the search adapter to use in the search
      * - `adapters`: configured search adapters
      */
     'Search' => [

--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -13,6 +13,8 @@
 namespace BEdita\API\Test\IntegrationTest;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use Cake\Database\Driver\Postgres;
+use Cake\Datasource\ConnectionManager;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 
@@ -268,6 +270,7 @@ class FilterQueryStringTest extends IntegrationTestCase
                 [
                     '8',
                 ],
+                true,
             ],
             'users' => [
                 '/users?filter[query]=second',
@@ -373,11 +376,16 @@ class FilterQueryStringTest extends IntegrationTestCase
      * @return void
      * @param string $url Url string.
      * @param array $expected Expected result.
+     * @param bool $caseInsensitive Whether test case relies on case-insensitive comparison.
      * @dataProvider searchFilterProvider
      * @coversNothing
      */
-    public function testSearchFilter($url, $expected)
+    public function testSearchFilter($url, $expected, bool $caseInsensitive = false)
     {
+        if ($caseInsensitive && ConnectionManager::get('default')->getDriver() instanceof Postgres) {
+            static::markTestSkipped('Case-insensitive test cases are skipped on Postgres');
+        }
+
         $this->configRequestHeaders();
         $this->get($url);
         $result = json_decode((string)$this->_response->getBody(), true);

--- a/plugins/BEdita/Core/src/Model/Behavior/ObjectModelBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/ObjectModelBehavior.php
@@ -17,6 +17,7 @@ use BEdita\Core\Model\Action\AddRelatedObjectsAction;
 use BEdita\Core\Model\Action\RemoveRelatedObjectsAction;
 use BEdita\Core\Model\Action\SetRelatedObjectsAction;
 use BEdita\Core\Model\Entity\ObjectEntity;
+use BEdita\Core\Search\SimpleSearchTrait;
 use Cake\ORM\Behavior;
 
 /**
@@ -27,9 +28,9 @@ use Cake\ORM\Behavior;
 class ObjectModelBehavior extends Behavior
 {
     /**
-     * Add behaviors common to all tables implementing an object type model
-     *
      * {@inheritDoc}
+     *
+     * Add behaviors common to all tables implementing an object type model
      */
     public function initialize(array $config): void
     {
@@ -43,14 +44,10 @@ class ObjectModelBehavior extends Behavior
         $table->addBehavior('BEdita/Core.CustomProperties');
         $table->addBehavior('BEdita/Core.UniqueName');
         $table->addBehavior('BEdita/Core.Relations');
-        $table->addBehavior('BEdita/Core.Searchable', [
-            'fields' => [
-                'title' => 10,
-                'description' => 7,
-                'body' => 5,
-            ],
-        ]);
+        $table->addBehavior('BEdita/Core.Searchable');
         $table->addBehavior('BEdita/Core.Status');
+
+        $table->setupSimpleSearch(['fields' => ['title', 'description', 'body']]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Behavior/ObjectModelBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/ObjectModelBehavior.php
@@ -17,6 +17,7 @@ use BEdita\Core\Model\Action\AddRelatedObjectsAction;
 use BEdita\Core\Model\Action\RemoveRelatedObjectsAction;
 use BEdita\Core\Model\Action\SetRelatedObjectsAction;
 use BEdita\Core\Model\Entity\ObjectEntity;
+use BEdita\Core\Search\SimpleSearchTrait;
 use Cake\ORM\Behavior;
 
 /**
@@ -26,6 +27,8 @@ use Cake\ORM\Behavior;
  */
 class ObjectModelBehavior extends Behavior
 {
+    use SimpleSearchTrait;
+
     /**
      * {@inheritDoc}
      *
@@ -46,7 +49,7 @@ class ObjectModelBehavior extends Behavior
         $table->addBehavior('BEdita/Core.Searchable');
         $table->addBehavior('BEdita/Core.Status');
 
-        $table->setupSimpleSearch(['fields' => ['title', 'description', 'body']]);
+        $this->setupSimpleSearch(['fields' => ['title', 'description', 'body']], $table);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Behavior/ObjectModelBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/ObjectModelBehavior.php
@@ -17,7 +17,6 @@ use BEdita\Core\Model\Action\AddRelatedObjectsAction;
 use BEdita\Core\Model\Action\RemoveRelatedObjectsAction;
 use BEdita\Core\Model\Action\SetRelatedObjectsAction;
 use BEdita\Core\Model\Entity\ObjectEntity;
-use BEdita\Core\Search\SimpleSearchTrait;
 use Cake\ORM\Behavior;
 
 /**

--- a/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
@@ -118,7 +118,7 @@ class SearchableBehavior extends Behavior
      */
     protected function getAdapter(?string $name = null): BaseAdapter
     {
-        $name ??= 'default';
+        $name ??= (string)Configure::read('Search.use', 'default');
         $searchRegistry = $this->getSearchRegistry();
         if ($searchRegistry->has($name)) {
             return $searchRegistry->get($name);
@@ -159,8 +159,7 @@ class SearchableBehavior extends Behavior
 
         unset($options[0], $options['string']);
 
-        return $this->getAdapter(Configure::read('Search.use'))
-            ->search($query, $text, $options);
+        return $this->getAdapter()->search($query, $text, $options);
     }
 
     /**
@@ -187,7 +186,7 @@ class SearchableBehavior extends Behavior
             // `fields` key in SimpleAdapter is changed.
             // It is now a list of fields without unused priority.
             if ($key === 'fields') {
-                deprecationWarning('"fields" must be a list of fields. Unused priorities have been removed.');
+                deprecationWarning('"fields" must be a list of strings. Unused priorities have been removed.');
                 $conf = array_keys($conf);
             }
 

--- a/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
@@ -176,7 +176,7 @@ class SearchableBehavior extends Behavior
                 $conf = array_keys($conf);
             }
 
-            $this->setConfig($key, $conf, false);
+            $adapter->setConfig($key, $conf, false);
         }
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/AnnotationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/AnnotationsTable.php
@@ -13,6 +13,7 @@
 
 namespace BEdita\Core\Model\Table;
 
+use BEdita\Core\Search\SimpleSearchTrait;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Datasource\EntityInterface;
@@ -39,6 +40,8 @@ use Cake\Validation\Validator;
  */
 class AnnotationsTable extends Table
 {
+    use SimpleSearchTrait;
+
     /**
      * @inheritDoc
      */
@@ -58,11 +61,7 @@ class AnnotationsTable extends Table
                 ],
             ],
         ]);
-        $this->addBehavior('BEdita/Core.Searchable', [
-            'fields' => [
-                'description' => 10,
-            ],
-        ]);
+        $this->addBehavior('BEdita/Core.Searchable');
 
         $this->belongsTo('Objects', [
             'foreignKey' => 'object_id',
@@ -74,6 +73,8 @@ class AnnotationsTable extends Table
             'joinType' => 'INNER',
             'className' => 'BEdita/Core.Users',
         ]);
+
+        $this->setupSimpleSearch(['fields' => ['description']]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Exception\ImmutableResourceException;
+use BEdita\Core\Search\SimpleSearchTrait;
 use BEdita\Core\State\CurrentApplication;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
@@ -43,6 +44,8 @@ use Cake\Validation\Validator;
  */
 class ApplicationsTable extends Table
 {
+    use SimpleSearchTrait;
+
     /**
      * Default application id
      *
@@ -61,18 +64,15 @@ class ApplicationsTable extends Table
 
         $this->setDisplayField('name');
         $this->addBehavior('Timestamp');
-        $this->addBehavior('BEdita/Core.Searchable', [
-            'fields' => [
-                'name' => 10,
-                'description' => 5,
-            ],
-        ]);
+        $this->addBehavior('BEdita/Core.Searchable');
         $this->addBehavior('BEdita/Core.QueryCache');
         $this->addBehavior('BEdita/Core.ResourceName');
 
         $this->hasMany('EndpointPermissions', [
             'dependent' => true,
         ]);
+
+        $this->setupSimpleSearch(['fields' => ['name', 'description']]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
@@ -16,6 +16,7 @@ namespace BEdita\Core\Model\Table;
 use ArrayObject;
 use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Model\Validation\Validation;
+use BEdita\Core\Search\SimpleSearchTrait;
 use Cake\Collection\CollectionInterface;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
@@ -46,6 +47,8 @@ use Cake\Validation\Validator;
  */
 class CategoriesTable extends Table
 {
+    use SimpleSearchTrait;
+
     /**
      * Initialize method
      *
@@ -62,12 +65,7 @@ class CategoriesTable extends Table
         $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
-        $this->addBehavior('BEdita/Core.Searchable', [
-            'fields' => [
-                'label' => 10,
-                'name' => 8,
-            ],
-        ]);
+        $this->addBehavior('BEdita/Core.Searchable');
         $this->addBehavior('Tree', [
             'left' => 'tree_left',
             'right' => 'tree_right',
@@ -95,6 +93,8 @@ class CategoriesTable extends Table
             'targetForeignKey' => 'object_id',
             'through' => 'BEdita/Core.ObjectCategories',
         ]);
+
+        $this->setupSimpleSearch(['fields' => ['label', 'name']]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
@@ -50,18 +50,18 @@ class LocationsTable extends Table
 
         $this->extensionOf('Objects');
 
-        $this->getBehavior('Searchable')->setConfig([
+        $this->addBehavior('BEdita/Core.Geometry');
+
+        $this->setupSimpleSearch([
             'fields' => [
-                'title' => 10,
-                'description' => 7,
-                'body' => 5,
-                'address' => 1,
-                'locality' => 2,
-                'country_name' => 2,
-                'region' => 2,
+                'title',
+                'description',
+                'body',
+                'address',
+                'locality',
+                'country_name',
+                'region',
             ],
         ]);
-
-        $this->addBehavior('BEdita/Core.Geometry');
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/MediaTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/MediaTable.php
@@ -44,19 +44,19 @@ class MediaTable extends Table
             'prefix' => 'media-',
         ]);
 
-        $this->getBehavior('Searchable')->setConfig([
-            'fields' => [
-                'title' => 10,
-                'description' => 7,
-                'body' => 5,
-                'provider' => 5,
-                'name' => 8,
-            ],
-        ]);
-
         $this->hasMany('Streams', [
             'foreignKey' => 'object_id',
             'className' => 'BEdita/Core.Streams',
+        ]);
+
+        $this->setupSimpleSearch([
+            'fields' => [
+                'title',
+                'description',
+                'body',
+                'provider',
+                'name',
+            ],
         ]);
     }
 

--- a/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
@@ -16,6 +16,7 @@ namespace BEdita\Core\Model\Table;
 use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Model\Validation\ObjectTypesValidator;
 use BEdita\Core\ORM\Rule\IsUniqueAmongst;
+use BEdita\Core\Search\SimpleSearchTrait;
 use Cake\Cache\Cache;
 use Cake\Core\App;
 use Cake\Database\Expression\ComparisonExpression;
@@ -50,6 +51,8 @@ use Cake\Utility\Inflector;
  */
 class ObjectTypesTable extends Table
 {
+    use SimpleSearchTrait;
+
     /**
      * Cache config name for object types.
      *
@@ -138,13 +141,9 @@ class ObjectTypesTable extends Table
             'left' => 'tree_left',
             'right' => 'tree_right',
         ]);
-        $this->addBehavior('BEdita/Core.Searchable', [
-            'fields' => [
-                'name' => 10,
-                'singular' => 10,
-                'description' => 5,
-            ],
-        ]);
+        $this->addBehavior('BEdita/Core.Searchable');
+
+        $this->setupSimpleSearch(['fields' => ['name', 'singular', 'description']]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsBaseTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsBaseTable.php
@@ -13,6 +13,7 @@
 namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\ORM\Inheritance\Table;
+use BEdita\Core\Search\SimpleSearchTrait;
 
 /**
  * Base Table class for every Table implementing a BEdita Object
@@ -22,6 +23,8 @@ use BEdita\Core\ORM\Inheritance\Table;
  */
 abstract class ObjectsBaseTable extends Table
 {
+    use SimpleSearchTrait;
+
     /**
      * {@inheritDoc}
      *

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -16,6 +16,7 @@ namespace BEdita\Core\Model\Table;
 use BEdita\Core\Exception\LockedResourceException;
 use BEdita\Core\Model\Entity\ObjectEntity;
 use BEdita\Core\Model\Validation\ObjectsValidator;
+use BEdita\Core\Search\SimpleSearchTrait;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Core\Configure;
 use Cake\Database\Expression\QueryExpression;
@@ -55,6 +56,8 @@ use Cake\Utility\Hash;
  */
 class ObjectsTable extends Table
 {
+    use SimpleSearchTrait;
+
     /**
      * @inheritDoc
      */

--- a/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
@@ -58,20 +58,20 @@ class ProfilesTable extends Table
             'prefix' => 'profile-',
         ]);
 
-        $this->getBehavior('Searchable')->setConfig([
+        $this->setupSimpleSearch([
             'fields' => [
-                'title' => 10,
-                'description' => 7,
-                'body' => 5,
-                'name' => 10,
-                'surname' => 10,
-                'email' => 7,
-                'company_name' => 10,
-                'street_address' => 1,
-                'city' => 2,
-                'country' => 2,
-                'state_name' => 2,
-                'pseudonym' => 10,
+                'title',
+                'description',
+                'body',
+                'name',
+                'surname',
+                'email',
+                'company_name',
+                'street_address',
+                'city',
+                'country',
+                'state_name',
+                'pseudonym',
             ],
         ]);
     }

--- a/plugins/BEdita/Core/src/Model/Table/PropertiesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/PropertiesTable.php
@@ -17,6 +17,7 @@ use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Model\Entity\Property;
 use BEdita\Core\Model\Entity\StaticProperty;
 use BEdita\Core\Model\Validation\Validation;
+use BEdita\Core\Search\SimpleSearchTrait;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Query as DatabaseQuery;
 use Cake\Database\Schema\TableSchemaInterface;
@@ -45,6 +46,8 @@ use Cake\Validation\Validator;
  */
 class PropertiesTable extends Table
 {
+    use SimpleSearchTrait;
+
     /**
      * {@inheritDoc}
      *
@@ -70,12 +73,9 @@ class PropertiesTable extends Table
             'className' => 'BEdita/Core.ObjectTypes',
         ]);
 
-        $this->addBehavior('BEdita/Core.Searchable', [
-            'fields' => [
-                'name' => 10,
-                'description' => 5,
-            ],
-        ]);
+        $this->addBehavior('BEdita/Core.Searchable');
+
+        $this->setupSimpleSearch(['fields' => ['name', 'description']]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/PropertyTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/PropertyTypesTable.php
@@ -15,6 +15,7 @@ namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Exception\ImmutableResourceException;
 use BEdita\Core\Model\Validation\Validation;
+use BEdita\Core\Search\SimpleSearchTrait;
 use Cake\Cache\Cache;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Datasource\EntityInterface;
@@ -38,6 +39,8 @@ use Cake\Validation\Validator;
  */
 class PropertyTypesTable extends Table
 {
+    use SimpleSearchTrait;
+
     /**
      * Map between specific column types and property types names.
      *
@@ -63,15 +66,12 @@ class PropertyTypesTable extends Table
         $this->setDisplayField('name');
 
         $this->addBehavior('Timestamp');
-        $this->addBehavior('BEdita/Core.Searchable', [
-            'fields' => [
-                'name' => 10,
-                'params' => 8,
-            ],
-        ]);
+        $this->addBehavior('BEdita/Core.Searchable');
         $this->addBehavior('BEdita/Core.ResourceName');
 
         $this->hasMany('Properties');
+
+        $this->setupSimpleSearch(['fields' => ['name', 'params']]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
@@ -16,6 +16,7 @@ namespace BEdita\Core\Model\Table;
 use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Model\Validation\Validation;
 use BEdita\Core\ORM\Rule\IsUniqueAmongst;
+use BEdita\Core\Search\SimpleSearchTrait;
 use Cake\Cache\Cache;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\TableSchemaInterface;
@@ -43,6 +44,8 @@ use Cake\Validation\Validator;
  */
 class RelationsTable extends Table
 {
+    use SimpleSearchTrait;
+
     /**
      * {@inheritDoc}
      *
@@ -78,16 +81,18 @@ class RelationsTable extends Table
                 $through->aliasField('side') => 'right',
             ],
         ]);
-        $this->addBehavior('BEdita/Core.Searchable', [
+        $this->addBehavior('BEdita/Core.Searchable');
+        $this->addBehavior('BEdita/Core.ResourceName');
+
+        $this->setupSimpleSearch([
             'fields' => [
-                'name' => 10,
-                'inverse_name' => 10,
-                'description' => 5,
-                'label' => 5,
-                'inverse_label' => 5,
+                'name',
+                'inverse_name',
+                'description',
+                'label',
+                'inverse_label',
             ],
         ]);
-        $this->addBehavior('BEdita/Core.ResourceName');
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/RolesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RolesTable.php
@@ -15,6 +15,7 @@ namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Exception\ImmutableResourceException;
 use BEdita\Core\Model\Validation\Validation;
+use BEdita\Core\Search\SimpleSearchTrait;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
@@ -39,6 +40,8 @@ use Cake\Validation\Validator;
  */
 class RolesTable extends Table
 {
+    use SimpleSearchTrait;
+
     /**
      * Administrator role id
      *
@@ -68,13 +71,10 @@ class RolesTable extends Table
         $this->hasMany('ObjectPermissions', [
             'dependent' => true,
         ]);
-        $this->addBehavior('BEdita/Core.Searchable', [
-            'fields' => [
-                'name' => 10,
-                'description' => 5,
-            ],
-        ]);
+        $this->addBehavior('BEdita/Core.Searchable');
         $this->addBehavior('BEdita/Core.ResourceName');
+
+        $this->setupSimpleSearch(['fields' => ['name', 'description']]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/TagsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TagsTable.php
@@ -16,6 +16,7 @@ namespace BEdita\Core\Model\Table;
 use ArrayObject;
 use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Model\Validation\Validation;
+use BEdita\Core\Search\SimpleSearchTrait;
 use Cake\Collection\CollectionInterface;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
@@ -41,6 +42,8 @@ use Cake\Validation\Validator;
  */
 class TagsTable extends Table
 {
+    use SimpleSearchTrait;
+
     /**
      * Initialize method
      *
@@ -57,12 +60,7 @@ class TagsTable extends Table
         $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
-        $this->addBehavior('BEdita/Core.Searchable', [
-            'fields' => [
-                'label' => 10,
-                'name' => 8,
-            ],
-        ]);
+        $this->addBehavior('BEdita/Core.Searchable');
 
         $this->hasMany('ObjectTags', [
             'foreignKey' => 'tag_id',
@@ -74,6 +72,8 @@ class TagsTable extends Table
             'targetForeignKey' => 'object_id',
             'through' => 'BEdita/Core.ObjectTags',
         ]);
+
+        $this->setupSimpleSearch(['fields' => ['label', 'name']]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/TranslationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TranslationsTable.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Exception\BadFilterException;
+use BEdita\Core\Search\SimpleSearchTrait;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Datasource\Exception\RecordNotFoundException;
@@ -42,6 +43,8 @@ use Cake\Validation\Validator;
  */
 class TranslationsTable extends Table
 {
+    use SimpleSearchTrait;
+
     /**
      * {@inheritDoc}
      *
@@ -57,15 +60,7 @@ class TranslationsTable extends Table
 
         $this->addBehavior('Timestamp');
         $this->addBehavior('BEdita/Core.UserModified');
-        $this->addBehavior('BEdita/Core.Searchable', [
-            'fields' => [
-                'translated_fields' => 10,
-            ],
-            'columnTypes' => [
-                'json',
-                'text',
-            ],
-        ]);
+        $this->addBehavior('BEdita/Core.Searchable');
         $this->addBehavior('BEdita/Core.Status');
 
         $this->belongsTo('Objects', [
@@ -82,6 +77,14 @@ class TranslationsTable extends Table
             'className' => 'Users',
             'foreignKey' => 'modified_by',
             'joinType' => 'INNER',
+        ]);
+
+        $this->setupSimpleSearch([
+            'fields' => ['translated_fields'],
+            'columnTypes' => [
+                'json',
+                'text',
+            ],
         ]);
     }
 

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -91,24 +91,24 @@ class UsersTable extends Table
             'prefix' => 'user-',
         ]);
 
-        $this->getBehavior('Searchable')->setConfig([
-            'fields' => [
-                'username' => 10,
-                'title' => 10,
-                'name' => 10,
-                'surname' => 10,
-                'email' => 7,
-                'description' => 7,
-                'body' => 5,
-            ],
-        ]);
-
         $this->hasMany('ExternalAuth', [
             'foreignKey' => 'user_id',
         ]);
 
         $this->belongsToMany('Roles', [
             'through' => 'RolesUsers',
+        ]);
+
+        $this->setupSimpleSearch([
+            'fields' => [
+                'username',
+                'title',
+                'name',
+                'surname',
+                'email',
+                'description',
+                'body',
+            ],
         ]);
 
         EventManager::instance()->on('Authentication.afterIdentify', [$this, 'login']);

--- a/plugins/BEdita/Core/src/Search/Adapter/SimpleAdapter.php
+++ b/plugins/BEdita/Core/src/Search/Adapter/SimpleAdapter.php
@@ -80,10 +80,10 @@ class SimpleAdapter extends BaseAdapter
         $fields = (array)$this->getConfig('fields');
         $allFields = $this->getAllFields($table);
         if (in_array('*', $this->getConfig('fields'))) {
-            return $allFields;
+            return array_values($allFields);
         }
 
-        return array_intersect($fields, $allFields);
+        return array_values(array_intersect($fields, $allFields));
     }
 
     /**
@@ -162,7 +162,7 @@ class SimpleAdapter extends BaseAdapter
         $fields = [];
         /** @var \Cake\ORM\Table $table */
         $table = $query->getRepository();
-        foreach ($this->getConfig('fields') as $field) {
+        foreach ((array)$this->getFields($table) as $field) {
             $fields[] = $query->func()->coalesce([
                 $table->aliasField($field) => 'identifier',
                 '',

--- a/plugins/BEdita/Core/src/Search/BaseAdapter.php
+++ b/plugins/BEdita/Core/src/Search/BaseAdapter.php
@@ -52,10 +52,9 @@ abstract class BaseAdapter
      * @param \Cake\ORM\Query $query The query instance
      * @param string $text The text to look for
      * @param array $options Options for search
-     * @param array $config Search configuration
      * @return \Cake\ORM\Query
      */
-    abstract public function search(Query $query, string $text, array $options = [], array $config = []): Query;
+    abstract public function search(Query $query, string $text, array $options = []): Query;
 
     /**
      * Index a resource by `$operation`.

--- a/plugins/BEdita/Core/src/Search/SimpleSearchTrait.php
+++ b/plugins/BEdita/Core/src/Search/SimpleSearchTrait.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Core\Search;
+
+use BEdita\Core\Search\Adapter\SimpleAdapter;
+use Cake\Event\Event;
+use Cake\Event\EventDispatcherTrait;
+use Cake\ORM\Table;
+
+/**
+ * A trait to help to setup simple search adapter.
+ *
+ * @since 5.14.0
+ */
+trait SimpleSearchTrait
+{
+    use EventDispatcherTrait;
+
+    /**
+     * Setup a listener on `SearchAdapter.initialize` event
+     * to override configuration of `\BEdita\Core\Search\Adapter\SimpleAdapter`.
+     *
+     * @param array $config Configuration
+     * @param \Cake\ORM\Table|null $refTable The reference table
+     * @return void
+     */
+    protected function setupSimpleSearch(array $config, ?Table $refTable = null): void
+    {
+        $refTable ??= $this;
+        $this->getEventManager()->on(
+            'SearchAdapter.initialize',
+            function (Event $event, Table $table) use ($config, $refTable): void {
+                if ($table !== $refTable || !$event->getSubject() instanceof SimpleAdapter) {
+                    return;
+                }
+
+                $event->getSubject()->setConfig($config, null, false);
+            }
+        );
+    }
+}

--- a/plugins/BEdita/Core/src/Search/SimpleSearchTrait.php
+++ b/plugins/BEdita/Core/src/Search/SimpleSearchTrait.php
@@ -36,7 +36,7 @@ trait SimpleSearchTrait
      * @param \Cake\ORM\Table|null $refTable The reference table
      * @return void
      */
-    protected function setupSimpleSearch(array $config, ?Table $refTable = null): void
+    public function setupSimpleSearch(array $config, ?Table $refTable = null): void
     {
         $refTable ??= $this;
         $this->getEventManager()->on(

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
@@ -171,6 +171,7 @@ class SearchableBehaviorTest extends TestCase
      * @return void
      * @covers ::afterSave()
      * @covers ::afterDelete()
+     * @covers ::getSearchAdapters()
      * @covers ::getAdapter()
      */
     public function testAfterSaveDelete(): void

--- a/plugins/BEdita/Core/tests/TestCase/Search/SimpleSearchTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Search/SimpleSearchTraitTest.php
@@ -1,0 +1,136 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Core\Test\TestCase\Search;
+
+use BEdita\Core\Search\Adapter\SimpleAdapter;
+use BEdita\Core\Search\BaseAdapter;
+use BEdita\Core\Search\SimpleSearchTrait;
+use Cake\Datasource\EntityInterface;
+use Cake\Event\Event;
+use Cake\ORM\Query;
+use Cake\ORM\Table;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
+
+/**
+ * @coversDefaultClass \BEdita\Core\Search\SimpleSearchTrait
+ */
+class SimpleSearchTraitTest extends TestCase
+{
+    /**
+     * @inheritDoc
+     */
+    protected $fixtures = [
+        'plugin.BEdita/Core.FakeSearches',
+    ];
+
+    /**
+     * Test `setupSimpleSearch()`
+     *
+     * @return void
+     * @covers ::setupSimpleSearch()
+     */
+    public function testSetupSimpleSearch(): void
+    {
+        $table = $this->fetchTable('FakeSearches');
+        $adapter = new SimpleAdapter();
+        $subject = $this->getMockForTrait(SimpleSearchTrait::class);
+        $conf = [
+            'fields' => ['name'],
+        ];
+
+        $subject->setupSimpleSearch($conf, $table);
+
+        $expected = ['*'];
+        static::assertEquals($expected, $adapter->getConfig('fields'));
+        static::assertCount(1, $subject->getEventManager()->listeners('SearchAdapter.initialize'));
+
+        $event = new Event('SearchAdapter.initialize', $adapter, [$table]);
+        $subject->getEventManager()->dispatch($event);
+
+        static::assertEquals(Hash::get($conf, 'fields'), $adapter->getConfig('fields'));
+    }
+
+    /**
+     * Test that for adapter different from `SimpleAdapter` conf is not changed.
+     *
+     * @return void
+     * @covers ::setupSimpleSearch()
+     */
+    public function testSetupSimpleSearchWrongAdapter(): void
+    {
+        $table = $this->fetchTable('FakeSearches');
+        $adapter = new class extends BaseAdapter {
+            protected $_defaultConfig = [
+                'customConf' => 'complicated configuration',
+            ];
+
+            public function indexResource(EntityInterface $entity, string $operation): void
+            {
+            }
+
+            public function search(Query $query, string $text, array $options = []): Query
+            {
+                return $query;
+            }
+        };
+
+        $subject = $this->getMockForTrait(SimpleSearchTrait::class);
+        $conf = [
+            'customConf' => 'very simple configuration',
+        ];
+        $subject->setupSimpleSearch($conf, $table);
+
+        $expected = 'complicated configuration';
+        static::assertEquals($expected, $adapter->getConfig('customConf'));
+        static::assertCount(1, $subject->getEventManager()->listeners('SearchAdapter.initialize'));
+
+        $event = new Event('SearchAdapter.initialize', $adapter, [$table]);
+        $subject->getEventManager()->dispatch($event);
+
+        static::assertEquals($expected, $adapter->getConfig('customConf'));
+    }
+
+    /**
+     * Test that conf is not changed if table.
+     *
+     * @return void
+     * @covers ::setupSimpleSearch()
+     */
+    public function testSetupSimpleSearchWrongTable(): void
+    {
+        $table = new class extends Table {
+            use SimpleSearchTrait;
+
+            public function initialize(array $config): void
+            {
+                parent::initialize($config);
+
+                $this->setupSimpleSearch(['adapterConf' => 'table conf']);
+            }
+        };
+
+        $expected = 'default conf';
+        $adapter = new SimpleAdapter();
+        $adapter->initialize(['adapterConf' => 'default conf']);
+        static::assertEquals($expected, $adapter->getConfig('adapterConf'));
+        static::assertCount(1, $table->getEventManager()->listeners('SearchAdapter.initialize'));
+
+        $event = new Event('SearchAdapter.initialize', $adapter, [$this->fetchTable('FakeSearches')]);
+        $table->getEventManager()->dispatch($event);
+
+        static::assertEquals($expected, $adapter->getConfig('adapterConf'));
+    }
+}


### PR DESCRIPTION
This PR integrates the use of search adapters in `SearchableBehavior`.

To keep code clean `SearchableBehavior` isn't initialized with previous configuration (`fields`, ...) anymore because that configuration was valid for simple search only. That configuration was moved in `SimpleAdapter`.

Now  `fields` and other configurations are set taking adavantage of `SearchAdapter.initialize` event fired from `SearchableBehavior` when search adapters are loaded.

For backward compatibility the `SearchableBehavior` can be initialized with the old config yet but it's discouraged.
