### PR TITLE
Do not reindex entities that are not the primary saved entity

### DIFF
--- a/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace BEdita\Core\Model\Behavior;
 
+use ArrayObject;
 use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Search\Adapter\SimpleAdapter;
 use BEdita\Core\Search\BaseAdapter;
@@ -108,10 +109,16 @@ class SearchableBehavior extends Behavior
      *
      * @param \Cake\Event\EventInterface $event The event
      * @param \Cake\Datasource\EntityInterface $entity The resource entity
+     * @param \ArrayObject $options Save options.
      * @return void
      */
-    public function afterSave(EventInterface $event, EntityInterface $entity): void
+    public function afterSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void
     {
+        if (empty($options['_primary'])) {
+            // Do not reindex non-primary saved entities, as they will probably be incomplete.
+            return;
+        }
+
         $this->indexEntity($event, $entity);
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
@@ -222,6 +222,11 @@ class SearchableBehaviorTest extends TestCase
         static::assertEquals(1, $adapter->afterSaveCount);
         static::assertEquals(1, $adapter->initializedCount);
 
+        $entity->setDirty('name');
+        $table->saveOrFail($entity, ['_primary' => false]);
+        static::assertEquals(1, $adapter->afterSaveCount);
+        static::assertEquals(1, $adapter->initializedCount);
+
         static::assertEquals(0, $adapter->afterDeleteCount);
         $table->deleteOrFail($entity);
         static::assertEquals(1, $adapter->afterDeleteCount);


### PR DESCRIPTION
This PR fixes an issue that caused non-=primary entities to be reindexed, although this might have caused saving an entity in the search engine with incomplete data.