### PR TITLE
Fix in FilesystemAdapter::getPublicUrl

### DIFF
--- a/plugins/BEdita/Core/src/Filesystem/FilesystemAdapter.php
+++ b/plugins/BEdita/Core/src/Filesystem/FilesystemAdapter.php
@@ -102,7 +102,7 @@ abstract class FilesystemAdapter
     {
         return sprintf(
             '%s/%s',
-            rtrim($this->getConfig('baseUrl'), '/'),
+            rtrim((string)$this->getConfig('baseUrl'), '/'),
             ltrim($path, '/')
         );
     }


### PR DESCRIPTION
This PR fixes an issue on missing config when using `FilesystemAdapter` by casting a conf to string, when calling an `rtrim`.