### PR TITLE
chore: use adapter alias as option in `BuildSearchIndex` command

### DIFF
--- a/plugins/BEdita/Core/src/Command/BuildSearchIndexCommand.php
+++ b/plugins/BEdita/Core/src/Command/BuildSearchIndexCommand.php
@@ -136,7 +136,7 @@ class BuildSearchIndexCommand extends Command
         $indexed = 0;
         $table = $this->fetchTable($entity->getSource());
         foreach ($table->getSearchAdapters() as $adapter) {
-            if (!empty($adapters) && !in_array(get_class($adapter), $adapters)) {
+            if (!empty($adapters) && !in_array($adapter->getAlias(), $adapters)) {
                 continue;
             }
             $io->verbose(

--- a/plugins/BEdita/Core/tests/TestCase/Command/BuildSearchIndexCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/BuildSearchIndexCommandTest.php
@@ -327,7 +327,7 @@ class BuildSearchIndexCommandTest extends TestCase
         Configure::write('Search.adapters.dummy', [
             'className' => $adapter2,
         ]);
-        $adapters = [get_class($adapter2)];
+        $adapters = ['dummy'];
         $this->exec(sprintf('build_search_index --adapter "%s"', implode(',', $adapters)));
         static::assertSame(0, $adapter1->afterSaveCount);
         static::assertLessThan(0, $adapter2->afterSaveCount);


### PR DESCRIPTION
This PR changes the `BuildSearchIndex` command to use adapter alias as an option, instead of full class name.
