### PR TITLE
Dependabot config groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,12 @@
 
 version: 2
 updates:
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -12,3 +18,5 @@ updates:
     groups:
       gh-actions:
         patterns: ['actions/*']
+      docker:
+        patterns: ['docker/*']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,17 +6,10 @@
 version: 2
 updates:
 
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     groups:
       gh-actions:
-        patterns: ['actions/*']
-      docker:
-        patterns: ['docker/*']
+        patterns: ['actions/*', 'docker/*', 'codecov/*']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,8 @@ updates:
       interval: "weekly"
     groups:
       gh-actions:
-        patterns: ['actions/*', 'docker/*', 'codecov/*']
+        patterns: ['actions/*']
+      docker:
+        patterns: ['docker/*']
+      codecov:
+        patterns: ['codecov/*']


### PR DESCRIPTION
This changes dependabot conf to:
```yaml
version: 2
updates:

  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
    groups:
      gh-actions:
        patterns: ['actions/*']
      docker:
        patterns: ['docker/*']
      codecov:
        patterns: ['codecov/*']
```