### PR TITLE
Add commands to manage users external authentication records

### DIFF
--- a/plugins/BEdita/Core/src/Command/UserExternalAuthAddCommand.php
+++ b/plugins/BEdita/Core/src/Command/UserExternalAuthAddCommand.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace BEdita\Core\Command;
+
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+
+/**
+ * Command to add external authentication for a user.
+ */
+class UserExternalAuthAddCommand extends UserExternalAuthListCommand
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public static function defaultName(): string
+    {
+        return 'user:externalAuth add';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        return parent::buildOptionParser($parser)
+            ->setDescription('Add user\'s external authentications')
+            ->addOption('provider-username', [
+                'help' => 'Set provider username',
+            ])
+            ->addOption('provider-params', [
+                'help' => 'Set provider parameters',
+            ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(Arguments $args, ConsoleIo $io)
+    {
+        if (empty($args->getOption('provider'))) {
+            $io->error('Option "--provider" is required.');
+
+            return static::CODE_ERROR;
+        }
+        if (empty($args->getOption('provider-username'))) {
+            $io->error('Option "--provider-username" is required.');
+
+            return static::CODE_ERROR;
+        }
+
+        $user = $this->getUser($args);
+        if ($user === null) {
+            $io->error('One option between "--bedita-id" or "--bedita-username" must be provided.');
+
+            return static::CODE_ERROR;
+        }
+
+        /** @var \BEdita\Core\Model\Entity\AuthProvider $provider */
+        $provider = $this->fetchTable('AuthProviders')
+            ->find('enabled')
+            ->where(['name' => $args->getOption('provider')])
+            ->firstOrFail();
+        $ExternalAuth = $this->fetchTable('ExternalAuth');
+        $entity = $ExternalAuth->newEntity([
+            'user_id' => $user->id,
+            'auth_provider_id' => $provider->id,
+            'params' => $args->getOption('provider-params')
+                ? json_decode($args->getOption('provider-params'), true, 512, JSON_THROW_ON_ERROR)
+                : null,
+            'provider_username' => $args->getOption('provider-username'),
+        ]);
+        $ExternalAuth->saveOrFail($entity);
+        $io->out(sprintf(
+            'Added user "%s" external auth for provider "%s"',
+            $user->username,
+            $provider->name,
+        ));
+
+        return static::CODE_SUCCESS;
+    }
+}

--- a/plugins/BEdita/Core/src/Command/UserExternalAuthListCommand.php
+++ b/plugins/BEdita/Core/src/Command/UserExternalAuthListCommand.php
@@ -1,0 +1,122 @@
+<?php
+declare(strict_types=1);
+
+namespace BEdita\Core\Command;
+
+use BEdita\Core\Model\Entity\User;
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\ORM\Query;
+
+/**
+ * Command to list external authentication records for a user.
+ */
+class UserExternalAuthListCommand extends Command
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public static function defaultName(): string
+    {
+        return 'user:externalAuth list';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        return parent::buildOptionParser($parser)
+            ->setDescription('List user\'s external authentications')
+            ->addOption('bedita-id', [
+                'help' => 'Filter by BEdita user ID or uname',
+            ])
+            ->addOption('bedita-username', [
+                'help' => 'Filter by BEdita user username',
+            ])
+            ->addOption('provider', [
+                'short' => 'p',
+                'help' => 'Filter by provider name',
+            ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(Arguments $args, ConsoleIo $io)
+    {
+        $query = $this->fetchTable('ExternalAuth')
+            ->find()
+            ->contain(['AuthProviders', 'Users']);
+        if ($args->getOption('provider') !== null) {
+            $query = $query->find('authProvider', ['auth_provider' => $args->getOption('provider')]);
+        }
+        $user = $this->getUser($args);
+        if ($user !== null) {
+            $query = $query->innerJoinWith(
+                'Users',
+                fn (Query $q): Query => $q->where(['Users.id' => $user->id]),
+            );
+        }
+
+        $io->out(sprintf(
+            '%8s | %24.24s | %24.24s | %24.24s | %32.32s',
+            'ID',
+            'BEdita username',
+            'Provider',
+            'Provider username',
+            'Provider params',
+        ));
+        $io->hr(0, 124); // sum of all columns max widths + separators
+        foreach ($query->all() as $externalAuth) {
+            $io->out(sprintf(
+                '%8d | %24.24s | %24.24s | %24.24s | %32.32s', // fixed min and max width for each column
+                $externalAuth->id,
+                $externalAuth->user->username,
+                $externalAuth->auth_provider->name,
+                $externalAuth->provider_username ?? '<emtpy>',
+                $externalAuth->params !== null ? json_encode($externalAuth->params) : '<empty>',
+            ));
+        }
+
+        return static::CODE_SUCCESS;
+    }
+
+    /**
+     * Get user from command options.
+     *
+     * @param \Cake\Console\Arguments $args Command arguments
+     * @return \BEdita\Core\Model\Entity\User|null
+     */
+    protected function getUser(Arguments $args): ?User
+    {
+        $query = $this->fetchTable('Users')->find()
+            ->where([
+                'status IN' => ['on', 'draft'],
+                'deleted' => false,
+                'blocked' => false,
+            ])
+            ->contain(['ExternalAuth.AuthProviders']);
+        $value = $args->getOption('bedita-id');
+        $field = is_numeric($value) ? 'id' : 'uname';
+        if (empty($value)) {
+            $value = $args->getOption('bedita-username');
+            $field = 'username';
+        }
+        if (empty($value)) {
+            return null;
+        }
+
+        /** @var \BEdita\Core\Model\Entity\User $user */
+        $user = $query->andWhere([$field => $value])
+            ->firstOrFail();
+
+        return $user;
+    }
+}

--- a/plugins/BEdita/Core/src/Command/UserExternalAuthRemoveCommand.php
+++ b/plugins/BEdita/Core/src/Command/UserExternalAuthRemoveCommand.php
@@ -1,0 +1,100 @@
+<?php
+declare(strict_types=1);
+
+namespace BEdita\Core\Command;
+
+use BEdita\Core\Model\Entity\ExternalAuth;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+
+/**
+ * Command to remove external authentication for a user.
+ *
+ * @property \BEdita\Core\Model\Table\UsersTable $Users
+ */
+class UserExternalAuthRemoveCommand extends UserExternalAuthListCommand
+{
+    /**
+     * @inheritDoc
+     */
+    protected $defaultTable = 'Users';
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public static function defaultName(): string
+    {
+        return 'user:externalAuth remove';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        return parent::buildOptionParser($parser)
+            ->setDescription('Remove user\'s external authentications')
+            ->addOption('external-id', [
+                'help' => 'Remove by record ID',
+            ])
+            ->removeOption('provider')
+            ->addOption('provider', [
+                'short' => 'p',
+                'help' => 'Remove by provider name',
+            ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(Arguments $args, ConsoleIo $io)
+    {
+        $user = $this->getUser($args);
+        if ($user === null) {
+            $io->error('One option between "--bedita-id" or "--bedita-username" must be provided.');
+
+            return static::CODE_ERROR;
+        }
+
+        $value = $args->getOption('external-id');
+        $field = 'id';
+        if (empty($value) && !empty($args->getOption('provider'))) {
+            $value = $this->fetchTable('AuthProviders')
+                ->find()
+                ->where(['name' => $args->getOption('provider')])
+                ->firstOrFail()
+                ->id;
+            $field = 'auth_provider_id';
+        }
+        if (empty($value)) {
+            $io->error('One option between "--external-id" or "--provider" must be provided.');
+
+            return static::CODE_ERROR;
+        }
+
+        /** @var \BEdita\Core\Model\Entity\ExternalAuth|false $externalAuth */
+        $externalAuth = current(array_filter(
+            $user->external_auth,
+            fn (ExternalAuth $auth) => $auth->{$field} == $value,
+        ));
+        if ($externalAuth === false) {
+            $io->error('External auth record not found.');
+
+            return static::CODE_ERROR;
+        }
+
+        $this->fetchTable('ExternalAuth')->deleteOrFail($externalAuth);
+        $io->out(sprintf(
+            'Removed user "%s" external auth for provider "%s"',
+            $user->username,
+            $externalAuth->auth_provider->name,
+        ));
+
+        return static::CODE_SUCCESS;
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Command/UserExternalAuthCommandsTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/UserExternalAuthCommandsTest.php
@@ -1,0 +1,414 @@
+<?php
+declare(strict_types=1);
+
+namespace BEdita\Core\Test\TestCase\Command;
+
+use BEdita\Core\Command\UserExternalAuthAddCommand;
+use BEdita\Core\Command\UserExternalAuthListCommand;
+use BEdita\Core\Command\UserExternalAuthRemoveCommand;
+use BEdita\Core\Model\Entity\ExternalAuth;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\ORM\Exception\PersistenceFailedException;
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Test cases for {@see \BEdita\Core\Command\UserExternalAuthListCommand}, {@see \BEdita\Core\Command\UserExternalAuthAddCommand} and {@see \BEdita\Core\Command\UserExternalAuthRemoveCommand}.
+ */
+class UserExternalAuthCommandsTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+    use LocatorAwareTrait;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    protected $fixtures = [
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.Profiles',
+        'plugin.BEdita/Core.Users',
+        'plugin.BEdita/Core.AuthProviders',
+        'plugin.BEdita/Core.ExternalAuth',
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->cleanupConsoleTrait();
+        $this->useCommandRunner();
+    }
+
+    /**
+     * Test case for {@see \BEdita\Core\Command\UserExternalAuthListCommand} command.
+     *
+     * @return void
+     * @covers \BEdita\Core\Command\UserExternalAuthListCommand
+     */
+    public function testList(): void
+    {
+        /** @var \BEdita\Core\Model\Entity\ExternalAuth[] $externalAuth */
+        $externalAuth = $this->fetchTable('ExternalAuth')
+            ->find()
+            ->contain(['AuthProviders', 'Users'])
+            ->all();
+
+        $this->exec(UserExternalAuthListCommand::defaultName());
+        $this->assertExitSuccess();
+        foreach ($externalAuth as $auth) {
+            $this->assertOutputContains($auth->auth_provider->name);
+            $this->assertOutputContains($auth->user->username);
+            foreach (['id', 'provider_username', 'params'] as $field) {
+                $this->assertOutputContains(substr((string)($auth->{$field} ?? '<empty>'), 0, 24));
+            }
+        }
+    }
+
+    /**
+     * Test case for {@see \BEdita\Core\Command\UserExternalAuthListCommand} command.
+     *
+     * @return void
+     * @covers \BEdita\Core\Command\UserExternalAuthListCommand
+     */
+    public function testListById(): void
+    {
+        /** @var \BEdita\Core\Model\Entity\ExternalAuth[] $externalAuth */
+        $externalAuth = $this->fetchTable('ExternalAuth')
+            ->find()
+            ->where(['user_id' => 5])
+            ->contain(['AuthProviders', 'Users'])
+            ->all();
+
+        $this->exec(sprintf('%s --bedita-id 5', UserExternalAuthListCommand::defaultName()));
+        $this->assertExitSuccess();
+        foreach ($externalAuth as $auth) {
+            $this->assertOutputContains($auth->auth_provider->name);
+            $this->assertOutputContains($auth->user->username);
+            foreach (['id', 'provider_username', 'params'] as $field) {
+                $this->assertOutputContains(substr((string)($auth->{$field} ?? '<empty>'), 0, 24));
+            }
+        }
+    }
+
+    /**
+     * Test case for {@see \BEdita\Core\Command\UserExternalAuthListCommand} command.
+     *
+     * @return void
+     * @covers \BEdita\Core\Command\UserExternalAuthListCommand
+     */
+    public function testListByUsername(): void
+    {
+        /** @var \BEdita\Core\Model\Entity\ExternalAuth[] $externalAuth */
+        $externalAuth = $this->fetchTable('ExternalAuth')
+            ->find()
+            ->where(['user_id' => 5])
+            ->contain(['AuthProviders', 'Users'])
+            ->all();
+
+        $this->exec(sprintf('%s --bedita-username "second user"', UserExternalAuthListCommand::defaultName()));
+        $this->assertExitSuccess();
+        foreach ($externalAuth as $auth) {
+            $this->assertOutputContains($auth->auth_provider->name);
+            $this->assertOutputContains($auth->user->username);
+            foreach (['id', 'provider_username', 'params'] as $field) {
+                $this->assertOutputContains(substr((string)($auth->{$field} ?? '<empty>'), 0, 24));
+            }
+        }
+    }
+
+    /**
+     * Test case for {@see \BEdita\Core\Command\UserExternalAuthListCommand} command.
+     *
+     * @return void
+     * @covers \BEdita\Core\Command\UserExternalAuthListCommand
+     */
+    public function testListByProvider(): void
+    {
+        /** @var \BEdita\Core\Model\Entity\ExternalAuth[] $externalAuth */
+        $externalAuth = $this->fetchTable('ExternalAuth')
+            ->find()
+            ->where(['user_id' => 5])
+            ->contain(['AuthProviders', 'Users'])
+            ->all();
+
+        $this->exec(sprintf('%s --bedita-id 5 --provider linkedout', UserExternalAuthListCommand::defaultName()));
+        $this->assertExitSuccess();
+        foreach ($externalAuth as $auth) {
+            if ($auth->auth_provider->name !== 'linkedout') {
+                $this->assertOutputNotContains($auth->auth_provider->name);
+                foreach (['id', 'provider_username', 'params'] as $field) {
+                    if (!empty($auth->{$field})) {
+                        $this->assertOutputNotContains(substr((string)$auth->{$field}, 0, 24));
+                    }
+                }
+
+                continue;
+            }
+
+            $this->assertOutputContains($auth->auth_provider->name);
+            $this->assertOutputContains($auth->user->username);
+            foreach (['id', 'provider_username', 'params'] as $field) {
+                $this->assertOutputContains(substr((string)($auth->{$field} ?? '<empty>'), 0, 24));
+            }
+        }
+    }
+
+    /**
+     * Test case for {@see \BEdita\Core\Command\UserExternalAuthListCommand} command.
+     *
+     * @return void
+     * @covers \BEdita\Core\Command\UserExternalAuthListCommand
+     */
+    public function testListUserNotFound(): void
+    {
+        $this->expectException(RecordNotFoundException::class);
+        $this->expectExceptionMessage('Record not found');
+        $this->exec(sprintf('%s --bedita-id 5555 --provider linkedout', UserExternalAuthListCommand::defaultName()));
+    }
+
+    /**
+     * Test case for {@see \BEdita\Core\Command\UserExternalAuthAddCommand} command.
+     *
+     * @return void
+     * @covers \BEdita\Core\Command\UserExternalAuthAddCommand
+     */
+    public function testAdd()
+    {
+        $this->exec(sprintf('%s --bedita-id 5 --provider otp --provider-username erik', UserExternalAuthAddCommand::defaultName()));
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('Added user "second user" external auth for provider "otp"');
+
+        /** @var \BEdita\Core\Model\Entity\ExternalAuth|null $auth */
+        $auth = $this->fetchTable('ExternalAuth')
+            ->find('authProvider', ['auth_provider' => 'otp'])
+            ->where(['user_id' => 5])
+            ->contain(['AuthProviders'])
+            ->first();
+
+        static::assertNotNull($auth);
+        static::assertEquals('otp', $auth->auth_provider->name);
+        static::assertEquals('erik', $auth->provider_username);
+        static::assertNull($auth->params);
+    }
+
+    /**
+     * Test case for {@see \BEdita\Core\Command\UserExternalAuthAddCommand} command.
+     *
+     * @return void
+     * @covers \BEdita\Core\Command\UserExternalAuthAddCommand
+     */
+    public function testAddParams()
+    {
+        $this->exec(sprintf("%s --bedita-id 5 --provider otp --provider-username erik --provider-params '{\"test\":\"params are set\"}'", UserExternalAuthAddCommand::defaultName()));
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('Added user "second user" external auth for provider "otp"');
+
+        /** @var \BEdita\Core\Model\Entity\ExternalAuth|null $auth */
+        $auth = $this->fetchTable('ExternalAuth')
+            ->find('authProvider', ['auth_provider' => 'otp'])
+            ->where(['user_id' => 5])
+            ->contain(['AuthProviders'])
+            ->first();
+
+        static::assertNotNull($auth);
+        static::assertEquals('otp', $auth->auth_provider->name);
+        static::assertEquals('erik', $auth->provider_username);
+        static::assertEquals(['test' => 'params are set'], $auth->params);
+    }
+
+    /**
+     * Test case for {@see \BEdita\Core\Command\UserExternalAuthAddCommand} command.
+     *
+     * @return void
+     * @covers \BEdita\Core\Command\UserExternalAuthAddCommand
+     */
+    public function testAddNoUser(): void
+    {
+        $this->exec(sprintf('%s --provider otp --provider-username erik', UserExternalAuthAddCommand::defaultName()));
+
+        $this->assertExitError();
+        $this->assertErrorContains('One option between "--bedita-id" or "--bedita-username" must be provided');
+    }
+
+    /**
+     * Test case for {@see \BEdita\Core\Command\UserExternalAuthAddCommand} command.
+     *
+     * @return void
+     * @covers \BEdita\Core\Command\UserExternalAuthAddCommand
+     */
+    public function testAddDuplicateProvider()
+    {
+        $this->expectException(PersistenceFailedException::class);
+        $this->expectExceptionMessage('user_id._isUnique: "This value is already in use"');
+        $this->exec(sprintf('%s --bedita-id 5 --provider uuid --provider-username erik', UserExternalAuthAddCommand::defaultName()));
+    }
+
+    /**
+     * Test case for {@see \BEdita\Core\Command\UserExternalAuthAddCommand} command.
+     *
+     * @return void
+     * @covers \BEdita\Core\Command\UserExternalAuthAddCommand
+     */
+    public function testAddProviderNotFound()
+    {
+        $this->expectException(RecordNotFoundException::class);
+        $this->expectExceptionMessage('Record not found');
+        $this->exec(sprintf('%s --bedita-id 5 --provider qwerty --provider-username erik', UserExternalAuthAddCommand::defaultName()));
+    }
+
+    /**
+     * Test case for {@see \BEdita\Core\Command\UserExternalAuthAddCommand} command.
+     *
+     * @return void
+     * @covers \BEdita\Core\Command\UserExternalAuthAddCommand
+     */
+    public function testAddNoProvider()
+    {
+        $this->exec(sprintf('%s --bedita-id 5 --provider-username erik', UserExternalAuthAddCommand::defaultName()));
+
+        $this->assertExitError();
+        $this->assertErrorContains('Option "--provider" is required.');
+    }
+
+    /**
+     * Test case for {@see \BEdita\Core\Command\UserExternalAuthAddCommand} command.
+     *
+     * @return void
+     * @covers \BEdita\Core\Command\UserExternalAuthAddCommand
+     */
+    public function testAddNoProviderUsername()
+    {
+        $this->exec(sprintf('%s --bedita-id 5 --provider otp', UserExternalAuthAddCommand::defaultName()));
+
+        $this->assertExitError();
+        $this->assertErrorContains('Option "--provider-username" is required.');
+    }
+
+    /**
+     * Test case for {@see \BEdita\Core\Command\UserExternalAuthRemoveCommand} command.
+     *
+     * @return void
+     * @covers \BEdita\Core\Command\UserExternalAuthRemoveCommand
+     */
+    public function testRemoveById()
+    {
+        /** @var \BEdita\Core\Model\Entity\ExternalAuth[] $before */
+        $before = $this->fetchTable('ExternalAuth')
+            ->find()
+            ->where(['user_id' => 5])
+            ->contain(['AuthProviders'])
+            ->all()
+            ->toArray();
+        $this->exec(sprintf('%s --bedita-id 5 --external-id 2', UserExternalAuthRemoveCommand::defaultName()));
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('Removed user "second user" external auth for provider "uuid"');
+
+        /** @var \BEdita\Core\Model\Entity\ExternalAuth[] $after */
+        $after = $this->fetchTable('ExternalAuth')
+            ->find()
+            ->where(['user_id' => 5])
+            ->contain(['AuthProviders'])
+            ->all()
+            ->toArray();
+
+        static::assertLessThan(count($before), count($after));
+        static::assertNotContains('uuid', array_map(fn (ExternalAuth $auth): string => $auth->auth_provider->name, $after));
+    }
+
+    /**
+     * Test case for {@see \BEdita\Core\Command\UserExternalAuthRemoveCommand} command.
+     *
+     * @return void
+     * @covers \BEdita\Core\Command\UserExternalAuthRemoveCommand
+     */
+    public function testRemoveByProvider()
+    {
+        /** @var \BEdita\Core\Model\Entity\ExternalAuth[] $before */
+        $before = $this->fetchTable('ExternalAuth')
+            ->find()
+            ->where(['user_id' => 5])
+            ->contain(['AuthProviders'])
+            ->all()
+            ->toArray();
+        $this->exec(sprintf('%s --bedita-id 5 --provider uuid', UserExternalAuthRemoveCommand::defaultName()));
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('Removed user "second user" external auth for provider "uuid"');
+
+        /** @var \BEdita\Core\Model\Entity\ExternalAuth[] $after */
+        $after = $this->fetchTable('ExternalAuth')
+            ->find()
+            ->where(['user_id' => 5])
+            ->contain(['AuthProviders'])
+            ->all()
+            ->toArray();
+
+        static::assertLessThan(count($before), count($after));
+        static::assertNotContains('uuid', array_map(fn (ExternalAuth $auth): string => $auth->auth_provider->name, $after));
+    }
+
+    /**
+     * Test case for {@see \BEdita\Core\Command\UserExternalAuthRemoveCommand} command.
+     *
+     * @return void
+     * @covers \BEdita\Core\Command\UserExternalAuthRemoveCommand
+     */
+    public function testRemoveNoUser(): void
+    {
+        $this->exec(UserExternalAuthRemoveCommand::defaultName());
+
+        $this->assertExitError();
+        $this->assertErrorContains('One option between "--bedita-id" or "--bedita-username" must be provided');
+    }
+
+    /**
+     * Test case for {@see \BEdita\Core\Command\UserExternalAuthRemoveCommand} command.
+     *
+     * @return void
+     * @covers \BEdita\Core\Command\UserExternalAuthRemoveCommand
+     */
+    public function testRemoveNoOptions()
+    {
+        $this->exec(sprintf('%s --bedita-id 5', UserExternalAuthRemoveCommand::defaultName()));
+
+        $this->assertExitError();
+        $this->assertErrorContains('One option between "--external-id" or "--provider" must be provided.');
+    }
+
+    /**
+     * Test case for {@see \BEdita\Core\Command\UserExternalAuthRemoveCommand} command.
+     *
+     * @return void
+     * @covers \BEdita\Core\Command\UserExternalAuthRemoveCommand
+     */
+    public function testRemoveNotFoundByProvider()
+    {
+        $this->expectException(RecordNotFoundException::class);
+        $this->expectExceptionMessage('Record not found');
+        $this->exec(sprintf('%s --bedita-id 5 --provider qwerty', UserExternalAuthRemoveCommand::defaultName()));
+    }
+
+    /**
+     * Test case for {@see \BEdita\Core\Command\UserExternalAuthRemoveCommand} command.
+     *
+     * @return void
+     * @covers \BEdita\Core\Command\UserExternalAuthRemoveCommand
+     */
+    public function testRemoveNotFoundById()
+    {
+        $this->exec(sprintf('%s --bedita-id 5 --external-id 5555', UserExternalAuthRemoveCommand::defaultName()));
+
+        $this->assertExitError();
+        $this->assertErrorContains('External auth record not found.');
+    }
+}


### PR DESCRIPTION
This PR add commands to manage external authentication records (solves #2105).

List current records:
```shell
bin/cake user:externalAuth list [--bedita-id <user-id-or-uname> | --bedita-username <username>] [--provider <auth-provider-name>]
```

Add a record:
```shell
bin/cake user:externalAuth add [--bedita-id <user-id-or-uname> | --bedita-username <username>] [--provider <auth-provider-name>] [--provider-username <username-on-provider>] [--provider-params <json-string-params>]
```

Remove a record:
```shell
bin/cake user:externalAuth remove [--bedita-id <user-id-or-uname> | --bedita-username <username>] [--provider <auth-provider-name> | --external-id <external-auth-id>]
```