### PR TITLE
Dispatch event `AsyncJob.beforeRun` on `AsyncJob::run`

### DIFF
--- a/plugins/BEdita/Core/src/Model/Entity/AsyncJob.php
+++ b/plugins/BEdita/Core/src/Model/Entity/AsyncJob.php
@@ -104,7 +104,8 @@ class AsyncJob extends Entity implements JsonApiSerializable, EventDispatcherInt
         }
 
         $service = ServiceRegistry::get($this->service);
-        $this->dispatchEvent('AsyncJob.beforeRun', compact('options'), $service);
+        $entity = $this;
+        $this->dispatchEvent('AsyncJob.beforeRun', compact('entity', 'options'), $service);
 
         return $service->run($this->payload, $options);
     }

--- a/plugins/BEdita/Core/src/Model/Entity/AsyncJob.php
+++ b/plugins/BEdita/Core/src/Model/Entity/AsyncJob.php
@@ -16,6 +16,8 @@ namespace BEdita\Core\Model\Entity;
 
 use BEdita\Core\Job\ServiceRegistry;
 use BEdita\Core\Utility\JsonApiSerializable;
+use Cake\Event\EventDispatcherInterface;
+use Cake\Event\EventDispatcherTrait;
 use Cake\I18n\FrozenTime;
 use Cake\ORM\Entity;
 
@@ -37,9 +39,10 @@ use Cake\ORM\Entity;
  * @property array $results
  * @since 4.0.0
  */
-class AsyncJob extends Entity implements JsonApiSerializable
+class AsyncJob extends Entity implements JsonApiSerializable, EventDispatcherInterface
 {
     use JsonApiAdminTrait;
+    use EventDispatcherTrait;
 
     /**
      * @inheritDoc
@@ -101,6 +104,7 @@ class AsyncJob extends Entity implements JsonApiSerializable
         }
 
         $service = ServiceRegistry::get($this->service);
+        $this->dispatchEvent('AsyncJob.beforeRun', compact('options'), $service);
 
         return $service->run($this->payload, $options);
     }

--- a/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckFilesystemTaskTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Shell/Task/CheckFilesystemTaskTest.php
@@ -78,8 +78,12 @@ class CheckFilesystemTaskTest extends TestCase
     public function testExecuteAutodetectOk()
     {
         $user = exec('ps aux | grep -E "[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx" | grep -v root | head -1 | cut -d\\  -f1');
-        if (!$user) {
+        if (!$user || posix_getpwnam($user) === false) {
             static::markTestSkipped('No webserver running');
+        }
+        $u = posix_getpwnam($user);
+        if (empty($u['gid'])) {
+            static::markTestSkipped('No user gid');
         }
 
         mkdir(static::TEMP_DIR);


### PR DESCRIPTION
With this, on `AsyncJob::run`, an event `AsyncJob.beforeRun` is dispatched.

When necessary, main app can listen for the event and do some logic before running it (for instance, injecting container logic).