### PR TITLE
Fix regenerate unique name when is numeric

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/UniqueNameTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/UniqueNameTest.php
@@ -159,6 +159,34 @@ class UniqueNameTest extends IntegrationTestCase
     }
 
     /**
+     * Test invalid numeric unique name.
+     *
+     * @return void
+     * @coversNothing
+     */
+    public function testPostNumericTitle(): void
+    {
+        $authHeader = $this->getUserAuthHeader();
+        $this->configRequestHeaders('POST', $authHeader);
+
+        $data = [
+            'type' => 'documents',
+            'attributes' => [
+                'title' => '123',
+            ],
+        ];
+        $this->post('/documents', json_encode(compact('data')));
+
+        $this->assertResponseCode(201);
+        $this->assertContentType('application/vnd.api+json');
+        $this->assertResponseNotEmpty();
+        $body = json_decode((string)$this->_response->getBody(), true);
+        static::assertIsArray($body);
+        static::assertArrayHasKey('data', $body);
+        static::assertIsNotNumeric(Hash::get($body, 'data.attributes.uname'));
+    }
+
+    /**
      * Test invalid numeric unique name updating an object.
      *
      * @return void

--- a/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/UniqueNameBehavior.php
@@ -135,6 +135,9 @@ class UniqueNameBehavior extends Behavior
             $fieldValue = (string)$entity->get('type');
             $regenerate = true;
         }
+        if (is_numeric($fieldValue)) {
+            $regenerate = true;
+        }
 
         return $this->uniqueNameFromValue($fieldValue, $regenerate);
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
@@ -225,6 +225,22 @@ class UniqueNameBehaviorTest extends TestCase
     }
 
     /**
+     * Test generate unique name when title is numeric.
+     *
+     * @return array
+     * @covers ::generateUniqueName()
+     */
+    public function testGenerateUniqueNameFromNumericTitle(): void
+    {
+        $Profiles = $this->fetchTable('Profiles');
+        $profile = $Profiles->newEmptyEntity();
+        $Profiles->patchEntity($profile, ['title' => '12345']);
+        $config = ['sourceField' => 'title'];
+        $generatedUname = $Profiles->behaviors()->get('UniqueName')->generateUniqueName($profile, false, $config);
+        static::assertIsNotNumeric($generatedUname);
+    }
+
+    /**
      * Data provider for `testRegenerate` test case.
      *
      * @return array


### PR DESCRIPTION
This PR fixes a buggy behavior: when patching an object and source field is numeric string, uname with the same value is created; uname should never be a numeric string, to avoid confusion with field `id` (@see https://github.com/bedita/bedita/pull/2103).

With this, uname is forced to be non-numeric.