### PR TITLE
Return type of parent_id mutator

### DIFF
--- a/plugins/BEdita/Core/src/Model/Entity/Folder.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Folder.php
@@ -197,7 +197,7 @@ class Folder extends ObjectEntity
     /**
      * Setter for `parent_id` virtual property.
      *
-     * @param int|null $parentId The parent id to set
+     * @param int|string|null $parentId The parent id to set. Can be a numeric string
      * @return int|null
      */
     protected function _setParentId($parentId): ?int
@@ -216,7 +216,7 @@ class Folder extends ObjectEntity
             ])
             ->firstOrFail();
 
-        return $parentId;
+        return $this->parent->id;
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
@@ -142,6 +142,10 @@ class FolderTest extends TestCase
         $folder->parent_id = null;
         static::assertEquals(null, $folder->parent);
         static::assertEquals([], $folder->parents);
+
+        $folder->parent_id = '13';
+        static::assertEquals($parent, $folder->parent);
+        static::assertEquals(13, $folder->parent_id);
     }
 
     /**


### PR DESCRIPTION
Ensure that the returned type of `parent_id` mutator is consistent.