### PR TITLE
Config resources in project_model

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -179,7 +179,7 @@ jobs:
         run: 'vendor/bin/phpunit --coverage-clover=clover.xml'
 
       - name: 'Export coverage results'
-        uses: 'codecov/codecov-action@v4'
+        uses: 'codecov/codecov-action@v5'
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # required
           files: './clover.xml'

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ProjectControllerTest.php
@@ -472,6 +472,26 @@ class ProjectControllerTest extends IntegrationTestCase
                     'label' => 'Disabled category',
                 ],
             ],
+            'config' => [
+                [
+                    'name' => 'appVal',
+                    'context' => 'app',
+                    'content' => '{"val": 42}',
+                    'application' => 'First app',
+                ],
+                [
+                    'name' => 'someVal',
+                    'context' => 'core',
+                    'content' => '42',
+                    'application' => 'First app',
+                ],
+                [
+                    'name' => 'myVal',
+                    'context' => 'somecontext',
+                    'content' => '42',
+                    'application' => 'First app',
+                ],
+            ],
         ];
 
         $this->configRequestHeaders('GET', ['Accept' => 'application/json']);

--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -44,6 +44,7 @@ class ProjectModel
             'relations' => static::relations(),
             'properties' => static::properties(),
             'categories' => static::categories(),
+            'config' => static::configs(),
         ];
     }
 
@@ -204,6 +205,29 @@ class ProjectModel
     }
 
     /**
+     * Retrieve configurations.
+     *
+     * @return array
+     */
+    protected static function configs(): array
+    {
+        $applicationsTable = TableRegistry::getTableLocator()->get('Applications');
+        $configTable = TableRegistry::getTableLocator()->get('Config');
+
+        return $configTable
+            ->find()
+            ->select([
+                $configTable->aliasField('name'),
+                $configTable->aliasField('context'),
+                $configTable->aliasField('content'),
+                'application' => $applicationsTable->aliasField('name'),
+            ])
+            ->innerJoinWith('Applications')
+            ->order([$configTable->aliasField('context') => 'ASC', $configTable->aliasField('name') => 'ASC'])
+            ->toArray();
+    }
+
+    /**
      * Calculates the difference between the current project model
      * and a new project model passed by argument as array.
      * Diff array will contain 'create', 'update' and 'remove' keys
@@ -218,8 +242,9 @@ class ProjectModel
         $create = $update = $remove = [];
         $currentModel = json_decode(json_encode(static::generate()), true);
         foreach ($currentModel as $key => $items) {
-            if ($key === 'properties' || $key === 'categories') {
-                $diff = static::byObjectDiff((array)$items, (array)Hash::get($project, $key));
+            if (in_array($key, ['categories', 'config', 'properties'])) {
+                $method = $key === 'config' ? 'configDiff' : 'byObjectDiff';
+                $diff = static::$method((array)$items, (array)Hash::get($project, $key));
                 $create[$key] = $diff['create'];
                 $remove[$key] = $diff['remove'];
                 $update[$key] = $diff['update'];
@@ -297,6 +322,36 @@ class ProjectModel
     }
 
     /**
+     * Calculate diff between current and project model config resources.
+     *
+     * @param array $items Current items.
+     * @param array $projectItems Project items.
+     * @return array
+     */
+    protected static function configDiff(array $items, array $projectItems): array
+    {
+        $create = $update = $remove = $new = $current = [];
+        $currentKeys = array_unique(array_column($items, 'name'));
+        foreach ($currentKeys as $key) {
+            $current[$key] = Hash::extract($items, sprintf('{n}[name=%s]', $key));
+        }
+        $newKeys = array_unique(array_column($projectItems, 'name'));
+        foreach ($newKeys as $key) {
+            $new[$key] = Hash::extract($projectItems, sprintf('{n}[name=%s]', $key));
+        }
+        $allKeys = array_unique(array_merge($currentKeys, $newKeys));
+        foreach ($allKeys as $key) {
+            $newItems = (array)Hash::get($new, $key);
+            $currItems = (array)Hash::get($current, $key);
+            $create = array_merge($create, array_values(array_diff_key($newItems, $currItems)));
+            $remove = array_merge($remove, array_values(array_diff_key($currItems, $newItems)));
+            $update = array_merge($update, array_values(static::itemsToUpdate($currItems, $newItems)));
+        }
+
+        return compact('create', 'update', 'remove');
+    }
+
+    /**
      * Calculate items to update in a project model set.
      *
      * @param array $current Current items
@@ -306,9 +361,12 @@ class ProjectModel
     protected static function itemsToUpdate(array $current, array $new): array
     {
         return array_filter(array_map(
-            function ($k, array $v) use ($current) {
+            function ($k, $v) use ($current) {
                 if (empty($current[$k])) {
                     return null;
+                }
+                if (is_string($v)) {
+                    return $v !== $current[$k] ? $v : null;
                 }
                 if (empty(Hash::diff($v, (array)$current[$k]))) {
                     return null;

--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -361,12 +361,9 @@ class ProjectModel
     protected static function itemsToUpdate(array $current, array $new): array
     {
         return array_filter(array_map(
-            function ($k, $v) use ($current) {
+            function ($k, array $v) use ($current) {
                 if (empty($current[$k])) {
                     return null;
-                }
-                if (is_string($v)) {
-                    return $v !== $current[$k] ? $v : null;
                 }
                 if (empty(Hash::diff($v, (array)$current[$k]))) {
                     return null;

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -486,6 +486,7 @@ class ProjectModelTest extends TestCase
                 'label' => 'Disabled category',
             ],
         ],
+        'config' => [],
     ];
 
     /**
@@ -500,6 +501,7 @@ class ProjectModelTest extends TestCase
      * @covers ::relations()
      * @covers ::properties()
      * @covers ::categories()
+     * @covers ::configs()
      */
     public function testGenerate(): void
     {

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -657,4 +657,81 @@ class ProjectModelTest extends TestCase
         ProjectModel::categoriesToUpdate($update);
         static::assertEquals($expected, $update);
     }
+
+    /**
+     * Data provider for `testConfigDiff` test case.
+     *
+     * @return array
+     */
+    public function configDiffProvider(): array
+    {
+        return [
+            'empty' => [
+                [],
+                [],
+                ['create' => [], 'update' => [], 'remove' => []],
+            ],
+            'no changes' => [
+                [
+                    ['name' => 'Status', 'context' => 'core', 'content' => '{"level":"draft"}', 'application' => 'first-app'],
+                    ['name' => 'Status', 'context' => 'core', 'content' => '{"level":"on"}', 'application' => 'second-app'],
+                ],
+                [
+                    ['name' => 'Status', 'context' => 'core', 'content' => '{"level":"draft"}', 'application' => 'first-app'],
+                    ['name' => 'Status', 'context' => 'core', 'content' => '{"level":"on"}', 'application' => 'second-app'],
+                ],
+                ['create' => [], 'update' => [], 'remove' => []],
+            ],
+            'create, update, remove' => [
+                [
+                    ['name' => 'Status', 'context' => 'core', 'content' => '{"level":"draft"}', 'application' => 'first-app'],
+                    ['name' => 'Status', 'context' => 'core', 'content' => '{"level":"on"}', 'application' => 'second-app'],
+                    ['name' => 'Modules', 'context' => 'core', 'content' => '{"objects":{"color": "#230637"}}', 'application' => 'first-app'],
+                    ['name' => 'Properties', 'context' => 'core', 'content' => '{"audio":false}', 'application' => 'first-app'],
+                    ['name' => 'Debug', 'context' => 'core', 'content' => '{"level":"on"}', 'application' => 'third-app'],
+                ],
+                [
+                    ['name' => 'Status', 'context' => 'core', 'content' => '{"level":"draft"}', 'application' => 'first-app'],
+                    ['name' => 'Status', 'context' => 'core', 'content' => '{"level":"off"}', 'application' => 'second-app'],
+                    ['name' => 'Status', 'context' => 'core', 'content' => '{"level":"on"}', 'application' => 'third-app'],
+                    ['name' => 'Modules', 'context' => 'core', 'content' => '{"objects":{"color": "#230637"}}', 'application' => 'first-app'],
+                    ['name' => 'Properties', 'context' => 'core', 'content' => '{"audio":true}', 'application' => 'first-app'],
+                ],
+                [
+                    'create' => [
+                        ['name' => 'Status', 'context' => 'core', 'content' => '{"level":"on"}', 'application' => 'third-app'],
+                    ],
+                    'update' => [
+                        ['name' => 'Status', 'context' => 'core', 'content' => '{"level":"off"}', 'application' => 'second-app'],
+                        ['name' => 'Properties', 'context' => 'core', 'content' => '{"audio":true}', 'application' => 'first-app'],
+                    ],
+                    'remove' => [
+                        ['name' => 'Debug', 'context' => 'core', 'content' => '{"level":"on"}', 'application' => 'third-app'],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test `configDiff()` method
+     *
+     * @param array $old Old config
+     * @param array $current Current config
+     * @return void
+     * @dataProvider configDiffProvider()
+     * @covers ::configDiff()
+     * @covers ::itemsToUpdate()
+     */
+    public function testConfigDiff(array $old, array $current, array $expected): void
+    {
+        $projectModel = new class extends ProjectModel {
+            public static function configDiff(array $items, array $projectItems): array
+            {
+                return parent::configDiff($items, $projectItems);
+            }
+        };
+        $actual = $projectModel::configDiff($old, $current);
+        static::assertEquals($expected, $actual);
+    }
 }


### PR DESCRIPTION
This PR updates the `project_model` command utility to include `config` resources management.

Bonus: bump `codecov/codecov-action` from v4 to v5.