### PR TITLE
Fix return array in MailService

### DIFF
--- a/plugins/BEdita/Core/src/Job/JobService.php
+++ b/plugins/BEdita/Core/src/Job/JobService.php
@@ -27,7 +27,7 @@ interface JobService
      * - a boolean i.e. `true` on success, `false` on failure
      * - an array with keys:
      *   - 'success' (required) => `true` on success, `false` on failure
-     *   - 'message' (optional) => array of messages
+     *   - 'messages' (optional) => array of messages
      *
      * @param array $payload Input data for running this job.
      * @param array $options Options for running this job.

--- a/plugins/BEdita/Core/src/Job/JobService.php
+++ b/plugins/BEdita/Core/src/Job/JobService.php
@@ -23,9 +23,15 @@ interface JobService
     /**
      * Run an async job using $payload input data and optional $options.
      *
+     * It can return:
+     * - a boolean i.e. `true` on success, `false` on failure
+     * - an array with keys:
+     *   - 'success' (required) => `true` on success, `false` on failure
+     *   - 'message' (optional) => array of messages
+     *
      * @param array $payload Input data for running this job.
      * @param array $options Options for running this job.
-     * @return bool True on success, false on failure
+     * @return bool|array
      */
     public function run(array $payload, array $options = []);
 }

--- a/plugins/BEdita/Core/src/Job/Service/MailService.php
+++ b/plugins/BEdita/Core/src/Job/Service/MailService.php
@@ -32,9 +32,13 @@ class MailService implements JobService
      * Options can contain the following keys:
      *  - `transport`: mail transport to use (default: `'default'`).
      *
+     * Return result with keys:
+     * - `success` true
+     * - `email` Result from {@see \Cake\Mailer\Email::send()}.
+     *
      * @param array $payload Input data for this email job.
      * @param array $options Options for running this job.
-     * @return array Result from {@see \Cake\Mailer\Email::send()}.
+     * @return array
      */
     public function run(array $payload, array $options = [])
     {
@@ -44,6 +48,9 @@ class MailService implements JobService
             ->createFromArray($payload)
             ->setTransport($transport);
 
-        return $email->sendRaw();
+        return [
+            'success' => true,
+            'email' => $email->sendRaw(),
+        ];
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Job/Service/MailServiceTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/Service/MailServiceTest.php
@@ -16,6 +16,7 @@ namespace BEdita\Core\Test\TestCase\Job\Service;
 use BEdita\Core\Job\Service\MailService;
 use Cake\Mailer\TransportFactory;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 
 /**
  * {@see \BEdita\Core\Job\Service\MailService} Test Case
@@ -107,15 +108,17 @@ class MailServiceTest extends TestCase
 
         $mailService = new MailService();
         $result = $mailService->run($payload, ['transport' => 'test']);
-        array_walk($result, function (&$val) {
+        $email = Hash::get($result, 'email');
+        array_walk($email, function (&$val) {
             $val = explode("\r\n", $val);
         });
 
-        static::assertArrayHasKey('headers', $result);
+        static::assertTrue(Hash::get($result, 'success'));
+        static::assertArrayHasKey('headers', $email);
         foreach ($expected['headers'] as $header) {
-            static::assertContains($header, $result['headers']);
+            static::assertContains($header, $email['headers']);
         }
-        static::assertArrayHasKey('message', $result);
-        static::assertSame($expected['message'], $result['message']);
+        static::assertArrayHasKey('message', $email);
+        static::assertSame($expected['message'], $email['message']);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/Transport/AsyncJobsTransportTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/Transport/AsyncJobsTransportTest.php
@@ -187,6 +187,7 @@ class AsyncJobsTransportTest extends TestCase
             $val = explode("\r\n", $val);
         });
 
+        static::assertTrue(Hash::get($result, 'success'));
         static::assertArrayHasKey('headers', $email);
         foreach ($expected['headers'] as $header) {
             static::assertContains($header, $email['headers']);

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/Transport/AsyncJobsTransportTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/Transport/AsyncJobsTransportTest.php
@@ -19,6 +19,7 @@ use Cake\Mailer\Mailer;
 use Cake\Mailer\TransportFactory;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
@@ -181,15 +182,16 @@ class AsyncJobsTransportTest extends TestCase
 
         $mailService = new MailService();
         $result = $mailService->run($asyncJob->payload, ['transport' => 'debug']);
-        array_walk($result, function (&$val) {
+        $email = Hash::get($result, 'email');
+        array_walk($email, function (&$val) {
             $val = explode("\r\n", $val);
         });
 
-        static::assertArrayHasKey('headers', $result);
+        static::assertArrayHasKey('headers', $email);
         foreach ($expected['headers'] as $header) {
-            static::assertContains($header, $result['headers']);
+            static::assertContains($header, $email['headers']);
         }
-        static::assertArrayHasKey('message', $result);
-        static::assertArraySubset($expected['message'], $result['message']);
+        static::assertArrayHasKey('message', $email);
+        static::assertArraySubset($expected['message'], $email['message']);
     }
 }


### PR DESCRIPTION
This PR fixes an issue introduced after #2010.
`MailService` returned an array with email data (`headers` and `message`) , but `JobsShell` handle results as array with `success` key or boolean.
Now `MailService` returns an array with `success` equal to `true` and `email` with email data.
