### PR TITLE
Cast to array or string nullable `auth_providers` fields

### DIFF
--- a/plugins/BEdita/API/src/App/BaseApplication.php
+++ b/plugins/BEdita/API/src/App/BaseApplication.php
@@ -356,21 +356,21 @@ abstract class BaseApplication extends CakeBaseApplication implements Authentica
             ->each(function (AuthProvider $authProvider) use ($service, $name): void {
                 if ($authProvider->name === $name) {
                     $authenticator = $service->loadAuthenticator(
-                        $authProvider->auth_class,
+                        (string)$authProvider->auth_class,
                         compact('authProvider'),
                     );
                     if ($authenticator instanceof AbstractAuthenticator) {
                         $authenticator->setConfig(
-                            Hash::get($authProvider->params, 'config.authenticator', [])
+                            Hash::get((array)$authProvider->params, 'config.authenticator', [])
                         );
                     }
                     $identifier = $service->loadIdentifier(
-                        $authProvider->auth_class,
+                        (string)$authProvider->auth_class,
                         compact('authProvider'),
                     );
                     if ($identifier instanceof AbstractIdentifier) {
                         $identifier->setConfig(
-                            Hash::get($authProvider->params, 'config.identifier', [])
+                            Hash::get((array)$authProvider->params, 'config.identifier', [])
                         );
                     }
                 }


### PR DESCRIPTION
This PR fixes a bug when loading `auth_providers` in `BaseApplication::loadAuthProviders()` 
If `auth_providers.params` column is NULL we have a systematic error invoking `Hash::get` 

```
[InvalidArgumentException] Invalid data type, must be an array or \ArrayAccess instance. in src/Utility/Hash.php on line 52
```

