### PR TITLE
`async_jobs_clean` command

### DIFF
--- a/plugins/BEdita/Core/src/Command/AsyncJobsCleanCommand.php
+++ b/plugins/BEdita/Core/src/Command/AsyncJobsCleanCommand.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Command;
+
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\I18n\FrozenDate;
+use Cake\ORM\Locator\LocatorAwareTrait;
+
+/**
+ * AsyncJobsClean command.
+ */
+class AsyncJobsCleanCommand extends Command
+{
+    use LocatorAwareTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(Arguments $args, ConsoleIo $io)
+    {
+        $io->info('Cleaning async jobs older than 1 month');
+        $deleted = $this->fetchTable('AsyncJobs')->deleteAll(['created <' => new FrozenDate('-1 month')]);
+        $io->success(sprintf('Deleted %d async jobs', $deleted));
+        $io->info('Done');
+
+        return self::CODE_SUCCESS;
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Command/AsyncJobsCleanCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/AsyncJobsCleanCommandTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace BEdita\Core\Test\TestCase\Command;
+
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see BEdita\Core\Command\AsyncJobsCommand} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Command\AsyncJobsCommand
+ */
+class AsyncJobsCleanCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->useCommandRunner();
+    }
+
+    /**
+     * Test `execute` method
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testExecute(): void
+    {
+        $this->exec('async_jobs_clean --help');
+        $this->assertOutputContains('Cleaning async jobs older than 1 month');
+        $this->assertOutputContains('Deleted');
+        $this->assertOutputContains('Done');
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Command/AsyncJobsCleanCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/AsyncJobsCleanCommandTest.php
@@ -32,7 +32,7 @@ class AsyncJobsCleanCommandTest extends TestCase
      */
     public function testExecute(): void
     {
-        $this->exec('async_jobs_clean --help');
+        $this->exec('async_jobs_clean');
         $this->assertOutputContains('Cleaning async jobs older than 1 month');
         $this->assertOutputContains('Deleted');
         $this->assertOutputContains('Done');

--- a/plugins/BEdita/Core/tests/TestCase/Command/AsyncJobsCleanCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/AsyncJobsCleanCommandTest.php
@@ -25,6 +25,19 @@ class AsyncJobsCleanCommandTest extends TestCase
     }
 
     /**
+     * Test buildOptionParser method
+     *
+     * @return void
+     * @covers ::buildOptionParser()
+     */
+    public function testBuildOptionParser()
+    {
+        $this->exec('async_jobs_clean --help');
+        $this->assertOutputContains('Delete async jobs older than this date');
+        $this->assertOutputContains('Delete async jobs for this service');
+    }
+
+    /**
      * Test `execute` method
      *
      * @return void
@@ -33,7 +46,12 @@ class AsyncJobsCleanCommandTest extends TestCase
     public function testExecute(): void
     {
         $this->exec('async_jobs_clean');
-        $this->assertOutputContains('Cleaning async jobs older than 1 month');
+        $this->assertOutputContains('Cleaning async jobs, since -1 month');
+        $this->assertOutputContains('Deleted');
+        $this->assertOutputContains('Done');
+
+        $this->exec('async_jobs_clean --since 2024-01-01 --service dummy');
+        $this->assertOutputContains('Cleaning async jobs, since 2024-01-01, for service dummy');
         $this->assertOutputContains('Deleted');
         $this->assertOutputContains('Done');
     }

--- a/plugins/BEdita/Core/tests/TestCase/Command/AsyncJobsCleanCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/AsyncJobsCleanCommandTest.php
@@ -49,10 +49,21 @@ class AsyncJobsCleanCommandTest extends TestCase
         $this->assertOutputContains('Cleaning async jobs, since -1 month');
         $this->assertOutputContains('Deleted');
         $this->assertOutputContains('Done');
+        $this->assertExitSuccess();
+    }
 
+    /**
+     * Test `execute` method with `--since` option and `--service` option
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testExecuteSinceService(): void
+    {
         $this->exec('async_jobs_clean --since 2024-01-01 --service dummy');
         $this->assertOutputContains('Cleaning async jobs, since 2024-01-01, for service dummy');
         $this->assertOutputContains('Deleted');
         $this->assertOutputContains('Done');
+        $this->assertExitSuccess();
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Command/AsyncJobsCleanCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/AsyncJobsCleanCommandTest.php
@@ -1,5 +1,16 @@
 <?php
 declare(strict_types=1);
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 
 namespace BEdita\Core\Test\TestCase\Command;
 

--- a/plugins/BEdita/Core/tests/TestCase/Command/AsyncJobsCleanCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/AsyncJobsCleanCommandTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 /**
  * BEdita, API-first content management framework
- * Copyright 2023 Atlas Srl, Chialab Srl
+ * Copyright 2024 Atlas Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published


### PR DESCRIPTION
This PR provides the `async_jobs_clean` command to delete async jobs.
You can clean jobs by date (`--since <date>`) and/or by service (`--service <service name>`).
Default behaviour is cleaning all jobs older than 1 month.

Usage example:
```bash
$ bin/cake async_jobs_clean --help
Usage:
cake async_jobs_clean [-h] [-q] [--service] [--since] [-v]

Options:

--help, -h     Display this help.
--quiet, -q    Enable quiet output.
--service      Delete async jobs for this service
--since        Delete async jobs older than this date
--verbose, -v  Enable verbose output.

$ bin/cake async_jobs_clean --since '-6 months' --service credentials_change
Cleaning async jobs, since -6 months, for service credentials_change
Deleted 1452 async jobs
Done
```