### PR TITLE
Command `project_model` skips saving category if already present in database

### DIFF
--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -231,6 +231,14 @@ class ProjectModel
                 $update[$key] = array_values(static::itemsToUpdate($current, $new));
             }
         }
+        if (!empty($update['categories'])) {
+            $names = Hash::extract($update['categories'], '{n}.name');
+            $found = TableRegistry::getTableLocator()->get('Categories')->find()->where(['name IN' => $names])->toArray();
+            $found = (array)Hash::extract($found, '{n}.name');
+            $update['categories'] = array_filter($update['categories'], function ($category) use ($found) {
+                return !in_array($category['name'], $found);
+            });
+        }
 
         return array_filter(
             array_map('array_filter', compact('create', 'update', 'remove'))

--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -231,8 +231,8 @@ class ProjectModel
                 $update[$key] = array_values(static::itemsToUpdate($current, $new));
             }
         }
-        if (!empty($update['categories'])) {
-            $names = Hash::extract($update['categories'], '{n}.name');
+        if (Hash::check($update, 'categories.{n}.name')) {
+            $names = (array)Hash::extract($update['categories'], '{n}.name');
             $found = TableRegistry::getTableLocator()->get('Categories')->find()->where(['name IN' => $names])->toArray();
             $found = (array)Hash::extract($found, '{n}.name');
             $update['categories'] = array_filter($update['categories'], function ($category) use ($found) {

--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -231,18 +231,30 @@ class ProjectModel
                 $update[$key] = array_values(static::itemsToUpdate($current, $new));
             }
         }
-        if (Hash::check($update, 'categories.{n}.name')) {
-            $names = (array)Hash::extract($update['categories'], '{n}.name');
-            $found = TableRegistry::getTableLocator()->get('Categories')->find()->where(['name IN' => $names])->toArray();
-            $found = (array)Hash::extract($found, '{n}.name');
-            $update['categories'] = array_filter($update['categories'], function ($category) use ($found) {
-                return !in_array($category['name'], $found);
-            });
-        }
+        self::categoriesToUpdate($update);
 
         return array_filter(
             array_map('array_filter', compact('create', 'update', 'remove'))
         );
+    }
+
+    /**
+     * Check if there are categories to update.
+     *
+     * @param array $update Update array
+     * @return void
+     */
+    public static function categoriesToUpdate(array &$update): void
+    {
+        if (!Hash::check($update, 'categories.{n}.name')) {
+            return;
+        }
+        $names = (array)Hash::extract($update['categories'], '{n}.name');
+        $found = TableRegistry::getTableLocator()->get('Categories')->find()->where(['name IN' => $names])->toArray();
+        $found = (array)Hash::extract($found, '{n}.name');
+        $update['categories'] = array_values(array_filter($update['categories'], function ($category) use ($found) {
+            return !in_array($category['name'], $found);
+        }));
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -546,13 +546,15 @@ class ProjectModelTest extends TestCase
             'categories in db' => [
                 [
                     'categories' => [
-                        ['name' => 'first-cat', 'label' => 'test'], // in fixture db
-                        ['name' => 'my-cat', 'label' => 'My category'],
+                        ['name' => 'first-cat', 'object' => 'documents', 'label' => 'test'], // in fixture db
+                        ['name' => 'second-cat', 'object' => 'events', 'label' => 'test'], // not in fixture db: object type is not document
+                        ['name' => 'my-cat', 'object' => 'documents', 'label' => 'My category'],
                     ],
                 ],
                 [
                     'categories' => [
-                        ['name' => 'my-cat', 'label' => 'My category'],
+                        ['name' => 'second-cat', 'object' => 'events', 'label' => 'test'],
+                        ['name' => 'my-cat', 'object' => 'documents', 'label' => 'My category'],
                     ],
                 ],
             ],

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -530,4 +530,45 @@ class ProjectModelTest extends TestCase
         ];
         static::assertEquals(compact('update'), $result);
     }
+
+    /**
+     * Data provider for `testCategoriesToUpdate` test case.
+     *
+     * @return array
+     */
+    public function categoriesToUpdateProvider(): array
+    {
+        return [
+            'empty' => [
+                [],
+                [],
+            ],
+            'categories in db' => [
+                [
+                    'categories' => [
+                        ['name' => 'first-cat', 'label' => 'test'], // in fixture db
+                        ['name' => 'my-cat', 'label' => 'My category'],
+                    ],
+                ],
+                [
+                    'categories' => [
+                        ['name' => 'my-cat', 'label' => 'My category'],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `categoriesToUpdate` method
+     *
+     * @return void
+     * @covers ::categoriesToUpdate()
+     * @dataProvider categoriesToUpdateProvider()
+     */
+    public function testCategoriesToUpdate(array $update, array $expected): void
+    {
+        ProjectModel::categoriesToUpdate($update);
+        static::assertEquals($expected, $update);
+    }
 }


### PR DESCRIPTION
This PR fixes https://github.com/bedita/bedita/issues/2092

Project model command skip update categories if already present in database.