### PR TITLE
ResourcesCommand (+ single commands), ResourcesShell deprecated 

### DIFF
--- a/plugins/BEdita/Core/src/Command/ResourcesAddCommand.php
+++ b/plugins/BEdita/Core/src/Command/ResourcesAddCommand.php
@@ -90,11 +90,6 @@ class ResourcesAddCommand extends Command
     public function execute(Arguments $args, ConsoleIo $io): int
     {
         $type = $args->getOption('type');
-        if (empty($type)) {
-            $this->displayHelp($this->getOptionParser(), $args, $io);
-
-            return static::CODE_ERROR;
-        }
         $this->args = $args;
         $this->io = $io;
         $this->table = $this->fetchTable(Inflector::camelize($type));

--- a/plugins/BEdita/Core/src/Command/ResourcesAddCommand.php
+++ b/plugins/BEdita/Core/src/Command/ResourcesAddCommand.php
@@ -20,7 +20,6 @@ use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Datasource\EntityInterface;
-use Cake\Datasource\Locator\LocatorInterface;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\Utility\Inflector;
 
@@ -57,10 +56,10 @@ class ResourcesAddCommand extends Command
      *
      * @codeCoverageIgnore
      */
-    public function __construct(?ConsoleIo $io = null, ?LocatorInterface $locator = null)
+    public function __construct()
     {
         $this->setName('cake resources_add');
-        parent::__construct($io, $locator);
+        parent::__construct();
     }
 
     /**

--- a/plugins/BEdita/Core/src/Command/ResourcesAddCommand.php
+++ b/plugins/BEdita/Core/src/Command/ResourcesAddCommand.php
@@ -1,0 +1,162 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Command;
+
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\Datasource\EntityInterface;
+use Cake\Datasource\Locator\LocatorInterface;
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\Utility\Inflector;
+
+/**
+ * ResourcesAdd command.
+ */
+class ResourcesAddCommand extends Command
+{
+    use LocatorAwareTrait;
+
+    /**
+     * Console arguments
+     *
+     * @var \Cake\Console\Arguments
+     */
+    protected $args;
+
+    /**
+     * Console IO
+     *
+     * @var \Cake\Console\ConsoleIo
+     */
+    protected $io;
+
+    /**
+     * Async jobs table
+     *
+     * @var \BEdita\Core\Model\Table\AsyncJobsTable
+     */
+    protected $table;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function __construct(?ConsoleIo $io = null, ?LocatorInterface $locator = null)
+    {
+        $this->setName('cake resources_add');
+        parent::__construct($io, $locator);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        return $parser
+            ->addOption('type', [
+                'help' => 'Entity type',
+                'required' => true,
+                'short' => 't',
+                'choices' => ['applications', 'roles', 'endpoints', 'endpoint_permissions'],
+            ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Resources add';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(Arguments $args, ConsoleIo $io): int
+    {
+        $type = $args->getOption('type');
+        if (empty($type)) {
+            $this->displayHelp($this->getOptionParser(), $args, $io);
+
+            return static::CODE_ERROR;
+        }
+        $this->args = $args;
+        $this->io = $io;
+        $this->table = $this->fetchTable(Inflector::camelize($type));
+        $entity = $this->table->newEntity([]);
+        if ($type === 'endpoint_permissions') {
+            $this->setupEndpointPermissionEntity($entity);
+        } else {
+            $this->setupDefaultEntity($entity);
+        }
+        $this->table->saveOrFail($entity);
+        $this->io->out(sprintf('Resource with id %d created', $entity->id));
+
+        return static::CODE_SUCCESS;
+    }
+
+    /**
+     * Setup default entity for applications, roles, endpoints
+     *
+     * @param \Cake\Datasource\EntityInterface $entity Entity to add
+     * @return void
+     */
+    protected function setupDefaultEntity(EntityInterface $entity)
+    {
+        $name = $this->io->ask('Resource name');
+        if (empty($name)) {
+            $this->io->abort('Resource name cannot be empty');
+        }
+        $entity->set('name', $name);
+        $description = $this->io->ask('Resource description (optional)');
+        $entity->set('description', $description);
+    }
+
+    /**
+     * Setup entity for endpoint_permissions
+     *
+     * @param \Cake\Datasource\EntityInterface $entity Entity to add
+     * @return void
+     */
+    protected function setupEndpointPermissionEntity(EntityInterface $entity)
+    {
+        $fieldsTables = [
+            'application_id' => 'Applications',
+            'endpoint_id' => 'Endpoints',
+            'role_id' => 'Roles',
+        ];
+        foreach ($fieldsTables as $field => $modelName) {
+            $param = $this->io->ask(sprintf('%s id or name', $modelName));
+            if ($param && !is_numeric($param)) {
+                $param = $this->fetchTable($modelName)
+                    ->find()
+                    ->where(['name' => $param])
+                    ->firstOrFail()
+                    ->id;
+            }
+            $entity->set($field, $param);
+        }
+
+        $perms = ['true', 'false', 'block', 'mine'];
+        foreach (['read', 'write'] as $field) {
+            $perm = $this->io->askChoice("'$field' permission", $perms);
+            $entity->set($field, $perm);
+        }
+    }
+}

--- a/plugins/BEdita/Core/src/Command/ResourcesCommand.php
+++ b/plugins/BEdita/Core/src/Command/ResourcesCommand.php
@@ -115,6 +115,6 @@ class ResourcesCommand extends Command
             }
         }
 
-        return $this->executeCommand($this->subcommands[$subcommand]['class'], $subcommandArguments);
+        return $this->executeCommand($this->subcommands[$subcommand]['class'], $subcommandArguments, $io);
     }
 }

--- a/plugins/BEdita/Core/src/Command/ResourcesCommand.php
+++ b/plugins/BEdita/Core/src/Command/ResourcesCommand.php
@@ -100,7 +100,7 @@ class ResourcesCommand extends Command
     {
         $subcommand = $args->getArgument('subcommand');
         if (empty($subcommand) || !in_array($subcommand, array_keys($this->subcommands))) {
-            return $this->executeCommand($this, ['--help']);
+            return $this->executeCommand($this, ['--help'], $io);
         }
         $subcommandArguments = [];
         $allowedArguments = $this->subcommands[$subcommand]['arguments'];

--- a/plugins/BEdita/Core/src/Command/ResourcesCommand.php
+++ b/plugins/BEdita/Core/src/Command/ResourcesCommand.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Command;
+
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+
+/**
+ * Resources command.
+ */
+class ResourcesCommand extends Command
+{
+    /**
+     * Subcommands.
+     *
+     * @var array
+     */
+    protected array $subcommands = [
+        'add' => [
+            'class' => ResourcesAddCommand::class,
+            'arguments' => [],
+            'options' => ['type'],
+        ],
+        'edit' => [
+            'class' => ResourcesModifyCommand::class,
+            'arguments' => ['name|id'],
+            'options' => ['field', 'type'],
+        ],
+        'ls' => [
+            'class' => ResourcesListCommand::class,
+            'arguments' => [],
+            'options' => ['filter', 'type'],
+        ],
+        'rm' => [
+            'class' => ResourcesRemoveCommand::class,
+            'arguments' => ['name|id'],
+            'options' => ['type'],
+        ],
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        return $parser
+            ->addArgument('subcommand', [
+                'help' => 'Subcommand to perform',
+                'choices' => array_keys($this->subcommands),
+            ])
+            ->addArgument('name|id', [
+                'help' => 'Resource\'s name or id',
+                'required' => false, // required only in some subcommands
+            ])
+            ->addOption('type', [
+                'help' => 'Entity type',
+                'required' => false, // required only in some subcommands
+                'short' => 't',
+            ])
+            ->addOption('filter', [
+                'help' => 'List entities filtered by comma separated key=value pairs',
+                'required' => false,
+                'short' => 'q',
+            ])
+            ->addOption('field', [
+                'help' => 'Field name',
+                'required' => false, // required only in some subcommands
+                'short' => 'f',
+                'choices' => ResourcesModifyCommand::$editableFields,
+            ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Resources management command. Available subcommands: add, edit, ls, rm';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(Arguments $args, ConsoleIo $io): int
+    {
+        $subcommand = $args->getArgument('subcommand');
+        if (empty($subcommand) || !in_array($subcommand, array_keys($this->subcommands))) {
+            return $this->executeCommand($this, ['--help']);
+        }
+        $subcommandArguments = [];
+        $allowedArguments = $this->subcommands[$subcommand]['arguments'];
+        foreach ($allowedArguments as $argumentName) {
+            $subcommandArguments[] = $args->getArgument($argumentName);
+        }
+        $allowedOptions = $this->subcommands[$subcommand]['options'];
+        foreach ($args->getOptions() as $option => $value) {
+            if (in_array($option, $allowedOptions)) {
+                $subcommandArguments[] = sprintf('--%s', $option);
+                $subcommandArguments[] = $value;
+            }
+        }
+
+        return $this->executeCommand($this->subcommands[$subcommand]['class'], $subcommandArguments);
+    }
+}

--- a/plugins/BEdita/Core/src/Command/ResourcesListCommand.php
+++ b/plugins/BEdita/Core/src/Command/ResourcesListCommand.php
@@ -1,0 +1,115 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Command;
+
+use BEdita\Core\Model\Action\ListEntitiesAction;
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\Datasource\Locator\LocatorInterface;
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\Utility\Inflector;
+
+/**
+ * ResourcesList command.
+ */
+class ResourcesListCommand extends Command
+{
+    use LocatorAwareTrait;
+
+    /**
+     * Console arguments
+     *
+     * @var \Cake\Console\Arguments
+     */
+    protected $args;
+
+    /**
+     * Console IO
+     *
+     * @var \Cake\Console\ConsoleIo
+     */
+    protected $io;
+
+    /**
+     * Async jobs table
+     *
+     * @var \BEdita\Core\Model\Table\AsyncJobsTable
+     */
+    protected $table;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function __construct(?ConsoleIo $io = null, ?LocatorInterface $locator = null)
+    {
+        $this->setName('cake resources_list');
+        parent::__construct($io, $locator);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        return $parser
+            ->addOption('type', [
+                'help' => 'Entity type',
+                'required' => true,
+                'short' => 't',
+                'choices' => ['applications', 'roles', 'endpoints', 'endpoint_permissions'],
+            ])
+            ->addOption('filter', [
+                'help' => 'List entities filtered by comma separated key=value pairs',
+                'required' => false,
+            ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Resources list';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(Arguments $args, ConsoleIo $io): int
+    {
+        $type = $args->getOption('type');
+        if (empty($type)) {
+            $this->displayHelp($this->getOptionParser(), $args, $io);
+
+            return static::CODE_ERROR;
+        }
+        $this->args = $args;
+        $this->io = $io;
+        $this->table = $this->fetchTable(Inflector::camelize($type));
+        $action = new ListEntitiesAction(['table' => $this->table]);
+        $filter = $args->getOption('filter');
+        $query = $action(compact('filter'));
+        $results = $query->toArray();
+        $this->io->out(sprintf('<info>%d result(s) found</info>', count($results)));
+        $this->io->out($results);
+
+        return static::CODE_SUCCESS;
+    }
+}

--- a/plugins/BEdita/Core/src/Command/ResourcesListCommand.php
+++ b/plugins/BEdita/Core/src/Command/ResourcesListCommand.php
@@ -94,11 +94,6 @@ class ResourcesListCommand extends Command
     public function execute(Arguments $args, ConsoleIo $io): int
     {
         $type = $args->getOption('type');
-        if (empty($type)) {
-            $this->displayHelp($this->getOptionParser(), $args, $io);
-
-            return static::CODE_ERROR;
-        }
         $this->args = $args;
         $this->io = $io;
         $this->table = $this->fetchTable(Inflector::camelize($type));

--- a/plugins/BEdita/Core/src/Command/ResourcesListCommand.php
+++ b/plugins/BEdita/Core/src/Command/ResourcesListCommand.php
@@ -20,7 +20,6 @@ use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
-use Cake\Datasource\Locator\LocatorInterface;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\Utility\Inflector;
 
@@ -57,10 +56,10 @@ class ResourcesListCommand extends Command
      *
      * @codeCoverageIgnore
      */
-    public function __construct(?ConsoleIo $io = null, ?LocatorInterface $locator = null)
+    public function __construct()
     {
         $this->setName('cake resources_list');
-        parent::__construct($io, $locator);
+        parent::__construct();
     }
 
     /**

--- a/plugins/BEdita/Core/src/Command/ResourcesModifyCommand.php
+++ b/plugins/BEdita/Core/src/Command/ResourcesModifyCommand.php
@@ -1,0 +1,139 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Command;
+
+use BEdita\Core\Model\Table\ApplicationsTable;
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\ORM\Locator\LocatorInterface;
+use Cake\Utility\Inflector;
+
+/**
+ * ResourcesModify command.
+ */
+class ResourcesModifyCommand extends Command
+{
+    use LocatorAwareTrait;
+
+    /**
+     * Console arguments
+     *
+     * @var \Cake\Console\Arguments
+     */
+    protected $args;
+
+    /**
+     * Console IO
+     *
+     * @var \Cake\Console\ConsoleIo
+     */
+    protected $io;
+
+    /**
+     * Async jobs table
+     *
+     * @var \BEdita\Core\Model\Table\AsyncJobsTable
+     */
+    protected $table;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function __construct(?ConsoleIo $io = null, ?LocatorInterface $locator = null)
+    {
+        $this->setName('cake resources_modify');
+        parent::__construct($io, $locator);
+    }
+
+    /**
+     * Editable resource fields
+     *
+     * @var string[]
+     */
+    public static $editableFields = ['api_key', 'description', 'enabled', 'name', 'unchangeable'];
+
+    /**
+     * @inheritDoc
+     */
+    public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        return $parser
+            ->addArgument('name|id', [
+                'help' => 'Resource\'s name or id',
+                'required' => true,
+            ])
+            ->addOption('type', [
+                'help' => 'Entity type',
+                'required' => true,
+                'short' => 't',
+                'choices' => ['applications', 'roles', 'endpoints', 'endpoint_permissions'],
+            ])
+            ->addOption('field', [
+                'help' => 'Field name',
+                'required' => true,
+                'short' => 'f',
+                'choices' => static::$editableFields,
+            ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Resources modify';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(Arguments $args, ConsoleIo $io): int
+    {
+        $type = $args->getOption('type');
+        $field = $args->getOption('field');
+        if (empty($type) || empty($field)) {
+            $this->displayHelp($this->getOptionParser(), $args, $io);
+
+            return static::CODE_ERROR;
+        }
+        $this->args = $args;
+        $this->io = $io;
+        $this->table = $this->fetchTable(Inflector::camelize($type));
+        $id = $this->args->getArgument('name|id');
+        $condition = is_numeric($id) ? compact('id') : ['name' => $id];
+        $entity = $this->table->find()
+            ->where($condition)
+            ->first();
+        if (empty($entity)) {
+            $this->io->abort(sprintf('Resource with id %d not found', $id));
+        }
+        if ($field === 'api_key' && $this->table instanceof ApplicationsTable) {
+            $entity->set('api_key', ApplicationsTable::generateApiKey());
+        } else {
+            $value = $this->io->ask(sprintf('New value for "%s" [current is "%s"]', $field, $entity->get($field)));
+            $entity->set($field, $value);
+        }
+        $this->table->saveOrFail($entity);
+        $this->io->out(sprintf('Resource with id %d modified', $entity->id));
+
+        return static::CODE_SUCCESS;
+    }
+}

--- a/plugins/BEdita/Core/src/Command/ResourcesModifyCommand.php
+++ b/plugins/BEdita/Core/src/Command/ResourcesModifyCommand.php
@@ -83,7 +83,7 @@ class ResourcesModifyCommand extends Command
                 'help' => 'Entity type',
                 'required' => true,
                 'short' => 't',
-                'choices' => ['applications', 'roles', 'endpoints', 'endpoint_permissions'],
+                'choices' => ['applications', 'roles', 'endpoints'],
             ])
             ->addOption('field', [
                 'help' => 'Field name',

--- a/plugins/BEdita/Core/src/Command/ResourcesModifyCommand.php
+++ b/plugins/BEdita/Core/src/Command/ResourcesModifyCommand.php
@@ -108,11 +108,6 @@ class ResourcesModifyCommand extends Command
     {
         $type = $args->getOption('type');
         $field = $args->getOption('field');
-        if (empty($type) || empty($field)) {
-            $this->displayHelp($this->getOptionParser(), $args, $io);
-
-            return static::CODE_ERROR;
-        }
         $this->args = $args;
         $this->io = $io;
         $this->table = $this->fetchTable(Inflector::camelize($type));

--- a/plugins/BEdita/Core/src/Command/ResourcesModifyCommand.php
+++ b/plugins/BEdita/Core/src/Command/ResourcesModifyCommand.php
@@ -21,7 +21,6 @@ use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\ORM\Locator\LocatorAwareTrait;
-use Cake\ORM\Locator\LocatorInterface;
 use Cake\Utility\Inflector;
 
 /**
@@ -57,10 +56,10 @@ class ResourcesModifyCommand extends Command
      *
      * @codeCoverageIgnore
      */
-    public function __construct(?ConsoleIo $io = null, ?LocatorInterface $locator = null)
+    public function __construct()
     {
         $this->setName('cake resources_modify');
-        parent::__construct($io, $locator);
+        parent::__construct();
     }
 
     /**

--- a/plugins/BEdita/Core/src/Command/ResourcesModifyCommand.php
+++ b/plugins/BEdita/Core/src/Command/ResourcesModifyCommand.php
@@ -117,7 +117,7 @@ class ResourcesModifyCommand extends Command
             ->where($condition)
             ->first();
         if (empty($entity)) {
-            $this->io->abort(sprintf('Resource with id %d not found', $id));
+            $this->io->abort(sprintf('Resource with id %s not found', $id));
         }
         if ($field === 'api_key' && $this->table instanceof ApplicationsTable) {
             $entity->set('api_key', ApplicationsTable::generateApiKey());

--- a/plugins/BEdita/Core/src/Command/ResourcesRemoveCommand.php
+++ b/plugins/BEdita/Core/src/Command/ResourcesRemoveCommand.php
@@ -106,7 +106,7 @@ class ResourcesRemoveCommand extends Command
         if ($res !== 'y') {
             $this->io->info('No action performed');
 
-            return static::CODE_SUCCESS;
+            return static::CODE_ERROR;
         }
         $condition = is_numeric($id) ? compact('id') : ['name' => $id];
         $entity = $this->table->find()

--- a/plugins/BEdita/Core/src/Command/ResourcesRemoveCommand.php
+++ b/plugins/BEdita/Core/src/Command/ResourcesRemoveCommand.php
@@ -94,11 +94,6 @@ class ResourcesRemoveCommand extends Command
     public function execute(Arguments $args, ConsoleIo $io): int
     {
         $type = $args->getOption('type');
-        if (empty($type)) {
-            $this->displayHelp($this->getOptionParser(), $args, $io);
-
-            return static::CODE_ERROR;
-        }
         $this->args = $args;
         $this->io = $io;
         $this->table = $this->fetchTable(Inflector::camelize($type));
@@ -118,11 +113,11 @@ class ResourcesRemoveCommand extends Command
             ->where($condition)
             ->first();
         if (empty($entity)) {
-            $this->io->abort(sprintf('Resource with id %d not found', $id));
+            $this->io->abort(sprintf('Resource with id %s not found', $id));
         }
         $action = new DeleteEntityAction(['table' => $this->table]);
         $action(compact('entity'));
-        $this->io->out(sprintf('Record %d deleted', $id));
+        $this->io->out(sprintf('Record "%s" deleted', $id));
 
         return static::CODE_SUCCESS;
     }

--- a/plugins/BEdita/Core/src/Command/ResourcesRemoveCommand.php
+++ b/plugins/BEdita/Core/src/Command/ResourcesRemoveCommand.php
@@ -21,7 +21,6 @@ use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\ORM\Locator\LocatorAwareTrait;
-use Cake\ORM\Locator\LocatorInterface;
 use Cake\Utility\Inflector;
 
 /**
@@ -57,10 +56,10 @@ class ResourcesRemoveCommand extends Command
      *
      * @codeCoverageIgnore
      */
-    public function __construct(?ConsoleIo $io = null, ?LocatorInterface $locator = null)
+    public function __construct()
     {
         $this->setName('cake resources_remove');
-        parent::__construct($io, $locator);
+        parent::__construct();
     }
 
     /**

--- a/plugins/BEdita/Core/src/Command/ResourcesRemoveCommand.php
+++ b/plugins/BEdita/Core/src/Command/ResourcesRemoveCommand.php
@@ -1,0 +1,130 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Command;
+
+use BEdita\Core\Model\Action\DeleteEntityAction;
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\ORM\Locator\LocatorInterface;
+use Cake\Utility\Inflector;
+
+/**
+ * ResourcesRemove command.
+ */
+class ResourcesRemoveCommand extends Command
+{
+    use LocatorAwareTrait;
+
+    /**
+     * Console arguments
+     *
+     * @var \Cake\Console\Arguments
+     */
+    protected $args;
+
+    /**
+     * Console IO
+     *
+     * @var \Cake\Console\ConsoleIo
+     */
+    protected $io;
+
+    /**
+     * Async jobs table
+     *
+     * @var \BEdita\Core\Model\Table\AsyncJobsTable
+     */
+    protected $table;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function __construct(?ConsoleIo $io = null, ?LocatorInterface $locator = null)
+    {
+        $this->setName('cake resources_remove');
+        parent::__construct($io, $locator);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        return $parser
+            ->addArgument('name|id', [
+                'help' => 'Resource\'s name or id',
+                'required' => true,
+            ])
+            ->addOption('type', [
+                'help' => 'Entity type',
+                'required' => true,
+                'short' => 't',
+                'choices' => ['applications', 'roles', 'endpoints', 'endpoint_permissions'],
+            ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getDescription(): string
+    {
+        return 'Resources remove';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(Arguments $args, ConsoleIo $io): int
+    {
+        $type = $args->getOption('type');
+        if (empty($type)) {
+            $this->displayHelp($this->getOptionParser(), $args, $io);
+
+            return static::CODE_ERROR;
+        }
+        $this->args = $args;
+        $this->io = $io;
+        $this->table = $this->fetchTable(Inflector::camelize($type));
+        $id = $this->args->getArgument('name|id');
+        $res = $this->io->askChoice(
+            sprintf('You are REMOVING "%s" with name or id "%s" - are you sure?', $type, $id),
+            ['y', 'n'],
+            'n'
+        );
+        if ($res !== 'y') {
+            $this->io->info('No action performed');
+
+            return static::CODE_SUCCESS;
+        }
+        $condition = is_numeric($id) ? compact('id') : ['name' => $id];
+        $entity = $this->table->find()
+            ->where($condition)
+            ->first();
+        if (empty($entity)) {
+            $this->io->abort(sprintf('Resource with id %d not found', $id));
+        }
+        $action = new DeleteEntityAction(['table' => $this->table]);
+        $action(compact('entity'));
+        $this->io->out(sprintf('Record %d deleted', $id));
+
+        return static::CODE_SUCCESS;
+    }
+}

--- a/plugins/BEdita/Core/src/Shell/ResourcesShell.php
+++ b/plugins/BEdita/Core/src/Shell/ResourcesShell.php
@@ -29,6 +29,7 @@ use Cake\Utility\Inflector;
  * Resource shell commands: list, create, remove, enable and disable common entities
  *
  * @since 4.0.0
+ * @deprecated version 5.34.0 Use `BEdita/Core.Command/ResourcesCommand` instead
  */
 class ResourcesShell extends Shell /* @phpstan-ignore-line */
 {

--- a/plugins/BEdita/Core/src/Shell/ResourcesShell.php
+++ b/plugins/BEdita/Core/src/Shell/ResourcesShell.php
@@ -17,9 +17,11 @@ namespace BEdita\Core\Shell;
 use BEdita\Core\Model\Action\DeleteEntityAction;
 use BEdita\Core\Model\Action\ListEntitiesAction;
 use BEdita\Core\Model\Table\ApplicationsTable;
+use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use Cake\Datasource\EntityInterface;
+use Cake\ORM\Locator\LocatorInterface;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 
@@ -49,10 +51,20 @@ class ResourcesShell extends Shell /* @phpstan-ignore-line */
      *
      * @codeCoverageIgnore
      */
+    public function __construct(?ConsoleIo $io = null, ?LocatorInterface $locator = null)
+    {
+        deprecationWarning('"ResourcesShell" should not be used. Use `BEdita\Core\Command\ResourcesCommand` instead.');
+        parent::__construct($io, $locator);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @codeCoverageIgnore
+     */
     public function getOptionParser(): ConsoleOptionParser
     {
-        $parser = parent::getOptionParser(); /* @phpstan-ignore-line */
-
+        $parser = parent::getOptionParser();
         $options = [
             'type' => [
                 'help' => 'Entity type (applications, roles, endpoints, endpoint_permissions)',

--- a/plugins/BEdita/Core/src/Shell/ResourcesShell.php
+++ b/plugins/BEdita/Core/src/Shell/ResourcesShell.php
@@ -29,7 +29,7 @@ use Cake\Utility\Inflector;
  * Resource shell commands: list, create, remove, enable and disable common entities
  *
  * @since 4.0.0
- * @deprecated version 5.34.0 Use `BEdita/Core.Command/ResourcesCommand` instead
+ * @deprecated version 5.35.0 Use `BEdita/Core.Command/ResourcesCommand` instead
  */
 class ResourcesShell extends Shell /* @phpstan-ignore-line */
 {

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesAddCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesAddCommandTest.php
@@ -39,6 +39,7 @@ class ResourcesAddCommandTest extends TestCase
         'plugin.BEdita/Core.Endpoints',
         'plugin.BEdita/Core.Applications',
         'plugin.BEdita/Core.EndpointPermissions',
+        'plugin.BEdita/Core.Roles',
     ];
 
     /**
@@ -64,6 +65,7 @@ class ResourcesAddCommandTest extends TestCase
      *
      * @return void
      * @covers ::buildOptionParser()
+     * @covers ::getDescription()
      */
     public function testBuildOptionParser()
     {
@@ -160,5 +162,31 @@ class ResourcesAddCommandTest extends TestCase
         foreach ($expectedResource as $field => $value) {
             $this->assertEquals($value, $resource->get($field));
         }
+    }
+
+    /**
+     * Test add resource with missing type required options
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testExecuteEmptyType(): void
+    {
+        $this->exec('resources_add "First app"', ['A sample description']);
+        $this->assertExitCode(Command::CODE_ERROR);
+        $this->assertErrorContains('Missing required option. The `type` option is required and has no default value');
+    }
+
+    /**
+     * Test add resource with wrong type
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testExecuteWrongType(): void
+    {
+        $this->exec('resources_add "First app" --type wrong', ['A sample description']);
+        $this->assertExitCode(Command::CODE_ERROR);
+        $this->assertErrorContains('"wrong" is not a valid value for --type. Please use one of "applications, roles, endpoints, endpoint_permissions"');
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesAddCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesAddCommandTest.php
@@ -36,10 +36,19 @@ class ResourcesAddCommandTest extends TestCase
      * @var array
      */
     protected $fixtures = [
-        'plugin.BEdita/Core.Endpoints',
-        'plugin.BEdita/Core.Applications',
-        'plugin.BEdita/Core.EndpointPermissions',
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.RelationTypes',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.Profiles',
+        'plugin.BEdita/Core.Users',
         'plugin.BEdita/Core.Roles',
+        'plugin.BEdita/Core.RolesUsers',
+        'plugin.BEdita/Core.Applications',
+        'plugin.BEdita/Core.Endpoints',
+        'plugin.BEdita/Core.EndpointPermissions',
     ];
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesAddCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesAddCommandTest.php
@@ -1,0 +1,164 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Command;
+
+use BEdita\Core\Job\ServiceRegistry;
+use Cake\Command\Command;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Inflector;
+
+/**
+ * {@see BEdita\Core\Command\ResourcesAddCommand} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Command\ResourcesAddCommand
+ */
+class ResourcesAddCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    protected $fixtures = [
+        'plugin.BEdita/Core.Endpoints',
+        'plugin.BEdita/Core.Applications',
+        'plugin.BEdita/Core.EndpointPermissions',
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->useCommandRunner();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        ServiceRegistry::reset();
+    }
+
+    /**
+     * Test buildOptionParser method
+     *
+     * @return void
+     * @covers ::buildOptionParser()
+     */
+    public function testBuildOptionParser()
+    {
+        $this->exec('resources_add --help');
+        $this->assertOutputContains('Resources add');
+        $this->assertOutputContains('cake resources_add [-h] [-q] -t applications|roles|endpoints|endpoint_permissions [-v]');
+        $this->assertOutputContains('Entity type');
+        $this->assertOutputContains('applications|roles|endpoints|endpoint_permissions');
+    }
+
+    /**
+     * Data provider for `testExecute` test case.
+     *
+     * @return array
+     */
+    public function executeProvider(): array
+    {
+        return [
+            'add application' => [
+                'applications',
+                [
+                    'test-app',
+                    'test app description',
+                ],
+                [
+                    'name' => 'test-app',
+                    'description' => 'test app description',
+                ],
+            ],
+            'add role' => [
+                'roles',
+                [
+                    'test-role',
+                    'test role description',
+                ],
+                [
+                    'name' => 'test-role',
+                    'description' => 'test role description',
+                ],
+            ],
+            'add endpoint' => [
+                'endpoints',
+                [
+                    'test-endpoint',
+                    'test endpoint description',
+                ],
+                [
+                    'name' => 'test-endpoint',
+                    'description' => 'test endpoint description',
+                ],
+            ],
+            'endpoint_permissions' => [
+                'endpoint_permissions',
+                [
+                    'First app', // application
+                    'home', // endpoint
+                    '1', // role
+                    'mine',
+                    'mine',
+                ],
+                [
+                    'application_id' => 1,
+                    'endpoint_id' => 2,
+                    'role_id' => 1,
+                    'permission' => 5,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test add resource
+     *
+     * @param string $resourceType Resource type.
+     * @param array $input Input data.
+     * @param array $expectedResource Expected resource data.
+     * @return void
+     * @covers ::execute()
+     * @covers ::setupDefaultEntity()
+     * @covers ::setupEndpointPermissionEntity()
+     * @dataProvider executeProvider()
+     */
+    public function testExecute(string $resourceType, array $input, array $expectedResource): void
+    {
+        $tableName = Inflector::camelize($resourceType);
+        $table = $this->fetchTable($tableName);
+        $expected = $table->find()->count() + 1;
+        $this->exec(sprintf('resources_add --type=%s', $resourceType), $input);
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $actual = $table->find()->count();
+        $this->assertEquals($expected, $actual);
+        $resource = $table->find()->all()->last();
+        $this->assertNotEmpty($resource);
+        foreach ($expectedResource as $field => $value) {
+            $this->assertEquals($value, $resource->get($field));
+        }
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesAddCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesAddCommandTest.php
@@ -189,4 +189,18 @@ class ResourcesAddCommandTest extends TestCase
         $this->assertExitCode(Command::CODE_ERROR);
         $this->assertErrorContains('"wrong" is not a valid value for --type. Please use one of "applications, roles, endpoints, endpoint_permissions"');
     }
+
+    /**
+     * Test add resource with missing name
+     *
+     * @return void
+     * @covers ::execute()
+     * @covers ::setupDefaultEntity()
+     */
+    public function testResourceNameEmpty(): void
+    {
+        $this->exec('resources_add --type applications', ['']);
+        $this->assertExitCode(Command::CODE_ERROR);
+        $this->assertErrorContains('Resource name cannot be empty');
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesCommandTest.php
@@ -16,9 +16,11 @@ declare(strict_types=1);
 namespace BEdita\Core\Test\TestCase\Command;
 
 use BEdita\Core\Job\ServiceRegistry;
+use BEdita\Core\Model\Entity\EndpointPermission;
 use Cake\Command\Command;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Inflector;
 
 /**
  * {@see BEdita\Core\Command\ResourcesCommand} Test Case
@@ -117,7 +119,7 @@ class ResourcesCommandTest extends TestCase
      * @return void
      * @covers ::execute()
      */
-    public function testAdd(): void
+    public function testAddResource(): void
     {
         $expected = $this->fetchTable('Applications')->find()->count() + 1;
         $this->exec('resources add --type=applications', ['dummy-app', 'Dummy Application']);
@@ -131,19 +133,121 @@ class ResourcesCommandTest extends TestCase
     }
 
     /**
-     * Test list resources
+     * Data provider for `testAddDefault` test case.
      *
-     * @return void
-     * @covers ::execute()
+     * @return array
      */
-    public function testList(): void
+    public function addProvider(): array
     {
-        $count = $this->fetchTable('Applications')->find()->count();
-        $this->exec('resources ls --type=applications');
+        return [
+            'role' => [
+                true,
+                'roles',
+                'newrole',
+            ],
+            'app' => [
+                true,
+                'applications',
+                'newapp',
+                'description of the new app',
+            ],
+            'abort' => [
+                'Resource name cannot be empty',
+                'endpoints',
+                '',
+                null,
+            ],
+        ];
+    }
+
+    /**
+     * Test `add` method
+     *
+     * @param bool|string $expected Expected success or error message.
+     * @param string $type Resource type.
+     * @param string $name Resource name.
+     * @param string $description Resource description.
+     * @return void
+     * @dataProvider addProvider()
+     * @covers ::add()
+     * @covers ::getTable()
+     * @covers ::setupDefaultEntity()
+     */
+    public function testAddDefault($expected, $type, $name, $description = ''): void
+    {
+        $input = array_filter(
+            [$name, $description],
+            function ($val) {
+                return !is_null($val);
+            }
+        );
+        $this->exec(sprintf('resources add -t %s', $type), $input);
+
+        $exists = $this->fetchTable(Inflector::camelize($type))->exists(compact('name'));
+        if ($expected === true) {
+            static::assertTrue($exists);
+            $this->assertExitCode(Command::CODE_SUCCESS);
+            $this->assertErrorEmpty();
+        } else {
+            static::assertFalse($exists);
+            $this->assertExitCode(Command::CODE_ERROR);
+            $this->assertErrorContains($expected);
+        }
+    }
+
+    /**
+     * Data provider for `testAddPermission` test case.
+     *
+     * @return array
+     */
+    public function addPermissionProvider(): array
+    {
+        return [
+            [
+                '1',
+                'home',
+                '2',
+                'mine',
+                'block',
+            ],
+            [
+                '1',
+                '3',
+                'first role',
+                'true',
+                'true',
+            ],
+        ];
+    }
+
+    /**
+     * Test `add` method
+     *
+     * @param mixed $application Application name or id
+     * @param mixed $endpoint Endpoint name or id
+     * @param mixed $role Role name or id
+     * @param string $read Read permission
+     * @param string $write Write permission
+     * @return void
+     * @dataProvider addPermissionProvider
+     * @covers ::add()
+     * @covers ::getTable()
+     * @covers ::setupEndpointPermissionEntity()
+     */
+    public function testAddPermission($application, $endpoint, $role, $read, $write): void
+    {
+        $this->exec('resources add -t endpoint_permissions', [$application, $endpoint, $role, $read, $write]);
+
         $this->assertExitCode(Command::CODE_SUCCESS);
-        $this->assertOutputContains(sprintf('%d result(s) found', $count));
-        $this->assertOutputContains('First app');
-        $this->assertOutputContains('Disabled app');
+        $this->assertErrorEmpty();
+
+        $endpointPermission = $this->fetchTable('EndpointPermissions')->find()->all()->last();
+
+        $read = EndpointPermission::decode(EndpointPermission::encode($read));
+        $write = EndpointPermission::decode(EndpointPermission::encode($write));
+
+        static::assertSame($read, $endpointPermission->read);
+        static::assertSame($write, $endpointPermission->write);
     }
 
     /**
@@ -152,7 +256,7 @@ class ResourcesCommandTest extends TestCase
      * @return void
      * @covers ::execute()
      */
-    public function testEdit(): void
+    public function testEditResource(): void
     {
         $table = $this->fetchTable('Applications');
         $table->save($table->newEntity([
@@ -169,12 +273,145 @@ class ResourcesCommandTest extends TestCase
     }
 
     /**
+     * Data provider for `testEdit` method.
+     *
+     * @return array
+     */
+    public function editProvider(): array
+    {
+        return [
+            'Applications.api_key' => [
+                'applications',
+                'Disabled app',
+                'api_key',
+            ],
+            'Applications.enabled' => [
+                'applications',
+                2,
+                'enabled',
+                '1',
+            ],
+        ];
+    }
+
+    /**
+     * Test enable method
+     *
+     * @param string $type Resource type.
+     * @param string|int $resId Resource ID or name.
+     * @param string $field Field to be updated.
+     * @param mixed|null $value New field value.
+     * @return void
+     * @dataProvider editProvider
+     * @covers ::edit()
+     * @covers ::getEntity()
+     * @covers ::getTable()
+     */
+    public function testEdit($type, $resId, $field, $value = null): void
+    {
+        $table = $this->fetchTable(Inflector::camelize($type));
+        if (is_numeric($resId)) {
+            $entity = $table->get($resId);
+        } else {
+            $entity = $table->find()->where(['name' => $resId])->firstOrFail();
+        }
+        $oldValue = $entity->get($field);
+
+        $input = array_filter(
+            [$value],
+            function ($val) {
+                return !is_null($val);
+            }
+        );
+        $this->exec(sprintf('resources edit -t %s -f %s "%s"', $type, $field, $resId), $input);
+
+        $newValue = $table->get($entity->id)->get($field);
+        if ($value !== null) {
+            $this->assertExitCode(Command::CODE_SUCCESS);
+            $this->assertErrorEmpty();
+            static::assertEquals($value, $newValue);
+        } else {
+            static::assertNotEquals($oldValue, $newValue);
+        }
+    }
+
+    /**
+     * Test `edit` failure
+     *
+     * @return void
+     * @covers ::edit()
+     */
+    public function testEditFail(): void
+    {
+        $this->exec('resources edit -t applications -f description 1111');
+        $this->assertErrorContains('Resource with id 1111 not found');
+        $this->assertExitCode(Command::CODE_ERROR);
+    }
+
+    /**
+     * Test list resources
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testListResources(): void
+    {
+        $count = $this->fetchTable('Applications')->find()->count();
+        $this->exec('resources ls --type=applications');
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertOutputContains(sprintf('%d result(s) found', $count));
+        $this->assertOutputContains('First app');
+        $this->assertOutputContains('Disabled app');
+    }
+
+    /**
+     * Data provider for `testList` test case.
+     *
+     * @return array
+     */
+    public function listProvider(): array
+    {
+        return [
+            'applications' => [
+                2,
+                'applications',
+            ],
+            'endpoints' => [
+                3,
+                'endpoints',
+            ],
+            'roles' => [
+                2,
+                'roles',
+            ],
+        ];
+    }
+
+    /**
+     * Test ls method
+     *
+     * @param int $expected Expected count.
+     * @param string $type Resource type.
+     * @return void
+     * @dataProvider listProvider()
+     * @covers ::ls()
+     */
+    public function testList($expected, $type): void
+    {
+        $this->exec(sprintf('resources ls -t %s', $type));
+
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertErrorEmpty();
+        $this->assertOutputContains(sprintf('%d result(s) found', $expected));
+    }
+
+    /**
      * Test remove resource
      *
      * @return void
      * @covers ::execute()
      */
-    public function testRm(): void
+    public function testRmResource(): void
     {
         $table = $this->fetchTable('Applications');
         $table->save($table->newEntity([
@@ -188,6 +425,61 @@ class ResourcesCommandTest extends TestCase
         $this->exec(sprintf('resources rm %d --type=applications', $id), ['y']);
         $actual = $table->find()->count();
         $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Data provider for `testRemove` test case.
+     *
+     * @return array
+     */
+    public function removeProvider(): array
+    {
+        return [
+            'no confirm' => [
+                false,
+                2,
+                'n',
+            ],
+            'confirm' => [
+                true,
+                2,
+                'y',
+            ],
+            'not found' => [
+                false,
+                'this-app-does-not-exist',
+                'y',
+            ],
+        ];
+    }
+
+    /**
+     * Test rm method
+     *
+     * @param bool $expected Expected result.
+     * @param int|string $id Resource ID or name.
+     * @param string $answer Given answer (y/n).
+     * @return void
+     * @dataProvider removeProvider()
+     * @covers ::rm()
+     * @covers ::getEntity()
+     */
+    public function testRemove(bool $expected, int|string $id, string $answer): void
+    {
+        $countBefore = $this->fetchTable('Applications')->find()->count();
+
+        $this->exec(sprintf('resources rm -t applications %s', $id), [$answer]);
+
+        $countAfter = $this->fetchTable('Applications')->find()->count();
+
+        if ($expected) {
+            $this->assertExitCode(Command::CODE_SUCCESS);
+            $this->assertErrorEmpty();
+            static::assertSame($countBefore - 1, $countAfter);
+        } else {
+            $this->assertExitCode(Command::CODE_ERROR);
+            static::assertSame($countBefore, $countAfter);
+        }
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesCommandTest.php
@@ -457,14 +457,14 @@ class ResourcesCommandTest extends TestCase
      * Test rm method
      *
      * @param bool $expected Expected result.
-     * @param mixed $id Resource ID or name.
+     * @param int|string $id Resource ID or name.
      * @param string $answer Given answer (y/n).
      * @return void
      * @dataProvider removeProvider()
      * @covers ::rm()
      * @covers ::getEntity()
      */
-    public function testRemove(bool $expected, mixed $id, string $answer): void
+    public function testRemove($expected, $id, $answer): void
     {
         $countBefore = $this->fetchTable('Applications')->find()->count();
 

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesCommandTest.php
@@ -1,0 +1,159 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Command;
+
+use BEdita\Core\Job\ServiceRegistry;
+use Cake\Command\Command;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * {@see BEdita\Core\Command\ResourcesCommand} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Command\ResourcesCommand
+ */
+class ResourcesCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    protected $fixtures = [
+        'plugin.BEdita/Core.Endpoints',
+        'plugin.BEdita/Core.Applications',
+        'plugin.BEdita/Core.EndpointPermissions',
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->useCommandRunner();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        ServiceRegistry::reset();
+    }
+
+    /**
+     * Test buildOptionParser method
+     *
+     * @return void
+     * @covers ::buildOptionParser()
+     */
+    public function testBuildOptionParser()
+    {
+        $this->exec('resources --help');
+        $this->assertOutputContains('Resources management command. Available subcommands: add, edit, ls, rm');
+        $this->assertOutputContains('cake resources [-f api_key|description|enabled|name|unchangeable] [-q] [-h] [-q] [-t] [-v] [<add|edit|ls|rm>] [<name|id>]');
+        $this->assertOutputContains('Field name');
+        $this->assertOutputContains('api_key|description|enabled|name|unchangeable)');
+        $this->assertOutputContains('List entities filtered by comma separated key=value pairs');
+        $this->assertOutputContains('Entity type');
+        $this->assertOutputContains('Subcommand to perform');
+        $this->assertOutputContains('(choices: add|edit|ls|rm)');
+        $this->assertOutputContains('Resource\'s name or id');
+    }
+
+    /**
+     * Test add resource
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testAdd(): void
+    {
+        $expected = $this->fetchTable('Applications')->find()->count() + 1;
+        $this->exec('resources add --type=applications', ['dummy-app', 'Dummy Application']);
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $actual = $this->fetchTable('Applications')->find()->count();
+        $this->assertEquals($expected, $actual);
+        $application = $this->fetchTable('Applications')->find()->all()->last();
+        $this->assertNotEmpty($application);
+        $this->assertEquals('dummy-app', $application->get('name'));
+        $this->assertEquals('Dummy Application', $application->get('description'));
+    }
+
+    /**
+     * Test list resources
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testList(): void
+    {
+        $count = $this->fetchTable('Applications')->find()->count();
+        $this->exec('resources ls --type=applications');
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertOutputContains(sprintf('%d result(s) found', $count));
+        $this->assertOutputContains('First app');
+        $this->assertOutputContains('Disabled app');
+    }
+
+    /**
+     * Test edit resource
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testEdit(): void
+    {
+        $table = $this->fetchTable('Applications');
+        $table->save($table->newEntity([
+            'name' => 'dummy-app',
+            'description' => 'Dummy Application',
+        ]));
+        $application = $table->find()->where(['name' => 'dummy-app'])->firstOrFail();
+        $id = $application->get('id');
+        $this->exec(sprintf('resources edit %d --field description --type=applications', $id), ['My Dummy Application']);
+        $application = $table->find()->where(['name' => 'dummy-app'])->firstOrFail();
+        $this->assertNotEmpty($application);
+        $this->assertEquals('dummy-app', $application->get('name'));
+        $this->assertEquals('My Dummy Application', $application->get('description'));
+    }
+
+    /**
+     * Test remove resource
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testRm(): void
+    {
+        $table = $this->fetchTable('Applications');
+        $table->save($table->newEntity([
+            'name' => 'dummy-app',
+            'description' => 'Dummy Application',
+        ]));
+        $actual = $table->find()->count();
+        $expected = $actual - 1;
+        $application = $table->find()->where(['name' => 'dummy-app'])->firstOrFail();
+        $id = $application->get('id');
+        $this->exec(sprintf('resources rm %d --type=applications', $id), ['y']);
+        $actual = $table->find()->count();
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesCommandTest.php
@@ -63,10 +63,33 @@ class ResourcesCommandTest extends TestCase
      *
      * @return void
      * @covers ::buildOptionParser()
+     * @covers ::getDescription()
      */
     public function testBuildOptionParser()
     {
         $this->exec('resources --help');
+        $this->assertOutputContains('Resources management command. Available subcommands: add, edit, ls, rm');
+        $this->assertOutputContains('cake resources [-f api_key|description|enabled|name|unchangeable] [-q] [-h] [-q] [-t] [-v] [<add|edit|ls|rm>] [<name|id>]');
+        $this->assertOutputContains('Field name');
+        $this->assertOutputContains('api_key|description|enabled|name|unchangeable)');
+        $this->assertOutputContains('List entities filtered by comma separated key=value pairs');
+        $this->assertOutputContains('Entity type');
+        $this->assertOutputContains('Subcommand to perform');
+        $this->assertOutputContains('(choices: add|edit|ls|rm)');
+        $this->assertOutputContains('Resource\'s name or id');
+    }
+
+    /**
+     * Test execute on `resources --help`
+     *
+     * @return void
+     * @covers ::buildOptionParser()
+     * @covers ::execute()
+     * @covers ::getDescription()
+     */
+    public function testHelp()
+    {
+        $this->exec('resources add --help');
         $this->assertOutputContains('Resources management command. Available subcommands: add, edit, ls, rm');
         $this->assertOutputContains('cake resources [-f api_key|description|enabled|name|unchangeable] [-q] [-h] [-q] [-t] [-v] [<add|edit|ls|rm>] [<name|id>]');
         $this->assertOutputContains('Field name');

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesCommandTest.php
@@ -179,4 +179,17 @@ class ResourcesCommandTest extends TestCase
         $actual = $table->find()->count();
         $this->assertEquals($expected, $actual);
     }
+
+    /**
+     * Test error on missing subcommand
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testNoSubcommand(): void
+    {
+        $this->exec('resources');
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertOutputContains('Resources management command. Available subcommands: add, edit, ls, rm');
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesCommandTest.php
@@ -35,8 +35,18 @@ class ResourcesCommandTest extends TestCase
      * @var array
      */
     protected $fixtures = [
-        'plugin.BEdita/Core.Endpoints',
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.RelationTypes',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.Profiles',
+        'plugin.BEdita/Core.Users',
+        'plugin.BEdita/Core.Roles',
+        'plugin.BEdita/Core.RolesUsers',
         'plugin.BEdita/Core.Applications',
+        'plugin.BEdita/Core.Endpoints',
         'plugin.BEdita/Core.EndpointPermissions',
     ];
 

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesCommandTest.php
@@ -457,14 +457,14 @@ class ResourcesCommandTest extends TestCase
      * Test rm method
      *
      * @param bool $expected Expected result.
-     * @param int|string $id Resource ID or name.
+     * @param mixed $id Resource ID or name.
      * @param string $answer Given answer (y/n).
      * @return void
      * @dataProvider removeProvider()
      * @covers ::rm()
      * @covers ::getEntity()
      */
-    public function testRemove(bool $expected, int|string $id, string $answer): void
+    public function testRemove(bool $expected, mixed $id, string $answer): void
     {
         $countBefore = $this->fetchTable('Applications')->find()->count();
 

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesListCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesListCommandTest.php
@@ -1,0 +1,169 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Command;
+
+use BEdita\Core\Job\ServiceRegistry;
+use Cake\Command\Command;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Inflector;
+
+/**
+ * {@see BEdita\Core\Command\ResourcesListCommand} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Command\ResourcesListCommand
+ */
+class ResourcesListCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    protected $fixtures = [
+        'plugin.BEdita/Core.Endpoints',
+        'plugin.BEdita/Core.Applications',
+        'plugin.BEdita/Core.EndpointPermissions',
+        'plugin.BEdita/Core.Roles',
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->useCommandRunner();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        ServiceRegistry::reset();
+    }
+
+    /**
+     * Test buildOptionParser method
+     *
+     * @return void
+     * @covers ::buildOptionParser()
+     * @covers ::getDescription()
+     */
+    public function testBuildOptionParser()
+    {
+        $this->exec('resources_list --help');
+        $this->assertOutputContains('Resources list');
+        $this->assertOutputContains('cake resources_list [--filter] [-h] [-q] -t applications|roles|endpoints|endpoint_permissions [-v]');
+        $this->assertOutputContains('List entities filtered by comma separated key=value pairs');
+        $this->assertOutputContains('Entity type');
+        $this->assertOutputContains('applications|roles|endpoints|endpoint_permissions');
+    }
+
+    /**
+     * Data provider for `testExecute` test case.
+     *
+     * @return array
+     */
+    public function executeProvider(): array
+    {
+        return [
+            'applications, no filter' => [
+                'applications',
+                '',
+                '{n} result(s) found',
+            ],
+            'applications, filter' => [
+                'applications',
+                'name="First app"',
+                '1 result(s) found',
+            ],
+            'endpoints, no filter' => [
+                'endpoints',
+                '',
+                '{n} result(s) found',
+            ],
+            'endpoints, filter' => [
+                'endpoints',
+                'name="home"',
+                '1 result(s) found',
+            ],
+            'roles, no filter' => [
+                'roles',
+                '',
+                '{n} result(s) found',
+            ],
+            'roles, no filter' => [
+                'roles',
+                'name="first role"',
+                '1 result(s) found',
+            ],
+            'endpoint_permissions, no filter' => [
+                'endpoint_permissions',
+                '',
+                '{n} result(s) found',
+            ],
+            'endpoint_permissions, filter' => [
+                'endpoint_permissions',
+                'endpoint_id=1',
+                '1 result(s) found',
+            ],
+        ];
+    }
+
+    /**
+     * Test modify resource
+     *
+     * @param string $resourceType Resource type.
+     * @param string $resourceFilter Resource ID.
+     * @param string $expected Expected output.
+     * @return void
+     * @covers ::execute()
+     * @dataProvider executeProvider()
+     */
+    public function testExecute(string $resourceType, string $resourceFilter, string $expected): void
+    {
+        $tableName = Inflector::camelize($resourceType);
+        $command = sprintf('resources_list --type %s', $resourceType);
+        if (!empty($resourceFilter)) {
+            $command .= sprintf(' --filter %s', $resourceFilter);
+        } else {
+            $table = $this->fetchTable($tableName);
+            $count = $table->find()->count();
+            $expected = str_replace('{n}', (string)$count, $expected);
+        }
+        $this->exec($command);
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertOutputContains($expected);
+    }
+
+    /**
+     * Test list resource with wrong type
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testExecuteWrongType(): void
+    {
+        $this->exec('resources_list --type wrong', ['y']);
+        $this->assertExitCode(Command::CODE_ERROR);
+        $this->assertErrorContains('"wrong" is not a valid value for --type. Please use one of "applications, roles, endpoints, endpoint_permissions"');
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesListCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesListCommandTest.php
@@ -110,7 +110,7 @@ class ResourcesListCommandTest extends TestCase
                 '',
                 '{n} result(s) found',
             ],
-            'roles, no filter' => [
+            'roles, filter' => [
                 'roles',
                 'name="first role"',
                 '1 result(s) found',

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesListCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesListCommandTest.php
@@ -36,10 +36,19 @@ class ResourcesListCommandTest extends TestCase
      * @var array
      */
     protected $fixtures = [
-        'plugin.BEdita/Core.Endpoints',
-        'plugin.BEdita/Core.Applications',
-        'plugin.BEdita/Core.EndpointPermissions',
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.RelationTypes',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.Profiles',
+        'plugin.BEdita/Core.Users',
         'plugin.BEdita/Core.Roles',
+        'plugin.BEdita/Core.RolesUsers',
+        'plugin.BEdita/Core.Applications',
+        'plugin.BEdita/Core.Endpoints',
+        'plugin.BEdita/Core.EndpointPermissions',
     ];
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesModifyCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesModifyCommandTest.php
@@ -144,8 +144,6 @@ class ResourcesModifyCommandTest extends TestCase
      * @param array $expectedResource Expected resource data.
      * @return void
      * @covers ::execute()
-     * @covers ::setupDefaultEntity()
-     * @covers ::setupEndpointPermissionEntity()
      * @dataProvider executeProvider()
      */
     public function testExecute(string $resourceId, string $resourceType, string $resourceField, array $input, array $expectedResource): void

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesModifyCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesModifyCommandTest.php
@@ -222,14 +222,14 @@ class ResourcesModifyCommandTest extends TestCase
     }
 
     /**
-     * Test modify resource with invalid field
+     * Test modify resource not found
      *
      * @return void
      * @covers ::execute()
      */
     public function testExecuteResourceNotFound(): void
     {
-        $this->exec('resources_modify 999 --type applications --field description', ['A sample description']);
+        $this->exec('resources_modify 999 --type applications --field description');
         $this->assertExitCode(Command::CODE_ERROR);
         $this->assertErrorContains('Resource with id 999 not found');
     }

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesModifyCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesModifyCommandTest.php
@@ -1,0 +1,238 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Command;
+
+use BEdita\Core\Job\ServiceRegistry;
+use Cake\Command\Command;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Inflector;
+
+/**
+ * {@see BEdita\Core\Command\ResourcesModifyCommand} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Command\ResourcesModifyCommand
+ */
+class ResourcesModifyCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    protected $fixtures = [
+        'plugin.BEdita/Core.Endpoints',
+        'plugin.BEdita/Core.Applications',
+        'plugin.BEdita/Core.EndpointPermissions',
+        'plugin.BEdita/Core.Roles',
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->useCommandRunner();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        ServiceRegistry::reset();
+    }
+
+    /**
+     * Test buildOptionParser method
+     *
+     * @return void
+     * @covers ::buildOptionParser()
+     * @covers ::getDescription()
+     */
+    public function testBuildOptionParser()
+    {
+        $this->exec('resources_modify --help');
+        $this->assertOutputContains('Resources modify');
+        $this->assertOutputContains('cake resources_modify -f api_key|description|enabled|name|unchangeable [-h] [-q] -t applications|roles|endpoints [-v] <name|id>');
+        $this->assertOutputContains('Field name');
+        $this->assertOutputContains('api_key|description|enabled|name|unchangeable');
+        $this->assertOutputContains('Entity type');
+        $this->assertOutputContains('applications|roles|endpoints');
+        $this->assertOutputContains('Arguments');
+        $this->assertOutputContains('Resource\'s name or id');
+    }
+
+    /**
+     * Data provider for `testExecute` test case.
+     *
+     * @return array
+     */
+    public function executeProvider(): array
+    {
+        return [
+            'modify application api_key' => [
+                'First app',
+                'applications',
+                'api_key',
+                [],
+                [
+                    'name' => 'First app',
+                ],
+            ],
+            'modify application description' => [
+                'First app',
+                'applications',
+                'description',
+                ['A sample description'],
+                [
+                    'name' => 'First app',
+                    'description' => 'A sample description',
+                ],
+            ],
+            'modify role' => [
+                'first role',
+                'roles',
+                'description',
+                [
+                    'Another description for first role',
+                ],
+                [
+                    'name' => 'first role',
+                    'description' => 'Another description for first role',
+                ],
+            ],
+            'modify endpoint' => [
+                'home',
+                'endpoints',
+                'description',
+                [
+                    'Another description for home endpoint',
+                ],
+                [
+                    'name' => 'home',
+                    'description' => 'Another description for home endpoint',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test modify resource
+     *
+     * @param string $resourceId Resource ID.
+     * @param string $resourceType Resource type.
+     * @param string $resourceField Resource field.
+     * @param array $input Input data.
+     * @param array $expectedResource Expected resource data.
+     * @return void
+     * @covers ::execute()
+     * @covers ::setupDefaultEntity()
+     * @covers ::setupEndpointPermissionEntity()
+     * @dataProvider executeProvider()
+     */
+    public function testExecute(string $resourceId, string $resourceType, string $resourceField, array $input, array $expectedResource): void
+    {
+        $tableName = Inflector::camelize($resourceType);
+        $table = $this->fetchTable($tableName);
+        $originalApiKey = null;
+        $field = is_numeric($resourceId) ? 'id' : 'name';
+        if ($resourceField === 'api_key') {
+            $originalApiKey = $table->find()->where([$field => $resourceId])->firstOrFail()->get('api_key');
+        }
+        $this->exec(sprintf('resources_modify "%s" --type %s --field %s', $resourceId, $resourceType, $resourceField), $input);
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $resource = $table->find()->where([$field => $resourceId])->firstOrFail();
+        $this->assertOutputContains(sprintf('Resource with id %d modified', $resource->id));
+        $this->assertNotEmpty($resource);
+        foreach ($expectedResource as $field => $value) {
+            $this->assertEquals($value, $resource->get($field));
+        }
+        if ($resourceField === 'api_key') {
+            $newApiKey = $resource->get('api_key');
+            $this->assertNotEquals($originalApiKey, $newApiKey);
+        }
+    }
+
+    /**
+     * Test modify resource with missing type required options
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testExecuteEmptyType(): void
+    {
+        $this->exec('resources_modify "First app" --field description', ['A sample description']);
+        $this->assertExitCode(Command::CODE_ERROR);
+        $this->assertErrorContains('Missing required option. The `type` option is required and has no default value');
+    }
+
+    /**
+     * Test modify resource with missing field required options
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testExecuteEmptyField(): void
+    {
+        $this->exec('resources_modify "First app" --type applications', ['A sample description']);
+        $this->assertExitCode(Command::CODE_ERROR);
+        $this->assertErrorContains('Missing required option. The `field` option is required and has no default value');
+    }
+
+    /**
+     * Test modify resource with wrong type
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testExecuteWrongType(): void
+    {
+        $this->exec('resources_modify "First app" --type wrong --field description', ['A sample description']);
+        $this->assertExitCode(Command::CODE_ERROR);
+        $this->assertErrorContains('"wrong" is not a valid value for --type. Please use one of "applications, roles, endpoints"');
+    }
+
+    /**
+     * Test modify resource with wrong field
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testExecuteWrongField(): void
+    {
+        $this->exec('resources_modify "First app" --type applications --field wrong', ['A sample description']);
+        $this->assertExitCode(Command::CODE_ERROR);
+        $this->assertErrorContains('"wrong" is not a valid value for --field. Please use one of "api_key, description, enabled, name, unchangeable"');
+    }
+
+    /**
+     * Test modify resource with invalid field
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testExecuteResourceNotFound(): void
+    {
+        $this->exec('resources_modify 999 --type applications --field description', ['A sample description']);
+        $this->assertExitCode(Command::CODE_ERROR);
+        $this->assertErrorContains('Resource with id 999 not found');
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesModifyCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesModifyCommandTest.php
@@ -36,10 +36,19 @@ class ResourcesModifyCommandTest extends TestCase
      * @var array
      */
     protected $fixtures = [
-        'plugin.BEdita/Core.Endpoints',
-        'plugin.BEdita/Core.Applications',
-        'plugin.BEdita/Core.EndpointPermissions',
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.RelationTypes',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.Profiles',
+        'plugin.BEdita/Core.Users',
         'plugin.BEdita/Core.Roles',
+        'plugin.BEdita/Core.RolesUsers',
+        'plugin.BEdita/Core.Applications',
+        'plugin.BEdita/Core.Endpoints',
+        'plugin.BEdita/Core.EndpointPermissions',
     ];
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesRemoveCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesRemoveCommandTest.php
@@ -165,12 +165,13 @@ class ResourcesRemoveCommandTest extends TestCase
         $expected = $count - $expectedCountDiff;
         $field = is_numeric($resourceId) ? 'id' : 'name';
         $this->exec(sprintf('resources_remove "%s" --type %s', $resourceId, $resourceType), $input);
-        $this->assertExitCode(Command::CODE_SUCCESS);
         $actual = $table->find()->count();
         $this->assertEquals($expected, $actual);
         if ($expectedCountDiff === 1) {
             $this->assertOutputContains(sprintf('Record "%s" deleted', $resourceId));
+            $this->assertExitCode(Command::CODE_SUCCESS);
         } else {
+            $this->assertExitCode(Command::CODE_ERROR);
             $this->assertOutputContains('No action performed');
             $resource = $table->find()->where([$field => $resourceId])->firstOrFail();
             $this->assertNotEmpty($resource);

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesRemoveCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesRemoveCommandTest.php
@@ -1,0 +1,196 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2024 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\Core\Test\TestCase\Command;
+
+use BEdita\Core\Job\ServiceRegistry;
+use Cake\Command\Command;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Inflector;
+
+/**
+ * {@see BEdita\Core\Command\ResourcesRemoveCommand} Test Case
+ *
+ * @coversDefaultClass \BEdita\Core\Command\ResourcesRemoveCommand
+ */
+class ResourcesRemoveCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    protected $fixtures = [
+        'plugin.BEdita/Core.Endpoints',
+        'plugin.BEdita/Core.Applications',
+        'plugin.BEdita/Core.EndpointPermissions',
+        'plugin.BEdita/Core.Roles',
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->useCommandRunner();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        ServiceRegistry::reset();
+    }
+
+    /**
+     * Test buildOptionParser method
+     *
+     * @return void
+     * @covers ::buildOptionParser()
+     * @covers ::getDescription()
+     */
+    public function testBuildOptionParser()
+    {
+        $this->exec('resources_remove --help');
+        $this->assertOutputContains('Resources remove');
+        $this->assertOutputContains('cake resources_remove [-h] [-q] -t applications|roles|endpoints|endpoint_permissions [-v] <name|id>');
+        $this->assertOutputContains('Entity type');
+        $this->assertOutputContains('applications|roles|endpoints|endpoint_permissions');
+        $this->assertOutputContains('Arguments');
+        $this->assertOutputContains('Resource\'s name or id');
+    }
+
+    /**
+     * Data provider for `testExecute` test case.
+     *
+     * @return array
+     */
+    public function executeProvider(): array
+    {
+        return [
+            'remove application (n)' => [
+                'Disabled app',
+                'applications',
+                ['n'],
+                0,
+            ],
+            'remove application (y)' => [
+                'Disabled app',
+                'applications',
+                ['y'],
+                1,
+            ],
+            'remove role (n)' => [
+                'second role',
+                'roles',
+                ['n'],
+                0,
+            ],
+            'remove role (y)' => [
+                'second role',
+                'roles',
+                ['y'],
+                1,
+            ],
+            'remove endpoint (n)' => [
+                'disabled',
+                'endpoints',
+                ['n'],
+                0,
+            ],
+            'remove endpoint (y)' => [
+                'disabled',
+                'endpoints',
+                ['y'],
+                1,
+            ],
+            'remove endpoint permission (n)' => [
+                '1',
+                'endpoint_permissions',
+                ['n'],
+                0,
+            ],
+            'remove endpoint permission (y)' => [
+                '1',
+                'endpoint_permissions',
+                ['y'],
+                1,
+            ],
+        ];
+    }
+
+    /**
+     * Test modify resource
+     *
+     * @param string $resourceId Resource ID.
+     * @param string $resourceType Resource type.
+     * @param array $input Input data.
+     * @param int $expectedCountDiff Expected resource count difference.
+     * @return void
+     * @covers ::execute()
+     * @dataProvider executeProvider()
+     */
+    public function testExecute(string $resourceId, string $resourceType, array $input, int $expectedCountDiff): void
+    {
+        $tableName = Inflector::camelize($resourceType);
+        $table = $this->fetchTable($tableName);
+        $count = $table->find()->count();
+        $expected = $count - $expectedCountDiff;
+        $field = is_numeric($resourceId) ? 'id' : 'name';
+        $this->exec(sprintf('resources_remove "%s" --type %s', $resourceId, $resourceType), $input);
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $actual = $table->find()->count();
+        $this->assertEquals($expected, $actual);
+        if ($expectedCountDiff === 1) {
+            $this->assertOutputContains(sprintf('Record "%s" deleted', $resourceId));
+        } else {
+            $this->assertOutputContains('No action performed');
+            $resource = $table->find()->where([$field => $resourceId])->firstOrFail();
+            $this->assertNotEmpty($resource);
+        }
+    }
+
+    /**
+     * Test remove resource with wrong type
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testExecuteWrongType(): void
+    {
+        $this->exec('resources_remove "First app" --type wrong', ['y']);
+        $this->assertExitCode(Command::CODE_ERROR);
+        $this->assertErrorContains('"wrong" is not a valid value for --type. Please use one of "applications, roles, endpoints, endpoint_permissions"');
+    }
+
+    /**
+     * Test remove resource not found
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testExecuteResourceNotFound(): void
+    {
+        $this->exec('resources_remove 999 --type applications', ['y']);
+        $this->assertExitCode(Command::CODE_ERROR);
+        $this->assertErrorContains('Resource with id 999 not found');
+    }
+}

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesRemoveCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesRemoveCommandTest.php
@@ -36,10 +36,19 @@ class ResourcesRemoveCommandTest extends TestCase
      * @var array
      */
     protected $fixtures = [
-        'plugin.BEdita/Core.Endpoints',
-        'plugin.BEdita/Core.Applications',
-        'plugin.BEdita/Core.EndpointPermissions',
+        'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.Relations',
+        'plugin.BEdita/Core.RelationTypes',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.Profiles',
+        'plugin.BEdita/Core.Users',
         'plugin.BEdita/Core.Roles',
+        'plugin.BEdita/Core.RolesUsers',
+        'plugin.BEdita/Core.Applications',
+        'plugin.BEdita/Core.Endpoints',
+        'plugin.BEdita/Core.EndpointPermissions',
     ];
 
     /**


### PR DESCRIPTION
This PR introduces `ResourcesCommand` (+ `ResourcesAddCommand`, `ResourcesModifyCommand`, `ResourcesRemoveCommand`, `ResourcesListCommand`) and deprecates `ResourcesShell`.

```
BEdita/Core:
 [...]
 - resources
 └─── Resources management command. Available subcommands: add, edit, ls, rm
 - resources_add
 └─── Resources add
 - resources_list
 └─── Resources list
 - resources_modify
 └─── Resources modify
 - resources_remove
 └─── Resources remove
```

It is part of https://github.com/bedita/bedita/issues/1987.