### PR TITLE
Reset created, modified, created_by and modified_by on clone

### DIFF
--- a/plugins/BEdita/Core/src/Model/Action/CloneObjectAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/CloneObjectAction.php
@@ -93,7 +93,10 @@ class CloneObjectAction extends BaseAction
     public function cloneEntity(ObjectEntity $sourceEntity, array $attributes): EntityInterface
     {
         $schema = $this->Table->getSchema();
-        $reset = SchemaTools::getPrimaryFields($schema, ['count' => 1]) + ['created', 'modified'];
+        $reset = array_merge(
+            SchemaTools::getPrimaryFields($schema, ['count' => 1]),
+            ['created', 'modified', 'created_by', 'modified_by']
+        );
         $unique = SchemaTools::getUniqueFields($schema, ['count' => 1]);
         $nullable = SchemaTools::getNullableFields($schema);
         $schemaInfo = compact('reset', 'unique', 'nullable', 'attributes');

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/CloneObjectActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/CloneObjectActionTest.php
@@ -83,7 +83,7 @@ class CloneObjectActionTest extends IntegrationTestCase
      */
     public function testClone(): void
     {
-        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader('second user', 'password2'));
         // document with ID 2 from fixtures has 5 relationships records and 4 translations records
         $id = 2;
         $title = 'new title for my clone';
@@ -100,6 +100,11 @@ class CloneObjectActionTest extends IntegrationTestCase
         $this->assertEquals($clone->title, $actual->title);
         $this->assertEquals($clone->status, $actual->status);
         $this->assertEquals('new-title-for-my-clone', $clone->uname);
+        // verify created, modified, created_by, modified_by are reset
+        $this->assertNotSame($clone->created, $original->created);
+        $this->assertNotSame($clone->modified, $original->modified);
+        $this->assertNotSame($clone->created_by, $original->created_by);
+        $this->assertNotSame($clone->modified_by, $original->modified_by);
         // relation test
         $relatedTest = $clone->get('test');
         $originalRelatedTest = $original->get('test');


### PR DESCRIPTION
This PR provides a fix on cloning object: reset fields `created`, `modified`, `created_by` and `modified_by`.