### PR TITLE
Set `manager` as default application

### DIFF
--- a/plugins/BEdita/Core/config/Migrations/20171027164507_DefaultApplication.php
+++ b/plugins/BEdita/Core/config/Migrations/20171027164507_DefaultApplication.php
@@ -35,13 +35,13 @@ class DefaultApplication extends AbstractMigration
             ->insert([
                 [
                     'id' => 1,
-                    'name' => 'default-app',
+                    'name' => 'manager',
                     'api_key' => ApplicationsTable::generateApiKey(),
-                    'description' => 'Default application',
+                    'description' => 'Manager application',
                     'created' => date('Y-m-d H:i:s'),
                     'modified' => date('Y-m-d H:i:s'),
                     'enabled' => 1,
-                ]
+                ],
             ])
             ->save();
     }


### PR DESCRIPTION
This PR is a simple change on an old migration that will be effective only for new setups: use `manager` instead of `default-app` as initial default application. 
`default-app` is not very meaningful instead a `manager` application will almost always be used
