### PR TITLE
OAuth2: verify token via callback and add authenticator/identifier config

### DIFF
--- a/plugins/BEdita/API/src/Identifier/OAuth2Identifier.php
+++ b/plugins/BEdita/API/src/Identifier/OAuth2Identifier.php
@@ -43,9 +43,9 @@ class OAuth2Identifier extends AbstractIdentifier
         $authProvider = $this->getConfig('authProvider');
         $options = (array)Hash::get((array)$authProvider->get('params'), 'options');
 
-        $credentialsCallback = Hash::get($options,'credentials_callback');
+        $credentialsCallback = Hash::get($options, 'credentials_callback');
         if ($credentialsCallback && is_callable($credentialsCallback)) {
-            if(!$credentialsCallback($credentials)) {
+            if (!$credentialsCallback($credentials)) {
                 return null;
             }
         } else {

--- a/plugins/BEdita/API/src/Identifier/OAuth2Identifier.php
+++ b/plugins/BEdita/API/src/Identifier/OAuth2Identifier.php
@@ -17,13 +17,11 @@ namespace BEdita\API\Identifier;
 use Authentication\Identifier\AbstractIdentifier;
 use Authentication\Identifier\Resolver\ResolverAwareTrait;
 use BEdita\Core\Utility\OAuth2;
-use Cake\Log\LogTrait;
 use Cake\Utility\Hash;
 
 class OAuth2Identifier extends AbstractIdentifier
 {
     use ResolverAwareTrait;
-    use LogTrait;
 
     /**
      * @inheritDoc
@@ -42,13 +40,11 @@ class OAuth2Identifier extends AbstractIdentifier
     public function identify(array $credentials)
     {
         /** @var \BEdita\Core\Model\Entity\AuthProvider $authProvider */
-        $this->log('[OAuth2Identifier] Identify with credentials: ' . json_encode($credentials), 'info');
         $authProvider = $this->getConfig('authProvider');
         $options = (array)Hash::get((array)$authProvider->get('params'), 'options');
 
         $credentialsCallback = Hash::get($options,'credentials_callback');
         if ($credentialsCallback && is_callable($credentialsCallback)) {
-            $this->log('[OAuth2Identifier] Using callback: ' . json_encode($credentialsCallback), 'info');
             if(!$credentialsCallback($credentials)) {
                 return null;
             }

--- a/plugins/BEdita/API/tests/TestCase/Identifier/OAuth2IdentifierTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Identifier/OAuth2IdentifierTest.php
@@ -181,5 +181,13 @@ class OAuth2IdentifierTest extends TestCase
         ]);
 
         static::assertNotEmpty($result);
+
+        $result = $identifier->identify([
+            'auth_provider' => 'example',
+            'provider_username' => 'another_user',
+            'access_token' => 'very-log-string',
+        ]);
+
+        static::assertNull($result);
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Identifier/OAuth2IdentifierTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Identifier/OAuth2IdentifierTest.php
@@ -153,4 +153,33 @@ class OAuth2IdentifierTest extends TestCase
         }
         static::assertSame($expected, $result);
     }
+
+    /**
+     * Test `identify` method with callback.
+     *
+     * @return void
+     * @covers ::identify()
+     */
+    public function testIdentifyWithCallback(): void
+    {
+        $authProvider = $this->fetchTable('AuthProviders')->get(1);
+        $authProvider->set('params', [
+            'options' => [
+                'credentials_callback' => function (array $credentials): bool {
+                    return $credentials['provider_username'] === 'first_user';
+                },
+            ],
+        ]);
+
+        $identifier = new OAuth2Identifier();
+        $identifier->setConfig(compact('authProvider'));
+
+        $result = $identifier->identify([
+            'auth_provider' => 'example',
+            'provider_username' => 'first_user',
+            'access_token' => 'very-log-string',
+        ]);
+
+        static::assertNotEmpty($result);
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -354,7 +354,7 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
         $credentialsCallback = Hash::get($options, 'credentials_callback');
         if ($credentialsCallback && is_callable($credentialsCallback)) {
             if (!$credentialsCallback($data)) {
-                throw new UnauthorizedException(__d('bedita', 'External auth via callback failed'));
+                throw new UnauthorizedException(__d('bedita', 'External auth failed'));
             }
         } else {
             $providerResponse = $this->getOAuth2Response(

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -351,9 +351,9 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
             throw new UnauthorizedException(__d('bedita', 'External auth provider not found'));
         }
         $options = (array)Hash::get((array)$authProvider->get('params'), 'options');
-        $credentialsCallback = Hash::get($options,'credentials_callback');
+        $credentialsCallback = Hash::get($options, 'credentials_callback');
         if ($credentialsCallback && is_callable($credentialsCallback)) {
-            if(!$credentialsCallback($data)) {
+            if (!$credentialsCallback($data)) {
                 throw new UnauthorizedException(__d('bedita', 'External auth via callback failed'));
             }
         } else {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -353,7 +353,7 @@ class SignupUserActionTest extends TestCase
     }
 
     /**
-     * Test command execution with external auth callback
+     * Test action execution with external auth callback
      *
      * @return void
      */
@@ -388,6 +388,46 @@ class SignupUserActionTest extends TestCase
     {
         return true;
     }
+
+    /**
+     * Test action failure with external auth callback
+     *
+     * @return void
+     */
+    public function testExecuteExtAuthCallbackFail(): void
+    {
+        $this->expectException(UnauthorizedException::class);
+        $this->expectExceptionMessage('External auth failed');
+
+        $authProvider = $this->fetchTable('AuthProviders')->get(1);
+        $authProvider->params = [
+            'options' => [
+                'credentials_callback' => [static::class, 'testCallbackFalse'],
+            ],
+        ];
+        $this->fetchTable('AuthProviders')->saveOrFail($authProvider);
+        $data = [
+            'username' => 'testsignup',
+            'email' => 'testsignup@example.com',
+            'auth_provider' => 'example',
+            'provider_username' => 'not-found',
+            'provider_userdata' => [],
+            'access_token' => 'incredibly-long-string',
+        ];
+        $action = new SignupUserAction();
+        $result = $action(compact('data'));
+    }
+
+    /**
+     * Another dummy test callback method
+     *
+     * @return bool
+     */
+    public static function testCallbackFalse(): bool
+    {
+        return false;
+    }
+
 
     /**
      * Test signup action when activation is not required.

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -428,7 +428,6 @@ class SignupUserActionTest extends TestCase
         return false;
     }
 
-
     /**
      * Test signup action when activation is not required.
      *

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -382,7 +382,7 @@ class SignupUserActionTest extends TestCase
     /**
      * Dummy test callback method
      *
-     * @return boolean
+     * @return bool
      */
     public static function testCallback(): bool
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -353,6 +353,43 @@ class SignupUserActionTest extends TestCase
     }
 
     /**
+     * Test command execution with external auth callback
+     *
+     * @return void
+     */
+    public function testExecuteExtAuthCallback(): void
+    {
+        $authProvider = $this->fetchTable('AuthProviders')->get(1);
+        $authProvider->params = [
+            'options' => [
+                'credentials_callback' => [static::class, 'testCallback'],
+            ],
+        ];
+        $this->fetchTable('AuthProviders')->saveOrFail($authProvider);
+        $data = [
+            'username' => 'testsignup',
+            'email' => 'testsignup@example.com',
+            'auth_provider' => 'example',
+            'provider_username' => 'not-found',
+            'provider_userdata' => [],
+            'access_token' => 'incredibly-long-string',
+        ];
+        $action = new SignupUserAction();
+        $result = $action(compact('data'));
+        static::assertTrue((bool)$result);
+    }
+
+    /**
+     * Dummy test callback method
+     *
+     * @return boolean
+     */
+    public static function testCallback(): bool
+    {
+        return true;
+    }
+
+    /**
      * Test signup action when activation is not required.
      *
      * @return void


### PR DESCRIPTION
This PR improves OAuth2 authentication process supporting providers like Apple that requires a different approach.

User verification is not performed by calling the OAuth2 provider with an access token, but via JWT `id_token` decrypting and validation.

* OAuth2 identifier and authenticator classes can now be configured via `config.authenticator` in `auth_providers.params` JSON field 
* if a `credentials_callback` callable has been defined in `auth_providers.params` this callback is used to verify the authenticated used otherwise the usual OAuth2 provider call is performed

