### PR TITLE
Fix: add status finder for translations

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/TranslationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TranslationsControllerTest.php
@@ -40,10 +40,10 @@ class TranslationsControllerTest extends IntegrationTestCase
             ],
             'meta' => [
                 'pagination' => [
-                    'count' => 3,
+                    'count' => 4,
                     'page' => 1,
                     'page_count' => 1,
-                    'page_items' => 3,
+                    'page_items' => 4,
                     'page_size' => 20,
                 ],
             ],
@@ -147,6 +147,38 @@ class TranslationsControllerTest extends IntegrationTestCase
                         ],
                     ],
                 ],
+                [
+                    'id' => '4',
+                    'type' => 'translations',
+                    'attributes' => [
+                        'status' => 'off',
+                        'lang' => 'no',
+                        'object_id' => 2,
+                        'translated_fields' => [
+                            'description' => 'beskrivelse her',
+                            'extra' => [
+                                'list' => ['én', 'to', 'tre'],
+                            ],
+                        ],
+                    ],
+                    'meta' => [
+                        'created' => '2018-01-01T00:00:00+00:00',
+                        'modified' => '2018-01-01T00:00:00+00:00',
+                        'created_by' => 1,
+                        'modified_by' => 1,
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/translations/4',
+                    ],
+                    'relationships' => [
+                        'object' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/translations/4/object',
+                                'self' => 'http://api.example.com/translations/4/relationships/object',
+                            ],
+                        ],
+                    ],
+                ],
             ],
         ];
 
@@ -242,7 +274,7 @@ class TranslationsControllerTest extends IntegrationTestCase
         $this->assertResponseCode(201);
         $this->assertContentType('application/vnd.api+json');
         static::assertArrayHasKey('data', $result);
-        $this->assertHeader('Location', 'http://api.example.com/translations/4');
+        $this->assertHeader('Location', 'http://api.example.com/translations/5');
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -149,6 +149,7 @@ class ObjectsTable extends Table
         $this->hasMany('Translations', [
             'className' => 'Translations',
             'foreignKey' => 'object_id',
+            'finder' => 'available',
         ]);
         $this->hasMany('Permissions', [
             'className' => 'ObjectPermissions',

--- a/plugins/BEdita/Core/src/Model/Table/TranslationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TranslationsTable.php
@@ -15,6 +15,7 @@ namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Search\SimpleSearchTrait;
+use Cake\Core\Configure;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Datasource\Exception\RecordNotFoundException;
@@ -189,5 +190,16 @@ class TranslationsTable extends Table
         }
 
         return $objectType->id;
+    }
+
+    /**
+     * Finder for available objects based on the status level.
+     *
+     * @param \Cake\ORM\Query $query Query object instance.
+     * @return \Cake\ORM\Query
+     */
+    protected function findAvailable(Query $query): Query
+    {
+        return $query->find('statusLevel', [Configure::read('Status.level', 'all')]);
     }
 }

--- a/plugins/BEdita/Core/tests/Fixture/TranslationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/TranslationsFixture.php
@@ -74,6 +74,21 @@ class TranslationsFixture extends TestFixture
                     ],
                 ],
             ],
+            [
+                'object_id' => 2,
+                'lang' => 'no',
+                'status' => 'off',
+                'created' => '2018-01-01 00:00:00',
+                'modified' => '2018-01-01 00:00:00',
+                'created_by' => 1,
+                'modified_by' => 1,
+                'translated_fields' => [
+                    'description' => 'beskrivelse her',
+                    'extra' => [
+                        'list' => ['én', 'to', 'tre'],
+                    ],
+                ],
+            ],
         ];
 
         parent::init();

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/TranslationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/TranslationsTableTest.php
@@ -14,6 +14,7 @@
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use BEdita\Core\Exception\BadFilterException;
+use Cake\Core\Configure;
 use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -154,11 +155,11 @@ class TranslationsTableTest extends TestCase
     {
         return [
             'documents' => [
-                [1, 2, 3],
+                [1, 2, 3, 4],
                 ['documents'],
             ],
             'multiple' => [
-                [1, 2, 3],
+                [1, 2, 3, 4],
                 ['document', 'profiles'],
             ],
             'bad type' => [
@@ -170,7 +171,7 @@ class TranslationsTableTest extends TestCase
                 [],
             ],
             'by id' => [
-                [1, 2, 3],
+                [1, 2, 3, 4],
                 [2],
             ],
         ];
@@ -199,5 +200,46 @@ class TranslationsTableTest extends TestCase
         sort($result);
 
         $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Data provider for `testFindAvailable`.
+     *
+     * @return array
+     */
+    public function findAvailableProvider(): array
+    {
+        return [
+            'no status' => [
+                4,
+            ],
+            'status on' => [
+                2,
+                'on',
+            ],
+            'status draft' => [
+                3,
+                'draft',
+            ],
+        ];
+    }
+
+    /**
+     * Test `findAvailable()`.
+     *
+     * @param int $expected Expected results.
+     * @param string $statusLevel Configuration to write.
+     * @return void
+     * @dataProvider findAvailableProvider()
+     * @covers ::findAvailable()
+     */
+    public function testFindAvailable(int $expected, ?string $statusLevel = null): void
+    {
+        if (!empty($statusLevel)) {
+            Configure::write('Status.level', $statusLevel);
+        }
+
+        $count = $this->Translations->find('available')->count();
+        static::assertSame($expected, $count);
     }
 }


### PR DESCRIPTION
This PR adds a finder for the Translations entities to use `status` level if specified by the configuration.

Currently, the lack of this finder causes translations to be returned in the frontends without taking the set status level into account.
