### PR TITLE
Introduce custom `UserMailer`

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -166,6 +166,13 @@ return [
     // ],
 
     /**
+     * Uncomment to define custom mailer classes to load
+     */
+    // 'Mailer' => [
+    //     'User' => '\MyPlugin\Mailer\UserMailer',
+    // ],
+
+    /**
      * Signup settings.
      *
      * - `requireActivation` - boolean (default: true) - Are new users required to verify their contact method

--- a/plugins/BEdita/Core/src/Mailer/UserMailer.php
+++ b/plugins/BEdita/Core/src/Mailer/UserMailer.php
@@ -24,7 +24,7 @@ use Cake\Mailer\Mailer;
  *
  * @since 4.0.0
  */
-class UserMailer extends Mailer
+class UserMailer extends Mailer implements UserMailerInterface
 {
     /**
      * Welcome message.
@@ -36,7 +36,7 @@ class UserMailer extends Mailer
      * @return \Cake\Mailer\Mailer
      * @throws \LogicException When missing some required parameter
      */
-    public function welcome($options)
+    public function welcome($options): Mailer
     {
         if (empty($options['params']['user'])) {
             throw new \LogicException(__d('bedita', 'Parameter "{0}" missing', ['params.user']));
@@ -73,7 +73,7 @@ class UserMailer extends Mailer
      * @return \Cake\Mailer\Mailer
      * @throws \LogicException When missing some required parameter
      */
-    public function signup(array $options)
+    public function signup(array $options): Mailer
     {
         if (empty($options['params']['activationUrl'])) {
             throw new \LogicException(__d('bedita', 'Parameter "{0}" missing', ['params.activationUrl']));
@@ -115,7 +115,7 @@ class UserMailer extends Mailer
      * @return \Cake\Mailer\Mailer
      * @throws \LogicException When missing some required parameter
      */
-    public function changeRequest(array $options)
+    public function changeRequest(array $options): Mailer
     {
         if (empty($options['params']['changeUrl'])) {
             throw new \LogicException(__d('bedita', 'Parameter "{0}" missing', ['params.changeUrl']));

--- a/plugins/BEdita/Core/src/Mailer/UserMailerInterface.php
+++ b/plugins/BEdita/Core/src/Mailer/UserMailerInterface.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Mailer;
+
+use Cake\Mailer\Mailer;
+
+/**
+ * Mailer class to send notifications to users
+ *
+ * @since 5.28.0
+ */
+interface UserMailerInterface
+{
+    /**
+     * Welcome message.
+     *
+     * It requires `$options['params']` with:
+     * - `user` the user Entity to send welcome email
+     *
+     * @param array $options Email options
+     * @return \Cake\Mailer\Mailer
+     * @throws \LogicException When missing some required parameter
+     */
+    public function welcome($options): Mailer;
+
+    /**
+     * Signup message.
+     *
+     * It requires `$options['params']` with:
+     * - `user` the User Entity to send signup email
+     * - `activationUrl` the activation url to follow
+     *
+     * @param array $options Email options
+     * @return \Cake\Mailer\Mailer
+     * @throws \LogicException When missing some required parameter
+     */
+    public function signup(array $options): Mailer;
+
+    /**
+     * Credentials change message.
+     *
+     * It requires `$options['params']` with:
+     * - `user` the user id to send signup email
+     * - `changeUrl` the change url to follow
+     *
+     * @param array $options Email options
+     * @return \Cake\Mailer\Mailer
+     * @throws \LogicException When missing some required parameter
+     */
+    public function changeRequest(array $options): Mailer;
+}

--- a/plugins/BEdita/Core/src/Mailer/UserMailerTrait.php
+++ b/plugins/BEdita/Core/src/Mailer/UserMailerTrait.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Mailer;
+
+use Cake\Core\Configure;
+use Cake\Mailer\Mailer;
+use Cake\Mailer\MailerAwareTrait;
+use LogicException;
+
+/**
+ * Mailer class to send notifications to users
+ *
+ * @since 5.28.0
+ */
+trait UserMailerTrait
+{
+    use MailerAwareTrait;
+
+    /**
+     * Returns a mailer instance.
+     *
+     * @param string $name Mailer's name.
+     * @param array<string, mixed>|string|null $config Array of configs, or profile name string.
+     * @return \Cake\Mailer\Mailer
+     * @throws \LogicException if mailer class doesn't implement interface.
+     */
+    protected function getUserMailer(): Mailer
+    {
+        $mailerClass = Configure::read('Mailer.User', 'BEdita/Core.User');
+        $mailer = $this->getMailer($mailerClass);
+        if (!$mailer instanceof UserMailerInterface) {
+            throw new LogicException(sprintf('Mailer class "%s" must implement UserMailerInterface', $mailerClass));
+        }
+
+        return $mailer;
+    }
+}

--- a/plugins/BEdita/Core/src/Mailer/UserMailerTrait.php
+++ b/plugins/BEdita/Core/src/Mailer/UserMailerTrait.php
@@ -40,7 +40,7 @@ trait UserMailerTrait
         $mailerClass = Configure::read('Mailer.User', 'BEdita/Core.User');
         $mailer = $this->getMailer($mailerClass);
         if (!$mailer instanceof UserMailerInterface) {
-            throw new LogicException(sprintf('Mailer class "%s" must implement UserMailerInterface', $mailerClass));
+            throw new LogicException(sprintf('Mailer class "%s" must implement UserMailerInterface', get_class($mailer)));
         }
 
         return $mailer;

--- a/plugins/BEdita/Core/src/Mailer/UserMailerTrait.php
+++ b/plugins/BEdita/Core/src/Mailer/UserMailerTrait.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 /**
@@ -33,8 +32,6 @@ trait UserMailerTrait
     /**
      * Returns a mailer instance.
      *
-     * @param string $name Mailer's name.
-     * @param array<string, mixed>|string|null $config Array of configs, or profile name string.
      * @return \Cake\Mailer\Mailer
      * @throws \LogicException if mailer class doesn't implement interface.
      */

--- a/plugins/BEdita/Core/src/Model/Action/ChangeCredentialsRequestAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ChangeCredentialsRequestAction.php
@@ -19,6 +19,7 @@ use BEdita\Core\Exception\InvalidDataException;
 use BEdita\Core\Model\Entity\AsyncJob;
 use BEdita\Core\Model\Entity\User;
 use BEdita\Core\Model\Validation\Validation;
+use Cake\Core\Configure;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventInterface;
@@ -175,7 +176,8 @@ class ChangeCredentialsRequestAction extends BaseAction implements EventListener
         $options = [
             'params' => compact('user', 'changeUrl'),
         ];
-        $this->getMailer('BEdita/Core.User')->send('changeRequest', [$options]);
+        $mailerClass = Configure::read('Mailer.User', 'BEdita/Core.User');
+        $this->getMailer($mailerClass)->send('changeRequest', [$options]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/ChangeCredentialsRequestAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ChangeCredentialsRequestAction.php
@@ -16,16 +16,15 @@ declare(strict_types=1);
 namespace BEdita\Core\Model\Action;
 
 use BEdita\Core\Exception\InvalidDataException;
+use BEdita\Core\Mailer\UserMailerTrait;
 use BEdita\Core\Model\Entity\AsyncJob;
 use BEdita\Core\Model\Entity\User;
 use BEdita\Core\Model\Validation\Validation;
-use Cake\Core\Configure;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventInterface;
 use Cake\Event\EventListenerInterface;
 use Cake\I18n\FrozenTime;
-use Cake\Mailer\MailerAwareTrait;
 use Cake\ORM\TableRegistry;
 use Cake\Validation\Validator;
 
@@ -43,7 +42,7 @@ use Cake\Validation\Validator;
 class ChangeCredentialsRequestAction extends BaseAction implements EventListenerInterface
 {
     use EventDispatcherTrait;
-    use MailerAwareTrait;
+    use UserMailerTrait;
 
     /**
      * The UsersTable table
@@ -176,8 +175,7 @@ class ChangeCredentialsRequestAction extends BaseAction implements EventListener
         $options = [
             'params' => compact('user', 'changeUrl'),
         ];
-        $mailerClass = Configure::read('Mailer.User', 'BEdita/Core.User');
-        $this->getMailer($mailerClass)->send('changeRequest', [$options]);
+        $this->getUserMailer()->send('changeRequest', [$options]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -460,7 +460,8 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
         $options = [
             'params' => compact('activationUrl', 'user'),
         ];
-        $this->getMailer('BEdita/Core.User')->send('signup', [$options]);
+        $mailerClass = Configure::read('Mailer.User', 'BEdita/Core.User');
+        $this->getMailer($mailerClass)->send('signup', [$options]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -17,6 +17,7 @@ namespace BEdita\Core\Model\Action;
 
 use BEdita\Core\Exception\InvalidDataException;
 use BEdita\Core\Exception\UserExistsException;
+use BEdita\Core\Mailer\UserMailerTrait;
 use BEdita\Core\Model\Entity\AsyncJob;
 use BEdita\Core\Model\Entity\User;
 use BEdita\Core\Model\Table\RolesTable;
@@ -43,7 +44,7 @@ use Cake\Validation\Validator;
 class SignupUserAction extends BaseAction implements EventListenerInterface
 {
     use EventDispatcherTrait;
-    use MailerAwareTrait;
+    use UserMailerTrait;
 
     /**
      * 400 Username already registered
@@ -460,8 +461,7 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
         $options = [
             'params' => compact('activationUrl', 'user'),
         ];
-        $mailerClass = Configure::read('Mailer.User', 'BEdita/Core.User');
-        $this->getMailer($mailerClass)->send('signup', [$options]);
+        $this->getUserMailer()->send('signup', [$options]);
     }
 
     /**
@@ -477,8 +477,7 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
         $options = [
             'params' => compact('user'),
         ];
-        $mailerClass = Configure::read('Mailer.User', 'BEdita/Core.User');
-        $this->getMailer($mailerClass)->send('welcome', [$options]);
+        $this->getUserMailer()->send('welcome', [$options]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -30,7 +30,6 @@ use Cake\Event\EventInterface;
 use Cake\Event\EventListenerInterface;
 use Cake\Http\Exception\UnauthorizedException;
 use Cake\I18n\FrozenTime;
-use Cake\Mailer\MailerAwareTrait;
 use Cake\ORM\TableRegistry;
 use Cake\Routing\Router;
 use Cake\Utility\Hash;

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -476,7 +476,8 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
         $options = [
             'params' => compact('user'),
         ];
-        $this->getMailer('BEdita/Core.User')->send('welcome', [$options]);
+        $mailerClass = Configure::read('Mailer.User', 'BEdita/Core.User');
+        $this->getMailer($mailerClass)->send('welcome', [$options]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserActivationAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserActivationAction.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace BEdita\Core\Model\Action;
 
 use BEdita\Core\Model\Entity\User;
+use Cake\Core\Configure;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventInterface;
 use Cake\Event\EventListenerInterface;
@@ -112,7 +113,8 @@ class SignupUserActivationAction extends BaseAction implements EventListenerInte
         $options = [
             'params' => compact('user'),
         ];
-        $this->getMailer('BEdita/Core.User')->send('welcome', [$options]);
+        $mailerClass = Configure::read('Mailer.User', 'BEdita/Core.User');
+        $this->getMailer($mailerClass)->send('welcome', [$options]);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserActivationAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserActivationAction.php
@@ -15,15 +15,14 @@ declare(strict_types=1);
 
 namespace BEdita\Core\Model\Action;
 
+use BEdita\Core\Mailer\UserMailerTrait;
 use BEdita\Core\Model\Entity\User;
-use Cake\Core\Configure;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventInterface;
 use Cake\Event\EventListenerInterface;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\ConflictException;
 use Cake\I18n\FrozenTime;
-use Cake\Mailer\MailerAwareTrait;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -34,7 +33,7 @@ use Cake\ORM\TableRegistry;
 class SignupUserActivationAction extends BaseAction implements EventListenerInterface
 {
     use EventDispatcherTrait;
-    use MailerAwareTrait;
+    use UserMailerTrait;
 
     /**
      * The UsersTable table
@@ -113,8 +112,7 @@ class SignupUserActivationAction extends BaseAction implements EventListenerInte
         $options = [
             'params' => compact('user'),
         ];
-        $mailerClass = Configure::read('Mailer.User', 'BEdita/Core.User');
-        $this->getMailer($mailerClass)->send('welcome', [$options]);
+        $this->getUserMailer()->send('welcome', [$options]);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTraitTest.php
@@ -23,13 +23,6 @@ use Cake\TestSuite\TestCase;
 use LogicException;
 
 /**
- * Test Mailer class.
- */
-class TestMailer extends Mailer
-{
-}
-
-/**
  * {@see \BEdita\Core\Mailer\UserMailerTrait} Test Case.
  *
  * @coversDefaultClass \BEdita\Core\Mailer\UserMailerTrait
@@ -46,9 +39,9 @@ class UserMailerTraitTest extends TestCase
      */
     public function testGetUserMailerFailure(): void
     {
-        Configure::write('Mailer.User', TestMailer::class);
+        Configure::write('Mailer.User', Mailer::class);
         $this->expectException(LogicException::class);
-        $msg = sprintf('Mailer class "%s" must implement UserMailerInterface', TestMailer::class);
+        $msg = sprintf('Mailer class "%s" must implement UserMailerInterface', Mailer::class);
         $this->expectExceptionMessage($msg);
         $this->getUserMailer();
         Configure::delete('Mailer.User');

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTraitTest.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Mailer;
+
+use BEdita\Core\Mailer\UserMailerInterface;
+use BEdita\Core\Mailer\UserMailerTrait;
+use Cake\Core\Configure;
+use Cake\Mailer\Mailer;
+use Cake\TestSuite\TestCase;
+use LogicException;
+
+/**
+ * {@see \BEdita\Core\Mailer\UserMailerTrait} Test Case.
+ *
+ * @coversDefaultClass \BEdita\Core\Mailer\UserMailerTrait
+ */
+class UserMailerTraitTest extends TestCase
+{
+    use UserMailerTrait;
+
+    /**
+     * Test `getUserMailer` failure.
+     *
+     * @return void
+     * @covers ::getUserMailer()
+     */
+    public function testGetUserMailerFailure(): void
+    {
+        $mailer = new class extends Mailer {};
+        $class = get_class($mailer);
+        Configure::write('Mailer.User', $class);
+        $this->expectException(LogicException::class);
+        $msg = sprintf('Mailer class "%s" must implement UserMailerInterface', $class);
+        $this->expectExceptionMessage($msg);
+        $this->getUserMailer();
+        Configure::delete('Mailer.User');
+    }
+
+    /**
+     * Test `getUserMailer`
+     *
+     * @return void
+     * @covers ::getUserMailer()
+     */
+    public function testGetUserMailer(): void
+    {
+        $mailer = $this->getUserMailer();
+        static::assertInstanceOf(UserMailerInterface::class, $mailer);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTraitTest.php
@@ -39,7 +39,8 @@ class UserMailerTraitTest extends TestCase
      */
     public function testGetUserMailerFailure(): void
     {
-        $mailer = new class extends Mailer {};
+        $mailer = new class extends Mailer {
+        };
         $class = get_class($mailer);
         Configure::write('Mailer.User', $class);
         $this->expectException(LogicException::class);

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/UserMailerTraitTest.php
@@ -23,6 +23,13 @@ use Cake\TestSuite\TestCase;
 use LogicException;
 
 /**
+ * Test Mailer class.
+ */
+class TestMailer extends Mailer
+{
+}
+
+/**
  * {@see \BEdita\Core\Mailer\UserMailerTrait} Test Case.
  *
  * @coversDefaultClass \BEdita\Core\Mailer\UserMailerTrait
@@ -39,12 +46,9 @@ class UserMailerTraitTest extends TestCase
      */
     public function testGetUserMailerFailure(): void
     {
-        $mailer = new class extends Mailer {
-        };
-        $class = get_class($mailer);
-        Configure::write('Mailer.User', $class);
+        Configure::write('Mailer.User', TestMailer::class);
         $this->expectException(LogicException::class);
-        $msg = sprintf('Mailer class "%s" must implement UserMailerInterface', $class);
+        $msg = sprintf('Mailer class "%s" must implement UserMailerInterface', TestMailer::class);
         $this->expectExceptionMessage($msg);
         $this->getUserMailer();
         Configure::delete('Mailer.User');


### PR DESCRIPTION
This PR introduces custom user mailers. 
With a new `Mailer` key configuration you can define a custom `UserMailer` class to handle `signup/welcome/changeRequest` messages like this:

```php
    'Mailer' => [
         'User' => '\MyApp\Mailer\UserMailer',
    ],
```

* a new `UserMailerInterface` with required methods has been added 
* a new `UserMailerTrait` with a `getUserMailer` method to load either the default or the custom mailer 

