### PR TITLE
Add `delay` option to `QueueManager` to avoid job lock issues

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -232,4 +232,31 @@ return [
     //     // default lang tag - may be null
     //     'default' => null,
     // ],
+
+    /**
+     * Queue settings
+     */
+    // 'Queue' => [
+    //     'default' => [
+    //         // A DSN for your configured backend. default: null
+    //         // Can contain protocol/port/username/password or be null if the backend defaults to localhost
+    //         'url' => 'redis://127.0.01:6379',
+
+    //         // The queue that will be used for sending messages. default: default
+    //         // This can be overridden when queuing or processing messages
+    //         'queue' => 'default',
+
+    //         // Delay in seconds to use in `QueueManager::push` action, default: 1
+    //         // 'pushDelay' => 1,
+
+    //         // The name of a configured logger, default: null
+    //         // 'logger' => 'stdout',
+
+    //         // The name of an event listener class to associate with the worker
+    //         // 'listener' => \App\Listener\WorkerListener::class,
+
+    //         // The amount of time in milliseconds to sleep if no jobs are currently available. default: 10000
+    //         'receiveTimeout' => 10000,
+    //     ],
+    // ],
 ];

--- a/plugins/BEdita/Core/src/Model/Table/AsyncJobsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/AsyncJobsTable.php
@@ -4,6 +4,7 @@ namespace BEdita\Core\Model\Table;
 use BEdita\Core\Job\QueueJob;
 use BEdita\Core\Model\Entity\AsyncJob;
 use BEdita\Core\Model\Validation\Validation;
+use Cake\Core\Configure;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Datasource\ConnectionManager;
@@ -143,7 +144,13 @@ class AsyncJobsTable extends Table
             return;
         }
 
-        QueueManager::push(QueueJob::class, ['uuid' => $entity->uuid]);
+        $delay = (int)Configure::read('Queue.default.pushDelay', 1);
+
+        QueueManager::push(
+            QueueJob::class,
+            ['uuid' => $entity->uuid],
+            compact('delay'),
+        );
     }
 
     /**


### PR DESCRIPTION
This PR fixes a problem with async jobs if async `Queue` is configured: some `QueueJob` actions may start to soon and async job record locking may fail. 

If we add a small delay (1 second as default) we can avoid this possible conflict.
This delay, in seconds, can be changed via optional `Queue.default.pushDelay` configuration.
