### PR TITLE
Remove order in `project_model` command must be reversed

### DIFF
--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -91,7 +91,7 @@ class ProjectModelCommand extends Command
             $io->warning('Items to remove: ' . json_encode($diff['remove']));
             if ($args->getOption('delete')) {
                 $io->warning('Removing items');
-                $keys = array_keys($diff['remove']);
+                $keys = array_reverse(array_keys($diff['remove']));
                 foreach ($keys as $key) {
                     $this->remove(
                         $key,


### PR DESCRIPTION
This PR fixes a little problem when removing model items via `bin/cake project_model --delete` 

The removal order must be the reverse of the creation order, for instance: you have to first create a property type, then a property referencing this property type. But you you must remove the property before removing the linked property type.
