### PR TITLE
Introduce strict types declaration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require-dev": {
         "cakephp/bake": "^2.7",
         "cakephp/debug_kit": "^4.8.1",
-        "cakephp/cakephp-codesniffer": "~4.5.1",
+        "cakephp/cakephp-codesniffer": "^4.7",
         "phpstan/phpdoc-parser": "1.5.1",
         "cakephp/repl": "^0.1",
         "phpunit/phpunit": "^9.5",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,7 +3,5 @@
     <arg name="colors"/>
     <config name="installed_paths" value="../../cakephp/cakephp-codesniffer"/>
 
-    <rule ref="CakePHP">
-        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes" />
-    </rule>
+    <rule ref="CakePHP"/>
 </ruleset>

--- a/plugins/BEdita/API/composer.json
+++ b/plugins/BEdita/API/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "cakephp/cakephp-codesniffer": "~4.5.1"
+        "cakephp/cakephp-codesniffer": "^4.7"
     },
     "autoload": {
         "psr-4": {

--- a/plugins/BEdita/API/src/App/BaseApplication.php
+++ b/plugins/BEdita/API/src/App/BaseApplication.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/Admin/AdminController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/AdminController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/Admin/ApplicationsController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/ApplicationsController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/Admin/AsyncJobsController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/AsyncJobsController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/Admin/ConfigController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/ConfigController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/Admin/EndpointPermissionsController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/EndpointPermissionsController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 Atlas Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/Admin/EndpointsController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/EndpointsController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/Admin/SysinfoController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/SysinfoController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/AnnotationsController.php
+++ b/plugins/BEdita/API/src/Controller/AnnotationsController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/AppController.php
+++ b/plugins/BEdita/API/src/Controller/AppController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/ApplicationsController.php
+++ b/plugins/BEdita/API/src/Controller/ApplicationsController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/JsonApiComponent.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/Component/UploadComponent.php
+++ b/plugins/BEdita/API/src/Controller/Component/UploadComponent.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/ConfigController.php
+++ b/plugins/BEdita/API/src/Controller/ConfigController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/FoldersController.php
+++ b/plugins/BEdita/API/src/Controller/FoldersController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/HistoryController.php
+++ b/plugins/BEdita/API/src/Controller/HistoryController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/HomeController.php
+++ b/plugins/BEdita/API/src/Controller/HomeController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * BEdita, API-first content management framework

--- a/plugins/BEdita/API/src/Controller/JsonBaseController.php
+++ b/plugins/BEdita/API/src/Controller/JsonBaseController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/LoginController.php
+++ b/plugins/BEdita/API/src/Controller/LoginController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018-2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/MediaController.php
+++ b/plugins/BEdita/API/src/Controller/MediaController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/Model/CategoriesController.php
+++ b/plugins/BEdita/API/src/Controller/Model/CategoriesController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/Model/ModelController.php
+++ b/plugins/BEdita/API/src/Controller/Model/ModelController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/Model/ObjectTypesController.php
+++ b/plugins/BEdita/API/src/Controller/Model/ObjectTypesController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/Model/ProjectController.php
+++ b/plugins/BEdita/API/src/Controller/Model/ProjectController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/Model/PropertiesController.php
+++ b/plugins/BEdita/API/src/Controller/Model/PropertiesController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/Model/PropertyTypesController.php
+++ b/plugins/BEdita/API/src/Controller/Model/PropertyTypesController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/Model/RelationsController.php
+++ b/plugins/BEdita/API/src/Controller/Model/RelationsController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/Model/SchemaController.php
+++ b/plugins/BEdita/API/src/Controller/Model/SchemaController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/Model/TagsController.php
+++ b/plugins/BEdita/API/src/Controller/Model/TagsController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/ObjectPermissionsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectPermissionsController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2023 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/RolesController.php
+++ b/plugins/BEdita/API/src/Controller/RolesController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/SignupController.php
+++ b/plugins/BEdita/API/src/Controller/SignupController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/StatusController.php
+++ b/plugins/BEdita/API/src/Controller/StatusController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/StreamsController.php
+++ b/plugins/BEdita/API/src/Controller/StreamsController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/TranslationsController.php
+++ b/plugins/BEdita/API/src/Controller/TranslationsController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/TrashController.php
+++ b/plugins/BEdita/API/src/Controller/TrashController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/TreesController.php
+++ b/plugins/BEdita/API/src/Controller/TreesController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/UploadController.php
+++ b/plugins/BEdita/API/src/Controller/UploadController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Controller/UsersController.php
+++ b/plugins/BEdita/API/src/Controller/UsersController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Datasource/JsonApiPaginator.php
+++ b/plugins/BEdita/API/src/Datasource/JsonApiPaginator.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Error/ErrorHandler.php
+++ b/plugins/BEdita/API/src/Error/ErrorHandler.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Error/ExceptionRenderer.php
+++ b/plugins/BEdita/API/src/Error/ExceptionRenderer.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Event/CommonEventHandler.php
+++ b/plugins/BEdita/API/src/Event/CommonEventHandler.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Exception/ExpiredTokenException.php
+++ b/plugins/BEdita/API/src/Exception/ExpiredTokenException.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Middleware/AnalyticsMiddleware.php
+++ b/plugins/BEdita/API/src/Middleware/AnalyticsMiddleware.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Middleware/AnalyticsMiddleware.php
+++ b/plugins/BEdita/API/src/Middleware/AnalyticsMiddleware.php
@@ -116,7 +116,7 @@ class AnalyticsMiddleware implements MiddlewareInterface
         if ($response->getStatusCode() < 400) {
             return null;
         }
-        $body = json_decode($response->getBody(), true);
+        $body = json_decode((string)$response->getBody(), true);
         if (empty($body['error']['code'])) {
             return null;
         }

--- a/plugins/BEdita/API/src/Middleware/BodyParserMiddleware.php
+++ b/plugins/BEdita/API/src/Middleware/BodyParserMiddleware.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Middleware/CorsMiddleware.php
+++ b/plugins/BEdita/API/src/Middleware/CorsMiddleware.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Model/Action/UpdateAssociatedAction.php
+++ b/plugins/BEdita/API/src/Model/Action/UpdateAssociatedAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Model/Action/UpdateRelatedAction.php
+++ b/plugins/BEdita/API/src/Model/Action/UpdateRelatedAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Network/Exception/UnsupportedMediaTypeException.php
+++ b/plugins/BEdita/API/src/Network/Exception/UnsupportedMediaTypeException.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/TestSuite/IntegrationTestCase.php
+++ b/plugins/BEdita/API/src/TestSuite/IntegrationTestCase.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Utility/JWTHandler.php
+++ b/plugins/BEdita/API/src/Utility/JWTHandler.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/Utility/JsonApi.php
+++ b/plugins/BEdita/API/src/Utility/JsonApi.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/src/View/JsonApiView.php
+++ b/plugins/BEdita/API/src/View/JsonApiView.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/AdminResourcesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/AdminResourcesTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/AssociatedEntitiesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/AssociatedEntitiesTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/AuthenticationTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/AuthenticationTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/ChildrenRelationshipTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ChildrenRelationshipTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/CountQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/CountQueryStringTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/CustomPropertiesFilterTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/CustomPropertiesFilterTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/DateTimeTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/DateTimeTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/DefaultValuesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/DefaultValuesTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/DeleteFolderTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/DeleteFolderTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/ExceptionRendererTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ExceptionRendererTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/FieldsQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FieldsQueryStringTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/I18nTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/I18nTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/MarshallInheritedPropertiesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/MarshallInheritedPropertiesTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/MetadataTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/MetadataTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/NewObjectTypesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/NewObjectTypesTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/PaginationTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/PaginationTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/PublishStartEndTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/PublishStartEndTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/RelationshipsParamsTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/RelationshipsParamsTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/RelationshipsPriorityTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/RelationshipsPriorityTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/ResourceNamesValidationTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ResourceNamesValidationTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/SortQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/SortQueryStringTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/StatusLevelTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/StatusLevelTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/TagsCategoriesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/TagsCategoriesTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/UniqueNameTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/UniqueNameTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/IntegrationTest/UuidLoginTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/UuidLoginTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/App/BaseApplicationTest.php
+++ b/plugins/BEdita/API/tests/TestCase/App/BaseApplicationTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/AdminControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/AdminControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/ApplicationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/ApplicationsControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/AsyncJobsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/AsyncJobsControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/ConfigControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/ConfigControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/EndpointsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/EndpointsControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/SysinfoControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/SysinfoControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2023 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/AnnotationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AnnotationsControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/AppControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AppControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/ApplicationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ApplicationsControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/JsonApiComponentTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/UploadComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/UploadComponentTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/ConfigControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ConfigControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/HistoryControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/HistoryControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/HomeControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/JsonBaseControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/JsonBaseControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/LoginControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/MediaControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/MediaControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/MediaControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/MediaControllerTest.php
@@ -170,7 +170,7 @@ class MediaControllerTest extends IntegrationTestCase
      * Test `thumbs` method.
      *
      * @param array $expected Expected thumbnails.
-     * @param int|int[] $id List of IDs.
+     * @param int|int[]|string $id List of IDs.
      * @param array $query Query options.
      * @return void
      * @dataProvider thumbsProvider()
@@ -183,7 +183,7 @@ class MediaControllerTest extends IntegrationTestCase
         $this->configRequestHeaders('GET');
 
         $path = '/media/thumbs';
-        if (!is_array($id) && strpos($id, ',') === false) {
+        if (!is_array($id) && strpos((string)$id, ',') === false) {
             $path .= '/' . $id;
         } else {
             $query['ids'] = $id;

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertiesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertiesControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/SchemaControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/SchemaControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectPermissionsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectPermissionsControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2023 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/StatusControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/StatusControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/StreamsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/StreamsControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/TranslationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TranslationsControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/TrashControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TrashControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/TreesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TreesControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/UploadControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/UploadControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Datasource/JsonApiPaginatorTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Datasource/JsonApiPaginatorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Error/ErrorHandlerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Error/ExceptionRendererTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Error/MyExceptionRenderer.php
+++ b/plugins/BEdita/API/tests/TestCase/Error/MyExceptionRenderer.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Event/CommonEventHandlerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Event/CommonEventHandlerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Identifier/OAuth2IdentifierTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Identifier/OAuth2IdentifierTest.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 /**

--- a/plugins/BEdita/API/tests/TestCase/Middleware/AnalyticsMiddlewareTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Middleware/AnalyticsMiddlewareTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Middleware/BodyParserMiddlewareTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Middleware/BodyParserMiddlewareTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Middleware/CorsMiddlewareTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Middleware/CorsMiddlewareTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateAssociatedActionTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateAssociatedActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateRelatedActionTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateRelatedActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Network/Exception/UnsupportedMediaTypeExceptionTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Network/Exception/UnsupportedMediaTypeExceptionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
+++ b/plugins/BEdita/API/tests/TestCase/TestSuite/IntegrationTestCaseTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Utility/JWTHandlerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JWTHandlerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
+++ b/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
+++ b/plugins/BEdita/API/tests/TestCase/View/JsonApiViewTest.php
@@ -463,7 +463,7 @@ class JsonApiViewTest extends TestCase
         $Controller->set($data);
         $Controller->viewBuilder()->setClassName('BEdita/API.JsonApi');
 
-        $result = $Controller->createView()->render(false);
+        $result = $Controller->createView()->render();
 
         static::assertJsonStringEqualsJsonString($expected, $result);
     }

--- a/plugins/BEdita/API/tests/TestConstants.php
+++ b/plugins/BEdita/API/tests/TestConstants.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/composer.json
+++ b/plugins/BEdita/Core/composer.json
@@ -32,7 +32,7 @@
         "swaggest/json-schema": "~0.12.39"
     },
     "require-dev": {
-        "cakephp/cakephp-codesniffer": "~4.5.1",
+        "cakephp/cakephp-codesniffer": "^4.7",
         "enqueue/fs": "^0.10.16",
         "phpunit/phpunit": "^9.5"
     },

--- a/plugins/BEdita/Core/src/Cache/Engine/LayeredEngine.php
+++ b/plugins/BEdita/Core/src/Cache/Engine/LayeredEngine.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Command/AsyncJobsCleanCommand.php
+++ b/plugins/BEdita/Core/src/Command/AsyncJobsCleanCommand.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2024 Channelweb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Command/CustomPropsCommand.php
+++ b/plugins/BEdita/Core/src/Command/CustomPropsCommand.php
@@ -71,7 +71,7 @@ class CustomPropsCommand extends Command
         }
         $errors = 0;
         foreach ($types as $type) {
-            $errors += $this->customPropsByType($type, $args->getOption('id'), $io);
+            $errors += $this->customPropsByType($type, (int)$args->getOption('id'), $io);
         }
         if ($errors) {
             $io->error(sprintf('Errors found (%d)', $errors));

--- a/plugins/BEdita/Core/src/Command/CustomPropsCommand.php
+++ b/plugins/BEdita/Core/src/Command/CustomPropsCommand.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Command/FixHistoryCommand.php
+++ b/plugins/BEdita/Core/src/Command/FixHistoryCommand.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Command/ObjectsDeleteCommand.php
+++ b/plugins/BEdita/Core/src/Command/ObjectsDeleteCommand.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2024 Channelweb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Command/ThumbsCommand.php
+++ b/plugins/BEdita/Core/src/Command/ThumbsCommand.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2024 Channelweb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Command/TreeCheckCommand.php
+++ b/plugins/BEdita/Core/src/Command/TreeCheckCommand.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 Atlas Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Command/TreeRecoverCommand.php
+++ b/plugins/BEdita/Core/src/Command/TreeRecoverCommand.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 Atlas Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Configure/Engine/DatabaseConfig.php
+++ b/plugins/BEdita/Core/src/Configure/Engine/DatabaseConfig.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Database/Type/BoolType.php
+++ b/plugins/BEdita/Core/src/Database/Type/BoolType.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Database/Type/DateTimeType.php
+++ b/plugins/BEdita/Core/src/Database/Type/DateTimeType.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Database/Type/DateType.php
+++ b/plugins/BEdita/Core/src/Database/Type/DateType.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Database/Type/JsonObjectType.php
+++ b/plugins/BEdita/Core/src/Database/Type/JsonObjectType.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Event/ImageThumbsHandler.php
+++ b/plugins/BEdita/Core/src/Event/ImageThumbsHandler.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2024 Channelweb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Exception/BadFilterException.php
+++ b/plugins/BEdita/Core/src/Exception/BadFilterException.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Exception/ImmutableResourceException.php
+++ b/plugins/BEdita/Core/src/Exception/ImmutableResourceException.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Exception/InvalidDataException.php
+++ b/plugins/BEdita/Core/src/Exception/InvalidDataException.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Exception/LockedResourceException.php
+++ b/plugins/BEdita/Core/src/Exception/LockedResourceException.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 Atlas Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Exception/UserExistsException.php
+++ b/plugins/BEdita/Core/src/Exception/UserExistsException.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Filesystem/Adapter/LocalAdapter.php
+++ b/plugins/BEdita/Core/src/Filesystem/Adapter/LocalAdapter.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Filesystem/Exception/InvalidStreamException.php
+++ b/plugins/BEdita/Core/src/Filesystem/Exception/InvalidStreamException.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Filesystem/Exception/InvalidThumbnailOptionsException.php
+++ b/plugins/BEdita/Core/src/Filesystem/Exception/InvalidThumbnailOptionsException.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Filesystem/FilesystemAdapter.php
+++ b/plugins/BEdita/Core/src/Filesystem/FilesystemAdapter.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Filesystem/FilesystemRegistry.php
+++ b/plugins/BEdita/Core/src/Filesystem/FilesystemRegistry.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Filesystem/GeneratorInterface.php
+++ b/plugins/BEdita/Core/src/Filesystem/GeneratorInterface.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Filesystem/Thumbnail.php
+++ b/plugins/BEdita/Core/src/Filesystem/Thumbnail.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Filesystem/Thumbnail/AsyncGenerator.php
+++ b/plugins/BEdita/Core/src/Filesystem/Thumbnail/AsyncGenerator.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Filesystem/Thumbnail/GlideGenerator.php
+++ b/plugins/BEdita/Core/src/Filesystem/Thumbnail/GlideGenerator.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Filesystem/ThumbnailGenerator.php
+++ b/plugins/BEdita/Core/src/Filesystem/ThumbnailGenerator.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Filesystem/ThumbnailRegistry.php
+++ b/plugins/BEdita/Core/src/Filesystem/ThumbnailRegistry.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/I18n/MessagesFileLoader.php
+++ b/plugins/BEdita/Core/src/I18n/MessagesFileLoader.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl
@@ -45,7 +47,7 @@ class MessagesFileLoader extends BaseLoader
     /**
      * {@inheritDoc}
      *
-     * @param string[] $plugins Additional plugins to look up in for translations.
+     * @param string[] $name Additional plugins to look up in for translations.
      */
     public function __construct(string $name, string $locale, string $extension = 'po', array $plugins = [])
     {

--- a/plugins/BEdita/Core/src/Job/JobService.php
+++ b/plugins/BEdita/Core/src/Job/JobService.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Job/Service/MailService.php
+++ b/plugins/BEdita/Core/src/Job/Service/MailService.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Job/Service/ThumbnailService.php
+++ b/plugins/BEdita/Core/src/Job/Service/ThumbnailService.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Job/Service/ThumbnailService.php
+++ b/plugins/BEdita/Core/src/Job/Service/ThumbnailService.php
@@ -50,7 +50,7 @@ class ThumbnailService implements JobService
             return true;
         } catch (\Exception $e) {
             // Another error occurred. Log the error, and mark job as failed.
-            Log::error($e);
+            Log::error($e->getMessage());
 
             return false;
         }

--- a/plugins/BEdita/Core/src/Job/ServiceRegistry.php
+++ b/plugins/BEdita/Core/src/Job/ServiceRegistry.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Mailer/Email.php
+++ b/plugins/BEdita/Core/src/Mailer/Email.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Mailer/Preview/UserMailerPreview.php
+++ b/plugins/BEdita/Core/src/Mailer/Preview/UserMailerPreview.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Mailer/Transport/AsyncJobsTransport.php
+++ b/plugins/BEdita/Core/src/Mailer/Transport/AsyncJobsTransport.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Mailer/UserMailer.php
+++ b/plugins/BEdita/Core/src/Mailer/UserMailer.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Migration/ResourcesMigration.php
+++ b/plugins/BEdita/Core/src/Migration/ResourcesMigration.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/ActionTrait.php
+++ b/plugins/BEdita/Core/src/Model/Action/ActionTrait.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/AddAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/AddAssociatedAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/AddRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/AddRelatedObjectsAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/AssociatedTrait.php
+++ b/plugins/BEdita/Core/src/Model/Action/AssociatedTrait.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/BaseAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/BaseAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/ChangeCredentialsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ChangeCredentialsAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/ChangeCredentialsRequestAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ChangeCredentialsRequestAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/CountRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/CountRelatedObjectsAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/DeleteEntityAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/DeleteEntityAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/DeleteObjectAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/DeleteObjectAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/GetEntityAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/GetEntityAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/GetObjectAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/GetObjectAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/ListEntitiesAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListEntitiesAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/ListObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListObjectsAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedFoldersAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedFoldersAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/RemoveAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/RemoveAssociatedAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/RemoveRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/RemoveRelatedObjectsAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/SaveEntityAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SaveEntityAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/SetAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SetAssociatedAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/SetRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SetRelatedObjectsAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserActivationAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserActivationAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/UpdateAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/UpdateAssociatedAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/UpdateRelatedObjectsAction.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Behavior/CategoriesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CategoriesBehavior.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Behavior/DataCleanupBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/DataCleanupBehavior.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Behavior/GeometryBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/GeometryBehavior.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Behavior/HistoryBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/HistoryBehavior.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Behavior/ObjectModelBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/ObjectModelBehavior.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Behavior/ObjectTypeBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/ObjectTypeBehavior.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Behavior/PriorityBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/PriorityBehavior.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Behavior/QueryCacheBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/QueryCacheBehavior.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Behavior/ResourceNameBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/ResourceNameBehavior.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Behavior/StatusBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/StatusBehavior.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/TreeBehavior.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Behavior/UploadableBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UploadableBehavior.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017-2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Behavior/UserModifiedBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UserModifiedBehavior.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/Annotation.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Annotation.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/AppConfig.php
+++ b/plugins/BEdita/Core/src/Model/Entity/AppConfig.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/Application.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Application.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/AsyncJob.php
+++ b/plugins/BEdita/Core/src/Model/Entity/AsyncJob.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Model\Entity;
 
 use BEdita\Core\Job\ServiceRegistry;

--- a/plugins/BEdita/Core/src/Model/Entity/AuthProvider.php
+++ b/plugins/BEdita/Core/src/Model/Entity/AuthProvider.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/Category.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Category.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/Config.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Config.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/DateRange.php
+++ b/plugins/BEdita/Core/src/Model/Entity/DateRange.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/Endpoint.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Endpoint.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/EndpointPermission.php
+++ b/plugins/BEdita/Core/src/Model/Entity/EndpointPermission.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/ExternalAuth.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ExternalAuth.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/Folder.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Folder.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/History.php
+++ b/plugins/BEdita/Core/src/Model/Entity/History.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiAdminTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiAdminTrait.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiModelTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiModelTrait.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/Link.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Link.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/Location.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Location.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/Media.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Media.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectCategory.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectCategory.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectPermission.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectPermission.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Model\Entity;
 
 use BEdita\Core\Utility\JsonApiSerializable;

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectProperty.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectProperty.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Model\Entity;
 
 use Cake\ORM\Entity;

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectRelation.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectRelation.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Model\Entity;
 
 use Cake\ORM\Entity;

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectTag.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectTag.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectTypeNameTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectTypeNameTrait.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/Profile.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Profile.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/Property.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Property.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/PropertyType.php
+++ b/plugins/BEdita/Core/src/Model/Entity/PropertyType.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/Publication.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Publication.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/Relation.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Relation.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/RelationType.php
+++ b/plugins/BEdita/Core/src/Model/Entity/RelationType.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/Role.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Role.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/RolesUser.php
+++ b/plugins/BEdita/Core/src/Model/Entity/RolesUser.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/StaticProperty.php
+++ b/plugins/BEdita/Core/src/Model/Entity/StaticProperty.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/Stream.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Stream.php
@@ -334,7 +334,7 @@ class Stream extends Entity implements JsonApiSerializable
         );
 
         try {
-            $exif = exif_read_data($resource, null, true);
+            $exif = exif_read_data($resource, '', true);
         } catch (\ErrorException $e) {
             // Log a warning if reading EXIF throws an error, but keep going
             // so that other metadata is eventually updated

--- a/plugins/BEdita/Core/src/Model/Entity/Stream.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Stream.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/Tag.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Tag.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/Translation.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Translation.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/Tree.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Tree.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/User.php
+++ b/plugins/BEdita/Core/src/Model/Entity/User.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Entity/UserToken.php
+++ b/plugins/BEdita/Core/src/Model/Entity/UserToken.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/AnnotationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/AnnotationsTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/AppConfigTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/AppConfigTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/AsyncJobsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/AsyncJobsTable.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Job\QueueJob;

--- a/plugins/BEdita/Core/src/Model/Table/AuthProvidersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/AuthProvidersTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/ConfigTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ConfigTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/DateRangesTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/EndpointPermissionsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/EndpointPermissionsTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/EndpointsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/EndpointsTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/ExternalAuthTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ExternalAuthTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/HistoryTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/HistoryTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/LinksTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/LinksTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/LocationsTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/MediaTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/MediaTable.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Model\Table\ObjectsBaseTable as Table;

--- a/plugins/BEdita/Core/src/Model/Table/ObjectCategoriesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectCategoriesTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/ObjectPermissionsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectPermissionsTable.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Utility\LoggedUser;

--- a/plugins/BEdita/Core/src/Model/Table/ObjectPropertiesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectPropertiesTable.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Model\Table;
 
 use Cake\ORM\RulesChecker;

--- a/plugins/BEdita/Core/src/Model/Table/ObjectRelationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectRelationsTable.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Model\Validation\Validation;

--- a/plugins/BEdita/Core/src/Model/Table/ObjectTagsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectTagsTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsBaseTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsBaseTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ProfilesTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/PropertiesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/PropertiesTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/PropertyTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/PropertyTypesTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/PublicationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/PublicationsTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/RelationTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationTypesTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * BEdita, API-first content management framework

--- a/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/RolesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RolesTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/RolesUsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RolesUsersTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/StaticPropertiesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/StaticPropertiesTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/StreamsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/StreamsTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/TagsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TagsTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/TranslationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TranslationsTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/TreesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TreesTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/UserTokensTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UserTokensTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -343,7 +343,7 @@ class UsersTable extends Table
     {
         $names = $ids = [];
         foreach ($options as $opt) {
-            $items = (array)explode(',', $opt);
+            $items = (array)explode(',', (string)$opt);
             foreach ($items as $item) {
                 if (is_numeric($item)) {
                     $ids[] = $item;

--- a/plugins/BEdita/Core/src/Model/Validation/LocationsValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/LocationsValidator.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Validation/MediaValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/MediaValidator.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Validation/ObjectTypesValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/ObjectTypesValidator.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Validation/ObjectsValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/ObjectsValidator.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Validation/ProfilesValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/ProfilesValidator.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Validation/SqlConventionsValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/SqlConventionsValidator.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Validation/UsersValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/UsersValidator.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Model/Validation/Validation.php
+++ b/plugins/BEdita/Core/src/Model/Validation/Validation.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/ORM/Association/RelatedTo.php
+++ b/plugins/BEdita/Core/src/ORM/Association/RelatedTo.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/ORM/Inheritance/AssociationCollection.php
+++ b/plugins/BEdita/Core/src/ORM/Inheritance/AssociationCollection.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/ORM/Inheritance/InheritanceEventHandler.php
+++ b/plugins/BEdita/Core/src/ORM/Inheritance/InheritanceEventHandler.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/ORM/Inheritance/Marshaller.php
+++ b/plugins/BEdita/Core/src/ORM/Inheritance/Marshaller.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/ORM/Inheritance/Query.php
+++ b/plugins/BEdita/Core/src/ORM/Inheritance/Query.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/ORM/Inheritance/Table.php
+++ b/plugins/BEdita/Core/src/ORM/Inheritance/Table.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/ORM/Locator/TableLocator.php
+++ b/plugins/BEdita/Core/src/ORM/Locator/TableLocator.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
+++ b/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/ORM/Rule/IsUniqueAmongst.php
+++ b/plugins/BEdita/Core/src/ORM/Rule/IsUniqueAmongst.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Shell/BeditaShell.php
+++ b/plugins/BEdita/Core/src/Shell/BeditaShell.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Shell/DbAdminShell.php
+++ b/plugins/BEdita/Core/src/Shell/DbAdminShell.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Shell/JobsShell.php
+++ b/plugins/BEdita/Core/src/Shell/JobsShell.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Shell/ResourcesShell.php
+++ b/plugins/BEdita/Core/src/Shell/ResourcesShell.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Shell/StreamsShell.php
+++ b/plugins/BEdita/Core/src/Shell/StreamsShell.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Shell/Task/CheckApiKeyTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/CheckApiKeyTask.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Shell/Task/CheckFilesystemTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/CheckFilesystemTask.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Shell/Task/CheckSchemaTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/CheckSchemaTask.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Shell/Task/InitSchemaTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/InitSchemaTask.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Shell/Task/SetupAdminUserTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/SetupAdminUserTask.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Shell/Task/SetupConnectionTask.php
+++ b/plugins/BEdita/Core/src/Shell/Task/SetupConnectionTask.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/SingletonTrait.php
+++ b/plugins/BEdita/Core/src/SingletonTrait.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017-2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/State/CurrentApplication.php
+++ b/plugins/BEdita/Core/src/State/CurrentApplication.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Utility/Database.php
+++ b/plugins/BEdita/Core/src/Utility/Database.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Utility/JsonApiSerializable.php
+++ b/plugins/BEdita/Core/src/Utility/JsonApiSerializable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Utility/JsonSchema.php
+++ b/plugins/BEdita/Core/src/Utility/JsonSchema.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Utility/LoggedUser.php
+++ b/plugins/BEdita/Core/src/Utility/LoggedUser.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Utility/OAuth2.php
+++ b/plugins/BEdita/Core/src/Utility/OAuth2.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * BEdita, API-first content management framework

--- a/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
+++ b/plugins/BEdita/Core/src/Utility/ObjectsHandler.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * BEdita, API-first content management framework

--- a/plugins/BEdita/Core/src/Utility/Properties.php
+++ b/plugins/BEdita/Core/src/Utility/Properties.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Utility/Relations.php
+++ b/plugins/BEdita/Core/src/Utility/Relations.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Utility/Resources.php
+++ b/plugins/BEdita/Core/src/Utility/Resources.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Utility/ResourcesBase.php
+++ b/plugins/BEdita/Core/src/Utility/ResourcesBase.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Utility/System.php
+++ b/plugins/BEdita/Core/src/Utility/System.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/src/Utility/Text.php
+++ b/plugins/BEdita/Core/src/Utility/Text.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/AnnotationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/AnnotationsFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2023 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/ApplicationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ApplicationsFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/AsyncJobsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/AsyncJobsFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2023 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/AuthProvidersFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/AuthProvidersFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/CategoriesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/CategoriesFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/ConfigFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ConfigFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/DateRangesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/DateRangesFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/EndpointPermissionsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/EndpointPermissionsFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/EndpointsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/EndpointsFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/ExternalAuthFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ExternalAuthFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/FakeAnimalsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeAnimalsFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/FakeArticlesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeArticlesFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/FakeArticlesTagsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeArticlesTagsFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/FakeCategoriesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeCategoriesFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/FakeFelinesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeFelinesFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/FakeLabelsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeLabelsFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/FakeMammalsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeMammalsFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/FakeSearchesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeSearchesFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/FakeTagsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/FakeTagsFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/HistoryFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/HistoryFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/JsonSchemaTableFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/JsonSchemaTableFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/LinksFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/LinksFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2023 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/LocationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/LocationsFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2023 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/MediaFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/MediaFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2023 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/ObjectCategoriesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ObjectCategoriesFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/ObjectPermissionsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ObjectPermissionsFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2023 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/ObjectPropertiesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ObjectPropertiesFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2023 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/ObjectRelationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ObjectRelationsFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2023 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/ObjectTagsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ObjectTagsFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/ObjectTypesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ObjectTypesFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/ObjectsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ObjectsFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2023 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/ProfilesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/ProfilesFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/PropertiesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/PropertiesFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2023 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/PropertyTypesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/PropertyTypesFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/PublicationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/PublicationsFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2023 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/RelationTypesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/RelationTypesFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/RelationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/RelationsFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/RolesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/RolesFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/RolesUsersFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/RolesUsersFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/StreamsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/StreamsFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/TagsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/TagsFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/TranslationsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/TranslationsFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/TreesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/TreesFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2023 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/UserTokensFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/UserTokensFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Fixture/UsersFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/UsersFixture.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Cache/Engine/LayeredEngineTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Cache/Engine/LayeredEngineTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Command/AsyncJobsCleanCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/AsyncJobsCleanCommandTest.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2024 Channelweb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Command/CustomPropsCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/CustomPropsCommandTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Command/FixHistoryCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/FixHistoryCommandTest.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Test\TestCase\Command;
 
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;

--- a/plugins/BEdita/Core/tests/TestCase/Command/ObjectsDeleteCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ObjectsDeleteCommandTest.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2024 Channelweb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Command/ThumbsCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ThumbsCommandTest.php
@@ -1,6 +1,6 @@
 <?php
-
 declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2024 Channelweb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Command/TreeCheckCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/TreeCheckCommandTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 Channelweb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Command/TreeRecoverCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/TreeRecoverCommandTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 Channelweb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Configure/Engine/DatabaseConfigTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Configure/Engine/DatabaseConfigTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Database/Type/BoolTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Database/Type/BoolTypeTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Database/Type/DateTypeTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Database/Type/JsonObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Database/Type/JsonObjectTypeTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Event/ImageThumbsHandlerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Event/ImageThumbsHandlerTest.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2024 Channelweb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/Adapter/LocalAdapterTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/Adapter/LocalAdapterTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/FilesystemAdapterTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/FilesystemAdapterTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/FilesystemRegistryTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/FilesystemRegistryTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/AsyncGeneratorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/AsyncGeneratorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/GlideGeneratorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/GlideGeneratorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/TestGenerator.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/TestGenerator.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/ThumbnailGeneratorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/ThumbnailGeneratorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/ThumbnailRegistryTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/ThumbnailRegistryTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/ThumbnailTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/ThumbnailTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/I18n/MessagesFileLoaderTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/I18n/MessagesFileLoaderTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Job/QueueJobTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/QueueJobTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Job/Service/MailServiceTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/Service/MailServiceTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Job/Service/ThumbnailServiceTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/Service/ThumbnailServiceTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Job/ServiceRegistryTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/ServiceRegistryTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/EmailTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/EmailTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/Transport/AsyncJobsTransportTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/Transport/AsyncJobsTransportTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Migration/Migrations/TestAdd.php
+++ b/plugins/BEdita/Core/tests/TestCase/Migration/Migrations/TestAdd.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Test\TestCase\Migration\Migrations;
 
 use BEdita\Core\Migration\ResourcesMigration;

--- a/plugins/BEdita/Core/tests/TestCase/Migration/Migrations/TestColumns.php
+++ b/plugins/BEdita/Core/tests/TestCase/Migration/Migrations/TestColumns.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Test\TestCase\Migration\Migrations;
 
 use BEdita\Core\Migration\ResourcesMigration;

--- a/plugins/BEdita/Core/tests/TestCase/Migration/Migrations/TestMissing.php
+++ b/plugins/BEdita/Core/tests/TestCase/Migration/Migrations/TestMissing.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Test\TestCase\Migration\Migrations;
 
 use BEdita\Core\Migration\ResourcesMigration;

--- a/plugins/BEdita/Core/tests/TestCase/Migration/MockMigrationsTable.php
+++ b/plugins/BEdita/Core/tests/TestCase/Migration/MockMigrationsTable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Migration/ResourcesMigrationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Migration/ResourcesMigrationTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ActionTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ActionTraitTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddAssociatedActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/AddRelatedObjectsActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/BaseActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/BaseActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ChangeCredentialsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ChangeCredentialsActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ChangeCredentialsRequestActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ChangeCredentialsRequestActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/CountRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/CountRelatedObjectsActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteEntityActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteEntityActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteObjectActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteObjectActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/GetEntityActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/GetEntityActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/GetObjectActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/GetObjectActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListEntitiesActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListEntitiesActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListObjectsActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedFoldersActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedFoldersActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListRelatedObjectsActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveAssociatedActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/RemoveRelatedObjectsActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SaveEntityActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SaveEntityActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SetAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SetAssociatedActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SetRelatedObjectsActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -364,7 +364,7 @@ class SignupUserActionTest extends TestCase
         $authProvider = $this->fetchTable('AuthProviders')->get(1);
         $authProvider->params = [
             'options' => [
-                'credentials_callback' => [static::class, 'testCallback'],
+                'credentials_callback' => [static::class, 'dummyCallback'],
             ],
         ];
         $this->fetchTable('AuthProviders')->saveOrFail($authProvider);
@@ -386,7 +386,7 @@ class SignupUserActionTest extends TestCase
      *
      * @return bool
      */
-    public static function testCallback(): bool
+    public static function dummyCallback(): bool
     {
         return true;
     }
@@ -404,7 +404,7 @@ class SignupUserActionTest extends TestCase
         $authProvider = $this->fetchTable('AuthProviders')->get(1);
         $authProvider->params = [
             'options' => [
-                'credentials_callback' => [static::class, 'testCallbackFalse'],
+                'credentials_callback' => [static::class, 'dummyCallbackFalse'],
             ],
         ];
         $this->fetchTable('AuthProviders')->saveOrFail($authProvider);
@@ -425,7 +425,7 @@ class SignupUserActionTest extends TestCase
      *
      * @return bool
      */
-    public static function testCallbackFalse(): bool
+    public static function dummyCallbackFalse(): bool
     {
         return false;
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActivationActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActivationActionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CategoriesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CategoriesBehaviorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/DataCleanupBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/DataCleanupBehaviorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/GeometryBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/GeometryBehaviorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/HistoryBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/HistoryBehaviorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectModelBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectModelBehaviorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectTypeBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectTypeBehaviorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/PriorityBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/PriorityBehaviorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/QueryCacheBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/QueryCacheBehaviorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/RelationsBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/RelationsBehaviorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ResourceNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ResourceNameBehaviorTest.php
@@ -1,6 +1,17 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Test\TestCase\Model\Behavior;
 
 use Cake\Datasource\Exception\RecordNotFoundException;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/StatusBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/StatusBehaviorTest.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Test\TestCase\Model\Behavior;
 
 use BEdita\Core\Exception\BadFilterException;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Test\TestCase\Model\Behavior;
 
 use Cake\ORM\Entity;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UserModifiedBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UserModifiedBehaviorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ApplicationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ApplicationTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/AsyncJobTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/AsyncJobTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/AuthProviderTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/AuthProviderTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/CategoryTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/CategoryTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2023 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ConfigTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ConfigTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/DateRangeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/DateRangeTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointPermissionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointPermissionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/EndpointTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ExternalAuthTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ExternalAuthTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiAdminTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiAdminTraitTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/LocationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/LocationTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/MediaTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/MediaTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectEntityTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectEntityTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeNameTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeNameTraitTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ProfileTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ProfileTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/PropertyTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/PropertyTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/PropertyTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/PropertyTypeTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/PublicationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/PublicationTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2023 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/RelationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/RelationTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/RoleTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/RoleTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/StaticPropertyTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/StaticPropertyTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/StreamTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/StreamTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/TagTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/TagTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2023 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/TreeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/TreeTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/UserTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/UserTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/AnnotationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/AnnotationsTableTest.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use BEdita\Core\Utility\LoggedUser;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/AppConfigTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/AppConfigTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ApplicationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ApplicationsTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/AsyncJobsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/AsyncJobsTableTest.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use BEdita\Core\Model\Entity\AsyncJob;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/AuthProvidersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/AuthProvidersTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/CategoriesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/CategoriesTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ConfigTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/DateRangesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/DateRangesTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointPermissionsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointPermissionsTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/EndpointsTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ExternalAuthTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ExternalAuthTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/HistoryTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/HistoryTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/LinksTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/LinksTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/LocationsTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/MediaTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/MediaTableTest.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use BEdita\Core\Utility\LoggedUser;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectCategoriesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectCategoriesTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectPermissionsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectPermissionsTableTest.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use BEdita\Core\Utility\LoggedUser;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectPropertiesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectPropertiesTableTest.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use Cake\TestSuite\TestCase;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectRelationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectRelationsTableTest.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use BEdita\Core\Model\Table\ObjectRelationsTable;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTagsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTagsTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use BEdita\Core\Exception\LockedResourceException;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ProfilesTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertiesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertiesTableTest.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use BEdita\Core\Exception\BadFilterException;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertyTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/PropertyTypesTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/PublicationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/PublicationsTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationTypesTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RelationsTableTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * BEdita, API-first content management framework

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesUsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/RolesUsersTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/StaticPropertiesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/StaticPropertiesTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/StreamsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/StreamsTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/TagsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/TagsTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/TranslationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/TranslationsTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/TreesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/TreesTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UserTokensTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UserTokensTableTest.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use BEdita\Core\Model\Table\UserTokensTable;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/LocationsValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/LocationsValidatorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/MediaValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/MediaValidatorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/ObjectsValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/ObjectsValidatorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/ProfilesValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/ProfilesValidatorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/SqlConventionsValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/SqlConventionsValidatorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/UsersValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/UsersValidatorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/ValidationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/ValidationTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/MySingletonClass.php
+++ b/plugins/BEdita/Core/tests/TestCase/MySingletonClass.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Association/RelatedToTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Association/RelatedToTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/AssociationCollectionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/AssociationCollectionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/FakeAnimalsTrait.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/FakeAnimalsTrait.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/InheritanceEventHandlerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/InheritanceEventHandlerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/MarshallerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/MarshallerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2018 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/QueryTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/QueryTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/TableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/TableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/ORM/TableLocatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/TableLocatorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Shell/BeditaShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/BeditaShellTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Shell/JobsShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/JobsShellTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Shell/ResourcesShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/ResourcesShellTest.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Test\TestCase\Shell;
 
 use BEdita\Core\Model\Entity\EndpointPermission;

--- a/plugins/BEdita/Core/tests/TestCase/Shell/StreamsShellTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/StreamsShellTest.php
@@ -1,4 +1,17 @@
 <?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 namespace BEdita\Core\Test\TestCase\Shell;
 
 use BEdita\Core\Test\Utility\TestFilesystemTrait;

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckApiKeyTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckApiKeyTaskTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckFilesystemTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckFilesystemTaskTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckSchemaTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckSchemaTaskTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/InitSchemaTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/InitSchemaTaskTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/SetupAdminUserTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/SetupAdminUserTaskTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/SetupConnectionTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/SetupConnectionTaskTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/SingletonTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/SingletonTraitTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/State/CurrentApplicationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/State/CurrentApplicationTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Utility/DatabaseTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/DatabaseTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Utility/JsonSchemaTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/JsonSchemaTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Utility/LoggedUserTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/LoggedUserTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Utility/OAuth2Test.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/OAuth2Test.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHandlerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ObjectsHandlerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Utility/PropertiesTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/PropertiesTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Utility/RelationsTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/RelationsTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2019 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesBaseTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesBaseTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2021 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Utility/SystemTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/SystemTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2016 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/TestCase/Utility/TextTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/TextTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2017 ChannelWeb Srl, Chialab Srl

--- a/plugins/BEdita/Core/tests/Utility/TestFilesystemTrait.php
+++ b/plugins/BEdita/Core/tests/Utility/TestFilesystemTrait.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/src/Application.php
+++ b/src/Application.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2022 ChannelWeb Srl, Chialab Srl

--- a/src/Console/Installer.php
+++ b/src/Console/Installer.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/tests/TestCase/ApplicationTest.php
+++ b/tests/TestCase/ApplicationTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * BEdita, API-first content management framework
  * Copyright 2020 ChannelWeb Srl, Chialab Srl

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * Test runner bootstrap.
  *


### PR DESCRIPTION
This "boring" PR introduces strict types declaration in almost all files.

This feature has been intentionally excluded when we upgraded form 4.x to 5.x to allow easily integrations between the two versions.
Now it doesn't make sense anymore.
