### PR TITLE
Search default configuration load by bootstrap

### DIFF
--- a/plugins/BEdita/Core/config/bootstrap.php
+++ b/plugins/BEdita/Core/config/bootstrap.php
@@ -114,3 +114,17 @@ if (!FilesystemRegistry::configured()) {
 if (!Thumbnail::configured()) {
     Thumbnail::setConfig(Configure::read('Thumbnails.generators') ?: []);
 }
+
+/**
+ * Set search default configuration, if missing.
+ */
+if (!Configure::isConfigured('Search')) {
+    Configure::write('Search', [
+        'use' => 'default',
+        'adapters' => [
+            'default' => [
+                'className' => 'BEdita/Core.Simple',
+            ],
+        ],
+    ]);
+}

--- a/plugins/BEdita/Core/config/bootstrap.php
+++ b/plugins/BEdita/Core/config/bootstrap.php
@@ -118,7 +118,7 @@ if (!Thumbnail::configured()) {
 /**
  * Set search default configuration, if missing.
  */
-if (!Configure::isConfigured('Search')) {
+if (!Configure::check('Search')) {
     Configure::write('Search', [
         'use' => 'default',
         'adapters' => [


### PR DESCRIPTION
This PR provides a default `Search` configuration set by `BEdita/Core/config/bootstrap.php`, if missing.

This is done to avoid that app that uses BEdita should explicitely set the default `SimpleSearchAdapter` in `Search` in `config/app.php`.