### PR TITLE
Project model command option delete

### DIFF
--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -154,12 +154,12 @@ class ProjectModelCommand extends Command
     protected function remove(string $resourceType, array $items, ConsoleIo $io): void
     {
         foreach ($items as $item) {
-            $message = sprintf(
-                'Remove %s %s from model %s. Are you sure?',
-                $resourceType,
-                $item['name'],
-                $item['object']
-            );
+            $name = (string)Hash::get($item, 'name');
+            $message = sprintf('Remove %s %s', $resourceType, $name);
+            if (!empty($item['object'])) {
+                $message .= sprintf(' from model %s', (string)$item['object']);
+            }
+            $message .= '. Are you sure?';
             $choice = $io->askChoice($message, ['y', 'n'], 'n');
             if ($choice === 'y') {
                 if ($resourceType === 'properties') {

--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -162,11 +162,7 @@ class ProjectModelCommand extends Command
             $message .= '. Are you sure?';
             $choice = $io->askChoice($message, ['y', 'n'], 'n');
             if ($choice === 'y') {
-                if ($resourceType === 'properties') {
-                    Properties::remove([$item]);
-                } else {
-                    Resources::remove($resourceType, [$item]);
-                }
+                Resources::remove($resourceType, [$item]);
             }
         }
     }

--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -155,9 +155,8 @@ class ProjectModelCommand extends Command
         foreach ($items as $item) {
             $name = (string)Hash::get($item, 'name');
             $message = sprintf('Remove %s %s', $resourceType, $name);
-            if (!empty($item['object'])) {
-                $message .= sprintf(' from model %s', (string)$item['object']);
-            }
+            $fromModel = sprintf(' from model %s', (string)$item['object']);
+            $message = !empty($item['object']) ? $message . $fromModel : $message;
             $message .= '. Are you sure?';
             $choice = $io->askChoice($message, ['y', 'n'], 'n');
             if ($choice === 'y') {

--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -155,7 +155,7 @@ class ProjectModelCommand extends Command
         foreach ($items as $item) {
             $name = (string)Hash::get($item, 'name');
             $message = sprintf('Remove %s %s', $resourceType, $name);
-            $fromModel = sprintf(' from model %s', (string)$item['object']);
+            $fromModel = sprintf(' from model %s', (string)Hash::get($item, 'object'));
             $message = !empty($item['object']) ? $message . $fromModel : $message;
             $message .= '. Are you sure?';
             $choice = $io->askChoice($message, ['y', 'n'], 'n');

--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -13,7 +13,6 @@
 namespace BEdita\Core\Command;
 
 use BEdita\Core\Utility\ProjectModel;
-use BEdita\Core\Utility\Properties;
 use BEdita\Core\Utility\Resources;
 use Cake\Cache\Cache;
 use Cake\Command\Command;

--- a/plugins/BEdita/Core/src/Model/Table/PropertiesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/PropertiesTable.php
@@ -26,6 +26,7 @@ use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
+use Cake\Utility\Hash;
 use Cake\Validation\Validation as CakeValidation;
 use Cake\Validation\Validator;
 
@@ -167,6 +168,29 @@ class PropertiesTable extends Table
                         ->select([$this->ObjectTypes->aliasField($this->ObjectTypes->getBindingKey())])
                 );
             });
+    }
+
+    /**
+     * Find property resource by name and object type.
+     * Options array argument MUST contain 'name' and 'object_type_name' keys.
+     *
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @param array $options Options array.
+     * @return \Cake\ORM\Query
+     * @throws \BEdita\Core\Exception\BadFilterException
+     */
+    protected function findResource(Query $query, array $options): Query
+    {
+        if (empty($options['name'])) {
+            throw new BadFilterException(__d('bedita', 'Missing required parameter "{0}"', 'name'));
+        }
+        $object = Hash::get($options, 'object_type_name', Hash::get($options, 'object'));
+        if (empty($object)) {
+            throw new BadFilterException(__d('bedita', 'Missing required parameter "{0}"', 'object_type_name'));
+        }
+
+        return $this->find('objectType', [$object])
+            ->where([$this->aliasField('name') => $options['name']]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Utility/Resources.php
+++ b/plugins/BEdita/Core/src/Utility/Resources.php
@@ -84,6 +84,7 @@ class Resources extends ResourcesBase
         'auth_providers',
         'categories',
         'config',
+        'properties',
         'property_types',
         'object_types',
         'roles',

--- a/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
@@ -156,6 +156,7 @@ class ProjectModelCommandTest extends TestCase
     {
         $model = ProjectModelTest::PROJECT_MODEL;
         unset($model['property_types'][0]);
+        unset($model['properties'][0]);
         $path = TMP . '__test.json';
         file_put_contents($path, json_encode($model));
         $this->exec('project_model --file ' . $path . ' --delete', ['y']);

--- a/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
@@ -156,7 +156,6 @@ class ProjectModelCommandTest extends TestCase
     {
         $model = ProjectModelTest::PROJECT_MODEL;
         unset($model['property_types'][0]);
-        unset($model['properties'][0]);
         $path = TMP . '__test.json';
         file_put_contents($path, json_encode($model));
         $this->exec('project_model --file ' . $path . ' --delete', ['y']);

--- a/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
@@ -150,6 +150,7 @@ class ProjectModelCommandTest extends TestCase
      *
      * @return void
      * @covers ::execute()
+     * @covers ::remove()
      */
     public function testRemove(): void
     {
@@ -157,7 +158,7 @@ class ProjectModelCommandTest extends TestCase
         unset($model['property_types'][0]);
         $path = TMP . '__test.json';
         file_put_contents($path, json_encode($model));
-        $this->exec('project_model --file ' . $path);
+        $this->exec('project_model --file ' . $path . ' --delete', ['y']);
         unlink($path);
         $this->assertErrorContains('Items to remove');
         $this->assertExitSuccess();

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertiesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertiesTableTest.php
@@ -220,6 +220,57 @@ class PropertiesTableTest extends TestCase
     }
 
     /**
+     * Data provider for `testFindResource()`.
+     *
+     * @return array
+     */
+    public function findResourceProvider(): array
+    {
+        return [
+            'property' => [
+                1,
+                [
+                    'name' => 'another_title',
+                    'object_type_name' => 'documents',
+                ],
+            ],
+            'no name' => [
+                new BadFilterException('Missing required parameter "name"'),
+                [
+                    'object_type_name' => 'documents',
+                ],
+            ],
+            'no type' => [
+                new BadFilterException('Missing required parameter "object_type_name"'),
+                [
+                    'name' => 'a-name',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test custom finder `findResource()`.
+     *
+     * @param int $expected The value expected
+     * @param array $options The options for the finder
+     * @return void
+     * @covers ::findResource()
+     * @dataProvider findResourceProvider()
+     */
+    public function testFindResource($expected, $options)
+    {
+        if ($expected instanceof \Exception) {
+            $this->expectException(get_class($expected));
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+        $query = $this->Properties->find('resource', $options);
+        $entity = $query->first();
+        static::assertEquals(1, $query->count());
+        static::assertEquals($expected, $entity->id);
+    }
+
+    /**
      * Data provider for `testFindType` test case.
      *
      * @return array


### PR DESCRIPTION
This provides an argument `delete` to `ProjectModelCommand` to allow you to delete unused resources (not found in `project_model.json`).

Usage example:
```bash
$ bin/cake project_model --delete

Items to remove: {"properties":[{"name":"control_panel_link","description":null,"is_nullable":true,"read_only":false,"object":"projects","property":"url"},{"name":"industry_sector","description":null,"is_nullable":true,"read_only":false,"object":"projects","property":"industry_sector"},{"name":"spv_expenses_med","description":null,"is_nullable":true,"read_only":false,"object":"projects","property":"number"}]}
Removing items
Remove properties control_panel_link from model projects. Are you sure? (y/n) 
[n] > y
Remove properties industry_sector from model projects. Are you sure? (y/n) 
[n] > y
Remove properties spv_expenses_med from model projects. Are you sure? (y/n) 
[n] > y
Project model updated
```