### PR TITLE
`objects_delete` command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "dereuromark/cakephp-ide-helper": "^1.17"
     },
     "conflict": {
+        "symfony/console": "^7",
         "symfony/filesystem": "^7"
     },
     "autoload": {

--- a/plugins/BEdita/Core/src/Command/ObjectsDeleteCommand.php
+++ b/plugins/BEdita/Core/src/Command/ObjectsDeleteCommand.php
@@ -52,8 +52,8 @@ class ObjectsDeleteCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io)
     {
-        $since = $args->getOption('since') ?? '-1 month';
-        $type = $args->getOption('type');
+        $since = $args->getOption('since');
+        $types = (array)$args->getOption('type');
         $message = 'Deleting from trash objects, since ' . $since;
         $message .= $type ? ', for type ' . $type : '';
         $io->info($message);

--- a/plugins/BEdita/Core/src/Command/ObjectsDeleteCommand.php
+++ b/plugins/BEdita/Core/src/Command/ObjectsDeleteCommand.php
@@ -38,10 +38,12 @@ class ObjectsDeleteCommand extends Command
             ->addOption('since', [
                 'help' => 'Delete objects in trash since this date',
                 'required' => false,
+                'default' => '-1 month',
             ])
             ->addOption('type', [
                 'help' => 'Delete objects in trash by type',
                 'required' => false,
+                'multiple' => true,
             ]);
     }
 

--- a/plugins/BEdita/Core/src/Command/ObjectsDeleteCommand.php
+++ b/plugins/BEdita/Core/src/Command/ObjectsDeleteCommand.php
@@ -55,12 +55,15 @@ class ObjectsDeleteCommand extends Command
         $since = $args->getOption('since');
         $types = (array)$args->getOption('type');
         $message = 'Deleting from trash objects, since ' . $since;
-        $message .= $types ? ', for type ' . implode(',', $types) : '';
+        $message .= !empty($types) ? ', for type(s) ' . implode(',', $types) : '';
         $io->info($message);
         $conditions = ['deleted' => true, 'locked' => false, 'modified <' => new FrozenDate($since)];
         $deleted = $errors = 0;
-        foreach ($types as $type) {
-            foreach ($this->objectsIterator($type, $conditions) as $object) {
+        if (empty($types)) {
+            $types = [null];
+        }
+        foreach ($types as $objectType) {
+            foreach ($this->objectsIterator($objectType, $conditions) as $object) {
                 try {
                     $io->verbose(sprintf('Deleting object %s', $object->id));
                     $object->getTable()->deleteOrFail($object);

--- a/plugins/BEdita/Core/src/Command/ObjectsDeleteCommand.php
+++ b/plugins/BEdita/Core/src/Command/ObjectsDeleteCommand.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace BEdita\Core\Command;
 
+use BEdita\Core\Model\Entity\ObjectEntity;
 use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
@@ -64,21 +65,34 @@ class ObjectsDeleteCommand extends Command
         }
         foreach ($types as $objectType) {
             foreach ($this->objectsIterator($objectType, $conditions) as $object) {
-                try {
-                    $io->verbose(sprintf('Deleting object %s', $object->id));
-                    $object->getTable()->deleteOrFail($object);
-                } catch (\Throwable $e) {
-                    $io->error(sprintf('Error deleting object %s: %s', $object->id, $e->getMessage()));
-                    $errors++;
-                    continue;
-                }
-                $deleted++;
+                $this->deleteObject($io, $object, $deleted, $errors);
             }
         }
         $io->success(sprintf('Deleted from trash %d objects [%d errors]', $deleted, $errors));
         $io->info('Done');
 
         return self::CODE_SUCCESS;
+    }
+
+    /**
+     * Delete object.
+     *
+     * @param \Cake\Console\ConsoleIo $io The console io
+     * @param \BEdita\Core\Model\Entity\ObjectEntity $object The object
+     * @param int $deleted The number of deleted objects
+     * @param int $errors The number of errors
+     * @return void
+     */
+    private function deleteObject(ConsoleIo $io, ObjectEntity $object, int &$deleted, int &$errors): void
+    {
+        try {
+            $io->verbose(sprintf('Deleting object %s', $object->id));
+            $object->getTable()->deleteOrFail($object);
+            $deleted++;
+        } catch (\Throwable $e) {
+            $io->error(sprintf('Error deleting object %s: %s', $object->id, $e->getMessage()));
+            $errors++;
+        }
     }
 
     /**

--- a/plugins/BEdita/Core/src/Command/ObjectsDeleteCommand.php
+++ b/plugins/BEdita/Core/src/Command/ObjectsDeleteCommand.php
@@ -111,7 +111,7 @@ class ObjectsDeleteCommand extends Command
         while (true) {
             $q = clone $query;
             $q = $q->where(fn (QueryExpression $exp): QueryExpression => $exp->gt($table->aliasField('id'), $lastId));
-            $results = $q->all();
+            $results = $q->orderAsc($table->aliasField('id'))->all();
             if ($results->isEmpty()) {
                 break;
             }

--- a/plugins/BEdita/Core/src/Command/ObjectsDeleteCommand.php
+++ b/plugins/BEdita/Core/src/Command/ObjectsDeleteCommand.php
@@ -1,0 +1,104 @@
+<?php
+declare(strict_types=1);
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Command;
+
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\Database\Expression\QueryExpression;
+use Cake\I18n\FrozenDate;
+use Cake\ORM\Locator\LocatorAwareTrait;
+
+/**
+ * ObjectsDelete command.
+ */
+class ObjectsDeleteCommand extends Command
+{
+    use LocatorAwareTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        return $parser
+            ->addOption('since', [
+                'help' => 'Delete objects in trash since this date',
+                'required' => false,
+            ])
+            ->addOption('type', [
+                'help' => 'Delete objects in trash by type',
+                'required' => false,
+            ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(Arguments $args, ConsoleIo $io)
+    {
+        $since = $args->getOption('since') ?? '-1 month';
+        $type = $args->getOption('type');
+        $message = 'Deleting from trash objects, since ' . $since;
+        $message .= $type ? ', for type ' . $type : '';
+        $io->info($message);
+        $conditions = ['deleted' => true, 'locked' => false, 'modified <' => new FrozenDate($since)];
+        $deleted = $errors = 0;
+        foreach ($this->objectsIterator($type, $conditions) as $object) {
+            try {
+                $io->verbose(sprintf('Deleting object %s', $object->id));
+                $object->getTable()->deleteOrFail($object);
+            } catch (\Throwable $e) {
+                $io->error(sprintf('Error deleting object %s: %s', $object->id, $e->getMessage()));
+                $errors++;
+                continue;
+            }
+            $deleted++;
+        }
+        $io->success(sprintf('Deleted from trash %d objects [%d errors]', $deleted, $errors));
+        $io->info('Done');
+
+        return self::CODE_SUCCESS;
+    }
+
+    /**
+     * Get objects as iterable.
+     *
+     * @param string|null $type The object type
+     * @param array $conditions The conditions
+     * @return iterable
+     */
+    private function objectsIterator(?string $type, array $conditions): iterable
+    {
+        $table = $this->fetchTable('Objects');
+        $query = empty($type) ? $table->find() : $table->find('type', [$type]);
+        $query = $query->where($conditions)->limit(200);
+        $lastId = 0;
+        while (true) {
+            $q = clone $query;
+            $q = $q->where(fn (QueryExpression $exp): QueryExpression => $exp->gt($table->aliasField('id'), $lastId));
+            $results = $q->all();
+            if ($results->isEmpty()) {
+                break;
+            }
+            foreach ($results as $entity) {
+                $lastId = $entity->id;
+
+                yield $entity;
+            }
+        }
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Command/ObjectsDeleteCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ObjectsDeleteCommandTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace BEdita\Core\Test\TestCase\Command;
 
+use BEdita\Core\Command\ObjectsDeleteCommand;
+use BEdita\Core\Model\Entity\ObjectEntity;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
@@ -73,6 +75,7 @@ class ObjectsDeleteCommandTest extends TestCase
      * @return void
      * @covers ::execute()
      * @covers ::objectsIterator()
+     * @covers ::deleteObject()
      */
     public function testExecute(): void
     {
@@ -89,6 +92,7 @@ class ObjectsDeleteCommandTest extends TestCase
      * @return void
      * @covers ::execute()
      * @covers ::objectsIterator()
+     * @covers ::deleteObject()
      */
     public function testExecuteSince(): void
     {
@@ -97,5 +101,25 @@ class ObjectsDeleteCommandTest extends TestCase
         $this->assertOutputContains('Deleted from trash 2 objects [0 errors]');
         $this->assertOutputContains('Done');
         $this->assertExitSuccess();
+    }
+
+    /**
+     * Test `deleteObject` method
+     *
+     * @return void
+     * @covers ::deleteObject()
+     */
+    public function testDeleteObject(): void
+    {
+        $deleted = $errors = 0;
+        $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
+        $object = new ObjectEntity([]);
+        $command = new ObjectsDeleteCommand();
+        $reflectionClass = new \ReflectionClass($command);
+        $method = $reflectionClass->getMethod('deleteObject');
+        $method->setAccessible(true);
+        $method->invokeArgs($command, [$io, $object, &$deleted, &$errors]);
+        $this->assertEquals(0, $deleted);
+        $this->assertEquals(1, $errors);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Command/ObjectsDeleteCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ObjectsDeleteCommandTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace BEdita\Core\Test\TestCase\Command;
 
-use Cake\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
 /**

--- a/plugins/BEdita/Core/tests/TestCase/Command/ObjectsDeleteCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ObjectsDeleteCommandTest.php
@@ -27,6 +27,25 @@ class ObjectsDeleteCommandTest extends TestCase
     use ConsoleIntegrationTestTrait;
 
     /**
+     * Fixtures
+     *
+     * @var array
+     */
+    protected $fixtures = [
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.RelationTypes',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.Locations',
+        'plugin.BEdita/Core.Media',
+        'plugin.BEdita/Core.Profiles',
+        'plugin.BEdita/Core.Users',
+        'plugin.BEdita/Core.Streams',
+    ];
+
+    /**
      * @inheritDoc
      */
     public function setUp(): void
@@ -58,7 +77,7 @@ class ObjectsDeleteCommandTest extends TestCase
     {
         $this->exec('objects_delete --type documents');
         $this->assertOutputContains('Deleting from trash objects, since -1 month, for type documents');
-        $this->assertOutputContains('Deleted from trash 0 objects [0 errors]');
+        $this->assertOutputContains('Deleted from trash 2 objects [0 errors]');
         $this->assertOutputContains('Done');
         $this->assertExitSuccess();
     }

--- a/plugins/BEdita/Core/tests/TestCase/Command/ObjectsDeleteCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ObjectsDeleteCommandTest.php
@@ -77,7 +77,23 @@ class ObjectsDeleteCommandTest extends TestCase
     public function testExecute(): void
     {
         $this->exec('objects_delete --type documents');
-        $this->assertOutputContains('Deleting from trash objects, since -1 month, for type documents');
+        $this->assertOutputContains('Deleting from trash objects, since -1 month, for type(s) documents');
+        $this->assertOutputContains('Deleted from trash 2 objects [0 errors]');
+        $this->assertOutputContains('Done');
+        $this->assertExitSuccess();
+    }
+
+    /**
+     * Test `execute` method
+     *
+     * @return void
+     * @covers ::execute()
+     * @covers ::objectsIterator()
+     */
+    public function testExecuteSince(): void
+    {
+        $this->exec('objects_delete --since "-1 weeks"');
+        $this->assertOutputContains('Deleting from trash objects, since -1 weeks');
         $this->assertOutputContains('Deleted from trash 2 objects [0 errors]');
         $this->assertOutputContains('Done');
         $this->assertExitSuccess();

--- a/plugins/BEdita/Core/tests/TestCase/Command/ObjectsDeleteCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ObjectsDeleteCommandTest.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Command;
+
+use Cake\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see BEdita\Core\Command\ObjectsDeleteCommand} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Command\ObjectsDeleteCommand
+ */
+class ObjectsDeleteCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->useCommandRunner();
+    }
+
+    /**
+     * Test buildOptionParser method
+     *
+     * @return void
+     * @covers ::buildOptionParser()
+     */
+    public function testBuildOptionParser()
+    {
+        $this->exec('objects_delete --help');
+        $this->assertOutputContains('Delete objects in trash since this date');
+        $this->assertOutputContains('Delete objects in trash by type');
+    }
+
+    /**
+     * Test `execute` method
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testExecute(): void
+    {
+        $this->exec('objects_delete --type documents');
+        $this->assertOutputContains('Deleting from trash objects, since -1 month, for type documents');
+        $this->assertOutputContains('Deleted from trash 0 objects [0 errors]');
+        $this->assertOutputContains('Done');
+        $this->assertExitSuccess();
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Command/ObjectsDeleteCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ObjectsDeleteCommandTest.php
@@ -72,6 +72,7 @@ class ObjectsDeleteCommandTest extends TestCase
      *
      * @return void
      * @covers ::execute()
+     * @covers ::objectsIterator()
      */
     public function testExecute(): void
     {

--- a/plugins/BEdita/Core/tests/TestCase/Command/ObjectsDeleteCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ObjectsDeleteCommandTest.php
@@ -112,8 +112,9 @@ class ObjectsDeleteCommandTest extends TestCase
     public function testExecuteError(): void
     {
         $throwError = function () {
-            throw new \Exception('Fake error');
+            throw new \Exception('An error');
         };
+
         // add listener to global event manager
         EventManager::instance()->on('Model.beforeDelete', $throwError);
 


### PR DESCRIPTION
This PR resolves https://github.com/bedita/bedita/issues/2047

Command usage:
```bash
// delete all users in trashcan since more than 3 months
$ bin/cake objects_delete --type users --since '-3 months'

// delete all documents and events in trashcan since more than 1 week
$ bin/cake objects_delete --type documents,events --since '-1 weeks'
```

This also fixes a dependency issue with `symfony/console: ^7`, by adding a conflict rule in composer.json.