### PR TITLE
Fix wrong validation for numeric uname

### DIFF
--- a/plugins/BEdita/Core/src/Model/Validation/ObjectsValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/ObjectsValidator.php
@@ -47,6 +47,7 @@ class ObjectsValidator extends Validator
             ->notEmptyString('status')
 
             ->ascii('uname')
+            ->notNumeric('uname')
             ->allowEmptyString('uname')
 
             ->boolean('locked')
@@ -77,5 +78,24 @@ class ObjectsValidator extends Validator
 
             ->add('publish_end', 'dateTime', ['rule' => [Validation::class, 'dateTime']])
             ->allowEmptyDateTime('publish_end');
+    }
+
+    /**
+     * Add a **not** numeric value validation rule to a field.
+     *
+     * @param string $field The field you want to apply the rule to.
+     * @param string|null $message The error message when the rule fails.
+     * @param callable|string|null $when Either 'create' or 'update' or a callable that returns
+     *   true when the validation rule should be applied.
+     * @see \BEdita\Core\Model\Validation\Validation::notNumeric()
+     * @return $this
+     */
+    public function notNumeric(string $field, ?string $message = null, $when = null)
+    {
+        $extra = array_filter(['on' => $when, 'message' => $message]);
+
+        return $this->add($field, 'notNumeric', $extra + [
+            'rule' => [Validation::class, 'notNumeric'],
+        ]);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Validation/Validation.php
+++ b/plugins/BEdita/Core/src/Model/Validation/Validation.php
@@ -201,4 +201,16 @@ class Validation
 
         return __d('bedita', 'Invalid date or datetime "{0}"', print_r($value, true));
     }
+
+    /**
+     * Check if a value is not numeric.
+     *
+     * @param mixed $check Value to check
+     * @return bool
+     * @codeCoverageIgnore
+     */
+    public static function notNumeric($check): bool
+    {
+        return !is_numeric($check);
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectsTableTest.php
@@ -184,6 +184,13 @@ class ObjectsTableTest extends TestCase
                     'status' => null,
                 ],
             ],
+            'numericUname' => [
+                false,
+                [
+                    'title' => 'title four',
+                    'uname' => '123',
+                ],
+            ],
         ];
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/ObjectsValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/ObjectsValidatorTest.php
@@ -20,7 +20,7 @@ use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
 
 /**
- * @coversNothing
+ * @coversDefaultClass \BEdita\Core\Model\Validation\ObjectsValidator
  */
 class ObjectsValidatorTest extends TestCase
 {
@@ -85,6 +85,14 @@ class ObjectsValidatorTest extends TestCase
                     'publish_end' => 'somewhen',
                 ],
             ],
+            'uname numeric not valid' => [
+                [
+                    'uname.notNumeric',
+                ],
+                [
+                    'uname' => '123',
+                ],
+            ],
         ];
     }
 
@@ -96,8 +104,9 @@ class ObjectsValidatorTest extends TestCase
      * @param bool $newRecord Is this a new record?
      * @return void
      * @dataProvider validationProvider()
+     * @coversNothing
      */
-    public function testValidation(array $expected, array $data, $newRecord = true)
+    public function testValidation(array $expected, array $data, $newRecord = true): void
     {
         $validator = new ObjectsValidator();
 
@@ -105,5 +114,32 @@ class ObjectsValidatorTest extends TestCase
         $errors = Hash::flatten($errors);
 
         static::assertEquals($expected, array_keys($errors));
+    }
+
+    /**
+     * Test not numeric validation.
+     *
+     * @return void
+     * @covers ::notNumeric()
+     */
+    public function testNotNumeric(): void
+    {
+        $validator = new ObjectsValidator();
+        $this->assertNotEmpty($validator->validate(['uname' => '22']));
+        $this->assertEmpty($validator->validate(['uname' => 'a']));
+
+        $validator->notNumeric('fake_field', 'The provided value must be NOT numeric', 'create');
+        $errors = $validator->validate(['fake_field' => '22']);
+        $this->assertNotEmpty($errors);
+        $this->assertEquals(
+            [
+                'fake_field' => [
+                    'notNumeric' => 'The provided value must be NOT numeric',
+                ],
+            ],
+            $errors
+        );
+        $errors = $validator->validate(['id' => 1000, 'fake_field' => '22'], false);
+        $this->assertEmpty($errors);
     }
 }


### PR DESCRIPTION
This PR fixes a bad bug with `uname` validation that allowed to save numeric `uname`.

An object `uname` must not be numeric to avoid confusion with `id`.

