### PR TITLE
Support email strings as username

### DIFF
--- a/bedita-app/models/account/user.php
+++ b/bedita-app/models/account/user.php
@@ -90,6 +90,9 @@ class User extends BEAppModel
 
     public function useridValidation($values) {
         $value = array_shift($values);  // Get value.
+		if (filter_var($value, FILTER_VALIDATE_EMAIL)) { // email is valid
+			return true;
+		}
 
         return preg_match('/^[[:print:]]+$/', $value) && preg_match('/^[^<>\|&\'"]+$/', $value);
     }


### PR DESCRIPTION
This PR fixes an issue with some chars valid form email but not for `userid` validation.
For example `'` or `$` are valid email chars for *local-part* but `userid` validation fails.

