### PR TITLE
Sort object relationship related data

### DIFF
--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -273,5 +273,10 @@ return function (RouteBuilder $routes) {
             ['controller' => 'Objects', 'action' => 'relationships'],
             ['_name' => 'objects:relationships']
         );
+        $routes->connect(
+            '/{object_type}/{id}/relationships/{relationship}/sort',
+            ['controller' => 'Objects', 'action' => 'relationshipsSort'],
+            ['_name' => 'objects:relationshipsSort']
+        );
     });
 };

--- a/plugins/BEdita/API/postman/BE5.postman_collection.json
+++ b/plugins/BEdita/API/postman/BE5.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "fb4edbaa-3cf1-4f6d-a731-60ab9ab87c9f",
+		"_postman_id": "250fd7c1-413e-4ba1-b07f-c05ad5230a6c",
 		"name": "BEdita 5 Core API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "864760"
+		"_exporter_id": "6916583"
 	},
 	"item": [
 		{
@@ -4214,6 +4214,60 @@
 								"1",
 								"relationships",
 								"{{relationName}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Sort related",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"tests[\"Status code is 200\"] = responseCode.code === 200;",
+									"tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.api+json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}"
+							},
+							{
+								"key": "X-Api-Key",
+								"value": "{{apiKey}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"meta\": {\n        \"field\": \"title\",\n        \"direction\": \"desc\"\n    }\n}"
+						},
+						"url": {
+							"raw": "{{be4Url}}/{{objectTypeName}}/{{objectId}}/relationships/{{relationName}}/sort",
+							"host": [
+								"{{be4Url}}"
+							],
+							"path": [
+								"{{objectTypeName}}",
+								"{{objectId}}",
+								"relationships",
+								"{{relationName}}",
+								"sort"
 							]
 						}
 					},

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -529,19 +529,22 @@ class ObjectsController extends ResourcesController
     public function relationshipsSort(): ?Response
     {
         $this->request->allowMethod(['patch']);
-        $id = $this->request->getParam('id');
-        $relationship = $this->request->getParam('relationship');
-        $payload = json_decode((string)$this->request->getBody(), true);
-        $field = (string)Hash::get($payload, 'meta.field');
-        $direction = (string)Hash::get($payload, 'meta.direction');
-        $association = $this->findAssociation($relationship);
-        $this->setRelationshipsAllowedMethods($association);
-        $action = new GetObjectAction(['table' => $this->Table, 'objectType' => $this->objectType]);
-        $entity = $action(['primaryKey' => $id]);
-        $action = new SortRelatedObjectsAction(compact('association'));
-        $count = $action(['entity' => $entity, 'field' => $field, 'direction' => $direction]);
-        if ($count === false) {
-            throw new InternalErrorException(__d('bedita', 'Could not sort and update relationship "{0}"', $relationship));
+        try {
+            $id = $this->request->getParam('id');
+            $relationship = $this->request->getParam('relationship');
+            $payload = json_decode((string)$this->request->getBody(), true);
+            $field = (string)Hash::get($payload, 'meta.field');
+            $direction = (string)Hash::get($payload, 'meta.direction');
+            $association = $this->findAssociation($relationship);
+            $this->setRelationshipsAllowedMethods($association);
+            $action = new GetObjectAction(['table' => $this->Table, 'objectType' => $this->objectType]);
+            $entity = $action(['primaryKey' => $id]);
+            $action = new SortRelatedObjectsAction(compact('association'));
+            $count = $action(['entity' => $entity, 'field' => $field, 'direction' => $direction]);
+        } catch (\Exception) {
+            throw new InternalErrorException(
+                __d('bedita', 'Could not sort and update relationship "{0}"', $relationship)
+            );
         }
         if ($count === 0) {
             return $this->response->withStatus(204);

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -541,9 +541,9 @@ class ObjectsController extends ResourcesController
             $entity = $action(['primaryKey' => $id]);
             $action = new SortRelatedObjectsAction(compact('association'));
             $count = $action(['entity' => $entity, 'field' => $field, 'direction' => $direction]);
-        } catch (\Exception) {
+        } catch (\Exception $e) {
             throw new InternalErrorException(
-                __d('bedita', 'Could not sort and update relationship "{0}"', $relationship)
+                __d('bedita', 'Could not sort and update relationship "{0}": {1}', $relationship, $e->getMessage())
             );
         }
         if ($count === 0) {

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -27,6 +27,7 @@ use BEdita\Core\Model\Action\ListRelatedObjectsAction;
 use BEdita\Core\Model\Action\RemoveRelatedObjectsAction;
 use BEdita\Core\Model\Action\SaveEntityAction;
 use BEdita\Core\Model\Action\SetRelatedObjectsAction;
+use BEdita\Core\Model\Action\SortRelatedObjectsAction;
 use BEdita\Core\Model\Entity\ObjectType;
 use BEdita\Core\Model\Table\ObjectsTable;
 use BEdita\Core\Model\Table\RolesTable;
@@ -36,6 +37,7 @@ use Cake\Event\EventInterface;
 use Cake\Http\Exception\ConflictException;
 use Cake\Http\Exception\ForbiddenException;
 use Cake\Http\Exception\InternalErrorException;
+use Cake\Http\Response;
 use Cake\ORM\Association;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
@@ -498,6 +500,54 @@ class ObjectsController extends ResourcesController
             $serialize = ['data'];
         }
         $this->setSerialize($serialize);
+
+        return null;
+    }
+
+    /**
+     * Sort relationships data for an object.
+     * This action replaces the related data with a sorted set of data.
+     * Data is sort by a field in ascending or descending order.
+     * The field and the direction are passed in the request meta data.
+     *
+     * Example:
+     * ```
+     * PATCH /{object_type}/{id}/relationships/{relationship}/sort
+     * {
+     *     "data": {
+     *         "id": "{{ id }}",
+     *         "type": "{{ object_type}}"
+     *     },
+     *     "meta": {
+     *         "field": "{{ field }}",
+     *         "direction": "{{ direction }}"
+     *     }
+     * }
+     * ```
+     *
+     * @return \Cake\Http\Response|null
+     */
+    public function relationshipsSort(): ?Response
+    {
+        $this->request->allowMethod(['patch']);
+        $id = $this->request->getParam('id');
+        $relationship = $this->request->getParam('relationship');
+        $payload = json_decode((string)$this->request->getBody(), true);
+        $field = (string)Hash::get($payload, 'meta.field');
+        $direction = (string)Hash::get($payload, 'meta.direction');
+        $association = $this->findAssociation($relationship);
+        $this->setRelationshipsAllowedMethods($association);
+        $action = new GetObjectAction(['table' => $this->Table, 'objectType' => $this->objectType]);
+        $entity = $action(['primaryKey' => $id]);
+        $action = new SortRelatedObjectsAction(compact('association'));
+        $count = $action(['entity' => $entity, 'field' => $field, 'direction' => $direction]);
+        if ($count === false) {
+            throw new InternalErrorException(__d('bedita', 'Could not sort and update relationship "{0}"', $relationship));
+        }
+        if ($count === 0) {
+            return $this->response->withStatus(204);
+        }
+        $this->setSerialize([]);
 
         return null;
     }

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -118,6 +118,9 @@ class ObjectsController extends ResourcesController
         if (isset($this->JsonApi) && $this->request->getParam('action') !== 'relationships') {
             $this->JsonApi->setConfig('resourceTypes', [$this->objectType->name], false);
         }
+        if (isset($this->JsonApi) && $this->request->getParam('action') === 'relationshipsSort') {
+            $this->JsonApi->setConfig('parseJson', false);
+        }
     }
 
     /**

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -529,23 +529,17 @@ class ObjectsController extends ResourcesController
     public function relationshipsSort(): ?Response
     {
         $this->request->allowMethod(['patch']);
-        try {
-            $id = $this->request->getParam('id');
-            $relationship = $this->request->getParam('relationship');
-            $payload = json_decode((string)$this->request->getBody(), true);
-            $field = (string)Hash::get($payload, 'meta.field');
-            $direction = (string)Hash::get($payload, 'meta.direction');
-            $association = $this->findAssociation($relationship);
-            $this->setRelationshipsAllowedMethods($association);
-            $action = new GetObjectAction(['table' => $this->Table, 'objectType' => $this->objectType]);
-            $entity = $action(['primaryKey' => $id]);
-            $action = new SortRelatedObjectsAction(compact('association'));
-            $count = $action(['entity' => $entity, 'field' => $field, 'direction' => $direction]);
-        } catch (\Exception $e) {
-            throw new InternalErrorException(
-                __d('bedita', 'Could not sort and update relationship "{0}": {1}', $relationship, $e->getMessage())
-            );
-        }
+        $id = $this->request->getParam('id');
+        $relationship = $this->request->getParam('relationship');
+        $payload = json_decode((string)$this->request->getBody(), true);
+        $field = (string)Hash::get($payload, 'meta.field');
+        $direction = (string)Hash::get($payload, 'meta.direction');
+        $association = $this->findAssociation($relationship);
+        $this->setRelationshipsAllowedMethods($association);
+        $action = new GetObjectAction(['table' => $this->Table, 'objectType' => $this->objectType]);
+        $entity = $action(['primaryKey' => $id]);
+        $action = new SortRelatedObjectsAction(compact('association'));
+        $count = $action(['entity' => $entity, 'field' => $field, 'direction' => $direction]);
         if ($count === 0) {
             return $this->response->withStatus(204);
         }

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -517,10 +517,6 @@ class ObjectsController extends ResourcesController
      * ```
      * PATCH /{object_type}/{id}/relationships/{relationship}/sort
      * {
-     *     "data": {
-     *         "id": "{{ id }}",
-     *         "type": "{{ object_type}}"
-     *     },
      *     "meta": {
      *         "field": "{{ field }}",
      *         "direction": "{{ direction }}"

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -3694,9 +3694,8 @@ class ObjectsControllerTest extends IntegrationTestCase
     {
         $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
         $this->patch('/documents/2/relationships/test/sort', json_encode([]));
-        $this->assertResponseCode(500);
+        $this->assertResponseCode(400);
         $this->assertContentType('application/vnd.api+json');
-        $this->assertResponseContains('Could not sort and update relationship');
         $this->assertResponseContains('Missing required key');
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -3597,4 +3597,116 @@ class ObjectsControllerTest extends IntegrationTestCase
 
         static::assertEquals($expected, Hash::get($result, 'data.0.meta.perms'));
     }
+
+    /**
+     * Test reorder related data performed by relationshipsSort.
+     *
+     * @return void
+     * @covers ::relationshipsSort()
+     */
+    public function testRelationshipsSort(): void
+    {
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $this->patch('/documents/2/relationships/test/sort', json_encode([
+            'data' => [
+                'id' => 2,
+                'type' => 'documents',
+            ],
+            'meta' => [
+                'field' => 'title',
+                'direction' => 'desc',
+            ],
+        ]));
+        $this->assertResponseCode(200);
+        $this->configRequestHeaders('GET', $this->getUserAuthHeader());
+        $this->get('/documents/2/relationships/test');
+        $result = json_decode((string)$this->_response->getBody(), true);
+        static::assertSame('3', Hash::get($result, 'data.0.id'));
+        static::assertSame('documents', Hash::get($result, 'data.0.type'));
+        static::assertSame('4', Hash::get($result, 'data.1.id'));
+        static::assertSame('profiles', Hash::get($result, 'data.1.type'));
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $this->patch('/documents/2/relationships/test/sort', json_encode([
+            'data' => [
+                'id' => 2,
+                'type' => 'documents',
+            ],
+            'meta' => [
+                'field' => 'title',
+                'direction' => 'asc',
+            ],
+        ]));
+        $this->configRequestHeaders('GET', $this->getUserAuthHeader());
+        $this->get('/documents/2/relationships/test');
+        $result = json_decode((string)$this->_response->getBody(), true);
+        static::assertSame('4', Hash::get($result, 'data.0.id'));
+        static::assertSame('profiles', Hash::get($result, 'data.0.type'));
+        static::assertSame('3', Hash::get($result, 'data.1.id'));
+        static::assertSame('documents', Hash::get($result, 'data.1.type'));
+    }
+
+    /**
+     * Test reorder related data performed by relationshipsSort with invalid data.
+     *
+     * @return void
+     * @covers ::relationshipsSort()
+     */
+    public function testRelationshipsSortEmpty(): void
+    {
+        $this->configRequestHeaders('GET', $this->getUserAuthHeader());
+        $this->get('/documents/2/relationships/test');
+        $result = json_decode((string)$this->_response->getBody(), true);
+        // remove all related objects
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $this->patch('/documents/2/relationships/test', json_encode([
+            'data' => [],
+        ]));
+        $this->assertResponseCode(200);
+        // reorder empty relationships
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $this->patch('/documents/2/relationships/test/sort', json_encode([
+            'data' => [
+                'id' => 2,
+                'type' => 'documents',
+            ],
+            'meta' => [
+                'field' => 'title',
+                'direction' => 'desc',
+            ],
+        ]));
+        $this->assertResponseCode(204);
+        // restore data
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $this->patch('/documents/2/relationships/test', json_encode([
+            'data' => [
+                [
+                    'id' => '4',
+                    'type' => 'profiles',
+                ],
+                [
+                    'id' => '3',
+                    'type' => 'documents',
+                ],
+            ],
+        ]));
+        $this->assertResponseCode(200);
+    }
+
+    /**
+     * Test reorder related data performed by relationshipsSort with invalid data.
+     *
+     * @return void
+     * @covers ::relationshipsSort()
+     */
+    public function testRelationshipsSortFalse(): void
+    {
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $this->patch('/documents/2/relationships/test/sort', json_encode([
+            'data' => [
+                'id' => 2,
+                'type' => 'documents',
+            ],
+        ]));
+        $this->assertResponseCode(500);
+    }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -3606,37 +3606,30 @@ class ObjectsControllerTest extends IntegrationTestCase
      */
     public function testRelationshipsSort(): void
     {
-        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $headers = $this->getUserAuthHeader() + ['Content-Type' => 'application/json'];
+        $this->configRequestHeaders('PATCH', $headers);
         $this->patch('/documents/2/relationships/test/sort', json_encode([
-            'data' => [
-                'id' => 2,
-                'type' => 'documents',
-            ],
             'meta' => [
                 'field' => 'title',
                 'direction' => 'desc',
             ],
         ]));
         $this->assertResponseCode(200);
-        $this->configRequestHeaders('GET', $this->getUserAuthHeader());
+        $this->configRequestHeaders('GET', $headers);
         $this->get('/documents/2/relationships/test');
         $result = json_decode((string)$this->_response->getBody(), true);
         static::assertSame('3', Hash::get($result, 'data.0.id'));
         static::assertSame('documents', Hash::get($result, 'data.0.type'));
         static::assertSame('4', Hash::get($result, 'data.1.id'));
         static::assertSame('profiles', Hash::get($result, 'data.1.type'));
-        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $this->configRequestHeaders('PATCH', $headers);
         $this->patch('/documents/2/relationships/test/sort', json_encode([
-            'data' => [
-                'id' => 2,
-                'type' => 'documents',
-            ],
             'meta' => [
                 'field' => 'title',
                 'direction' => 'asc',
             ],
         ]));
-        $this->configRequestHeaders('GET', $this->getUserAuthHeader());
+        $this->configRequestHeaders('GET', $headers);
         $this->get('/documents/2/relationships/test');
         $result = json_decode((string)$this->_response->getBody(), true);
         static::assertSame('4', Hash::get($result, 'data.0.id'));
@@ -3665,10 +3658,6 @@ class ObjectsControllerTest extends IntegrationTestCase
         // reorder empty relationships
         $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
         $this->patch('/documents/2/relationships/test/sort', json_encode([
-            'data' => [
-                'id' => 2,
-                'type' => 'documents',
-            ],
             'meta' => [
                 'field' => 'title',
                 'direction' => 'desc',
@@ -3701,12 +3690,7 @@ class ObjectsControllerTest extends IntegrationTestCase
     public function testRelationshipsSortFalse(): void
     {
         $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
-        $this->patch('/documents/2/relationships/test/sort', json_encode([
-            'data' => [
-                'id' => 2,
-                'type' => 'documents',
-            ],
-        ]));
+        $this->patch('/documents/2/relationships/test/sort', json_encode([]));
         $this->assertResponseCode(500);
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -3697,5 +3697,6 @@ class ObjectsControllerTest extends IntegrationTestCase
         $this->assertResponseCode(500);
         $this->assertContentType('application/vnd.api+json');
         $this->assertResponseContains('Could not sort and update relationship');
+        $this->assertResponseContains('Missing required key');
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -3603,6 +3603,7 @@ class ObjectsControllerTest extends IntegrationTestCase
      *
      * @return void
      * @covers ::relationshipsSort()
+     * @covers ::initialize()
      */
     public function testRelationshipsSort(): void
     {
@@ -3643,6 +3644,7 @@ class ObjectsControllerTest extends IntegrationTestCase
      *
      * @return void
      * @covers ::relationshipsSort()
+     * @covers ::initialize()
      */
     public function testRelationshipsSortEmpty(): void
     {
@@ -3686,6 +3688,7 @@ class ObjectsControllerTest extends IntegrationTestCase
      *
      * @return void
      * @covers ::relationshipsSort()
+     * @covers ::initialize()
      */
     public function testRelationshipsSortFalse(): void
     {

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -3690,10 +3690,12 @@ class ObjectsControllerTest extends IntegrationTestCase
      * @covers ::relationshipsSort()
      * @covers ::initialize()
      */
-    public function testRelationshipsSortFalse(): void
+    public function testRelationshipsSortException(): void
     {
         $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
         $this->patch('/documents/2/relationships/test/sort', json_encode([]));
         $this->assertResponseCode(500);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseContains('Could not sort and update relationship');
     }
 }

--- a/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
@@ -222,7 +222,9 @@ class ListAssociatedAction extends BaseAction
         if ($this->Association instanceof BelongsToMany && $joinData) {
             $query = $query->select($this->Association->junction());
         }
-        if ($this->Association instanceof BelongsToMany || $this->Association instanceof HasMany) {
+        if (!empty($data['sort'])) {
+            $query = $query->order([$table->aliasField($data['sort']['field']) => $data['sort']['direction']]);
+        } elseif ($this->Association instanceof BelongsToMany || $this->Association instanceof HasMany) {
             $sort = $this->sort($this->Association, $primaryKey);
             $query = $query->order($sort);
         }

--- a/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
@@ -65,16 +65,6 @@ class SortRelatedObjectsAction extends BaseAction
                 return $direction === 'asc' ? $val1 <=> $val2 : $val2 <=> $val1;
             }
         );
-        $priority = 1;
-        $count = count($relatedEntities);
-        foreach ($relatedEntities as &$related) {
-            $join = (array)$related->get('_joinData');
-            $priorities = [
-                'inv_priority' => $count--,
-                'priority' => $priority++,
-            ];
-            $related->set('_joinData', array_filter(array_merge($join, $priorities)));
-        }
         $action = new SetRelatedObjectsAction(compact('association'));
         $action(compact('entity', 'relatedEntities'));
 

--- a/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
@@ -65,6 +65,16 @@ class SortRelatedObjectsAction extends BaseAction
                 return $direction === 'asc' ? $val1 <=> $val2 : $val2 <=> $val1;
             }
         );
+        $priority = 1;
+        $count = count($relatedEntities);
+        foreach ($relatedEntities as &$related) {
+            $join = (array)$related->get('_joinData');
+            $priorities = [
+                'inv_priority' => $count--,
+                'priority' => $priority++,
+            ];
+            $related->set('_joinData', array_filter(array_merge($join, $priorities)));
+        }
         $action = new SetRelatedObjectsAction(compact('association'));
         $action(compact('entity', 'relatedEntities'));
 

--- a/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Model\Action;
+
+use BEdita\Core\Model\Entity\ObjectEntity;
+use Cake\Log\LogTrait;
+use Cake\Utility\Hash;
+
+/**
+ * Replace related objects with the same objects ordered by a specific field, with a direction.
+ *
+ * @since 4.0.0
+ */
+class SortRelatedObjectsAction extends BaseAction
+{
+    use LogTrait;
+
+    /**
+     * {@inheritDoc}
+     *
+     * Get related objects and sort them.
+     * Data must contain:
+     * - `entity` (ObjectEntity) the entity of the main object
+     * - `field` (string) the field to sort by
+     * - `direction` (string) the direction of the sort
+     */
+    public function execute(array $data = [])
+    {
+        $required = ['entity', 'field', 'direction'];
+        foreach ($required as $key) {
+            if (!array_key_exists($key, $data) || empty($data[$key])) {
+                $this->log(sprintf('Missing required key "%s"', $key), 'error');
+
+                return false;
+            }
+        }
+        /** @var \BEdita\Core\Model\Entity\ObjectEntity $entity */
+        $entity = Hash::get($data, 'entity');
+        $primaryKey = $entity->get('id');
+        $field = (string)Hash::get($data, 'field');
+        $direction = (string)Hash::get($data, 'direction');
+        $association = $this->getConfig('association');
+        $action = new ListRelatedObjectsAction(compact('association'));
+        $relatedEntities = $action(compact('primaryKey'));
+        $relatedEntities = $relatedEntities->toArray();
+        usort(
+            $relatedEntities,
+            function (ObjectEntity $item1, ObjectEntity $item2) use ($field, $direction) {
+                $val1 = (string)$item1->get($field);
+                $val2 = (string)$item2->get($field);
+
+                return $direction === 'asc' ? $val1 <=> $val2 : $val2 <=> $val1;
+            }
+        );
+        $priority = 1;
+        $count = count($relatedEntities);
+        foreach ($relatedEntities as &$related) {
+            $join = (array)$related->get('_joinData');
+            $priorities = [
+                'inv_priority' => $count--,
+                'priority' => $priority++,
+            ];
+            $related->set('_joinData', array_filter(array_merge($join, $priorities)));
+        }
+        $action = new SetRelatedObjectsAction(compact('association'));
+        $action(compact('entity', 'relatedEntities'));
+
+        return count($relatedEntities);
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
@@ -17,6 +17,7 @@ namespace BEdita\Core\Model\Action;
 
 use BEdita\Core\Exception\InvalidDataException;
 use BEdita\Core\Model\Entity\ObjectEntity;
+use BEdita\Core\ORM\Association\RelatedTo;
 use Cake\Log\LogTrait;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\Utility\Hash;
@@ -44,6 +45,10 @@ class SortRelatedObjectsAction extends BaseAction
      */
     public function execute(array $data = [])
     {
+        $association = $this->getConfig('association');
+        if (!$association instanceof RelatedTo) {
+            throw new InvalidDataException(sprintf('Invalid association: %s', $association->getName()));
+        }
         $required = ['entity', 'field', 'direction'];
         foreach ($required as $key) {
             if (!array_key_exists($key, $data) || empty($data[$key])) {
@@ -56,7 +61,6 @@ class SortRelatedObjectsAction extends BaseAction
         $primaryKey = $entity->get('id');
         $field = (string)Hash::get($data, 'field');
         $direction = (string)Hash::get($data, 'direction');
-        $association = $this->getConfig('association');
         $action = new ListRelatedObjectsAction(compact('association'));
         $relatedEntities = $action(compact('primaryKey'));
         $relatedEntities = $relatedEntities->toArray();

--- a/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
@@ -67,18 +67,16 @@ class SortRelatedObjectsAction extends BaseAction
         usort(
             $relatedEntities,
             function (ObjectEntity $item1, ObjectEntity $item2) use ($field, $direction) {
-                $val1 = (string)$item1->get($field);
-                $val2 = (string)$item2->get($field);
+                $val1 = strtolower((string)$item1->get($field));
+                $val2 = strtolower((string)$item2->get($field));
 
                 return $direction === 'asc' ? $val1 <=> $val2 : $val2 <=> $val1;
             }
         );
         $priority = 1;
-        $count = count($relatedEntities);
         foreach ($relatedEntities as &$related) {
-            $join = (array)$related->get('_joinData');
+            $join = $related->get('_joinData')->toArray();
             $priorities = [
-                'inv_priority' => $count--,
                 'priority' => $priority++,
             ];
             $related->set('_joinData', array_filter(array_merge($join, $priorities)));

--- a/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 namespace BEdita\Core\Model\Action;
 
 use BEdita\Core\Exception\InvalidDataException;
-use BEdita\Core\Model\Entity\ObjectEntity;
 use BEdita\Core\ORM\Association\RelatedTo;
 use Cake\Log\LogTrait;
 use Cake\ORM\Locator\LocatorAwareTrait;

--- a/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
@@ -62,17 +62,9 @@ class SortRelatedObjectsAction extends BaseAction
         $field = (string)Hash::get($data, 'field');
         $direction = (string)Hash::get($data, 'direction');
         $action = new ListRelatedObjectsAction(compact('association'));
-        $relatedEntities = $action(compact('primaryKey'));
-        $relatedEntities = $relatedEntities->toArray();
-        usort(
-            $relatedEntities,
-            function (ObjectEntity $item1, ObjectEntity $item2) use ($field, $direction) {
-                $val1 = strtolower((string)$item1->get($field));
-                $val2 = strtolower((string)$item2->get($field));
-
-                return $direction === 'asc' ? $val1 <=> $val2 : $val2 <=> $val1;
-            }
-        );
+        $relatedEntities = $action(compact('primaryKey'))
+            ->sort([$association->aliasField($field) => $direction])
+            ->toArray();
         $priority = 1;
         foreach ($relatedEntities as &$related) {
             $join = $related->get('_joinData')->toArray();

--- a/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
@@ -54,27 +54,29 @@ class SortRelatedObjectsAction extends BaseAction
                 throw new InvalidDataException(sprintf('Missing required key "%s"', $key));
             }
         }
-
-        /** @var \BEdita\Core\Model\Entity\ObjectEntity $entity */
-        $entity = Hash::get($data, 'entity');
-        $primaryKey = $entity->get('id');
-        $field = (string)Hash::get($data, 'field');
-        $direction = (string)Hash::get($data, 'direction');
-        $action = new ListRelatedObjectsAction(compact('association'));
-        $sort = compact('field', 'direction');
-        $relatedEntities = $action(compact('primaryKey', 'sort'))->toArray();
-        $priority = 1;
-        foreach ($relatedEntities as &$related) {
-            $join = $related->get('_joinData')->toArray();
-            $priorities = [
-                'priority' => $priority++,
-            ];
-            $related->set('_joinData', array_filter(array_merge($join, $priorities)));
-        }
-        $association->junction()->getBehavior('Priority')->setConfig('disabled', true);
-        $action = new SetRelatedObjectsAction(compact('association'));
-        $action(compact('entity', 'relatedEntities'));
-        $association->junction()->getBehavior('Priority')->setConfig('disabled', false);
+        $relatedEntities = [];
+        $association->getConnection()->transactional(function () use ($association, $data, $relatedEntities) {
+            /** @var \BEdita\Core\Model\Entity\ObjectEntity $entity */
+            $entity = Hash::get($data, 'entity');
+            $primaryKey = $entity->get('id');
+            $field = (string)Hash::get($data, 'field');
+            $direction = (string)Hash::get($data, 'direction');
+            $action = new ListRelatedObjectsAction(compact('association'));
+            $sort = compact('field', 'direction');
+            $relatedEntities = $action(compact('primaryKey', 'sort'))->toArray();
+            $priority = 1;
+            foreach ($relatedEntities as &$related) {
+                $join = $related->get('_joinData')->toArray();
+                $priorities = [
+                    'priority' => $priority++,
+                ];
+                $related->set('_joinData', array_filter(array_merge($join, $priorities)));
+            }
+            $association->junction()->getBehavior('Priority')->setConfig('disabled', true);
+            $action = new SetRelatedObjectsAction(compact('association'));
+            $action(compact('entity', 'relatedEntities'));
+            $association->junction()->getBehavior('Priority')->setConfig('disabled', false);
+        });
 
         return count($relatedEntities);
     }

--- a/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
@@ -55,15 +55,16 @@ class SortRelatedObjectsAction extends BaseAction
             }
         }
         $relatedEntities = [];
-        $association->getConnection()->transactional(function () use ($association, $data, $relatedEntities) {
-            /** @var \BEdita\Core\Model\Entity\ObjectEntity $entity */
-            $entity = Hash::get($data, 'entity');
-            $primaryKey = $entity->get('id');
-            $field = (string)Hash::get($data, 'field');
-            $direction = (string)Hash::get($data, 'direction');
+        /** @var \BEdita\Core\Model\Entity\ObjectEntity $entity */
+        $entity = Hash::get($data, 'entity');
+        $field = (string)Hash::get($data, 'field');
+        $direction = (string)Hash::get($data, 'direction');
+        $primaryKey = $entity->get('id');
+        $sort = compact('field', 'direction');
+        $params = compact('primaryKey', 'sort');
+        $association->getConnection()->transactional(function () use ($association, $entity, $params, $relatedEntities) {
             $action = new ListRelatedObjectsAction(compact('association'));
-            $sort = compact('field', 'direction');
-            $relatedEntities = $action(compact('primaryKey', 'sort'))->toArray();
+            $relatedEntities = $action($params)->toArray();
             $priority = 1;
             foreach ($relatedEntities as &$related) {
                 $join = $related->get('_joinData')->toArray();

--- a/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
@@ -61,9 +61,8 @@ class SortRelatedObjectsAction extends BaseAction
         $field = (string)Hash::get($data, 'field');
         $direction = (string)Hash::get($data, 'direction');
         $action = new ListRelatedObjectsAction(compact('association'));
-        $relatedEntities = $action(compact('primaryKey'))
-            ->sort([$association->aliasField($field) => $direction])
-            ->toArray();
+        $sort = compact('field', 'direction');
+        $relatedEntities = $action(compact('primaryKey', 'sort'))->toArray();
         $priority = 1;
         foreach ($relatedEntities as &$related) {
             $join = $related->get('_joinData')->toArray();

--- a/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SortRelatedObjectsAction.php
@@ -54,7 +54,7 @@ class SortRelatedObjectsAction extends BaseAction
                 throw new InvalidDataException(sprintf('Missing required key "%s"', $key));
             }
         }
-        $relatedEntities = [];
+        $count = 0;
         /** @var \BEdita\Core\Model\Entity\ObjectEntity $entity */
         $entity = Hash::get($data, 'entity');
         $field = (string)Hash::get($data, 'field');
@@ -62,7 +62,7 @@ class SortRelatedObjectsAction extends BaseAction
         $primaryKey = $entity->get('id');
         $sort = compact('field', 'direction');
         $params = compact('primaryKey', 'sort');
-        $association->getConnection()->transactional(function () use ($association, $entity, $params, $relatedEntities) {
+        $association->getConnection()->transactional(function () use ($association, $entity, $params, &$count) {
             $action = new ListRelatedObjectsAction(compact('association'));
             $relatedEntities = $action($params)->toArray();
             $priority = 1;
@@ -77,8 +77,9 @@ class SortRelatedObjectsAction extends BaseAction
             $action = new SetRelatedObjectsAction(compact('association'));
             $action(compact('entity', 'relatedEntities'));
             $association->junction()->getBehavior('Priority')->setConfig('disabled', false);
+            $count = count($relatedEntities);
         });
 
-        return count($relatedEntities);
+        return $count;
     }
 }

--- a/plugins/BEdita/Core/src/Model/Behavior/PriorityBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/PriorityBehavior.php
@@ -31,6 +31,7 @@ class PriorityBehavior extends Behavior
      * @inheritDoc
      */
     protected $_defaultConfig = [
+        'disabled' => false,
         'fields' => [],
     ];
 
@@ -68,9 +69,11 @@ class PriorityBehavior extends Behavior
      */
     public function beforeSave(EventInterface $event, EntityInterface $entity)
     {
-        $fields = $this->getConfig('fields');
-        foreach ($fields as $field => $config) {
-            $this->updateEntityPriorities($entity, $field, $config);
+        if ($this->getConfig('disabled') !== true) {
+            $fields = $this->getConfig('fields');
+            foreach ($fields as $field => $config) {
+                $this->updateEntityPriorities($entity, $field, $config);
+            }
         }
     }
 
@@ -83,9 +86,11 @@ class PriorityBehavior extends Behavior
      */
     public function beforeDelete(EventInterface $event, EntityInterface $entity)
     {
-        $fields = $this->getConfig('fields');
-        foreach ($fields as $field => $config) {
-            $this->compactEntityField($entity, $field, $config);
+        if ($this->getConfig('disabled') !== true) {
+            $fields = $this->getConfig('fields');
+            foreach ($fields as $field => $config) {
+                $this->compactEntityField($entity, $field, $config);
+            }
         }
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Command/AsyncJobsCleanCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/AsyncJobsCleanCommandTest.php
@@ -19,9 +19,9 @@ use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
 /**
- * {@see BEdita\Core\Command\AsyncJobsCommand} Test Case
+ * {@see BEdita\Core\Command\AsyncJobsCleanCommand} Test Case
  *
- * @coversDefaultClass \BEdita\Core\Command\AsyncJobsCommand
+ * @coversDefaultClass \BEdita\Core\Command\AsyncJobsCleanCommand
  */
 class AsyncJobsCleanCommandTest extends TestCase
 {

--- a/plugins/BEdita/Core/tests/TestCase/Command/ObjectsHistoryCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ObjectsHistoryCommandTest.php
@@ -79,7 +79,7 @@ class ObjectsHistoryCommandTest extends TestCase
      * @covers ::execute()
      * @covers ::read()
      * @covers ::fetchQuery()
-     * @covers ::objectsIterator()
+     * @covers ::historyIterator()
      */
     public function testExecute(): void
     {
@@ -97,7 +97,7 @@ class ObjectsHistoryCommandTest extends TestCase
      * @covers ::execute()
      * @covers ::read()
      * @covers ::fetchQuery()
-     * @covers ::objectsIterator()
+     * @covers ::historyIterator()
      */
     public function testExecuteByTypes(): void
     {
@@ -115,7 +115,7 @@ class ObjectsHistoryCommandTest extends TestCase
      * @covers ::execute()
      * @covers ::delete()
      * @covers ::fetchQuery()
-     * @covers ::objectsIterator()
+     * @covers ::historyIterator()
      */
     public function testDeleteWithException(): void
     {
@@ -142,7 +142,7 @@ class ObjectsHistoryCommandTest extends TestCase
      * @covers ::execute()
      * @covers ::delete()
      * @covers ::fetchQuery()
-     * @covers ::objectsIterator()
+     * @covers ::historyIterator()
      */
     public function testDeleteWithNoException(): void
     {

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
@@ -264,4 +264,23 @@ class ListAssociatedActionTest extends TestCase
         $result = json_decode(json_encode($result->toArray()), true);
         static::assertEquals(2, count($result));
     }
+
+    /**
+     * Test `buildQuery` method with sort param
+     *
+     * @return void
+     * @covers ::buildQuery()
+     */
+    public function testBuildQueryWithSortParam(): void
+    {
+        // association Children
+        $association = TableRegistry::getTableLocator()->get('Folders')->getAssociation('Children');
+        $action = new ListAssociatedAction(compact('association'));
+        $primaryKey = 11;
+        $sort = ['field' => 'title', 'direction' => 'asc'];
+        $result = $action(compact('primaryKey', 'sort'));
+        $result = json_decode(json_encode($result->toArray()), true);
+        static::assertEquals('Sub Folder', $result[0]['title']);
+        static::assertEquals('title one', $result[1]['title']);
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SortRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SortRelatedObjectsActionTest.php
@@ -82,10 +82,14 @@ class SortRelatedObjectsActionTest extends TestCase
         $relatedEntitiesDesc = $Documents->get($id, ['contain' => ['Test']])->get('test');
         static::assertEquals($relatedEntities[0]->get('id'), $relatedEntitiesDesc[1]->get('id'));
         static::assertEquals($relatedEntities[1]->get('id'), $relatedEntitiesDesc[0]->get('id'));
+        static::assertEquals(1, $relatedEntitiesDesc[0]->get('_joinData')['priority']);
+        static::assertEquals(2, $relatedEntitiesDesc[1]->get('_joinData')['priority']);
         $action(['entity' => $entity, 'field' => 'title', 'direction' => 'asc']);
         $relatedEntitiesDesc = $Documents->get($id, ['contain' => ['Test']])->get('test');
         static::assertEquals($relatedEntities[0]->get('id'), $relatedEntitiesDesc[0]->get('id'));
         static::assertEquals($relatedEntities[1]->get('id'), $relatedEntitiesDesc[1]->get('id'));
+        static::assertEquals(1, $relatedEntitiesDesc[0]->get('_joinData')['priority']);
+        static::assertEquals(2, $relatedEntitiesDesc[1]->get('_joinData')['priority']);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SortRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SortRelatedObjectsActionTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace BEdita\Core\Test\TestCase\Model\Action;
 
+use BEdita\Core\Exception\InvalidDataException;
 use BEdita\Core\Model\Action\SortRelatedObjectsAction;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\TestSuite\TestCase;
@@ -99,13 +100,14 @@ class SortRelatedObjectsActionTest extends TestCase
      */
     public function testExecuteMissingRequiredField(): void
     {
+        $expectedException = new InvalidDataException('Missing required key "direction"');
+        $this->expectExceptionObject($expectedException);
         $id = 2;
         $Documents = $this->fetchTable('documents');
         $entity = $Documents->get($id);
         $relatedEntities = $Documents->get($id, ['contain' => ['Test']])->get('test');
         $association = $Documents->getAssociation('Test');
         $action = new SortRelatedObjectsAction(compact('association'));
-        $actual = $action(['entity' => $entity, 'field' => 'title']);
-        static::assertFalse($actual);
+        $action(['entity' => $entity, 'field' => 'title']);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SortRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SortRelatedObjectsActionTest.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Model\Action;
+
+use BEdita\Core\Model\Action\SortRelatedObjectsAction;
+use BEdita\Core\Utility\LoggedUser;
+use Cake\TestSuite\TestCase;
+
+/**
+ * @covers \BEdita\Core\Model\Action\SortRelatedObjectsAction
+ * @covers \BEdita\Core\Model\Action\SetRelatedObjectsAction
+ * @covers \BEdita\Core\Model\Action\ListRelatedObjectsAction
+ */
+class SortRelatedObjectsActionTest extends TestCase
+{
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    protected $fixtures = [
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.RelationTypes',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.ObjectRelations',
+        'plugin.BEdita/Core.Profiles',
+        'plugin.BEdita/Core.Users',
+        'plugin.BEdita/Core.Roles',
+        'plugin.BEdita/Core.RolesUsers',
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        LoggedUser::setUserAdmin();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        LoggedUser::resetUser();
+    }
+
+    /**
+     * Test `execute`.
+     *
+     * @return void
+     */
+    public function testExecute(): void
+    {
+        $id = 2;
+        $Documents = $this->fetchTable('documents');
+        $entity = $Documents->get($id);
+        $relatedEntities = $Documents->get($id, ['contain' => ['Test']])->get('test');
+        $association = $Documents->getAssociation('Test');
+        $action = new SortRelatedObjectsAction(compact('association'));
+        $action(['entity' => $entity, 'field' => 'title', 'direction' => 'desc']);
+        $relatedEntitiesDesc = $Documents->get($id, ['contain' => ['Test']])->get('test');
+        static::assertEquals($relatedEntities[0]->get('id'), $relatedEntitiesDesc[1]->get('id'));
+        static::assertEquals($relatedEntities[1]->get('id'), $relatedEntitiesDesc[0]->get('id'));
+        $action(['entity' => $entity, 'field' => 'title', 'direction' => 'asc']);
+        $relatedEntitiesDesc = $Documents->get($id, ['contain' => ['Test']])->get('test');
+        static::assertEquals($relatedEntities[0]->get('id'), $relatedEntitiesDesc[0]->get('id'));
+        static::assertEquals($relatedEntities[1]->get('id'), $relatedEntitiesDesc[1]->get('id'));
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SortRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SortRelatedObjectsActionTest.php
@@ -87,4 +87,21 @@ class SortRelatedObjectsActionTest extends TestCase
         static::assertEquals($relatedEntities[0]->get('id'), $relatedEntitiesDesc[0]->get('id'));
         static::assertEquals($relatedEntities[1]->get('id'), $relatedEntitiesDesc[1]->get('id'));
     }
+
+    /**
+     * Test `execute` with missing required field.
+     *
+     * @return void
+     */
+    public function testExecuteMissingRequiredField(): void
+    {
+        $id = 2;
+        $Documents = $this->fetchTable('documents');
+        $entity = $Documents->get($id);
+        $relatedEntities = $Documents->get($id, ['contain' => ['Test']])->get('test');
+        $association = $Documents->getAssociation('Test');
+        $action = new SortRelatedObjectsAction(compact('association'));
+        $actual = $action(['entity' => $entity, 'field' => 'title']);
+        static::assertFalse($actual);
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SortRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SortRelatedObjectsActionTest.php
@@ -18,6 +18,7 @@ namespace BEdita\Core\Test\TestCase\Model\Action;
 use BEdita\Core\Exception\InvalidDataException;
 use BEdita\Core\Model\Action\SortRelatedObjectsAction;
 use BEdita\Core\Utility\LoggedUser;
+use Cake\ORM\Association\BelongsToMany;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -91,6 +92,20 @@ class SortRelatedObjectsActionTest extends TestCase
         static::assertEquals($relatedEntities[1]->get('id'), $relatedEntitiesDesc[1]->get('id'));
         static::assertEquals(1, $relatedEntitiesDesc[0]->get('_joinData')['priority']);
         static::assertEquals(2, $relatedEntitiesDesc[1]->get('_joinData')['priority']);
+    }
+
+    /**
+     * Test `execute` with invalid association.
+     *
+     * @return void
+     */
+    public function testExecuteInvalidAssociation(): void
+    {
+        $expectedException = new InvalidDataException('Invalid association: test');
+        $this->expectExceptionObject($expectedException);
+        $association = new BelongsToMany('test');
+        $action = new SortRelatedObjectsAction(compact('association'));
+        $action(['entity' => null, 'field' => 'title', 'direction' => 'desc']);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SortRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SortRelatedObjectsActionTest.php
@@ -76,22 +76,46 @@ class SortRelatedObjectsActionTest extends TestCase
     {
         $id = 2;
         $Documents = $this->fetchTable('documents');
+        $relationName = 'test';
+        $relationKey = 'Test';
         $entity = $Documents->get($id);
-        $relatedEntities = $Documents->get($id, ['contain' => ['Test']])->get('test');
-        $association = $Documents->getAssociation('Test');
+        $relatedEntities = $Documents->get($id, ['contain' => [$relationKey]])->get($relationName);
+        $association = $Documents->getAssociation($relationKey);
         $action = new SortRelatedObjectsAction(compact('association'));
         $action(['entity' => $entity, 'field' => 'title', 'direction' => 'desc']);
-        $relatedEntitiesDesc = $Documents->get($id, ['contain' => ['Test']])->get('test');
-        static::assertEquals($relatedEntities[0]->get('id'), $relatedEntitiesDesc[1]->get('id'));
-        static::assertEquals($relatedEntities[1]->get('id'), $relatedEntitiesDesc[0]->get('id'));
-        static::assertEquals(1, $relatedEntitiesDesc[0]->get('_joinData')['priority']);
-        static::assertEquals(2, $relatedEntitiesDesc[1]->get('_joinData')['priority']);
+        $relatedEntitiesCompare = $Documents->get($id, ['contain' => [$relationKey]])->get($relationName);
+        static::assertEquals($relatedEntities[0]->get('id'), $relatedEntitiesCompare[1]->get('id'));
+        static::assertEquals($relatedEntities[1]->get('id'), $relatedEntitiesCompare[0]->get('id'));
+        static::assertEquals(1, $relatedEntitiesCompare[0]->get('_joinData')['priority']);
+        static::assertEquals(2, $relatedEntitiesCompare[1]->get('_joinData')['priority']);
         $action(['entity' => $entity, 'field' => 'title', 'direction' => 'asc']);
-        $relatedEntitiesDesc = $Documents->get($id, ['contain' => ['Test']])->get('test');
-        static::assertEquals($relatedEntities[0]->get('id'), $relatedEntitiesDesc[0]->get('id'));
-        static::assertEquals($relatedEntities[1]->get('id'), $relatedEntitiesDesc[1]->get('id'));
-        static::assertEquals(1, $relatedEntitiesDesc[0]->get('_joinData')['priority']);
-        static::assertEquals(2, $relatedEntitiesDesc[1]->get('_joinData')['priority']);
+        $relatedEntitiesCompare = $Documents->get($id, ['contain' => [$relationKey]])->get($relationName);
+        static::assertEquals($relatedEntities[0]->get('id'), $relatedEntitiesCompare[0]->get('id'));
+        static::assertEquals($relatedEntities[1]->get('id'), $relatedEntitiesCompare[1]->get('id'));
+        static::assertEquals(1, $relatedEntitiesCompare[0]->get('_joinData')['priority']);
+        static::assertEquals(2, $relatedEntitiesCompare[1]->get('_joinData')['priority']);
+
+        // test inverse association
+        $id = 4; // gustavo supporto profile
+        $Profiles = $this->fetchTable('profiles');
+        $relationName = 'inverse_test';
+        $relationKey = 'InverseTest';
+        $entity = $Profiles->get($id);
+        $relatedEntities = $Profiles->get($id, ['contain' => [$relationKey]])->get($relationName);
+        $association = $Profiles->getAssociation($relationKey);
+        $action = new SortRelatedObjectsAction(compact('association'));
+        $action(['entity' => $entity, 'field' => 'title', 'direction' => 'asc']);
+        $relatedEntitiesCompare = $Profiles->get($id, ['contain' => [$relationKey]])->get($relationName);
+        static::assertEquals($relatedEntities[0]->get('id'), $relatedEntitiesCompare[1]->get('id'));
+        static::assertEquals($relatedEntities[1]->get('id'), $relatedEntitiesCompare[0]->get('id'));
+        static::assertEquals(1, $relatedEntitiesCompare[0]->get('_joinData')['inv_priority']);
+        static::assertEquals(2, $relatedEntitiesCompare[1]->get('_joinData')['inv_priority']);
+        $action(['entity' => $entity, 'field' => 'title', 'direction' => 'desc']);
+        $relatedEntitiesCompare = $Profiles->get($id, ['contain' => [$relationKey]])->get($relationName);
+        static::assertEquals($relatedEntities[0]->get('id'), $relatedEntitiesCompare[0]->get('id'));
+        static::assertEquals($relatedEntities[1]->get('id'), $relatedEntitiesCompare[1]->get('id'));
+        static::assertEquals(1, $relatedEntitiesCompare[0]->get('_joinData')['inv_priority']);
+        static::assertEquals(2, $relatedEntitiesCompare[1]->get('_joinData')['inv_priority']);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/MediaTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/MediaTableTest.php
@@ -21,7 +21,9 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
 /**
- * BEdita\Core\Model\Table\MediaTable Test Case
+ * {@see BEdita\Core\Model\Table\MediaTable} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Model\Table\MediaTable
  */
 class MediaTableTest extends TestCase
 {


### PR DESCRIPTION
This introduces the endpoint `/{object_type}/{id}/relationships/{relationship}/sort`.

Use this endpoint to force save related data using a specific sort.

Usage example:
```
# document 999, relation seealso, sort by title desc
PATCH /documents/999/relationships/seealso/sort
{
    "meta": {
        "field": "title",
        "direction": "desc"
    }
}
```

This also updates postman collection, adding "PATCH Sort related" in section "4. Objects".

Bonus: fix some phpunit tests warnings.