### PR TITLE
fix: use field collation joining history and objects table

### DIFF
--- a/plugins/BEdita/Core/src/Command/ObjectsHistoryCommand.php
+++ b/plugins/BEdita/Core/src/Command/ObjectsHistoryCommand.php
@@ -19,6 +19,7 @@ use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
+use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\I18n\FrozenDate;
 use Cake\ORM\Locator\LocatorAwareTrait;
@@ -139,13 +140,17 @@ class ObjectsHistoryCommand extends Command
     {
         $objectsTable = $this->fetchTable('Objects');
         $objectTypesTable = $this->fetchTable('ObjectTypes');
+        /** @var \Cake\ORM\Table $historyTable */
         $historyTable = $objectsTable->getBehavior('History')->Table;
         $historyTable->belongsTo('Objects', [
             'foreignKey' => false,
             'joinType' => 'INNER',
             'conditions' => function (QueryExpression $exp, Query $q) use ($historyTable, $objectsTable) {
                 return $exp->eq(
-                    $historyTable->aliasField('resource_id'),
+                    new IdentifierExpression(
+                        $historyTable->aliasField('resource_id'),
+                        Hash::get($historyTable->getSchema()->getColumn('resource_id'), 'collate')
+                    ),
                     $q->func()->cast($objectsTable->aliasField('id'), 'char')
                 );
             },


### PR DESCRIPTION
This PR fixes an issue in `ObjectsHistoryCommand` when the join between `history` and `objects` table was built and the encoding of database is `utf8mb4`.

In this case we need to specify the collation used to compare `history.resource_id` and `objects.id` cast to `CHAR` else an SQL error was thrown

```
PDOException: SQLSTATE[HY000]: General error: 1267 Illegal mix of collations (utf8mb4_0900_ai_ci,IMPLICIT) and (utf8mb4_general_ci,IMPLICIT) for operation '='
```

