### PR TITLE
fix: mark related entities as non-primary

### DIFF
--- a/plugins/BEdita/Core/src/Model/Action/AddAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/AddAssociatedAction.php
@@ -53,7 +53,7 @@ class AddAssociatedAction extends UpdateAssociatedAction
                 $this->dispatchEvent('Associated.beforeSave', compact('entity', 'relatedEntities') + ['action' => 'add', 'association' => $this->Association]);
 
                 $relatedEntities = $this->diff($entity, $relatedEntities->getArrayCopy(), false);
-                if (!$this->Association->link($entity, $relatedEntities, ['atomic' => false])) {
+                if (!$this->Association->link($entity, $relatedEntities, ['atomic' => false, '_skipSearchIndex' => true])) {
                     return false;
                 }
                 foreach ($relatedEntities as $relatedEntity) {

--- a/plugins/BEdita/Core/src/Model/Action/AddRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/AddRelatedObjectsAction.php
@@ -47,7 +47,7 @@ class AddRelatedObjectsAction extends UpdateRelatedObjectsAction
             $this->dispatchEvent('Associated.beforeSave', compact('entity', 'relatedEntities') + ['action' => 'add', 'association' => $this->Association]);
 
             $relatedEntities = $this->diff($entity, $relatedEntities->getArrayCopy(), false);
-            if (!$this->Association->link($entity, $relatedEntities)) {
+            if (!$this->Association->link($entity, $relatedEntities, ['_skipSearchIndex' => true])) {
                 return false;
             }
             $this->dispatchEvent('Associated.afterSave', compact('entity', 'relatedEntities') + ['action' => 'add', 'association' => $this->Association]);

--- a/plugins/BEdita/Core/src/Model/Action/AssociatedTrait.php
+++ b/plugins/BEdita/Core/src/Model/Action/AssociatedTrait.php
@@ -203,7 +203,7 @@ trait AssociatedTrait
         }
 
         if (!empty($data)) {
-            $this->Association->junction()->patchEntity($joinData, $data);
+            $this->Association->junction()->patchEntity($joinData, $data, ['_skipSearchIndex' => true]);
         }
         $errors = $joinData->getErrors();
         if (!empty($errors)) {
@@ -253,7 +253,7 @@ trait AssociatedTrait
         }
 
         $existingJoin->set($this->getJunctionExtraFields($source, $new), ['guard' => false]);
-        $existingJoin = $this->Association->junction()->patchEntity($existingJoin, $data);
+        $existingJoin = $this->Association->junction()->patchEntity($existingJoin, $data, ['_skipSearchIndex' => true]);
         $errors = $existingJoin->getErrors();
         if (!empty($errors)) {
             throw new InvalidDataException(__d('bedita', 'Invalid data'), $errors);

--- a/plugins/BEdita/Core/src/Model/Action/RemoveAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/RemoveAssociatedAction.php
@@ -53,7 +53,7 @@ class RemoveAssociatedAction extends UpdateAssociatedAction
 
                 $relatedEntities = $this->intersection((array)$this->existing($entity), $relatedEntities->getArrayCopy());
 
-                $this->Association->unlink($entity, $relatedEntities);
+                $this->Association->unlink($entity, $relatedEntities, ['_skipSearchIndex' => true]);
                 $this->dispatchEvent('Associated.afterSave', compact('entity', 'relatedEntities') + ['action' => 'remove', 'association' => $this->Association]);
 
                 return count($relatedEntities);

--- a/plugins/BEdita/Core/src/Model/Action/SetAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SetAssociatedAction.php
@@ -107,7 +107,7 @@ class SetAssociatedAction extends UpdateAssociatedAction
         $count = count($affectedEntities);
 
         if ($this->Association instanceof HasMany) {
-            if ($this->Association->replace($entity, $relatedEntities, ['atomic' => false]) === false) {
+            if ($this->Association->replace($entity, $relatedEntities, ['atomic' => false, '_skipSearchIndex' => true]) === false) {
                 return false;
             }
 
@@ -117,7 +117,7 @@ class SetAssociatedAction extends UpdateAssociatedAction
         }
 
         if ($this->Association instanceof BelongsToMany) {
-            if ($this->Association->replaceLinks($entity, $relatedEntities, ['atomic' => false]) === false) {
+            if ($this->Association->replaceLinks($entity, $relatedEntities, ['atomic' => false, '_skipSearchIndex' => true]) === false) {
                 return false;
             }
 
@@ -216,7 +216,7 @@ class SetAssociatedAction extends UpdateAssociatedAction
             $bindingKeyValue
         ));
 
-        if ($this->Association->getTarget()->save($relatedEntity) === false) {
+        if ($this->Association->getTarget()->save($relatedEntity, ['_skipSearchIndex' => true]) === false) {
             return false;
         }
 

--- a/plugins/BEdita/Core/src/Model/Action/SetRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SetRelatedObjectsAction.php
@@ -46,7 +46,7 @@ class SetRelatedObjectsAction extends UpdateRelatedObjectsAction
         $this->dispatchEvent('Associated.beforeSave', compact('entity', 'relatedEntities') + ['action' => 'set', 'association' => $this->Association]);
 
         $relatedEntities = $this->diff($entity, $relatedEntities->getArrayCopy(), true, $affectedEntities);
-        if (!$this->Association->replaceLinks($entity, $relatedEntities)) {
+        if (!$this->Association->replaceLinks($entity, $relatedEntities, ['_skipSearchIndex' => true])) {
             return false;
         }
         $this->dispatchEvent('Associated.afterSave', compact('entity', 'relatedEntities') + ['action' => 'set', 'association' => $this->Association]);

--- a/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/SearchableBehavior.php
@@ -115,8 +115,9 @@ class SearchableBehavior extends Behavior
      */
     public function afterSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void
     {
-        if (empty($options['_primary'])) {
-            // Do not reindex non-primary saved entities, as they will probably be incomplete.
+        if (empty($options['_primary']) || !empty($options['_skipSearchIndex'])) {
+            // Do not reindex non-primary saved entities, as they will probably be incomplete, nor entities for which
+            // skipping reindex is explicitly requested.
             return;
         }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
@@ -233,6 +233,13 @@ class SearchableBehaviorTest extends TestCase
         static::assertEquals(1, $default->afterSaveCount);
         static::assertEquals(1, $foo->initializedCount);
 
+        static::assertEquals(0, $default->afterDeleteCount);
+        static::assertEquals(0, $foo->afterDeleteCount);
+        $entity->setDirty('name');
+        $table->saveOrFail($entity, ['_skipSearchIndex' => true]);
+        static::assertEquals(1, $default->afterSaveCount);
+        static::assertEquals(1, $foo->initializedCount);
+
         static::assertEquals(0, $foo->afterDeleteCount);
         $table->deleteOrFail($entity);
         static::assertEquals(1, $default->afterDeleteCount);


### PR DESCRIPTION
rif. https://github.com/bedita/bedita/pull/2084

Add option to skip (re)indexing related entities when using actions, to prevent saving entities with incomplete data in the search engine.