### PR TITLE
Delete multiple resources

### DIFF
--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -205,7 +205,7 @@ return function (RouteBuilder $routes) {
         // Trash.
         $routes->connect(
             '/trash',
-            ['controller' => 'Trash', 'action' => 'index', '_method' => 'GET'],
+            ['controller' => 'Trash', 'action' => 'index', '_method' => ['GET', 'DELETE']],
             ['_name' => 'trash:index']
         );
         $routes->connect(

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -210,7 +210,7 @@ class ObjectsController extends ResourcesController
             }
             $filter = ['id' => explode(',', $ids)];
             $entities = $action(compact('filter'));
-            $action = new DeleteEntitiesAction(['table' => $this->Table]);
+            $action = new DeleteEntitiesAction();
             if (!$action(compact('entities'))) {
                 throw new InternalErrorException(__d('bedita', 'Delete failed'));
             }

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -203,12 +203,12 @@ class ObjectsController extends ResourcesController
         $this->request->allowMethod(['get', 'post', 'delete']);
 
         if ($this->request->is('delete')) {
-            $action = new ListEntitiesAction(['table' => $this->Table]);
             $ids = (string)$this->request->getQuery('ids');
             if (empty($ids)) {
                 throw new BadFilterException(__d('bedita', 'Missing required parameter "{0}"', 'ids'));
             }
             $filter = ['id' => explode(',', $ids)];
+            $action = new ListEntitiesAction(['table' => $this->Table]);
             $entities = $action(compact('filter'));
             $action = new DeleteEntitiesAction();
             if (!$action(compact('entities'))) {

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -18,8 +18,8 @@ use BEdita\API\Model\Action\UpdateRelatedAction;
 use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Model\Action\ActionTrait;
 use BEdita\Core\Model\Action\AddRelatedObjectsAction;
-use BEdita\Core\Model\Action\DeleteEntitiesAction;
 use BEdita\Core\Model\Action\DeleteObjectAction;
+use BEdita\Core\Model\Action\DeleteObjectsAction;
 use BEdita\Core\Model\Action\GetObjectAction;
 use BEdita\Core\Model\Action\ListEntitiesAction;
 use BEdita\Core\Model\Action\ListObjectsAction;
@@ -207,13 +207,11 @@ class ObjectsController extends ResourcesController
             if (empty($ids)) {
                 throw new BadFilterException(__d('bedita', 'Missing required parameter "{0}"', 'ids'));
             }
-            $filter = ['id' => explode(',', $ids)];
+            $filter = ['id' => explode(',', $ids), 'deleted' => false];
             $action = new ListEntitiesAction(['table' => $this->Table]);
             $entities = $action(compact('filter'));
-            $action = new DeleteEntitiesAction();
-            try {
-                $action(compact('entities'));
-            } catch (\Exception $e) {
+            $action = new DeleteObjectsAction();
+            if (!$action(compact('entities'))) {
                 throw new InternalErrorException(__d('bedita', 'Delete failed'));
             }
 

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -211,12 +211,13 @@ class ObjectsController extends ResourcesController
             $action = new ListEntitiesAction(['table' => $this->Table]);
             $entities = $action(compact('filter'));
             $action = new DeleteEntitiesAction();
-            if (!$action(compact('entities'))) {
+            try {
+                $action(compact('entities'));
+            } catch (InternalErrorException $e) {
                 throw new InternalErrorException(__d('bedita', 'Delete failed'));
             }
 
-            return $this->response
-                ->withStatus(204);
+            return $this->response->withStatus(204);
         } elseif ($this->request->is('post')) {
             // Add a new entity.
             if ($this->objectType->is_abstract) {

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace BEdita\API\Controller;
 
 use BEdita\API\Model\Action\UpdateRelatedAction;
+use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Model\Action\ActionTrait;
 use BEdita\Core\Model\Action\AddRelatedObjectsAction;
 use BEdita\Core\Model\Action\DeleteEntitiesAction;
@@ -203,8 +204,11 @@ class ObjectsController extends ResourcesController
 
         if ($this->request->is('delete')) {
             $action = new ListEntitiesAction(['table' => $this->Table]);
-            $filter = (array)$this->request->getQuery('filter');
-            $filter = ['id' => (array)Hash::get($filter, 'ids')];
+            $ids = (string)$this->request->getQuery('ids');
+            if (empty($ids)) {
+                throw new BadFilterException(__d('bedita', 'Missing required parameter "{0}"', 'ids'));
+            }
+            $filter = ['id' => explode(',', $ids)];
             $entities = $action(compact('filter'));
             $action = new DeleteEntitiesAction(['table' => $this->Table]);
             if (!$action(compact('entities'))) {

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -213,7 +213,7 @@ class ObjectsController extends ResourcesController
             $action = new DeleteEntitiesAction();
             try {
                 $action(compact('entities'));
-            } catch (InternalErrorException $e) {
+            } catch (\Exception $e) {
                 throw new InternalErrorException(__d('bedita', 'Delete failed'));
             }
 

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -146,7 +146,9 @@ abstract class ResourcesController extends AppController
             $action = new ListEntitiesAction(['table' => $this->Table]);
             $entities = $action(compact('filter'));
             $action = new DeleteEntitiesAction();
-            if (!$action(compact('entities'))) {
+            try {
+                $action(compact('entities'));
+            } catch (InternalErrorException $e) {
                 throw new InternalErrorException(__d('bedita', 'Delete failed'));
             }
 

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -129,6 +129,7 @@ abstract class ResourcesController extends AppController
      *
      * This action represents a collection of resources.
      * If the request is a `POST` request, this action creates a new resource.
+     * If the request is a `DELETE` request, this action deletes existing resources.
      *
      * @return void
      */
@@ -138,8 +139,8 @@ abstract class ResourcesController extends AppController
 
         if ($this->request->is('delete')) {
             $action = new ListEntitiesAction(['table' => $this->Table]);
-            $data = $this->request->getData();
-            $filter = ['id' => (array)Hash::get($data, 'ids')];
+            $filter = (array)$this->request->getQuery('filter');
+            $filter = ['id' => (array)Hash::get($filter, 'ids')];
             $entities = $action(compact('filter'));
             $action = new DeleteEntitiesAction(['table' => $this->Table]);
             if (!$action(compact('entities'))) {

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -145,7 +145,7 @@ abstract class ResourcesController extends AppController
             }
             $filter = ['id' => explode(',', $ids)];
             $entities = $action(compact('filter'));
-            $action = new DeleteEntitiesAction(['table' => $this->Table]);
+            $action = new DeleteEntitiesAction();
             if (!$action(compact('entities'))) {
                 throw new InternalErrorException(__d('bedita', 'Delete failed'));
             }

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -38,7 +38,6 @@ use Cake\ORM\Association\HasOne;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\Routing\Router;
-use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 
 /**

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -146,14 +146,9 @@ abstract class ResourcesController extends AppController
             $action = new ListEntitiesAction(['table' => $this->Table]);
             $entities = $action(compact('filter'));
             $action = new DeleteEntitiesAction();
-            try {
-                $action(compact('entities'));
-            } catch (\Exception $e) {
-                throw new InternalErrorException(__d('bedita', 'Delete failed'));
-            }
+            $action(compact('entities'));
 
-            return $this->response
-                ->withStatus(204);
+            return $this->response->withStatus(204);
         } elseif ($this->request->is('post')) {
             // Add a new entity.
             $entity = $this->Table->newEmptyEntity();

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace BEdita\API\Controller;
 
 use BEdita\API\Model\Action\UpdateAssociatedAction;
+use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Model\Action\AddAssociatedAction;
 use BEdita\Core\Model\Action\DeleteEntitiesAction;
 use BEdita\Core\Model\Action\DeleteEntityAction;
@@ -139,8 +140,11 @@ abstract class ResourcesController extends AppController
 
         if ($this->request->is('delete')) {
             $action = new ListEntitiesAction(['table' => $this->Table]);
-            $filter = (array)$this->request->getQuery('filter');
-            $filter = ['id' => (array)Hash::get($filter, 'ids')];
+            $ids = (string)$this->request->getQuery('ids');
+            if (empty($ids)) {
+                throw new BadFilterException(__d('bedita', 'Missing required parameter "{0}"', 'ids'));
+            }
+            $filter = ['id' => explode(',', $ids)];
             $entities = $action(compact('filter'));
             $action = new DeleteEntitiesAction(['table' => $this->Table]);
             if (!$action(compact('entities'))) {

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -138,12 +138,12 @@ abstract class ResourcesController extends AppController
         $this->request->allowMethod(['get', 'post', 'delete']);
 
         if ($this->request->is('delete')) {
-            $action = new ListEntitiesAction(['table' => $this->Table]);
             $ids = (string)$this->request->getQuery('ids');
             if (empty($ids)) {
                 throw new BadFilterException(__d('bedita', 'Missing required parameter "{0}"', 'ids'));
             }
             $filter = ['id' => explode(',', $ids)];
+            $action = new ListEntitiesAction(['table' => $this->Table]);
             $entities = $action(compact('filter'));
             $action = new DeleteEntitiesAction();
             if (!$action(compact('entities'))) {

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -148,7 +148,7 @@ abstract class ResourcesController extends AppController
             $action = new DeleteEntitiesAction();
             try {
                 $action(compact('entities'));
-            } catch (InternalErrorException $e) {
+            } catch (\Exception $e) {
                 throw new InternalErrorException(__d('bedita', 'Delete failed'));
             }
 

--- a/plugins/BEdita/API/src/Controller/TrashController.php
+++ b/plugins/BEdita/API/src/Controller/TrashController.php
@@ -74,7 +74,7 @@ class TrashController extends AppController
             $filter = (array)$this->request->getQuery('filter');
             $filter = ['id' => (array)Hash::get($filter, 'ids')];
             $entities = $action(compact('filter'));
-            $action = new DeleteObjectsAction(['table' => $this->Table]);
+            $action = new DeleteObjectsAction();
             $action(compact('entities') + ['hard' => true]);
 
             return $this->response

--- a/plugins/BEdita/API/src/Controller/TrashController.php
+++ b/plugins/BEdita/API/src/Controller/TrashController.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
  */
 namespace BEdita\API\Controller;
 
-use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Model\Action\DeleteObjectAction;
 use BEdita\Core\Model\Action\DeleteObjectsAction;
 use BEdita\Core\Model\Action\GetObjectAction;
@@ -23,7 +22,6 @@ use BEdita\Core\Model\Action\ListObjectsAction;
 use BEdita\Core\Model\Action\SaveEntityAction;
 use Cake\Http\Exception\ConflictException;
 use Cake\ORM\TableRegistry;
-use Cake\Utility\Hash;
 
 /**
  * Controller for `/trash` endpoint.

--- a/plugins/BEdita/API/src/Controller/TrashController.php
+++ b/plugins/BEdita/API/src/Controller/TrashController.php
@@ -71,9 +71,8 @@ class TrashController extends AppController
         if ($this->request->is('delete')) {
             $ids = (string)$this->request->getQuery('ids');
             $action = new ListEntitiesAction(['table' => $this->Table]);
-            $deleted = true;
-            $filter = ['id' => explode(',', $ids)];
-            $entities = $action(compact('filter', 'deleted'));
+            $filter = ['id' => explode(',', $ids), 'deleted' => true];
+            $entities = $action(compact('filter'));
             $action = new DeleteObjectsAction();
             $action(compact('entities') + ['hard' => true]);
 

--- a/plugins/BEdita/API/src/Controller/TrashController.php
+++ b/plugins/BEdita/API/src/Controller/TrashController.php
@@ -57,8 +57,8 @@ class TrashController extends AppController
             $objectType = TableRegistry::getTableLocator()->get('ObjectTypes')->find('objectId', compact('id'))
                 ->firstOrFail();
             $this->defaultTable = $objectType->alias;
-            $this->Table = $this->fetchTable();
         }
+        $this->Table = $this->fetchTable();
     }
 
     /**
@@ -71,8 +71,8 @@ class TrashController extends AppController
         $this->request->allowMethod(['get', 'delete']);
         if ($this->request->is('delete')) {
             $action = new ListEntitiesAction(['table' => $this->Table]);
-            $data = $this->request->getData();
-            $filter = ['id' => (array)Hash::get($data, 'ids')];
+            $filter = (array)$this->request->getQuery('filter');
+            $filter = ['id' => (array)Hash::get($filter, 'ids')];
             $entities = $action(compact('filter'));
             $action = new DeleteObjectsAction(['table' => $this->Table]);
             $action(compact('entities') + ['hard' => true]);

--- a/plugins/BEdita/API/src/Controller/TrashController.php
+++ b/plugins/BEdita/API/src/Controller/TrashController.php
@@ -71,8 +71,9 @@ class TrashController extends AppController
         if ($this->request->is('delete')) {
             $ids = (string)$this->request->getQuery('ids');
             $action = new ListEntitiesAction(['table' => $this->Table]);
+            $deleted = true;
             $filter = ['id' => explode(',', $ids)];
-            $entities = $action(compact('filter'));
+            $entities = $action(compact('filter', 'deleted'));
             $action = new DeleteObjectsAction();
             $action(compact('entities') + ['hard' => true]);
 

--- a/plugins/BEdita/API/src/Controller/TrashController.php
+++ b/plugins/BEdita/API/src/Controller/TrashController.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace BEdita\API\Controller;
 
+use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Model\Action\DeleteObjectAction;
 use BEdita\Core\Model\Action\DeleteObjectsAction;
 use BEdita\Core\Model\Action\GetObjectAction;
@@ -70,9 +71,9 @@ class TrashController extends AppController
     {
         $this->request->allowMethod(['get', 'delete']);
         if ($this->request->is('delete')) {
+            $ids = (string)$this->request->getQuery('ids');
             $action = new ListEntitiesAction(['table' => $this->Table]);
-            $filter = (array)$this->request->getQuery('filter');
-            $filter = ['id' => (array)Hash::get($filter, 'ids')];
+            $filter = ['id' => explode(',', $ids)];
             $entities = $action(compact('filter'));
             $action = new DeleteObjectsAction();
             $action(compact('entities') + ['hard' => true]);

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -889,7 +889,8 @@ class ObjectsControllerTest extends IntegrationTestCase
 
         // success test
         $this->configRequestHeaders('DELETE', $authHeader);
-        $this->_sendRequest('/objects?ids=7', 'DELETE');
+        // delete object 7 (document) and 13 (folder)
+        $this->_sendRequest('/objects?ids=7,13', 'DELETE');
         $this->assertResponseCode(204);
         $this->assertResponseEmpty();
         $notFound = false;
@@ -899,6 +900,24 @@ class ObjectsControllerTest extends IntegrationTestCase
             $notFound = true;
         }
         $this->assertTrue($notFound);
+        $notFound = false;
+        try {
+            $this->fetchTable('Objects')->get(13);
+        } catch (RecordNotFoundException $e) {
+            $notFound = true;
+        }
+        $this->assertTrue($notFound);
+        // restore folder 13
+        $this->configRequestHeaders('PATCH', $authHeader);
+        $this->patch(
+            sprintf('/trash/%s', 13),
+            json_encode([
+                'data' => [
+                    'id' => 13,
+                    'type' => 'folders',
+                ],
+            ])
+        );
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -938,6 +938,7 @@ class ObjectsControllerTest extends IntegrationTestCase
         $this->_sendRequest('/objects?ids=abc', 'DELETE');
         $this->assertResponseCode(500);
         $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseContains('Delete failed');
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -882,10 +882,6 @@ class ObjectsControllerTest extends IntegrationTestCase
      *
      * @return void
      * @covers ::index()
-     * @covers ::initialize()
-     * @covers ::addCount()
-     * @covers ::prepareFilter()
-     * @covers ::prepareInclude()
      */
     public function testIndexDelete(): void
     {
@@ -903,6 +899,24 @@ class ObjectsControllerTest extends IntegrationTestCase
             $notFound = true;
         }
         $this->assertTrue($notFound);
+    }
+
+    /**
+     * Test index method on DELETE with internal error.
+     *
+     * @return void
+     * @covers ::index()
+     */
+    public function testIndexDeleteInternalErrorException(): void
+    {
+        $authHeader = $this->getUserAuthHeader();
+
+        // failure test
+        $this->configRequestHeaders('DELETE', $authHeader);
+        $this->_sendRequest('/objects?filter[ids]=abc', 'DELETE');
+        $this->assertResponseCode(500);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseContains('Delete failed');
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -18,6 +18,7 @@ use Authentication\AuthenticationService;
 use BEdita\API\Controller\ObjectsController;
 use BEdita\API\Test\TestConstants;
 use BEdita\API\TestSuite\IntegrationTestCase;
+use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Http\ServerRequest;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
@@ -874,6 +875,34 @@ class ObjectsControllerTest extends IntegrationTestCase
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
         static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test index method on DELETE.
+     *
+     * @return void
+     * @covers ::index()
+     * @covers ::initialize()
+     * @covers ::addCount()
+     * @covers ::prepareFilter()
+     * @covers ::prepareInclude()
+     */
+    public function testIndexDelete(): void
+    {
+        $authHeader = $this->getUserAuthHeader();
+
+        // success test
+        $this->configRequestHeaders('DELETE', $authHeader);
+        $this->_sendRequest('/objects?filter[ids]=7', 'DELETE');
+        $this->assertResponseCode(204);
+        $this->assertResponseEmpty();
+        $notFound = false;
+        try {
+            $this->fetchTable('Objects')->get(7);
+        } catch (RecordNotFoundException $e) {
+            $notFound = true;
+        }
+        $this->assertTrue($notFound);
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -889,7 +889,7 @@ class ObjectsControllerTest extends IntegrationTestCase
 
         // success test
         $this->configRequestHeaders('DELETE', $authHeader);
-        $this->_sendRequest('/objects?filter[ids]=7', 'DELETE');
+        $this->_sendRequest('/objects?ids=7', 'DELETE');
         $this->assertResponseCode(204);
         $this->assertResponseEmpty();
         $notFound = false;
@@ -907,13 +907,16 @@ class ObjectsControllerTest extends IntegrationTestCase
      * @return void
      * @covers ::index()
      */
-    public function testIndexDeleteInternalErrorException(): void
+    public function testIndexDeleteException(): void
     {
         $authHeader = $this->getUserAuthHeader();
-
-        // failure test
         $this->configRequestHeaders('DELETE', $authHeader);
-        $this->_sendRequest('/objects?filter[ids]=abc', 'DELETE');
+        $this->_sendRequest('/objects?ids=', 'DELETE');
+        $this->assertResponseCode(400);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseContains('Missing required parameter');
+        $this->configRequestHeaders('DELETE', $authHeader);
+        $this->_sendRequest('/objects?ids=abc', 'DELETE');
         $this->assertResponseCode(500);
         $this->assertContentType('application/vnd.api+json');
         $this->assertResponseContains('Delete failed');

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -938,7 +938,6 @@ class ObjectsControllerTest extends IntegrationTestCase
         $this->_sendRequest('/objects?ids=abc', 'DELETE');
         $this->assertResponseCode(500);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertResponseContains('Delete failed');
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
@@ -388,7 +388,7 @@ class ResourcesControllerTest extends IntegrationTestCase
         $data = [
             'type' => 'roles',
             'attributes' => [
-                'name' => 'a-new-role-to-delete',
+                'name' => 'todelete',
             ],
         ];
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());

--- a/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
@@ -418,6 +418,7 @@ class ResourcesControllerTest extends IntegrationTestCase
         $this->_sendRequest('/roles?ids=abc', 'DELETE');
         $this->assertResponseCode(500);
         $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseContains('Delete failed');
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
@@ -418,7 +418,6 @@ class ResourcesControllerTest extends IntegrationTestCase
         $this->_sendRequest('/roles?ids=abc', 'DELETE');
         $this->assertResponseCode(500);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertResponseContains('Delete failed');
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
@@ -401,6 +401,24 @@ class ResourcesControllerTest extends IntegrationTestCase
     }
 
     /**
+     * Test index method on DELETE with internal error.
+     *
+     * @return void
+     * @covers ::index()
+     */
+    public function testIndexDeleteInternalErrorException(): void
+    {
+        $authHeader = $this->getUserAuthHeader();
+
+        // failure test
+        $this->configRequestHeaders('DELETE', $authHeader);
+        $this->_sendRequest('/roles?filter[ids]=abc', 'DELETE');
+        $this->assertResponseCode(500);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseContains('Delete failed');
+    }
+
+    /**
      * Test relationships method to replace existing relationships.
      *
      * @return void

--- a/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
@@ -19,6 +19,7 @@ use Authentication\AuthenticationService;
 use BEdita\API\Controller\ResourcesController;
 use BEdita\API\TestSuite\IntegrationTestCase;
 use BEdita\Core\Model\Table\UsersTable;
+use Cake\Event\EventManager;
 use Cake\Http\ServerRequest;
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
@@ -415,10 +416,15 @@ class ResourcesControllerTest extends IntegrationTestCase
         $this->assertContentType('application/vnd.api+json');
         $this->assertResponseContains('Missing required parameter');
         $this->configRequestHeaders('DELETE', $authHeader);
-        $this->_sendRequest('/roles?ids=abc', 'DELETE');
+        $handler = function () {
+            return false;
+        };
+        EventManager::instance()->on('Model.beforeDelete', $handler);
+        $this->_sendRequest('/roles?ids=1', 'DELETE');
         $this->assertResponseCode(500);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertResponseContains('Delete failed');
+        $this->assertResponseContains('Entity delete failure');
+        EventManager::instance()->off('Model.beforeDelete', $handler);
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
@@ -396,7 +396,7 @@ class ResourcesControllerTest extends IntegrationTestCase
         $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->configRequestHeaders('DELETE', $this->getUserAuthHeader());
-        $this->delete('/roles?filter[ids]=' . $result['data']['id']);
+        $this->delete('/roles?ids=' . $result['data']['id']);
         $this->assertResponseCode(204);
     }
 
@@ -406,13 +406,16 @@ class ResourcesControllerTest extends IntegrationTestCase
      * @return void
      * @covers ::index()
      */
-    public function testIndexDeleteInternalErrorException(): void
+    public function testIndexDeleteException(): void
     {
         $authHeader = $this->getUserAuthHeader();
-
-        // failure test
         $this->configRequestHeaders('DELETE', $authHeader);
-        $this->_sendRequest('/roles?filter[ids]=abc', 'DELETE');
+        $this->_sendRequest('/roles?ids=', 'DELETE');
+        $this->assertResponseCode(400);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseContains('Missing required parameter');
+        $this->configRequestHeaders('DELETE', $authHeader);
+        $this->_sendRequest('/roles?ids=abc', 'DELETE');
         $this->assertResponseCode(500);
         $this->assertContentType('application/vnd.api+json');
         $this->assertResponseContains('Delete failed');

--- a/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
@@ -377,6 +377,30 @@ class ResourcesControllerTest extends IntegrationTestCase
     }
 
     /**
+     * Test delete method
+     *
+     * @return void
+     * @covers ::index()
+     */
+    public function testDeleteMulti(): void
+    {
+        // add new role to delete
+        $data = [
+            'type' => 'roles',
+            'attributes' => [
+                'name' => 'a-new-role-to-delete',
+            ],
+        ];
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $this->post('/roles', json_encode(compact('data')));
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->configRequestHeaders('DELETE', $this->getUserAuthHeader());
+        $this->delete('/roles?filter[ids]=' . $result['data']['id']);
+        $this->assertResponseCode(204);
+    }
+
+    /**
      * Test relationships method to replace existing relationships.
      *
      * @return void

--- a/plugins/BEdita/API/tests/TestCase/Controller/TrashControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TrashControllerTest.php
@@ -356,7 +356,7 @@ class TrashControllerTest extends IntegrationTestCase
 
         // success test
         $this->configRequestHeaders('DELETE', $authHeader);
-        $this->_sendRequest('/trash?filter[ids]=7', 'DELETE');
+        $this->_sendRequest('/trash?ids=7', 'DELETE');
         $this->assertResponseCode(204);
         $this->assertResponseEmpty();
         $notFound = false;

--- a/plugins/BEdita/API/tests/TestCase/Controller/TrashControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TrashControllerTest.php
@@ -344,6 +344,31 @@ class TrashControllerTest extends IntegrationTestCase
     }
 
     /**
+     * Test delete many method.
+     *
+     * @return void
+     * @covers ::index()
+     * @covers ::initialize()
+     */
+    public function testDeleteMany(): void
+    {
+        $authHeader = $this->getUserAuthHeader();
+
+        // success test
+        $this->configRequestHeaders('DELETE', $authHeader);
+        $this->_sendRequest('/trash?filter[ids]=7', 'DELETE');
+        $this->assertResponseCode(204);
+        $this->assertResponseEmpty();
+        $notFound = false;
+        try {
+            $this->Objects->get(7);
+        } catch (RecordNotFoundException $e) {
+            $notFound = true;
+        }
+        $this->assertTrue($notFound);
+    }
+
+    /**
      * Test view method.
      *
      * @return void

--- a/plugins/BEdita/Core/src/Model/Action/DeleteEntitiesAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/DeleteEntitiesAction.php
@@ -21,7 +21,7 @@ use Cake\ORM\Locator\LocatorAwareTrait;
 /**
  * Command to delete entities.
  *
- * @since 5.27.0
+ * @since 5.28.0
  */
 class DeleteEntitiesAction extends BaseAction
 {

--- a/plugins/BEdita/Core/src/Model/Action/DeleteEntitiesAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/DeleteEntitiesAction.php
@@ -46,14 +46,15 @@ class DeleteEntitiesAction extends BaseAction
      */
     public function execute(array $data = [])
     {
+        $result = false;
         try {
-            $this->Table->deleteManyOrFail($data['entities']);
+            $result = $this->Table->deleteManyOrFail($data['entities']);
         } catch (\Throwable $e) {
             $this->log(sprintf('Delete many failed - data: %s', json_encode($data['data'])), 'error');
 
-            return false;
+            return $result;
         }
 
-        return true;
+        return $result;
     }
 }

--- a/plugins/BEdita/Core/src/Model/Action/DeleteEntitiesAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/DeleteEntitiesAction.php
@@ -36,16 +36,11 @@ class DeleteEntitiesAction extends BaseAction
         $result = true;
         $payload = $data;
         unset($payload['entities']);
-        try {
-            foreach ($data['entities'] as $entity) {
-                $payload['entity'] = $entity;
-                $table = $this->fetchTable($entity->get('type') ?: $entity->getSource());
-                $action = new DeleteEntityAction(compact('table'));
-                $result = $result && $action($payload);
-            }
-        } catch (\Exception $e) {
-            $this->log($e->getMessage(), 'error');
-            $result = false;
+        foreach ($data['entities'] as $entity) {
+            $payload['entity'] = $entity;
+            $table = $this->fetchTable($entity->get('type') ?: $entity->getSource());
+            $action = new DeleteEntityAction(compact('table'));
+            $result = $result && $action($payload);
         }
 
         return $result;

--- a/plugins/BEdita/Core/src/Model/Action/DeleteEntitiesAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/DeleteEntitiesAction.php
@@ -53,6 +53,7 @@ class DeleteEntitiesAction extends BaseAction
 
             return false;
         }
+
         return true;
     }
 }

--- a/plugins/BEdita/Core/src/Model/Action/DeleteEntitiesAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/DeleteEntitiesAction.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace BEdita\Core\Model\Action;
 
+use Cake\Log\LogTrait;
+
 /**
  * Command to delete entities.
  *
@@ -22,6 +24,8 @@ namespace BEdita\Core\Model\Action;
  */
 class DeleteEntitiesAction extends BaseAction
 {
+    use LogTrait;
+
     /**
      * Table.
      *
@@ -42,6 +46,13 @@ class DeleteEntitiesAction extends BaseAction
      */
     public function execute(array $data = [])
     {
-        return $this->Table->deleteManyOrFail($data['entities']);
+        try {
+            $this->Table->deleteManyOrFail($data['entities']);
+        } catch (\Throwable $e) {
+            $this->log(sprintf('Delete many failed - data: %s', json_encode($data['data'])), 'error');
+
+            return false;
+        }
+        return true;
     }
 }

--- a/plugins/BEdita/Core/src/Model/Action/DeleteEntitiesAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/DeleteEntitiesAction.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Model\Action;
+
+/**
+ * Command to delete entities.
+ *
+ * @since 5.27.0
+ */
+class DeleteEntitiesAction extends BaseAction
+{
+    /**
+     * Table.
+     *
+     * @var \Cake\ORM\Table
+     */
+    protected $Table;
+
+    /**
+     * @inheritDoc
+     */
+    protected function initialize(array $data)
+    {
+        $this->Table = $this->getConfig('table');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(array $data = [])
+    {
+        return $this->Table->deleteManyOrFail($data['entities']);
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Action/DeleteObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/DeleteObjectsAction.php
@@ -20,7 +20,7 @@ use Cake\ORM\Locator\LocatorAwareTrait;
 /**
  * Command to delete objects.
  *
- * @since 5.27.0
+ * @since 5.28.0
  */
 class DeleteObjectsAction extends BaseAction
 {

--- a/plugins/BEdita/Core/src/Model/Action/DeleteObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/DeleteObjectsAction.php
@@ -35,8 +35,8 @@ class DeleteObjectsAction extends BaseAction
         $payload = $data;
         unset($payload['entities']);
         foreach ($data['entities'] as $entity) {
-            $payload['entity'] = $entity;
             $table = $this->fetchTable($entity->get('type') ?: $entity->getSource());
+            $payload['entity'] = $table->get($entity->get('id'));
             $action = new DeleteObjectAction(compact('table'));
             $result = $result && $action($payload);
         }

--- a/plugins/BEdita/Core/src/Model/Action/DeleteObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/DeleteObjectsAction.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Model\Action;
+
+/**
+ * Command to delete objects.
+ *
+ * @since 5.27.0
+ */
+class DeleteObjectsAction extends BaseAction
+{
+    /**
+     * Table.
+     *
+     * @var \Cake\ORM\Table
+     */
+    protected $Table;
+
+    /**
+     * @inheritDoc
+     */
+    protected function initialize(array $data)
+    {
+        $this->Table = $this->getConfig('table');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(array $data = [])
+    {
+        $entities = $data['entities'];
+
+        if (!empty($data['hard'])) {
+            $action = new DeleteEntitiesAction(['table' => $this->Table]);
+
+            return $action(compact('entities'));
+        }
+        $result = true;
+        foreach ($entities as $entity) {
+            $entity->set('deleted', true);
+            $result = $result && (bool)$this->Table->save($entity);
+        }
+
+        return $result;
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteEntitiesActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteEntitiesActionTest.php
@@ -42,7 +42,7 @@ class DeleteEntitiesActionTest extends TestCase
      * @covers ::initialize()
      * @covers ::execute()
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $table = TableRegistry::getTableLocator()->get('FakeAnimals');
         $action = new DeleteEntitiesAction(compact('table'));
@@ -51,5 +51,21 @@ class DeleteEntitiesActionTest extends TestCase
         static::assertIsArray($actual);
         static::assertCount(1, $actual);
         static::assertFalse($table->exists(['id' => 1]));
+    }
+
+    /**
+     * Test command execution failure.
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testExecuteFail(): void
+    {
+        $table = TableRegistry::getTableLocator()->get('FakeAnimals');
+        $action = new DeleteEntitiesAction(compact('table'));
+        $data = ['wrongdata'];
+        $entities = ['wrongdata'];
+        $actual = $action(compact('data', 'entities'));
+        static::assertFalse($actual);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteEntitiesActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteEntitiesActionTest.php
@@ -45,11 +45,10 @@ class DeleteEntitiesActionTest extends TestCase
     public function testExecute(): void
     {
         $table = TableRegistry::getTableLocator()->get('FakeAnimals');
-        $action = new DeleteEntitiesAction(compact('table'));
+        $action = new DeleteEntitiesAction();
         $entities = [$table->get(1)];
         $actual = $action(compact('entities'));
-        static::assertIsArray($actual);
-        static::assertCount(1, $actual);
+        static::assertTrue($actual);
         static::assertFalse($table->exists(['id' => 1]));
     }
 
@@ -61,11 +60,10 @@ class DeleteEntitiesActionTest extends TestCase
      */
     public function testExecuteFail(): void
     {
-        $table = TableRegistry::getTableLocator()->get('FakeAnimals');
-        $action = new DeleteEntitiesAction(compact('table'));
-        $data = ['wrongdata'];
-        $entities = ['wrongdata'];
-        $actual = $action(compact('data', 'entities'));
+        $action = new DeleteEntitiesAction();
+        $entity = TableRegistry::getTableLocator()->get('FakeAnimals')->newEmptyEntity();
+        $entities = [$entity];
+        $actual = $action(compact('entities'));
         static::assertFalse($actual);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteEntitiesActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteEntitiesActionTest.php
@@ -60,10 +60,10 @@ class DeleteEntitiesActionTest extends TestCase
      */
     public function testExecuteFail(): void
     {
+        $this->expectException(\Cake\ORM\Exception\PersistenceFailedException::class);
         $action = new DeleteEntitiesAction();
         $entity = TableRegistry::getTableLocator()->get('FakeAnimals')->newEmptyEntity();
         $entities = [$entity];
-        $actual = $action(compact('entities'));
-        static::assertFalse($actual);
+        $action(compact('entities'));
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteEntitiesActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteEntitiesActionTest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Action;
+
+use BEdita\Core\Model\Action\DeleteEntitiesAction;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see \BEdita\Core\Model\Action\DeleteEntitiesAction} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Model\Action\DeleteEntitiesAction
+ */
+class DeleteEntitiesActionTest extends TestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    protected $fixtures = [
+        'plugin.BEdita/Core.FakeAnimals',
+    ];
+
+    /**
+     * Test command execution.
+     *
+     * @return void
+     * @covers ::initialize()
+     * @covers ::execute()
+     */
+    public function testExecute()
+    {
+        $table = TableRegistry::getTableLocator()->get('FakeAnimals');
+        $action = new DeleteEntitiesAction(compact('table'));
+        $entities = [$table->get(1)];
+        $actual = $action(compact('entities'));
+        static::assertIsArray($actual);
+        static::assertCount(1, $actual);
+        static::assertFalse($table->exists(['id' => 1]));
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteObjectsActionTest.php
@@ -75,7 +75,7 @@ class DeleteObjectsActionTest extends TestCase
     public function testExecute()
     {
         $table = TableRegistry::getTableLocator()->get('Documents');
-        $action = new DeleteObjectsAction(compact('table'));
+        $action = new DeleteObjectsAction();
         $entities = [$table->get(3)];
         $actual = $action(compact('entities'));
         static::assertTrue($actual);
@@ -91,11 +91,10 @@ class DeleteObjectsActionTest extends TestCase
     public function testExecuteHardDelete()
     {
         $table = TableRegistry::getTableLocator()->get('Documents');
-        $action = new DeleteObjectsAction(compact('table'));
+        $action = new DeleteObjectsAction();
         $entities = [$table->get(3)];
         $actual = $action(compact('entities') + ['hard' => true]);
-        static::assertIsArray($actual);
-        static::assertCount(1, $actual);
+        static::assertTrue($actual);
         static::assertFalse($table->exists(['id' => 3]));
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/DeleteObjectsActionTest.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Action;
+
+use BEdita\Core\Model\Action\DeleteObjectsAction;
+use BEdita\Core\Utility\LoggedUser;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * @covers \BEdita\Core\Model\Action\DeleteObjectsAction
+ */
+class DeleteObjectsActionTest extends TestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    protected $fixtures = [
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.RelationTypes',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.Users',
+        'plugin.BEdita/Core.ObjectRelations',
+        'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.Trees',
+        'plugin.BEdita/Core.Categories',
+        'plugin.BEdita/Core.ObjectCategories',
+        'plugin.BEdita/Core.Tags',
+        'plugin.BEdita/Core.ObjectTags',
+        'plugin.BEdita/Core.History',
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        LoggedUser::setUserAdmin();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        LoggedUser::resetUser();
+    }
+
+    /**
+     * Test command execution.
+     *
+     * @return void
+     */
+    public function testExecute()
+    {
+        $table = TableRegistry::getTableLocator()->get('Documents');
+        $action = new DeleteObjectsAction(compact('table'));
+        $entities = [$table->get(3)];
+        $actual = $action(compact('entities'));
+        static::assertTrue($actual);
+        static::assertTrue($table->exists(['id' => 3]));
+        static::assertTrue($table->get(3)->get('deleted'));
+    }
+
+    /**
+     * Test command execution with hard delete.
+     *
+     * @return void
+     */
+    public function testExecuteHardDelete()
+    {
+        $table = TableRegistry::getTableLocator()->get('Documents');
+        $action = new DeleteObjectsAction(compact('table'));
+        $entities = [$table->get(3)];
+        $actual = $action(compact('entities') + ['hard' => true]);
+        static::assertIsArray($actual);
+        static::assertCount(1, $actual);
+        static::assertFalse($table->exists(['id' => 3]));
+    }
+}


### PR DESCRIPTION
This PR introduces the possibility to delete (soft and hard) multiple objects by id (`ids` as filter query string).

Examples:
```
# soft delete
DELETE /:type?ids=142,232,241

# hard delete
DELETE /trash?ids=142,232,241
```