### PR TITLE
Fix clone translations

### DIFF
--- a/plugins/BEdita/Core/src/Model/Action/CloneObjectAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/CloneObjectAction.php
@@ -210,19 +210,8 @@ class CloneObjectAction extends BaseAction
 
             return $objectRelation;
         }, $objectRelations);
-        $clone = [];
-        foreach ($objectRelations as $objectRelation) {
-            $entity = $objectRelationsTable->newEmptyEntity();
-            $entity->set('left_id', $objectRelation->get('left_id'));
-            $entity->set('right_id', $objectRelation->get('right_id'));
-            $entity->set('relation_id', $objectRelation->get('relation_id'));
-            $entity->set('priority', $objectRelation->get('priority'));
-            $entity->set('inv_priority', $objectRelation->get('inv_priority'));
-            $entity->set('params', $objectRelation->get('params'));
-            $clone[] = $entity;
-        }
 
-        return $objectRelationsTable->saveManyOrFail($clone);
+        return $objectRelationsTable->saveManyOrFail($objectRelations);
     }
 
     /**
@@ -242,19 +231,11 @@ class CloneObjectAction extends BaseAction
         $objectTranslations = array_map(function ($objectTranslation) use ($destinationId) {
             $objectTranslation->set('object_id', $destinationId);
             $objectTranslation->setNew(true);
+            unset($objectTranslation->id);
 
             return $objectTranslation;
         }, $objectTranslations);
-        $clone = [];
-        foreach ($objectTranslations as $objectTranslation) {
-            $entity = $translationsTable->newEmptyEntity();
-            $entity->set('object_id', $objectTranslation->get('object_id'));
-            $entity->set('lang', $objectTranslation->get('lang'));
-            $entity->set('status', $objectTranslation->get('status'));
-            $entity->set('translated_fields', $objectTranslation->get('translated_fields'));
-            $clone[] = $entity;
-        }
 
-        return $translationsTable->saveManyOrFail($clone);
+        return $translationsTable->saveManyOrFail($objectTranslations);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Action/CloneObjectAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/CloneObjectAction.php
@@ -210,9 +210,8 @@ class CloneObjectAction extends BaseAction
 
             return $objectRelation;
         }, $objectRelations);
-        $objectRelationsTable->saveManyOrFail($objectRelations);
 
-        return $objectRelations;
+        return $objectRelationsTable->saveManyOrFail($objectRelationsTable->newEntities($objectRelations));
     }
 
     /**
@@ -235,8 +234,7 @@ class CloneObjectAction extends BaseAction
 
             return $objectTranslation;
         }, $objectTranslations);
-        $translationsTable->saveManyOrFail($objectTranslations);
 
-        return $objectTranslations;
+        return $translationsTable->saveManyOrFail($translationsTable->newEntities($objectTranslations));
     }
 }

--- a/plugins/BEdita/Core/src/Model/Action/CloneObjectAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/CloneObjectAction.php
@@ -210,8 +210,19 @@ class CloneObjectAction extends BaseAction
 
             return $objectRelation;
         }, $objectRelations);
+        $clone = [];
+        foreach ($objectRelations as $objectRelation) {
+            $entity = $objectRelationsTable->newEmptyEntity();
+            $entity->set('left_id', $objectRelation->get('left_id'));
+            $entity->set('right_id', $objectRelation->get('right_id'));
+            $entity->set('relation_id', $objectRelation->get('relation_id'));
+            $entity->set('priority', $objectRelation->get('priority'));
+            $entity->set('inv_priority', $objectRelation->get('inv_priority'));
+            $entity->set('params', $objectRelation->get('params'));
+            $clone[] = $entity;
+        }
 
-        return $objectRelationsTable->saveManyOrFail($objectRelationsTable->newEntities($objectRelations));
+        return $objectRelationsTable->saveManyOrFail($clone);
     }
 
     /**
@@ -234,7 +245,16 @@ class CloneObjectAction extends BaseAction
 
             return $objectTranslation;
         }, $objectTranslations);
+        $clone = [];
+        foreach ($objectTranslations as $objectTranslation) {
+            $entity = $translationsTable->newEmptyEntity();
+            $entity->set('object_id', $objectTranslation->get('object_id'));
+            $entity->set('lang', $objectTranslation->get('lang'));
+            $entity->set('status', $objectTranslation->get('status'));
+            $entity->set('translated_fields', $objectTranslation->get('translated_fields'));
+            $clone[] = $entity;
+        }
 
-        return $translationsTable->saveManyOrFail($translationsTable->newEntities($objectTranslations));
+        return $translationsTable->saveManyOrFail($clone);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/CloneObjectActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/CloneObjectActionTest.php
@@ -127,6 +127,38 @@ class CloneObjectActionTest extends IntegrationTestCase
                 }
             }
         }
+        // verify source object is not modified
+        $actual = $table->get($id, ['contain' => ['Test', 'TestSimple', 'TestDefaults', 'Translations']]);
+        $this->assertEquals($original->title, $actual->title);
+        $this->assertEquals($original->status, $actual->status);
+        // relation test
+        $expectedTest = $original->get('test');
+        $actualRelatedTest = $actual->get('test');
+        foreach ($expectedTest as $key => $item) {
+            $this->assertEquals($item->uname, $actualRelatedTest[$key]->uname);
+        }
+        // relation test_simple
+        $expectedTestSimple = $original->get('test_simple');
+        $actualRelatedTestSimple = $actual->get('test_simple');
+        foreach ($expectedTestSimple as $key => $item) {
+            $this->assertEquals($item->uname, $actualRelatedTestSimple[$key]->uname);
+        }
+        // relation test_defaults
+        $expectedTestDefaults = $original->get('test_defaults');
+        $actualRelatedTestDefaults = $actual->get('test_defaults');
+        foreach ($expectedTestDefaults as $key => $item) {
+            $this->assertEquals($item->uname, $actualRelatedTestDefaults[$key]->uname);
+        }
+        // translations
+        $actualTranslations = $actual->get('translations');
+        $this->assertCount(4, $actualTranslations);
+        foreach ($actualTranslations as $translation) {
+            foreach ($original->get('translations') as $expectedTranslation) {
+                if ($expectedTranslation->lang === $translation->lang) {
+                    $this->assertEquals($expectedTranslation->translated_fields, $translation->translated_fields);
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This fixes a buggy behavior in cloning an object with translations.

Buggy behavior: cloned object has translations, but source object looses them.

Expected behavior: both clone and source objects have translations.