### PR TITLE
Fix ObjectsDeleteCommand

### DIFF
--- a/plugins/BEdita/Core/src/Command/ObjectsDeleteCommand.php
+++ b/plugins/BEdita/Core/src/Command/ObjectsDeleteCommand.php
@@ -88,7 +88,9 @@ class ObjectsDeleteCommand extends Command
     {
         try {
             $io->verbose(sprintf('Deleting object %s', $object->id));
-            $object->getTable()->deleteOrFail($object);
+            $table = $object->getTable();
+            $object = $table->get($object->id);
+            $table->deleteOrFail($object);
             $deleted++;
         } catch (\Throwable $e) {
             $io->error(sprintf('Error deleting object %s: %s', $object->id, $e->getMessage()));

--- a/plugins/BEdita/Core/tests/TestCase/Command/ObjectsDeleteCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ObjectsDeleteCommandTest.php
@@ -138,4 +138,28 @@ class ObjectsDeleteCommandTest extends TestCase
         $this->assertOutputContains('Done');
         $this->assertExitSuccess();
     }
+
+    /**
+     * Test `execute` method
+     *
+     * @return void
+     * @covers ::execute()
+     * @covers ::objectsIterator()
+     * @covers ::deleteObject()
+     */
+    public function testDeleteMedia(): void
+    {
+        $table = $this->fetchTable('Files');
+        $entity = $table->newEntity([
+            'title' => 'New file in trash',
+            'media_property' => false,
+        ]);
+        $entity->created_by = 1;
+        $entity->modified_by = 1;
+        $entity->deleted = true;
+        $entity = $table->saveOrFail($entity);
+        $this->exec('objects_delete --type files --since tomorrow');
+        $this->assertOutputContains('Deleted from trash 1 objects [0 errors]');
+        $this->assertExitSuccess();
+    }
 }


### PR DESCRIPTION
The command `ObjectsDeleteCommand` uses the table `Objects` to load all the objects to be deleted ([here](https://github.com/bedita/bedita/blob/v5.36.7/plugins/BEdita/Core/src/Command/ObjectsDeleteCommand.php#L108)), which loads them as a `ObjectEntity` and causes the following error when deleting an object of type `file`:
```
BEdita\Core\Model\Table\MediaTable::beforeDelete(): Argument #2 ($entity) must be of type BEdita\Core\Model\Entity\Media, BEdita\Core\Model\Entity\ObjectEntity given, called in /app/vendor/cakephp/cakephp/src/Event/EventManager.php on line 309
```

This is because the method `MediaTable::beforeDelete()` requires a `Media` entity as second parameter (see [here](https://github.com/bedita/bedita/blob/v5.36.7/plugins/BEdita/Core/src/Model/Table/MediaTable.php#L96)).

The fix is to reload every object using its own table, before deleting it.