### PR TITLE
Improve queue system setting delay and expires

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/AsyncJobsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/AsyncJobsControllerTest.php
@@ -242,7 +242,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                         ],
                         'scheduled_from' => null,
                         'expires' => null,
-                        'max_attempts' => 1,
+                        'max_attempts' => 2,
                         'results' => null,
                     ],
                     'meta' => [

--- a/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
@@ -239,7 +239,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                         ],
                         'scheduled_from' => null,
                         'expires' => null,
-                        'max_attempts' => 1,
+                        'max_attempts' => 2,
                         'results' => null,
                     ],
                     'meta' => [

--- a/plugins/BEdita/Core/src/Job/QueueJob.php
+++ b/plugins/BEdita/Core/src/Job/QueueJob.php
@@ -42,6 +42,7 @@ class QueueJob implements JobInterface
         $this->AsyncJobs = $this->fetchTable('AsyncJobs');
         $uuid = $message->getArgument('uuid');
         $this->log(sprintf('Processing job "%s"', $uuid), 'debug');
+        $success = false;
         try {
             $success = $this->run($uuid);
         } catch (RecordNotFoundException $e) {

--- a/plugins/BEdita/Core/src/Job/QueueJob.php
+++ b/plugins/BEdita/Core/src/Job/QueueJob.php
@@ -42,9 +42,27 @@ class QueueJob implements JobInterface
         $this->AsyncJobs = $this->fetchTable('AsyncJobs');
         $uuid = $message->getArgument('uuid');
         $this->log(sprintf('Processing job "%s"', $uuid), 'debug');
-        $success = $this->run($uuid);
+        try {
+            $success = $this->run($uuid);
+        } catch (RecordNotFoundException $e) {
+            $this->log(sprintf('Could not obtain lock on job "%s"', $uuid), 'warning');
 
-        return $success ? Processor::ACK : Processor::REJECT;
+            return Processor::REJECT;
+        }
+
+        if ($success) {
+            return Processor::ACK;
+        }
+
+        try {
+            $asyncJob = $this->AsyncJobs->get($uuid);
+        } catch (RecordNotFoundException $e) {
+            $this->log(sprintf('Job "%s" not found', $uuid), 'warning');
+
+            return Processor::REJECT;
+        }
+
+        return $asyncJob->max_attempts > 0 ? Processor::REQUEUE : Processor::REJECT;
     }
 
     /**
@@ -55,14 +73,7 @@ class QueueJob implements JobInterface
      */
     protected function run($uuid): bool
     {
-        try {
-            $asyncJob = $this->AsyncJobs->lock($uuid);
-        } catch (RecordNotFoundException $e) {
-            $this->log(sprintf('Could not obtain lock on job "%s"', $uuid), 'warning');
-
-            return false;
-        }
-
+        $asyncJob = $this->AsyncJobs->lock($uuid);
         $success = false;
         $messages = [];
         try {

--- a/plugins/BEdita/Core/src/Model/Table/AsyncJobsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/AsyncJobsTable.php
@@ -146,11 +146,19 @@ class AsyncJobsTable extends Table
         }
 
         $delay = (int)Configure::read('Queue.default.pushDelay', 1);
+        if ($entity->scheduled_from && $entity->scheduled_from->isFuture()) {
+            $delay = $entity->scheduled_from->diffInSeconds();
+        }
+
+        $expires = null;
+        if ($entity->expires && $entity->expires->isFuture()) {
+            $expires = $entity->expires->diffInSeconds();
+        }
 
         QueueManager::push(
             QueueJob::class,
             ['uuid' => $entity->uuid],
-            compact('delay'),
+            compact('delay', 'expires'),
         );
     }
 

--- a/plugins/BEdita/Core/tests/Fixture/AsyncJobsFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/AsyncJobsFixture.php
@@ -55,7 +55,7 @@ class AsyncJobsFixture extends TestFixture
             ],
             'scheduled_from' => null,
             'expires' => null,
-            'max_attempts' => 1,
+            'max_attempts' => 2,
             'locked_until' => null,
             'created' => '2017-04-28 19:29:31',
             'modified' => '2017-04-28 19:29:31',

--- a/plugins/BEdita/Core/tests/TestCase/Job/QueueJobTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/QueueJobTest.php
@@ -121,6 +121,11 @@ class QueueJobTest extends TestCase
                 Processor::REJECT,
                 new RuntimeException('Big big error'),
             ],
+            'requeue' => [
+                Processor::REQUEUE,
+                false,
+                'e533e1cf-b12c-4dbe-8fb7-b25fafbd2f76',
+            ],
         ];
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Job/QueueJobTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/QueueJobTest.php
@@ -17,6 +17,10 @@ namespace BEdita\Core\Test\TestCase\Job;
 use BEdita\Core\Job\JobService;
 use BEdita\Core\Job\QueueJob;
 use BEdita\Core\Job\ServiceRegistry;
+use BEdita\Core\Model\Table\AsyncJobsTable;
+use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\Event\EventInterface;
+use Cake\Event\EventManager;
 use Cake\Queue\Job\Message;
 use Cake\TestSuite\TestCase;
 use Enqueue\Null\NullConnectionFactory;
@@ -149,5 +153,37 @@ class QueueJobTest extends TestCase
         $result = $job->execute($message);
 
         static::assertSame($expected, $result);
+    }
+
+    /**
+     * Test the case when the service fails and then the job is missing.
+     *
+     * @return void
+     * @covers ::execute()
+     */
+    public function testServiceFailsThenMissingAsyncJob(): void
+    {
+        ServiceRegistry::set('example', $this->getMockService(false));
+        $message = $this->createMessage(['data' => ['uuid' => self::TEST_UUID]]);
+
+        $count = 0;
+        $callback = function (EventInterface $event) use (&$count) {
+            if (!$event->getSubject() instanceof AsyncJobsTable) {
+                return;
+            }
+
+            // first time is `lock` then `unlock` and finally `get` in `QueueJob::execute`
+            if ($count >= 2) {
+                throw new RecordNotFoundException();
+            }
+            $count++;
+        };
+        EventManager::instance()->on('Model.beforeFind', $callback);
+
+        $job = new QueueJob();
+        $result = $job->execute($message);
+        static::assertEquals(Processor::REJECT, $result);
+
+        EventManager::instance()->off('Model.beforeFind', $callback);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/AsyncJobsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/AsyncJobsTableTest.php
@@ -17,6 +17,7 @@ namespace BEdita\Core\Test\TestCase\Model\Table;
 use BEdita\Core\Model\Entity\AsyncJob;
 use BEdita\Core\Model\Table\AsyncJobsTable;
 use Cake\Datasource\ConnectionManager;
+use Cake\I18n\FrozenTime;
 use Cake\ORM\TableRegistry;
 use Cake\Queue\QueueManager;
 use Cake\TestSuite\TestCase;
@@ -414,10 +415,20 @@ class AsyncJobsTableTest extends TestCase
             'queue' => 'test',
         ]);
 
-        $entity = $this->AsyncJobs->newEntity(['service' => 'example']);
+        $now = FrozenTime::now();
+        $scheduledFrom = $now->addHours(1);
+        $expires = $now->addHours(2);
+        $entity = $this->AsyncJobs->newEntity([
+            'service' => 'example',
+            'scheduled_from' => $scheduledFrom,
+            'expires' => $expires,
+        ]);
         $entity = $this->AsyncJobs->saveOrFail($entity);
         $this->assertFileExists($fsQueueFile);
-        $this->assertStringContainsString($entity->get('uuid'), file_get_contents($fsQueueFile));
+        $content = file_get_contents($fsQueueFile);
+        $this->assertStringContainsString($entity->get('uuid'), $content);
+        $this->assertStringContainsString(sprintf('"enqueue.delay":%s', $scheduledFrom->diffInSeconds()), $content);
+        $this->assertStringContainsString(sprintf('"enqueue.expire":%s', $expires->diffInSeconds()), $content);
         QueueManager::drop('default');
     }
 


### PR DESCRIPTION
This PR fixes wrong behaviors handling queue.

## Scheduled Job

When Queue system is enabled every time a new `AsyncJob` is created a `\BEdita\Core\Job\QueueJob` is pushed in a queue. Then a worker (`bin/cake queue worker`) takes care of handling the queue processing the jobs received.

At the moment we cannot to prepare a scheduled job because the `QueueJob` is immediately launched and it will fail because of the `scheduled_from` date saved in `async_jobs` table. We can only set a fixed delay for every job.

This PR solves that issue using `\BEdita\Core\Model\Entity\AsyncJob::$scheduled_from` and `\BEdita\Core\Model\Entity\AsyncJob::expires` to configure the `QueueJob` to be sent after some `delay` and not after the `expires`.

## Requeue failed job

Moreover when a `AsyncJob` fails the job is removed from the queue also if the `AsyncJob` would have some attempts to try yet. 

This PR introduces support for requeuing a failed job that fails and has `max_attempts > 0`.