### PR TITLE
Reduce memory usage of `bin/cake thumbs`, add more flexibility through flags

### DIFF
--- a/plugins/BEdita/Core/src/Command/ThumbsCommand.php
+++ b/plugins/BEdita/Core/src/Command/ThumbsCommand.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace BEdita\Core\Command;
 
 use BEdita\Core\Event\ImageThumbsHandler;
-use Cake\Collection\Collection;
 use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
@@ -98,17 +97,11 @@ class ThumbsCommand extends Command
     /**
      * Retrieve thumbnail presets without 'async' generators
      *
-     * @return array
+     * @return string[]
      */
     protected static function availablePresets(): array
     {
-        $collection = new Collection((array)Configure::read('Thumbnails.presets'));
-
-        return $collection->map(function (array $preset) {
-            unset($preset['generator']); // remove 'async' generators
-
-            return $preset;
-        })->toArray();
+        return array_keys(array_filter((array)Configure::read('Thumbnails.presets'), fn (array $preset) => !isset($preset['generator'])));
     }
 
     /**

--- a/plugins/BEdita/Core/src/Command/ThumbsCommand.php
+++ b/plugins/BEdita/Core/src/Command/ThumbsCommand.php
@@ -55,8 +55,6 @@ class ThumbsCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io)
     {
-        $io->out(sprintf('=====> Operation started at <info>%s</info>', FrozenTime::now()->toIso8601String()));
-
         $handler = new ImageThumbsHandler();
         $ids = (array)$args->getOption('id');
         $startAt = filter_var(
@@ -65,6 +63,12 @@ class ThumbsCommand extends Command
             ['options' => ['min_range' => 1], 'flags' => FILTER_NULL_ON_FAILURE],
         );
         $presets = (array)$args->getOption('preset') ?: ThumbsCommand::availablePresets();
+
+        $io->out(sprintf(
+            '=====> Operation started at <info>%s</info>, using presets: %s',
+            FrozenTime::now()->toIso8601String(),
+            implode(', ', array_map(fn (string $preset) => sprintf('<comment>%s</comment>', $preset), $presets)),
+        ));
 
         $success = $failed = 0;
         foreach ($this->imagesIterator($ids, $startAt) as $image) {
@@ -117,7 +121,7 @@ class ThumbsCommand extends Command
         $id = $startAt ?? 0;
         $idField = $table->aliasField('id');
 
-        $query = $table->find()
+        $query = $table->find('type', ['images'])
             ->matching('Streams')
             ->contain('Streams');
         if (!empty($ids)) {

--- a/plugins/BEdita/Core/tests/TestCase/Command/ThumbsCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ThumbsCommandTest.php
@@ -75,7 +75,7 @@ class ThumbsCommandTest extends TestCase
     public function testBuildOptionParser()
     {
         $this->exec('thumbs --help');
-        $this->assertOutputContains('Image id');
+        $this->assertOutputContains('Image ID');
     }
 
     /**
@@ -83,13 +83,14 @@ class ThumbsCommandTest extends TestCase
      *
      * @return void
      * @covers ::execute()
-     * @covers ::presets()
+     * @covers ::availablePresets()
+     * @covers ::imagesIterator()
      */
     public function testExecute(): void
     {
         $this->exec('thumbs');
-        $this->assertOutputContains('Update image thumbs');
-        $this->assertOutputContains('Thumbs updated');
+        $this->assertOutputContains('Operation started at ');
+        $this->assertOutputContains('Operation completed at ');
         $this->assertExitSuccess();
     }
 
@@ -98,14 +99,14 @@ class ThumbsCommandTest extends TestCase
      *
      * @return void
      * @covers ::execute()
-     * @covers ::presets()
+     * @covers ::availablePresets()
+     * @covers ::imagesIterator()
      */
     public function testExecuteId(): void
     {
         $this->exec('thumbs --id 123');
-        $this->assertOutputContains('Update image thumbs');
-        $this->assertOutputContains('Thumbs updated');
-        $this->assertOutputContains('Updated 0 images');
+        $this->assertOutputContains('Operation started at ');
+        $this->assertOutputContains('Operation completed at ');
         $this->assertExitSuccess();
     }
 }


### PR DESCRIPTION
This PR adds more flexibility to the `bin/cake thumbs` command:

1. The `--id` flag can be passed multiple times
2. A new `--start-at` flag can be passed to resume an interrupted operation from the last processed ID
3. A new `--preset` flag can be passed to regenerate only a specific preset. It can be passed multiple times for regenerating multiple presets at once.

Additionally, the memory usage has been lowered especially in installations with a large number of images, as the entire result set used to be preloaded in memory (!!), and a log is written for every processed image when `--verbose` is passed to make it easier to track issues and to have a direct feedback of the progress of the running command.
