### PR TITLE
Use `readOnly` schema attribute if `read_only` property is true

### DIFF
--- a/plugins/BEdita/API/tests/TestConstants.php
+++ b/plugins/BEdita/API/tests/TestConstants.php
@@ -30,7 +30,7 @@ class TestConstants
         'files' => '2463983178',
         'folders' => '3048758948',
         'locations' => '4113928771',
-        'profiles' => '3709705564',
+        'profiles' => '3444993517',
         'roles' => '122746925',
         'users' => '3368903199',
     ];

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
@@ -520,7 +520,7 @@ class ObjectType extends Entity implements JsonApiSerializable, EventDispatcherI
      */
     protected function accessMode(Property $property, EntityInterface $entity): ?string
     {
-        if (!$entity->isAccessible($property->name)) {
+        if (!$entity->isAccessible($property->name) || $property->read_only) {
             return 'readOnly';
         } elseif (in_array($property->name, $entity->getHidden())) {
             return 'writeOnly';

--- a/plugins/BEdita/Core/src/Model/Entity/Property.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Property.php
@@ -31,6 +31,7 @@ use Cake\Utility\Inflector;
  * @property string $description
  * @property bool $enabled
  * @property bool $is_nullable
+ * @property bool $read_only
  * @property bool $required
  * @property \Cake\I18n\Time $created
  * @property \Cake\I18n\Time $modified

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/PriorityBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/PriorityBehaviorTest.php
@@ -149,6 +149,7 @@ class PriorityBehaviorTest extends TestCase
                 'relation_id' => 1,
             ])
             ->order(['priority'])
+            ->all()
             ->toList();
 
         static::assertSame(4, $entities[0]->get('right_id'));
@@ -167,6 +168,7 @@ class PriorityBehaviorTest extends TestCase
                 'relation_id' => 1,
             ])
             ->order(['priority'])
+            ->all()
             ->toList();
 
         static::assertSame(7, $entities[0]->get('right_id'));
@@ -196,6 +198,7 @@ class PriorityBehaviorTest extends TestCase
                 'relation_id' => 1,
             ])
             ->order(['priority'])
+            ->all()
             ->toList();
 
         static::assertSame(4, $entities[0]->get('right_id'));
@@ -214,6 +217,7 @@ class PriorityBehaviorTest extends TestCase
                 'relation_id' => 1,
             ])
             ->order(['priority'])
+            ->all()
             ->toList();
 
         static::assertSame(3, $entities[0]->get('right_id'));
@@ -242,6 +246,7 @@ class PriorityBehaviorTest extends TestCase
                 'relation_id' => 1,
             ])
             ->order(['priority'])
+            ->all()
             ->toList();
 
         static::assertSame(4, $entities[0]->get('right_id'));
@@ -259,6 +264,7 @@ class PriorityBehaviorTest extends TestCase
                 'relation_id' => 1,
             ])
             ->order(['priority'])
+            ->all()
             ->toList();
 
         static::assertSame(4, $entities[0]->get('right_id'));

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -1008,6 +1008,19 @@ class ObjectTypeTest extends TestCase
     }
 
     /**
+     * Test `readOnly` property in schema.
+     *
+     * @covers ::accessMode()
+     * @return void
+     */
+    public function testReadOnlyProp(): void
+    {
+        $objectType = $this->ObjectTypes->get('profiles');
+        $schema = $objectType->schema;
+        static::assertTrue(Hash::get($schema, 'properties.another_birthdate.readOnly'));
+    }
+
+    /**
      * Test getter for `schema` with an event listener which modifies the schema.
      *
      * @param mixed $expected Expected result.


### PR DESCRIPTION
Whit this PR fixes a property with `read_only` set to `true` will be correctly mapped with `readOnly` set to `true` in its JSON Schema representation.

 