### PR TITLE
Fix clone entity preserve original `HasMany` associations (i.e. date_ranges)

### DIFF
--- a/plugins/BEdita/Core/src/Model/Action/CloneObjectAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/CloneObjectAction.php
@@ -22,9 +22,9 @@ use BEdita\Core\Utility\SchemaTools;
 use BEdita\Core\Utility\Text;
 use Cake\Datasource\EntityInterface;
 use Cake\Http\Exception\UnauthorizedException;
+use Cake\ORM\Association\HasMany;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\Utility\Hash;
-use Cake\Utility\Inflector;
 
 /**
  * Clone object action
@@ -132,13 +132,18 @@ class CloneObjectAction extends BaseAction
             return $attributes[$field];
         }
         $value = $sourceEntity->get($field);
-        if ($sourceEntity->getTable()->hasAssociation(Inflector::camelize($field))) {
-            $value = array_map(function ($data) {
-                $entityClass = get_class($data);
+        $association = $sourceEntity->getTable()->associations()->getByProperty($field);
+        if ($association instanceof HasMany) {
+            $targetTable = $association->getTarget();
+            $foreignKey = $association->getForeignKey();
+            $foreignKeys = is_array($foreignKey) ? $foreignKey : [$foreignKey];
+            $value = array_map(function ($data) use ($targetTable, $foreignKeys) {
                 unset($data['id']);
-                unset($data['object_id']);
+                foreach ($foreignKeys as $foreignKey) {
+                    unset($data[$foreignKey]);
+                }
 
-                return new $entityClass($data->toArray());
+                return $targetTable->newEntity($data->toArray());
             }, $value);
             $entity->set($field, $value);
 

--- a/plugins/BEdita/Core/src/Model/Action/CloneObjectAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/CloneObjectAction.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace BEdita\Core\Model\Action;
 
+use BEdita\Core\Model\Entity\DateRange;
 use BEdita\Core\Model\Entity\ObjectEntity;
 use BEdita\Core\Model\Entity\Stream;
 use BEdita\Core\Utility\LoggedUser;
@@ -131,6 +132,18 @@ class CloneObjectAction extends BaseAction
             return $attributes[$field];
         }
         $value = $sourceEntity->get($field);
+        if ($field === 'date_ranges') {
+            $value = array_map(function ($dateRange) {
+                return new DateRange([
+                    'start_date' => $dateRange['start_date'],
+                    'end_date' => $dateRange['end_date'],
+                    'params' => $dateRange['params'],
+                ]);
+            }, $value);
+            $entity->set($field, $value);
+
+            return $value;
+        }
         if (!in_array($field, (array)Hash::get($schemaInfo, 'unique'))) {
             $entity->set($field, $value);
 

--- a/plugins/BEdita/Core/src/Model/Action/CloneObjectAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/CloneObjectAction.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 
 namespace BEdita\Core\Model\Action;
 
-use BEdita\Core\Model\Entity\DateRange;
 use BEdita\Core\Model\Entity\ObjectEntity;
 use BEdita\Core\Model\Entity\Stream;
 use BEdita\Core\Utility\LoggedUser;
@@ -25,6 +24,7 @@ use Cake\Datasource\EntityInterface;
 use Cake\Http\Exception\UnauthorizedException;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\Utility\Hash;
+use Cake\Utility\Inflector;
 
 /**
  * Clone object action
@@ -132,13 +132,13 @@ class CloneObjectAction extends BaseAction
             return $attributes[$field];
         }
         $value = $sourceEntity->get($field);
-        if ($field === 'date_ranges') {
-            $value = array_map(function ($dateRange) {
-                return new DateRange([
-                    'start_date' => $dateRange['start_date'],
-                    'end_date' => $dateRange['end_date'],
-                    'params' => $dateRange['params'],
-                ]);
+        if ($sourceEntity->getTable()->hasAssociation(Inflector::camelize($field))) {
+            $value = array_map(function ($data) {
+                $entityClass = get_class($data);
+                unset($data['id']);
+                unset($data['object_id']);
+
+                return new $entityClass($data->toArray());
             }, $value);
             $entity->set($field, $value);
 

--- a/plugins/BEdita/Core/src/Model/Action/CloneObjectAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/CloneObjectAction.php
@@ -100,6 +100,9 @@ class CloneObjectAction extends BaseAction
         /** @var \BEdita\Core\Model\Entity\ObjectEntity $entity */
         $entity = $this->Table->newEmptyEntity();
         $entityAttributes = $sourceEntity->getVisible();
+        $entityAttributes = array_filter($entityAttributes, function ($field) {
+            return $field !== 'streams';
+        });
         foreach ($entityAttributes as $field) {
             $this->setEntityField($schemaInfo, $sourceEntity, $entity, $field);
         }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/CloneObjectActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/CloneObjectActionTest.php
@@ -462,5 +462,11 @@ class CloneObjectActionTest extends IntegrationTestCase
         $this->assertEquals($expected->start_date, $actual->start_date);
         $this->assertEquals($expected->end_date, $actual->end_date);
         $this->assertEquals($expected->params, $actual->params);
+        // verify that original is unchanged
+        $original = $table->get($id, ['contain' => ['DateRanges']]);
+        $originalDateRanges = $original->get('date_ranges');
+        $this->assertCount(1, $originalDateRanges);
+        $this->assertEquals($expected->start_date, $originalDateRanges[0]->start_date);
+        $this->assertEquals($expected->end_date, $originalDateRanges[0]->end_date);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/CloneObjectActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/CloneObjectActionTest.php
@@ -440,6 +440,7 @@ class CloneObjectActionTest extends IntegrationTestCase
      * @covers ::initialize()
      * @covers ::execute()
      * @covers ::cloneEntity()
+     * @covers ::setEntityField()
      */
     public function testCloneObjectWithDateRanges(): void
     {


### PR DESCRIPTION
This PR fixes a problem in cloning an object with association(s).

The problem: the clone object is fine, but the source object association(s) data is empty.