### PR TITLE
Increase `config.content` column size to MEDIUMTEXT

### DIFF
--- a/plugins/BEdita/Core/config/Migrations/20240919124057_ConfigContents.php
+++ b/plugins/BEdita/Core/config/Migrations/20240919124057_ConfigContents.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\AbstractMigration;
+use Phinx\Db\Adapter\MysqlAdapter;
+
+class ConfigContents extends AbstractMigration
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function up()
+    {
+        $limit = null;
+        if ($this->adapter->getAdapterType() === 'mysql') {
+            $limit = MysqlAdapter::TEXT_MEDIUM;
+        }
+        $this->table('config')
+            ->changeColumn('content', 'text', [
+                'comment' => 'configuration data as string or JSON',
+                'default' => null,
+                'limit' => $limit,
+                'null' => false,
+            ])
+            ->update();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function down()
+    {
+        $this->table('config')
+            ->changeColumn('content', 'text', [
+                'comment' => 'configuration data as string or JSON',
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+            ])
+            ->update();
+    }
+}


### PR DESCRIPTION
This PR adds a migration to increase `config.content` column size to MEDIUMTEXT
