### PR TITLE
Make `string` properties not translatable by default

### DIFF
--- a/plugins/BEdita/API/tests/TestConstants.php
+++ b/plugins/BEdita/API/tests/TestConstants.php
@@ -25,13 +25,13 @@ class TestConstants
      */
     public const SCHEMA_REVISIONS = [
         'applications' => '3594165375',
-        'documents' => '887094289',
+        'documents' => '1515432043',
         'events' => '2652801567',
-        'files' => '2463983178',
+        'files' => '3993182105',
         'folders' => '3048758948',
-        'locations' => '4113928771',
-        'profiles' => '3444993517',
+        'locations' => '3886336330',
+        'profiles' => '3201393399',
         'roles' => '122746925',
-        'users' => '3368903199',
+        'users' => '880938681',
     ];
 }

--- a/plugins/BEdita/Core/src/Model/Entity/Property.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Property.php
@@ -187,7 +187,7 @@ class Property extends Entity implements JsonApiSerializable
         }
         $spec = array_values(array_diff(array_keys($schema), ['type']));
         // only if `contentMediaType` is present we can assume that
-        // we have a translatable string by defatul (text/plain, text/html...)
+        // we have a translatable string by default (text/plain, text/html...)
         $item = (string)Hash::get($spec, '0');
 
         return $item === 'contentMediaType' && count($spec) === 1;

--- a/plugins/BEdita/Core/src/Model/Entity/Property.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Property.php
@@ -186,11 +186,11 @@ class Property extends Entity implements JsonApiSerializable
             return false;
         }
         $spec = array_values(array_diff(array_keys($schema), ['type']));
-        // if no other specifier is set or only `contentMediaType` is present
-        // we can assume that we have a translatable string
+        // only if `contentMediaType` is present we can assume that
+        // we have a translatable string by defatul (text/plain, text/html...)
         $item = (string)Hash::get($spec, '0');
 
-        return empty($item) || ($item === 'contentMediaType' && count($spec) === 1);
+        return $item === 'contentMediaType' && count($spec) === 1;
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Entity/StaticProperty.php
+++ b/plugins/BEdita/Core/src/Model/Entity/StaticProperty.php
@@ -207,7 +207,7 @@ class StaticProperty extends Property
     {
         $typeName = (string)$this->table->getSchema()->getColumnType($this->name);
 
-        return in_array($typeName, ['text', 'string']);
+        return $this->name === 'title' || $typeName === 'text';
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -748,7 +748,6 @@ class ObjectTypeTest extends TestCase
                     'translatable' => [
                         'body',
                         'description',
-                        'disabled_property',
                         'name',
                         'title',
                     ],
@@ -969,8 +968,6 @@ class ObjectTypeTest extends TestCase
                         ],
                     ],
                     'translatable' => [
-                        'another_description',
-                        'another_title',
                         'body',
                         'description',
                         'title',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/PropertyTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/PropertyTest.php
@@ -371,6 +371,10 @@ class PropertyTest extends TestCase
                 false,
                 'number',
             ],
+            'string' => [
+                false,
+                'string',
+            ],
         ];
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/StaticPropertyTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/StaticPropertyTest.php
@@ -449,6 +449,20 @@ class StaticPropertyTest extends TestCase
                     'name' => 'created',
                 ],
             ],
+            'title' => [
+                true,
+                [
+                    'table' => 'Objects',
+                    'name' => 'title',
+                ],
+            ],
+            'string type' => [
+                false,
+                [
+                    'table' => 'Profiles',
+                    'name' => 'surname',
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
In this PR a rule defining default translatable fields has been changed: simple `string` properties are not translatable by default, with the only exception of `title`.
Reason: sometimes those properties are actually translatable, and you can use `translation_rules` to make them translatable, but most of the time they are not. 