### PR TITLE
Add roots finder for categories

### DIFF
--- a/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/CategoriesTable.php
@@ -276,4 +276,16 @@ class CategoriesTable extends Table
         return $query->find('type', [$object])
             ->where([$this->aliasField('name') => $options['name']]);
     }
+
+    /**
+     * Finder for roots categories.
+     *
+     * @param \Cake\ORM\Query $query The query.
+     * @return \Cake\ORM\Query
+     */
+    protected function findRoots(Query $query): Query
+    {
+        return $query->where(fn (QueryExpression $exp): QueryExpression =>
+            $exp->isNull($this->aliasField('parent_id')));
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/CategoriesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/CategoriesTableTest.php
@@ -249,4 +249,16 @@ class CategoriesTableTest extends TestCase
 
         $this->Categories->find('ids', ['names' => ['unnamed']])->toArray();
     }
+
+    /**
+     * Test `findRoots` method.
+     *
+     * @return void
+     * @covers ::findRoots()
+     */
+    public function testFindRoots()
+    {
+        $roots = $this->Categories->find('roots')->toArray();
+        static::assertEquals([1, 2, 3], Hash::extract($roots, '{n}.id'));
+    }
 }


### PR DESCRIPTION
This PR add a new finder on categories table to get roots.

Can be used in API as filter: `/model/categories?filter[roots]=1`