### PR TITLE
Differentiate operation for soft-deletes, add adapter name

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,10 @@ on:
       - '.github/workflows/*'
       - '**/composer.json'
 
+concurrency:
+  group: '${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   cs:
     name: 'Check coding style'

--- a/plugins/BEdita/Core/src/Search/BaseAdapter.php
+++ b/plugins/BEdita/Core/src/Search/BaseAdapter.php
@@ -35,15 +35,49 @@ abstract class BaseAdapter
     protected $_defaultConfig = [];
 
     /**
+     * Adapter alias.
+     *
+     * @var string
+     */
+    protected string $alias;
+
+    /**
      * Initialize adapter with configuration.
      *
      * @param array $config Adapter configuration
-     * @return void
+     * @return $this
      * @codeCoverageIgnore
      */
-    public function initialize(array $config): void
+    public function initialize(array $config)
     {
         $this->setConfig($config);
+
+        return $this;
+    }
+
+    /**
+     * Set adapter alias.
+     *
+     * @param string $alias Adapter alias
+     * @return $this
+     * @codeCoverageIgnore
+     */
+    public function setAlias(string $alias)
+    {
+        $this->alias = $alias;
+
+        return $this;
+    }
+
+    /**
+     * Get adapter alias.
+     *
+     * @return string
+     * @codeCoverageIgnore
+     */
+    public function getAlias(): string
+    {
+        return $this->alias;
     }
 
     /**

--- a/plugins/BEdita/Core/src/Search/SearchRegistry.php
+++ b/plugins/BEdita/Core/src/Search/SearchRegistry.php
@@ -51,15 +51,13 @@ class SearchRegistry extends ObjectRegistry
             $instance = $class;
         } else {
             unset($config['className']);
-            $instance = new $class($config);
+            $instance = new $class();
         }
 
         if (!($instance instanceof BaseAdapter)) {
             throw new RuntimeException(sprintf('Search adapters must use %s as a base class.', BaseAdapter::class));
         }
 
-        $instance->initialize($config);
-
-        return $instance;
+        return $instance->setAlias($alias)->initialize($config);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/PriorityBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/PriorityBehaviorTest.php
@@ -149,6 +149,7 @@ class PriorityBehaviorTest extends TestCase
                 'relation_id' => 1,
             ])
             ->order(['priority'])
+            ->all()
             ->toList();
 
         static::assertSame(4, $entities[0]->get('right_id'));
@@ -167,6 +168,7 @@ class PriorityBehaviorTest extends TestCase
                 'relation_id' => 1,
             ])
             ->order(['priority'])
+            ->all()
             ->toList();
 
         static::assertSame(7, $entities[0]->get('right_id'));
@@ -196,6 +198,7 @@ class PriorityBehaviorTest extends TestCase
                 'relation_id' => 1,
             ])
             ->order(['priority'])
+            ->all()
             ->toList();
 
         static::assertSame(4, $entities[0]->get('right_id'));
@@ -214,6 +217,7 @@ class PriorityBehaviorTest extends TestCase
                 'relation_id' => 1,
             ])
             ->order(['priority'])
+            ->all()
             ->toList();
 
         static::assertSame(3, $entities[0]->get('right_id'));
@@ -242,6 +246,7 @@ class PriorityBehaviorTest extends TestCase
                 'relation_id' => 1,
             ])
             ->order(['priority'])
+            ->all()
             ->toList();
 
         static::assertSame(4, $entities[0]->get('right_id'));
@@ -259,6 +264,7 @@ class PriorityBehaviorTest extends TestCase
                 'relation_id' => 1,
             ])
             ->order(['priority'])
+            ->all()
             ->toList();
 
         static::assertSame(4, $entities[0]->get('right_id'));

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
@@ -171,6 +171,8 @@ class SearchableBehaviorTest extends TestCase
      * @return void
      * @covers ::afterSave()
      * @covers ::afterDelete()
+     * @covers ::indexEntity()
+     * @covers ::getOperation()
      * @covers ::getSearchAdapters()
      * @covers ::getAdapter()
      */


### PR DESCRIPTION
This PR adds configurability for the "operation" name based on the event and entity before launching the "index" operation on the search adapter.

It also adds the `setAlias()`/`getAlias()` accessors on the adapter instances in order to make them aware about their own alias. This might be useful in cases where the same adapter is attached multiple times with different configuration (e.g. different indices on the same search engine for different applications or different features of the same application).