### PR TITLE
Add StreamLog for logging in a containerised environment

### DIFF
--- a/bedita-app/libs/log/stream_log.php
+++ b/bedita-app/libs/log/stream_log.php
@@ -1,0 +1,90 @@
+<?php
+/*-----8<--------------------------------------------------------------------
+ *
+ * BEdita - a semantic content management framework
+ *
+ * Copyright 2014 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * BEdita is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * version 3 along with BEdita (see LICENSE.LGPL).
+ * If not, see <http://gnu.org/licenses/lgpl-3.0.html>.
+ *
+ *------------------------------------------------------------------->8-----
+ */
+
+/**
+ * Stream Storage for Logging.  Writes logs to a stream, optionally formatting it as a JSON.
+ */
+class StreamLog
+{
+
+    /**
+     * Stream to write logs to.
+     *
+     * @var string|resource
+     */
+    protected $_stream = null;
+
+    /**
+     * Whether or not to format the log output as JSON.
+     *
+     * @var bool
+     */
+    protected $_json = false;
+
+    /**
+     * Constructs a new File Logger.
+     *
+     * Options
+     *
+     * - `stream` the stream to write logs to. Defaults to `php://stderr`. Can be either an open resource, or a path to
+     *     write to that is accepted by {@see file_put_contents()}.
+     * - `json` whether or not to format the log output as JSON. Defaults to false.
+     *
+     * @param array{stream?: string|resource, json?: bool} $options Options for the FileLog, see above.
+     * @return void
+     */
+    public function __construct($options = [])
+    {
+        $options += ['stream' => 'php://stderr', 'json' => false];
+        $this->_stream = $options['stream'];
+        $this->_json = $options['json'];
+    }
+
+    /**
+     * Implements writing to log files.
+     *
+     * @param string $type The type of log you are making.
+     * @param string $message The message you want to log.
+     * @return boolean success of write.
+     */
+    public function write($type, $message)
+    {
+        $ts = time();
+        $out = $this->_json
+            ? json_encode([
+                'date' => date('c', $ts),
+                'type' => $type,
+                'message' => $message,
+                'timestamp' => $ts,
+            ])
+            : (date('Y-m-d H:i:s', $ts) . ' ' . ucfirst($type) . ': ' . $message);
+
+        if (is_resource($this->_stream)) {
+            return (bool)fwrite($this->_stream, $out. PHP_EOL);
+        }
+
+        return (bool)file_put_contents(
+            $this->_stream,
+            $out . PHP_EOL,
+            FILE_APPEND
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a logger engine `StreamLog` for logging in a containerised environment.

This makes it possible to collect logs written by BEdita, its add-ons and its frontends without additional processes needed to `tail` log files created by the original `FileLog` engine.

This engine also has an option to write logs as JSON, which may simplify things with multi-line logs (i.e. stack traces).

## Usage

In `bedita-app/config/core.php` (or `bedita-app/config/bedita.cfg.php` to configure the same logger for every frontend as well):

```php
CakeLog::config('stderr', [
    'engine' => 'StreamLog',
    'stream' => 'php://stderr',
    'json' => true,
]);
```