### PR TITLE
Handle `is_nullable` and `read_only` in `project_model`

### DIFF
--- a/plugins/BEdita/Core/src/Utility/Properties.php
+++ b/plugins/BEdita/Core/src/Utility/Properties.php
@@ -79,6 +79,8 @@ class Properties extends ResourcesBase
                 'property_type_name' => $p['property'],
                 'object_type_name' => $p['object'],
                 'description' => Hash::get($p, 'description'),
+                'is_nullable' => (bool)Hash::get($p, 'is_nullable', true),
+                'read_only' => (bool)Hash::get($p, 'read_only', false),
             ]);
 
             $Properties->saveOrFail($property, static::$defaults['save']);
@@ -138,6 +140,8 @@ class Properties extends ResourcesBase
                 ->firstOrFail();
             $property->set('property_type_name', $p['property']);
             $property->set('description', Hash::get($p, 'description'));
+            $property->set('is_nullable', (bool)Hash::get($p, 'is_nullable', true));
+            $property->set('read_only', (bool)Hash::get($p, 'read_only', false));
 
             $Properties->saveOrFail($property, static::$defaults['update']);
         }

--- a/plugins/BEdita/Core/tests/TestCase/Utility/PropertiesTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/PropertiesTest.php
@@ -60,6 +60,7 @@ class PropertiesTest extends TestCase
             'name' => 'custom_two',
             'object' => 'documents',
             'property' => 'string',
+            'is_nullable' => false,
         ],
     ];
 
@@ -88,6 +89,8 @@ class PropertiesTest extends TestCase
             ->where(['name IN' => ['custom_one', 'custom_two']])
             ->toArray();
         static::assertEquals(2, count($newProperties));
+        $prop = $newProperties[0]->get('name') === 'custom_two' ? $newProperties[0] : $newProperties[1];
+        static::assertFalse($prop->get('is_nullable'));
     }
 
     /**
@@ -134,6 +137,7 @@ class PropertiesTest extends TestCase
         Properties::create($this->properties);
 
         $this->properties[1]['property'] = 'text';
+        $this->properties[1]['read_only'] = true;
         Properties::update($this->properties);
 
         $newProp = $this->Properties
@@ -141,5 +145,6 @@ class PropertiesTest extends TestCase
             ->where(['name' => 'custom_two'])
             ->first();
         static::assertEquals('text', $newProp->get('property_type_name'));
+        static::assertTrue($newProp->get('read_only'));
     }
 }


### PR DESCRIPTION
This PR fixes a problem in `project_model` sync: `is_nullable` and `read_only` attributes of `properties` resources are not handled in the current version, resulting `properties` have always the default values.


