### PR TITLE
Feat: filter to re/index objects in a folder

### DIFF
--- a/plugins/BEdita/Core/src/Command/BuildSearchIndexCommand.php
+++ b/plugins/BEdita/Core/src/Command/BuildSearchIndexCommand.php
@@ -20,7 +20,6 @@ use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
-use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Utility\Hash;
 
 /**
@@ -101,20 +100,15 @@ class BuildSearchIndexCommand extends Command
             $counter = 0;
             try {
                 foreach ($this->objectsIterator($args, $type) as $entity) {
-                    try {
-                        $indexed = $this->doIndexResource($entity, $adapters, $io);
-                        $counter = $counter + $indexed;
-                    } catch (\Exception $e) {
-                        $io->error($e->getMessage());
-
-                        return Command::CODE_ERROR;
-                    }
+                    $indexed = $this->doIndexResource($entity, $adapters, $io);
+                    $counter = $counter + $indexed;
                 }
-            } catch (RecordNotFoundException $e) {
+            } catch (\Exception $e) {
                 $io->error($e->getMessage());
 
                 return Command::CODE_ERROR;
             }
+
             $io->verbose(sprintf('> %s: %d', $type, $counter));
             if ($counter > 0) {
                 $summary[] = sprintf('> %s: %d', $type, $counter);

--- a/plugins/BEdita/Core/src/Command/BuildSearchIndexCommand.php
+++ b/plugins/BEdita/Core/src/Command/BuildSearchIndexCommand.php
@@ -20,6 +20,7 @@ use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
+use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Utility\Hash;
 
 /**
@@ -65,6 +66,10 @@ class BuildSearchIndexCommand extends Command
             'help' => 'Reindex only one or more specific objects by uname.',
             'required' => false,
         ]);
+        $parser->addOption('ancestor', [
+            'help' => 'Reindex only objects with a specific ancestor folder.',
+            'required' => false,
+        ]);
         $parser->addOption('adapter', [
             'help' => 'Reindex only using one or more specific adapters.',
             'required' => false,
@@ -94,15 +99,21 @@ class BuildSearchIndexCommand extends Command
         foreach ($types as $type) {
             $io->verbose("\n" . sprintf('Indexing %s', $type) . "\n");
             $counter = 0;
-            foreach ($this->objectsIterator($args, $type) as $entity) {
-                try {
-                    $indexed = $this->doIndexResource($entity, $adapters, $io);
-                    $counter = $counter + $indexed;
-                } catch (\Exception $e) {
-                    $io->error($e->getMessage());
+            try {
+                foreach ($this->objectsIterator($args, $type) as $entity) {
+                    try {
+                        $indexed = $this->doIndexResource($entity, $adapters, $io);
+                        $counter = $counter + $indexed;
+                    } catch (\Exception $e) {
+                        $io->error($e->getMessage());
 
-                    return Command::CODE_ERROR;
+                        return Command::CODE_ERROR;
+                    }
                 }
+            } catch (RecordNotFoundException $e) {
+                $io->error($e->getMessage());
+
+                return Command::CODE_ERROR;
             }
             $io->verbose(sprintf('> %s: %d', $type, $counter));
             if ($counter > 0) {
@@ -173,6 +184,10 @@ class BuildSearchIndexCommand extends Command
         $uname = array_filter(explode(',', (string)$args->getOption('uname')));
         if (!empty($uname)) {
             $query = $query->where([$table->aliasField('uname') . ' IN' => $uname]);
+        }
+        $ancestor = (string)$args->getOption('ancestor');
+        if (!empty($ancestor)) {
+            $query = $query->find('ancestor', [$ancestor]);
         }
         $lastId = 0;
         while (true) {


### PR DESCRIPTION
This PR adds an option `--ancestor` to the command `build_search_index`, to limit a re/index to a single folder.