### PR TITLE
Add column `params` to table `Trees`

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -221,19 +221,16 @@ return [
     // ],
 
     /**
-     * Configuration for folders:
-     * - `params_schema` is the optional JSON schema for the `params` attribute of the children relation
+     * Optional schema for the `params` attribute of the children relationship.
      */
-    // 'Folders' => [
-    //     'params_schema' => [
-    //         'type' => 'object',
-    //         'required' => ['name'],
-    //         'properties' => [
-    //             'name' => ['type' => 'string'],
-    //             'hobby' => [
-    //                 'type' => 'string',
-    //                 'enum' => ['fishing', 'knitting', 'gaming'],
-    //             ],
+    // 'ChildrenParams' => [
+    //     'type' => 'object',
+    //     'required' => ['name'],
+    //     'properties' => [
+    //         'name' => ['type' => 'string'],
+    //         'hobby' => [
+    //             'type' => 'string',
+    //             'enum' => ['fishing', 'knitting', 'gaming'],
     //         ],
     //     ],
     // ],

--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -221,6 +221,24 @@ return [
     // ],
 
     /**
+     * Configuration for folders:
+     * - `params_schema` is the optional JSON schema for the `params` attribute of the children relation
+     */
+    // 'Folders' => [
+    //     'params_schema' => [
+    //         'type' => 'object',
+    //         'required' => ['name'],
+    //         'properties' => [
+    //             'name' => ['type' => 'string'],
+    //             'hobby' => [
+    //                 'type' => 'string',
+    //                 'enum' => ['fishing', 'knitting', 'gaming'],
+    //             ],
+    //         ],
+    //     ],
+    // ],
+
+    /**
      * I18n settings.
      * Language tags follow IETF RFC5646 https://tools.ietf.org/html/rfc5646
      * See also https://en.wikipedia.org/wiki/IETF_language_tag

--- a/plugins/BEdita/API/tests/IntegrationTest/ChildrenRelationshipTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ChildrenRelationshipTest.php
@@ -182,6 +182,7 @@ class ChildrenRelationshipTest extends IntegrationTestCase
             'depth_level' => 2,
             'menu' => true,
             'canonical' => true,
+            'params' => null,
         ];
         static::assertEquals($expected, Hash::get($result, 'data.0.meta.relation'));
     }

--- a/plugins/BEdita/API/tests/IntegrationTest/ChildrenRelationshipTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ChildrenRelationshipTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace BEdita\API\Test\IntegrationTest;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use Cake\Core\Configure;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 
@@ -185,5 +186,121 @@ class ChildrenRelationshipTest extends IntegrationTestCase
             'params' => null,
         ];
         static::assertEquals($expected, Hash::get($result, 'data.0.meta.relation'));
+    }
+
+    /**
+     * Test params of the trees table.
+     *
+     * @return void
+     */
+    public function testTreeParams()
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'item' => ['type' => 'string'],
+                'class' => [
+                    'type' => 'string',
+                    'enum' => ['safe', 'euclid', 'keter'],
+                ],
+                'contained' => ['type' => 'boolean'],
+                'location' => ['type' => 'string'],
+                'description' => ['anyOf' => [['type' => 'null'], ['type' => 'string']]],
+            ],
+        ];
+        Configure::write('ChildrenParams', $schema);
+        $authHeader = $this->getUserAuthHeader();
+        $folderId = 13;
+        $relationshipsEndpoint = sprintf('/folders/%s/relationships/children', $folderId);
+        $objects = [
+            [
+                'type' => 'documents',
+                'attributes' => [
+                    'title' => 'Doc one here',
+                    'description' => 'Document one',
+                ],
+            ],
+            [
+                'type' => 'documents',
+                'attributes' => [
+                    'title' => 'Doc two here',
+                    'description' => 'Document two',
+                ],
+            ],
+        ];
+        $params = [
+            'item' => 'SCP-4147',
+            'class' => 'safe',
+            'contained' => true,
+            'location' => 'Site 28',
+            'description' => 'SCP-4147 is a series of encyclopedias divided into several volumes each.',
+        ];
+        $childrenData = [];
+
+        // create documents
+        foreach ($objects as &$data) {
+            $this->configRequestHeaders('POST', $authHeader);
+            $this->post('/documents', json_encode(compact('data')));
+            $this->assertResponseCode(201);
+            $this->assertContentType('application/vnd.api+json');
+            $data['id'] = $this->lastObjectId();
+
+            $childrenData[] = [
+                'type' => $data['type'],
+                'id' => $data['id'],
+            ];
+        }
+        unset($data);
+
+        // add first children without params
+        $this->configRequestHeaders('POST', $authHeader);
+        $this->post($relationshipsEndpoint, json_encode(['data' => [$childrenData[0]]]));
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        // check first children empty params
+        $this->configRequestHeaders('GET', $authHeader);
+        $this->get(sprintf('/folders/%d/children', $folderId));
+        $this->assertResponseCode(200);
+        $result = json_decode((string)$this->_response->getBody(), true);
+        static::assertEquals(1, count($result['data']));
+        static::assertNull(Hash::get($result, 'data.0.meta.relation.params'));
+
+        // update first children with params
+        $this->configRequestHeaders('PATCH', $authHeader);
+        $this->post($relationshipsEndpoint, json_encode(['data' => [$childrenData[0] + ['meta' => ['relation' => compact('params')]]]]));
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        // check first children updated params
+        $this->configRequestHeaders('GET', $authHeader);
+        $this->get(sprintf('/folders/%d/children', $folderId));
+        $this->assertResponseCode(200);
+        $result = json_decode((string)$this->_response->getBody(), true);
+        static::assertEquals(1, count($result['data']));
+        static::assertEquals($params, Hash::get($result, 'data.0.meta.relation.params'));
+
+        // add second children with params
+        $this->configRequestHeaders('POST', $authHeader);
+        $this->post($relationshipsEndpoint, json_encode(['data' => [$childrenData[1] + ['meta' => ['relation' => compact('params')]]]]));
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        // check second children params
+        $this->configRequestHeaders('GET', $authHeader);
+        $this->get(sprintf('/folders/%d/children', $folderId));
+        $this->assertResponseCode(200);
+        $result = json_decode((string)$this->_response->getBody(), true);
+        static::assertEquals(2, count($result['data']));
+        static::assertEquals($params, Hash::get($result, 'data.1.meta.relation.params'));
+
+        // update second children with invalid params
+        $this->configRequestHeaders('PATCH', $authHeader);
+        $this->post($relationshipsEndpoint, json_encode(['data' => [$childrenData[1] + ['meta' => ['relation' => ['params' => ['item' => 4147]]]]]]));
+        $this->assertResponseCode(400);
+        $this->assertContentType('application/vnd.api+json');
+        $result = json_decode((string)$this->_response->getBody(), true);
+        static::assertEquals('Invalid data', Hash::get($result, 'error.title'));
+        static::assertStringContainsString('String expected, 4147 received', Hash::get($result, 'error.detail'));
     }
 }

--- a/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
@@ -333,6 +333,7 @@ class ParentsRelationshipTest extends IntegrationTestCase
             'depth_level' => 2,
             'menu' => true,
             'canonical' => true,
+            'params' => null,
         ];
         static::assertEquals($expected, Hash::get($result, 'data.0.meta.relation'));
 
@@ -346,6 +347,7 @@ class ParentsRelationshipTest extends IntegrationTestCase
             'depth_level' => 1,
             'menu' => true,
             'canonical' => true,
+            'params' => null,
         ];
         static::assertEquals($expected, Hash::get($result, 'data.meta.relation'));
     }

--- a/plugins/BEdita/Core/config/Migrations/20240930121402_TreesAddParams.php
+++ b/plugins/BEdita/Core/config/Migrations/20240930121402_TreesAddParams.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\AbstractMigration;
+
+class TreesAddParams extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * @return void
+     */
+    public function change()
+    {
+        $columnTypes = $this->getAdapter()->getColumnTypes();
+        $type = in_array('json', $columnTypes) ? 'json' : 'text';
+        $this->table('trees')
+            ->addColumn('params', $type, [
+                'comment' => 'Folder parameters (JSON)',
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->update();
+    }
+}

--- a/plugins/BEdita/Core/config/Migrations/20240930121402_TreesAddParams.php
+++ b/plugins/BEdita/Core/config/Migrations/20240930121402_TreesAddParams.php
@@ -16,7 +16,7 @@ class TreesAddParams extends AbstractMigration
         $type = in_array('json', $columnTypes) ? 'json' : 'text';
         $this->table('trees')
             ->addColumn('params', $type, [
-                'comment' => 'Folder parameters (JSON)',
+                'comment' => 'Parameters for the position on tree (JSON)',
                 'default' => null,
                 'limit' => null,
                 'null' => true,

--- a/plugins/BEdita/Core/src/Model/Entity/Tree.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Tree.php
@@ -31,6 +31,7 @@ use Cake\ORM\TableRegistry;
  * @property int $depth_level
  * @property bool $menu
  * @property bool $canonical
+ * @property array|null $params
  * @property int|string $position
  *
  * @property \BEdita\Core\Model\Entity\ObjectEntity $object
@@ -52,6 +53,7 @@ class Tree extends Entity
         'menu' => true,
         'position' => true,
         'canonical' => true,
+        'params' => true,
     ];
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/TreesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TreesTable.php
@@ -130,7 +130,7 @@ class TreesTable extends Table
 
         $validator
             ->allowEmptyArray('params', null, static::jsonSchema(null) === true)
-            ->requirePresence('params', fn ($context) => $context['newRecord'] && static::jsonSchema(null) !== true)
+            ->requirePresence('params', static::jsonSchema(null) === true ? false : 'create')
             ->add('params', 'valid', [
                 'rule' => 'jsonSchema',
                 'provider' => 'table',

--- a/plugins/BEdita/Core/src/Model/Table/TreesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TreesTable.php
@@ -130,9 +130,7 @@ class TreesTable extends Table
 
         $validator
             ->allowEmptyArray('params', null, static::jsonSchema(null) === true)
-            ->requirePresence('params', function ($context) {
-                return $context['newRecord'] && static::jsonSchema(null) !== true;
-            })
+            ->requirePresence('params', fn ($context) => $context['newRecord'] && static::jsonSchema(null) !== true)
             ->add('params', 'valid', [
                 'rule' => 'jsonSchema',
                 'provider' => 'table',
@@ -149,7 +147,7 @@ class TreesTable extends Table
      */
     public static function jsonSchema($value)
     {
-        $schema = Configure::read('Folder.params_schema');
+        $schema = Configure::read('Folders.params_schema');
         if (empty($schema)) {
             return true;
         }

--- a/plugins/BEdita/Core/src/Model/Table/TreesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TreesTable.php
@@ -147,7 +147,7 @@ class TreesTable extends Table
      */
     public static function jsonSchema($value)
     {
-        $schema = Configure::read('Folders.params_schema');
+        $schema = Configure::read('ChildrenParams');
         if (empty($schema)) {
             return true;
         }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -522,6 +522,7 @@ class JsonApiTraitTest extends TestCase
             'depth_level' => 2,
             'menu' => true,
             'canonical' => true,
+            'params' => null,
         ];
         static::assertEquals($expected, Hash::get($child, 'meta.relation'));
     }


### PR DESCRIPTION
This PR adds a `Trees.params` column, to store custom parameters for children association.

The parameters' JSON-schema is read from the `ChildrenParams` configuration, if available.