### PR TITLE
Upgrade firebase/php-jwt to fix security issue

### DIFF
--- a/plugins/BEdita/API/composer.json
+++ b/plugins/BEdita/API/composer.json
@@ -25,7 +25,7 @@
         "cakephp/authentication": "^2.9",
         "cakephp/authorization": "^2.2",
         "cakephp/cakephp": "~4.4.1",
-        "firebase/php-jwt": "^5.5.1"
+        "firebase/php-jwt": "^6.9"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/plugins/BEdita/API/src/Utility/JWTHandler.php
+++ b/plugins/BEdita/API/src/Utility/JWTHandler.php
@@ -55,11 +55,15 @@ class JWTHandler
      * @param string $token JWT token to decode.
      * @param array $options Decode options including key and algorithms.
      * @return array The token's payload as a PHP array.
+     * @throws \InvalidArgumentException If algorithm is not a string
      */
     public static function decode(string $token, array $options = []): array
     {
         $keyMaterial = Hash::get($options, 'key', Security::getSalt());
         $algorithm = Hash::get($options, 'algorithm', Configure::read('Security.jwt.algorithm', 'HS256'));
+        if (!is_string($algorithm)) {
+            throw new \InvalidArgumentException(__d('bedita', 'Algorithm must be a string'));
+        }
 
         return (array)JWT::decode($token, new Key($keyMaterial, $algorithm));
     }

--- a/plugins/BEdita/API/src/Utility/JWTHandler.php
+++ b/plugins/BEdita/API/src/Utility/JWTHandler.php
@@ -18,6 +18,7 @@ use Cake\Routing\Router;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
 use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 
 /**
  * Encode/decode JWT token.
@@ -48,8 +49,8 @@ class JWTHandler
     /**
      * Decode JWT token.
      * Options array may contain these keys:
-     *  - 'key' - Key or map of keys used in decode
-     *  - 'algorithms' -  List of supported verification algorithms
+     *  - 'key' - Key used in decode
+     *  - 'algorithm' -  Verification algorithm
      *
      * @param string $token JWT token to decode.
      * @param array $options Decode options including key and algorithms.
@@ -57,12 +58,10 @@ class JWTHandler
      */
     public static function decode(string $token, array $options = []): array
     {
-        $options += [
-            'key' => Security::getSalt(),
-            'algorithms' => Configure::read('Security.jwt.algorithm') ?: 'HS256',
-        ];
+        $keyMaterial = Hash::get($options, 'key', Security::getSalt());
+        $algorithm = Hash::get($options, 'algorithm', Configure::read('Security.jwt.algorithm', 'HS256'));
 
-        return (array)JWT::decode($token, $options['key'], (array)$options['algorithms']);
+        return (array)JWT::decode($token, new Key($keyMaterial, $algorithm));
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Utility/JWTHandlerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JWTHandlerTest.php
@@ -52,6 +52,13 @@ class JWTHandlerTest extends TestCase
                 new \Firebase\JWT\ExpiredException('Expired token'),
                 $expiredToken,
             ],
+            'wrongAlgorithmOption' => [
+                new \InvalidArgumentException('Algorithm must be a string'),
+                $token,
+                [
+                    'algorithm' => ['HS256'],
+                ],
+            ],
         ];
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Utility/JWTHandlerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JWTHandlerTest.php
@@ -20,6 +20,7 @@ use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Security;
 use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 
 /**
  * @coversDefaultClass \BEdita\API\Utility\JWTHandler
@@ -34,9 +35,9 @@ class JWTHandlerTest extends TestCase
     public function decodeProvider(): array
     {
         $payload = ['someData' => 'someValue'];
-        $token = JWT::encode($payload, Security::getSalt());
+        $token = JWT::encode($payload, Security::getSalt(), 'HS256');
         $invalidToken = 'gustavo';
-        $expiredToken = JWT::encode(['exp' => time() - 10], Security::getSalt());
+        $expiredToken = JWT::encode(['exp' => time() - 10], Security::getSalt(), 'HS256');
 
         return [
             'default' => [
@@ -95,7 +96,7 @@ class JWTHandlerTest extends TestCase
         static::assertArrayHasKey('jwt', $tokens);
         static::assertArrayHasKey('renew', $tokens);
 
-        $jwt = (array)JWT::decode($tokens['jwt'], Security::getSalt(), ['HS256']);
+        $jwt = (array)JWT::decode($tokens['jwt'], new Key(Security::getSalt(), 'HS256'));
 
         static::assertArrayHasKey('iat', $jwt);
         static::assertArrayHasKey('nbf', $jwt);
@@ -108,7 +109,7 @@ class JWTHandlerTest extends TestCase
         ];
         static::assertEquals($expected, $jwt);
 
-        $renew = (array)JWT::decode($tokens['renew'], Security::getSalt(), ['HS256']);
+        $renew = (array)JWT::decode($tokens['renew'], new Key(Security::getSalt(), 'HS256'));
 
         static::assertArrayHasKey('iat', $renew);
         static::assertArrayHasKey('nbf', $renew);
@@ -136,7 +137,7 @@ class JWTHandlerTest extends TestCase
         CurrentApplication::setApplication(new Application($app));
         $tokens = JWTHandler::tokens([], 'http://api.example.org');
 
-        $jwt = (array)JWT::decode($tokens['jwt'], Security::getSalt(), ['HS256']);
+        $jwt = (array)JWT::decode($tokens['jwt'], new Key(Security::getSalt(), 'HS256'));
         static::assertEquals($app, (array)$jwt['app']);
 
         CurrentApplication::setApplication(null);


### PR DESCRIPTION
This PR fixes a [security issue](https://github.com/advisories/GHSA-8xf4-w7qw-pjjw) of  `firebase/php-jwt`.
I have slightly changed `JWTHandler::decode()` method to avoid passing list of keys and algorithms because trying to decode using more algorithms requires now to create different `\Firebase\JWT\Key`

```php
use Firebase\JWT\Key;
$decoded = JWT::decode($jwt, [
    'kid1' => new Key($publicKey1, 'RS256'),
    'kid2' => new Key($publicKey2, 'RS256')
]);
```
and when providing multiple keys, you must provide the matching `$kid` as the fourth parameter
to the `JWT::encode()` function.

By the way `JWTHandler::decode()` was an old method currently not used. It was used in `4.x` version by `\BEdita\API\Middleware\TokenMiddleware` that has been removed in `5.x` version.
