### PR TITLE
Do not skip thumbnail generation when stream size is unknown

### DIFF
--- a/plugins/BEdita/Core/src/Filesystem/Thumbnail/GlideGenerator.php
+++ b/plugins/BEdita/Core/src/Filesystem/Thumbnail/GlideGenerator.php
@@ -20,6 +20,7 @@ use BEdita\Core\Filesystem\Exception\InvalidStreamException;
 use BEdita\Core\Filesystem\FilesystemRegistry;
 use BEdita\Core\Filesystem\ThumbnailGenerator;
 use BEdita\Core\Model\Entity\Stream;
+use Cake\Log\Log;
 use Cake\Utility\Hash;
 use Intervention\Image\Exception\NotReadableException;
 use Intervention\Image\ImageManager;
@@ -124,7 +125,9 @@ class GlideGenerator extends ThumbnailGenerator
 
         $maxImageSize = $this->getConfig('maxImageSize', 7680 * 4320); // 8K
         if (empty($stream->width) || empty($stream->height)) {
-            throw new InvalidStreamException(__d('bedita', 'Unable to obtain resolution for stream {0}', $stream->uuid));
+            Log::notice(sprintf('Unable to obtain resolution for stream %s', $stream->uuid));
+
+            return;
         }
 
         if ($stream->width * $stream->height <= $maxImageSize) {

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/GlideGeneratorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/GlideGeneratorTest.php
@@ -227,7 +227,7 @@ class GlideGeneratorTest extends TestCase
                 ['w' => 200],
             ],
             'jpg no resolution' => [
-                new InvalidStreamException('Unable to obtain resolution for stream 7ffcb45e-4cc1-492e-9775-74ee6999503f'),
+                true,
                 '7ffcb45e-4cc1-492e-9775-74ee6999503f',
                 ['w' => 200],
             ],


### PR DESCRIPTION
This PR fixes an issue that caused thumbnail generation to be skipped when the resolution of the Stream linked to the Media was unknown.

When the Stream resolution in pixels has not been persisted as stream metadata, the generator will now attempt to generate the thumbnail anyways. The rationale is that rather than giving up aforehand, it should be preferable to give it a try anyways.