### PR TITLE
Fix uname when source field is an HTML content

### DIFF
--- a/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
@@ -127,7 +127,7 @@ class UniqueNameBehavior extends Behavior
         if (is_callable($generator)) {
             return $generator($entity, $regenerate);
         }
-        $fieldValue = strip_tags($entity->get($config['sourceField']));
+        $fieldValue = strip_tags((string)$entity->get($config['sourceField']));
         if ($entity->isDirty('uname') && !empty($entity->get('uname'))) {
             $fieldValue = $entity->get('uname');
         }

--- a/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
@@ -127,7 +127,7 @@ class UniqueNameBehavior extends Behavior
         if (is_callable($generator)) {
             return $generator($entity, $regenerate);
         }
-        $fieldValue = $entity->get($config['sourceField']);
+        $fieldValue = strip_tags($entity->get($config['sourceField']));
         if ($entity->isDirty('uname') && !empty($entity->get('uname'))) {
             $fieldValue = $entity->get('uname');
         }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
@@ -240,6 +240,10 @@ class UniqueNameBehaviorTest extends TestCase
                 null,
                 'my-title',
             ],
+            'unameStripTags' => [
+                'strip-tags',
+                '<b>strip-tags</b>',
+            ],
         ];
     }
 


### PR DESCRIPTION
This provides a fix for uname generation when source field is an HTML content.