### PR TITLE
Tree slugs and new tree_paths endpoint

### DIFF
--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -244,6 +244,12 @@ return function (RouteBuilder $routes) {
             ['controller' => 'Trees', 'action' => 'index', '_method' => 'GET'],
             ['_name' => 'trees:index']
         );
+        // Tree paths.
+        $routes->connect(
+            '/tree_paths/**',
+            ['controller' => 'TreePaths', 'action' => 'index', '_method' => 'GET'],
+            ['_name' => 'tree_paths:index']
+        );
 
         // Upload file and create object.
         $routes->connect(

--- a/plugins/BEdita/API/src/Controller/TreePathsController.php
+++ b/plugins/BEdita/API/src/Controller/TreePathsController.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2025 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Controller;
+
+use Cake\Http\Exception\NotFoundException;
+
+/**
+ * Controller for `/tree_paths` endpoint.
+ *
+ * @since 5.36.12
+ */
+class TreePathsController extends TreesController
+{
+    /**
+     * Path information with ID, object type and slug of each object
+     * Associative array having keys:
+     *  - 'ids': ID path list
+     *  - 'slugs': slug path list
+     *  - 'types': object types id list
+     *
+     * @var array
+     */
+    protected $pathInfo = [
+        'ids' => [],
+        'slugs' => [],
+        'types' => [],
+    ];
+
+    /**
+     * Display object on a given path
+     *
+     * @param string $path Trees path
+     * @return \Cake\Http\Response|null
+     */
+    public function index(string $path)
+    {
+        $this->request->allowMethod(['get']);
+
+        // populate idList, unameList
+        $this->pathDetails($path);
+
+        $this->loadTreesNode();
+        $parents = $this->parents();
+
+        $ids = array_values((array)$this->pathInfo['ids']);
+        $entity = $this->loadObject(end($ids));
+
+        $this->checkPath($entity, $parents);
+
+        $entity->set('slug_path', sprintf('/%s', implode('/', $this->pathInfo['slugs'])));
+        $entity->setAccess('slug_path', false);
+        $entity->set('menu', (bool)$this->treesNode->get('menu'));
+
+        $this->set('_fields', $this->request->getQuery('fields', []));
+        $this->set(compact('entity'));
+        $this->setSerialize(['entity']);
+
+        return null;
+    }
+
+    /**
+     * Populate $pathInfo with path details on ID, uname and type:
+     *
+     * @param string $path Requested object path
+     * @return void
+     */
+    protected function pathDetails(string $path): void
+    {
+        $pathList = explode('/', $path);
+        foreach ($pathList as $p) {
+            if (is_numeric($p)) {
+                $item = $this->objectDetails(['id' => (int)$p]);
+            } else {
+                $item = $this->objectDetails([$this->Objects->getAssociation('TreeNodes')->aliasField('slug') => (string)$p]);
+            }
+            if (empty($item)) {
+                throw new NotFoundException(__d('bedita', 'Invalid path'));
+            }
+            $this->pathInfo['ids'][] = $item['id'];
+            $this->pathInfo['slugs'][] = $item['slug'];
+            $this->pathInfo['types'][] = $item['object_type_id'];
+        }
+    }
+
+    /**
+     * Get object main fields
+     *
+     * @param array $condition Query conditions
+     * @return string
+     */
+    protected function objectDetails(array $condition): array
+    {
+        return (array)$this->Objects->find('available')
+            ->where($condition)
+            ->select(['id', 'slug' => $this->Objects->getAssociation('TreeNodes')->aliasField('slug'), 'object_type_id'])
+            ->innerJoinWith('TreeNodes')
+            ->disableHydration()
+            ->first();
+    }
+}

--- a/plugins/BEdita/API/src/Controller/TreePathsController.php
+++ b/plugins/BEdita/API/src/Controller/TreePathsController.php
@@ -79,18 +79,20 @@ class TreePathsController extends TreesController
     protected function pathDetails(string $path): void
     {
         $pathList = explode('/', $path);
+        $parent = null;
         foreach ($pathList as $p) {
-            if (is_numeric($p)) {
-                $item = $this->objectDetails(['id' => (int)$p]);
-            } else {
-                $item = $this->objectDetails([$this->Objects->getAssociation('TreeNodes')->aliasField('slug') => (string)$p]);
+            $conditions = [$this->Objects->getAssociation('TreeNodes')->aliasField('slug') => (string)$p];
+            if ($parent !== null) {
+                $conditions['parent_id'] = $parent;
             }
+            $item = $this->objectDetails($conditions);
             if (empty($item)) {
                 throw new NotFoundException(__d('bedita', 'Invalid path'));
             }
             $this->pathInfo['ids'][] = $item['id'];
             $this->pathInfo['slugs'][] = $item['slug'];
             $this->pathInfo['types'][] = $item['object_type_id'];
+            $parent = $item['id'];
         }
     }
 

--- a/plugins/BEdita/API/src/Controller/TreePathsController.php
+++ b/plugins/BEdita/API/src/Controller/TreePathsController.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
  */
 namespace BEdita\API\Controller;
 
-use Cake\Http\Exception\NotFoundException;
-
 /**
  * Controller for `/tree_paths` endpoint.
  *
@@ -49,7 +47,7 @@ class TreePathsController extends TreesController
         $this->request->allowMethod(['get']);
 
         // populate idList, unameList
-        $this->pathDetails($path);
+        $this->pathInfo = $this->Objects->TreeNodes->getPathInfo($path);
 
         $this->loadTreesNode();
         $parents = $this->parents();
@@ -68,47 +66,5 @@ class TreePathsController extends TreesController
         $this->setSerialize(['entity']);
 
         return null;
-    }
-
-    /**
-     * Populate $pathInfo with path details on ID, uname and type:
-     *
-     * @param string $path Requested object path
-     * @return void
-     */
-    protected function pathDetails(string $path): void
-    {
-        $pathList = explode('/', $path);
-        $parent = null;
-        foreach ($pathList as $p) {
-            $conditions = [$this->Objects->getAssociation('TreeNodes')->aliasField('slug') => (string)$p];
-            if ($parent !== null) {
-                $conditions['parent_id'] = $parent;
-            }
-            $item = $this->objectDetails($conditions);
-            if (empty($item)) {
-                throw new NotFoundException(__d('bedita', 'Invalid path'));
-            }
-            $this->pathInfo['ids'][] = $item['id'];
-            $this->pathInfo['slugs'][] = $item['slug'];
-            $this->pathInfo['types'][] = $item['object_type_id'];
-            $parent = $item['id'];
-        }
-    }
-
-    /**
-     * Get object main fields
-     *
-     * @param array $condition Query conditions
-     * @return string
-     */
-    protected function objectDetails(array $condition): array
-    {
-        return (array)$this->Objects->find('available')
-            ->where($condition)
-            ->select(['id', 'slug' => $this->Objects->getAssociation('TreeNodes')->aliasField('slug'), 'object_type_id'])
-            ->innerJoinWith('TreeNodes')
-            ->disableHydration()
-            ->first();
     }
 }

--- a/plugins/BEdita/API/tests/IntegrationTest/ChildrenRelationshipTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ChildrenRelationshipTest.php
@@ -184,6 +184,7 @@ class ChildrenRelationshipTest extends IntegrationTestCase
             'menu' => true,
             'canonical' => true,
             'params' => null,
+            'slug' => 'gustavo-supporto-profile-4',
         ];
         static::assertEquals($expected, Hash::get($result, 'data.0.meta.relation'));
     }

--- a/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
@@ -334,6 +334,7 @@ class ParentsRelationshipTest extends IntegrationTestCase
             'menu' => true,
             'canonical' => true,
             'params' => null,
+            'slug' => 'gustavo-supporto-profile-4',
         ];
         static::assertEquals($expected, Hash::get($result, 'data.0.meta.relation'));
 
@@ -348,6 +349,7 @@ class ParentsRelationshipTest extends IntegrationTestCase
             'menu' => true,
             'canonical' => true,
             'params' => null,
+            'slug' => 'sub-folder-12',
         ];
         static::assertEquals($expected, Hash::get($result, 'data.meta.relation'));
     }

--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -112,6 +112,12 @@ class FoldersControllerTest extends IntegrationTestCase
                         'created_by' => 1,
                         'modified_by' => 1,
                         'path' => '/11',
+                        'slug_path' => [[
+                            'id' => 11,
+                            'menu' => false,
+                            'params' => null,
+                            'slug' => 'root-folder-11',
+                        ]],
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/folders/11',
@@ -160,6 +166,20 @@ class FoldersControllerTest extends IntegrationTestCase
                         'created_by' => 1,
                         'modified_by' => 1,
                         'path' => '/11/12',
+                        'slug_path' => [
+                            [
+                                'id' => 11,
+                                'menu' => false,
+                                'params' => null,
+                                'slug' => 'root-folder-11',
+                            ],
+                            [
+                                'id' => 12,
+                                'menu' => true,
+                                'params' => null,
+                                'slug' => 'sub-folder-12',
+                            ],
+                        ],
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/folders/12',
@@ -208,6 +228,12 @@ class FoldersControllerTest extends IntegrationTestCase
                         'created_by' => 1,
                         'modified_by' => 1,
                         'path' => '/13',
+                        'slug_path' => [[
+                            'id' => 13,
+                            'menu' => true,
+                            'params' => null,
+                            'slug' => 'another-root-folder-13',
+                        ]],
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/folders/13',
@@ -327,6 +353,12 @@ class FoldersControllerTest extends IntegrationTestCase
                     'created_by' => 1,
                     'modified_by' => 1,
                     'path' => '/11',
+                    'slug_path' => [[
+                        'id' => 11,
+                        'menu' => false,
+                        'params' => null,
+                        'slug' => 'root-folder-11',
+                    ]],
                 ],
                 'relationships' => [
                     'children' => [

--- a/plugins/BEdita/API/tests/TestCase/Controller/TreePathsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TreePathsControllerTest.php
@@ -28,7 +28,6 @@ class TreePathsControllerTest extends IntegrationTestCase
      *
      * @return void
      * @covers ::index()
-     * @covers ::objectDetails()
      * @covers ::pathDetails()
      */
     public function testIndexValidSlugPath(): void
@@ -148,7 +147,7 @@ class TreePathsControllerTest extends IntegrationTestCase
     {
         $treesTable = TableRegistry::getTableLocator()->get('Trees');
 
-        // Crea un nuovo oggetto con lo stesso slug ma in un path diverso
+        // Create a new object with the same slug but different paths
         $newTreeNode = $treesTable->newEntity([
             'object_id' => 14,
             'parent_id' => 13, // Another-root-folder-13
@@ -181,75 +180,13 @@ class TreePathsControllerTest extends IntegrationTestCase
         static::assertNotEquals(
             $response1['data']['id'],
             $response2['data']['id'],
-            'Gli ID degli oggetti devono essere diversi nonostante lo stesso slug.'
+            'Object IDS must be different even if they have the same slug'
         );
 
         static::assertNotEquals(
             $response1['data']['meta']['extra']['slug_path'],
             $response2['data']['meta']['extra']['slug_path'],
-            'I percorsi devono essere diversi per lo stesso slug.'
+            'Paths must me different for the same slug.'
         );
-    }
-
-    /**
-     * Test `pathDetails` with a valid multi-level path.
-     *
-     * @return void
-     * @covers ::pathDetails()
-     */
-    public function testPathDetailsValid(): void
-    {
-        $controller = $this->getMockBuilder(\BEdita\API\Controller\TreePathsController::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['objectDetails'])
-            ->getMock();
-
-        $controller->Objects = TableRegistry::getTableLocator()->get('Objects');
-
-        $controller->method('objectDetails')
-            ->willReturnCallback(function ($conditions) {
-                if (isset($conditions['parent_id'])) {
-                    return ['id' => 12, 'slug' => 'sub-folder-12', 'object_type_id' => 2];
-                }
-
-                return ['id' => 11, 'slug' => 'root-folder-11', 'object_type_id' => 1];
-            });
-
-        try {
-            $reflection = new \ReflectionClass($controller);
-            $method = $reflection->getMethod('pathDetails');
-            $method->invoke($controller, 'root-folder-11/sub-folder-12');
-
-            $this->assertTrue(true, 'pathDetails() è stato eseguito senza eccezioni.');
-        } catch (\Throwable $e) {
-            $this->fail('pathDetails() ha generato un\'eccezione: ' . $e->getMessage());
-        }
-    }
-
-    /**
-     * Test `pathDetails` when an invalid path is given.
-     *
-     * @return void
-     * @covers ::pathDetails()
-     * @throws \ReflectionException
-     */
-    public function testPathDetailsInvalid(): void
-    {
-        $controller = $this->getMockBuilder(\BEdita\API\Controller\TreePathsController::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['objectDetails'])
-            ->getMock();
-
-        $controller->Objects = TableRegistry::getTableLocator()->get('Objects');
-
-        $controller->method('objectDetails')
-            ->willReturn([]); // invalid path simulation
-
-        $this->expectException(\Cake\Http\Exception\NotFoundException::class);
-        $this->expectExceptionMessage('Invalid path');
-
-        $reflection = new \ReflectionClass($controller);
-        $method = $reflection->getMethod('pathDetails');
-        $method->invoke($controller, 'non-existent-path');
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/TreePathsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TreePathsControllerTest.php
@@ -1,0 +1,191 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2025 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\API\Test\TestCase\Controller;
+
+use BEdita\API\TestSuite\IntegrationTestCase;
+use Cake\ORM\TableRegistry;
+
+/**
+ * @coversDefaultClass \BEdita\API\Controller\TreePathsController
+ */
+class TreePathsControllerTest extends IntegrationTestCase
+{
+    /**
+     * Test `index` with a valid slug.
+     *
+     * @return void
+     * @covers ::index()
+     */
+    public function testIndexValidSlugPath(): void
+    {
+        $this->configRequestHeaders();
+        $this->get('/tree_paths/root-folder-11/sub-folder-12');
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        $response = json_decode((string)$this->_response->getBody(), true);
+
+        $expected = [
+            'data' => [
+                'id' => '12',
+                'type' => 'folders',
+                'attributes' => [
+                    'status' => 'on',
+                    'uname' => 'sub-folder',
+                    'title' => 'Sub Folder',
+                    'description' => 'sub folder of root folder',
+                    'body' => null,
+                    'extra' => null,
+                    'lang' => 'en',
+                    'publish_start' => null,
+                    'publish_end' => null,
+                    'children_order' => null,
+                    'menu' => true,
+                ],
+                'meta' => [
+                    'locked' => false,
+                    'path' => '/11/12',
+                    'slug_path' => [
+                        [
+                            'id' => 11,
+                            'menu' => false,
+                            'params' => null,
+                            'slug' => 'root-folder-11',
+                        ],
+                        [
+                            'id' => 12,
+                            'menu' => true,
+                            'params' => null,
+                            'slug' => 'sub-folder-12',
+                        ],
+                    ],
+                    'published' => null,
+                    'created_by' => 1,
+                    'modified_by' => 1,
+                    'created' => '2018-01-31T07:09:23+00:00',
+                    'modified' => '2018-01-31T08:30:00+00:00',
+                ],
+                'relationships' => [
+                    'translations' => [
+                        'links' => [
+                            'related' => 'http://api.example.com/folders/12/translations',
+                            'self' => 'http://api.example.com/folders/12/relationships/translations',
+                        ],
+                    ],
+                    'children' => [
+                        'links' => [
+                            'related' => 'http://api.example.com/folders/12/children',
+                            'self' => 'http://api.example.com/folders/12/relationships/children',
+                        ],
+                    ],
+                    'parent' => [
+                        'links' => [
+                            'related' => 'http://api.example.com/folders/12/parent',
+                            'self' => 'http://api.example.com/folders/12/relationships/parent',
+                        ],
+                    ],
+                ],
+            ],
+            'links' => [
+                'self' => 'http://api.example.com/tree_paths',
+                'home' => 'http://api.example.com/home',
+            ],
+            'meta' => [
+                'schema' => [
+                    'folders' => [
+                        '$id' => 'http://api.example.com/model/schema/folders',
+                        'revision' => '3048758948',
+                    ],
+                ],
+            ],
+        ];
+
+        static::assertEquals($expected, $response);
+    }
+
+    /**
+     * Test `index` with an invalid slug.
+     *
+     * @return void
+     * @covers ::index()
+     */
+    public function testIndexInvalidSlugPath(): void
+    {
+        $this->configRequestHeaders();
+        $this->get('/tree_paths/pippo/pluto');
+
+        $this->assertResponseCode(404);
+        $this->assertContentType('application/vnd.api+json');
+
+        $response = json_decode((string)$this->_response->getBody(), true);
+
+        static::assertEquals($response['error']['title'], 'Invalid path');
+    }
+
+    /**
+     * Verify that two object with the same slug are reachable with different paths.
+     *
+     * @return void
+     * @covers ::index()
+     */
+    public function testObjectsWithSameSlugDifferentPaths(): void
+    {
+        $treesTable = TableRegistry::getTableLocator()->get('Trees');
+
+        // Crea un nuovo oggetto con lo stesso slug ma in un path diverso
+        $newTreeNode = $treesTable->newEntity([
+            'object_id' => 14,
+            'parent_id' => 13, // Another-root-folder-13
+            'root_id' => 13,
+            'parent_node_id' => 5,
+            'tree_left' => 10,
+            'tree_right' => 11,
+            'depth_level' => 1,
+            'menu' => 1,
+            'canonical' => 1,
+            'slug' => 'gustavo-supporto-profile-4',
+        ]);
+
+        $treesTable->saveOrFail($newTreeNode);
+
+        $this->configRequestHeaders();
+        // First object in "another-root-folder-13/gustavo-supporto-profile-4"
+        $this->get('/tree_paths/another-root-folder-13/gustavo-supporto-profile-4');
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        $response1 = json_decode((string)$this->_response->getBody(), true);
+
+        $this->configRequestHeaders();
+        // Second object in "root-folder-11/sub-folder-12/gustavo-supporto-profile-4"
+        $this->get('/tree_paths/root-folder-11/sub-folder-12/gustavo-supporto-profile-4');
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        $response2 = json_decode((string)$this->_response->getBody(), true);
+
+        static::assertNotEquals(
+            $response1['data']['id'],
+            $response2['data']['id'],
+            'Gli ID degli oggetti devono essere diversi nonostante lo stesso slug.'
+        );
+
+        static::assertNotEquals(
+            $response1['data']['meta']['extra']['slug_path'],
+            $response2['data']['meta']['extra']['slug_path'],
+            'I percorsi devono essere diversi per lo stesso slug.'
+        );
+    }
+}

--- a/plugins/BEdita/API/tests/TestCase/Controller/TreePathsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TreePathsControllerTest.php
@@ -28,6 +28,8 @@ class TreePathsControllerTest extends IntegrationTestCase
      *
      * @return void
      * @covers ::index()
+     * @covers ::objectDetails()
+     * @covers ::pathDetails()
      */
     public function testIndexValidSlugPath(): void
     {
@@ -187,5 +189,67 @@ class TreePathsControllerTest extends IntegrationTestCase
             $response2['data']['meta']['extra']['slug_path'],
             'I percorsi devono essere diversi per lo stesso slug.'
         );
+    }
+
+    /**
+     * Test `pathDetails` with a valid multi-level path.
+     *
+     * @return void
+     * @covers ::pathDetails()
+     */
+    public function testPathDetailsValid(): void
+    {
+        $controller = $this->getMockBuilder(\BEdita\API\Controller\TreePathsController::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['objectDetails'])
+            ->getMock();
+
+        $controller->Objects = TableRegistry::getTableLocator()->get('Objects');
+
+        $controller->method('objectDetails')
+            ->willReturnCallback(function ($conditions) {
+                if (isset($conditions['parent_id'])) {
+                    return ['id' => 12, 'slug' => 'sub-folder-12', 'object_type_id' => 2];
+                }
+
+                return ['id' => 11, 'slug' => 'root-folder-11', 'object_type_id' => 1];
+            });
+
+        try {
+            $reflection = new \ReflectionClass($controller);
+            $method = $reflection->getMethod('pathDetails');
+            $method->invoke($controller, 'root-folder-11/sub-folder-12');
+
+            $this->assertTrue(true, 'pathDetails() è stato eseguito senza eccezioni.');
+        } catch (\Throwable $e) {
+            $this->fail('pathDetails() ha generato un\'eccezione: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Test `pathDetails` when an invalid path is given.
+     *
+     * @return void
+     * @covers ::pathDetails()
+     * @throws \ReflectionException
+     */
+    public function testPathDetailsInvalid(): void
+    {
+        $controller = $this->getMockBuilder(\BEdita\API\Controller\TreePathsController::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['objectDetails'])
+            ->getMock();
+
+        $controller->Objects = TableRegistry::getTableLocator()->get('Objects');
+
+        $controller->method('objectDetails')
+            ->willReturn([]); // invalid path simulation
+
+        $this->expectException(\Cake\Http\Exception\NotFoundException::class);
+        $this->expectExceptionMessage('Invalid path');
+
+        $reflection = new \ReflectionClass($controller);
+        $method = $reflection->getMethod('pathDetails');
+        $method->invoke($controller, 'non-existent-path');
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/TreesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TreesControllerTest.php
@@ -72,6 +72,20 @@ class TreesControllerTest extends IntegrationTestCase
                     'extra' => [
                         'uname_path' => '/root-folder/sub-folder',
                     ],
+                    'slug_path' => [
+                        [
+                            'id' => 11,
+                            'menu' => false,
+                            'params' => null,
+                            'slug' => 'root-folder-11',
+                        ],
+                        [
+                            'id' => 12,
+                            'menu' => true,
+                            'params' => null,
+                            'slug' => 'sub-folder-12',
+                        ],
+                    ],
                 ],
                 'relationships' => [
                     'children' => [

--- a/plugins/BEdita/Core/config/Migrations/20250224101936_TreesAddSlug.php
+++ b/plugins/BEdita/Core/config/Migrations/20250224101936_TreesAddSlug.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+use Cake\Database\Expression\QueryExpression;
+use Migrations\AbstractMigration;
+
+class TreesAddSlug extends AbstractMigration
+{
+    /**
+     * @return void
+     */
+    public function up()
+    {
+        $this->table('trees')
+            ->addColumn('slug', 'string', [
+                'comment' => 'URL-friendly name of an object',
+                'default' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                ['slug', 'parent_id'],
+                [
+                    'name' => 'trees_slugparentid_uq',
+                    'unique' => true,
+                ],
+            )
+            ->update();
+
+        $this->getQueryBuilder()
+            ->update('trees')
+            ->set(
+                'slug',
+                $this->getQueryBuilder()
+                    ->select('objects.uname')
+                    ->from('objects')
+                    ->where(
+                        fn (QueryExpression $exp): QueryExpression => $exp
+                            ->equalFields('objects.id', 'trees.object_id')
+                    ),
+            )
+            ->where(fn (QueryExpression $exp): QueryExpression => $exp->isNull('slug'))
+            ->execute();
+
+        $this->table('trees')
+            ->changeColumn('slug', 'string', [
+                'comment' => 'URL-friendly name of an object',
+                'default' => null,
+                'null' => true,
+            ])
+            ->update();
+    }
+
+    /**
+     * @return void
+     */
+    public function down()
+    {
+        $this->table('trees')
+            ->removeIndexByName('trees_slugparentid_uq')
+            ->removeColumn('slug')
+            ->update();
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Entity/Folder.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Folder.php
@@ -27,6 +27,7 @@ use Cake\Utility\Hash;
  *
  * @property int $parent_id
  * @property string $path
+ * @property array $slug_path
  *
  * @property \BEdita\Core\Model\Entity\Folder|null $parent
  * @property \BEdita\Core\Model\Entity\ObjectEntity[] $children
@@ -45,8 +46,8 @@ class Folder extends ObjectEntity
 
         $this->setAccess('parents', false);
         $this->setHidden(['parents', 'tree_parent_nodes'], true);
-        $this->setVirtual(['path'], true);
-        $this->setAccess('path', false);
+        $this->setVirtual(['path', 'slug_path'], true);
+        $this->setAccess(['path', 'slug_path'], false);
     }
 
     /**
@@ -286,6 +287,29 @@ class Folder extends ObjectEntity
         }
 
         return sprintf('/%s', implode('/', $path));
+    }
+
+    /**
+     * Getter for `slugPath` virtual property.
+     *
+     * @return array|null
+     * @throws \RuntimeException If folder is not found on tree.
+     */
+    protected function _getSlugPath()
+    {
+        if (!$this->has('id')) {
+            return null;
+        }
+
+        try {
+            return TableRegistry::getTableLocator()->get('Trees')
+                ->find('pathNodes', [$this->id])
+                ->select(['id' => 'object_id', 'menu', 'params', 'slug'], true)
+                ->disableHydration()
+                ->toArray();
+        } catch (RecordNotFoundException $previous) {
+            throw new \RuntimeException(__d('bedita', 'Folder "{0}" is not on the tree.', $this->id), 0, $previous);
+        }
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Entity/Tree.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Tree.php
@@ -31,6 +31,7 @@ use Cake\ORM\TableRegistry;
  * @property int $depth_level
  * @property bool $menu
  * @property bool $canonical
+ * @property string $slug
  * @property array|null $params
  * @property int|string $position
  *
@@ -53,6 +54,7 @@ class Tree extends Entity
         'menu' => true,
         'position' => true,
         'canonical' => true,
+        'slug' => true,
         'params' => true,
     ];
 

--- a/plugins/BEdita/Core/src/Model/Table/TreesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TreesTable.php
@@ -24,6 +24,7 @@ use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\Http\Exception\BadRequestException;
+use Cake\Http\Exception\NotFoundException;
 use Cake\ORM\Query;
 use Cake\ORM\Rule\IsUnique;
 use Cake\ORM\RulesChecker;
@@ -390,4 +391,63 @@ class TreesTable extends Table
             )
             ->orderAsc($lft);
     }
+
+    /**
+     * Get object main fields
+     *
+     * @param array $conditions Query conditions
+     * @return array
+     */
+    protected function loadSlugsPath(array $conditions): array
+    {
+        return (array)$this->Objects->find('available')
+            ->where($conditions)
+            ->select([
+                'id',
+                'slug' => $this->Objects->getAssociation('TreeNodes')->aliasField('slug'),
+                'object_type_id',
+            ])
+            ->innerJoinWith('TreeNodes')
+            ->disableHydration()
+            ->first();
+    }
+
+    /**
+     * Get path information with ID, object type, and slug.
+     *
+     * @param string $path Requested object path
+     * @return array Associative array with keys: 'ids', 'slugs', 'types'
+     * @throws \Cake\Http\Exception\NotFoundException If the path is invalid
+     */
+    public function getPathInfo(string $path): array
+    {
+        $pathInfo = [
+            'ids' => [],
+            'slugs' => [],
+            'types' => [],
+        ];
+
+        $pathList = explode('/', $path);
+        $parent = null;
+
+        foreach ($pathList as $p) {
+            $conditions = [$this->Objects->getAssociation('TreeNodes')->aliasField('slug') => (string)$p];
+            if ($parent !== null) {
+                $conditions['parent_id'] = $parent;
+            }
+
+            $item = $this->loadSlugsPath($conditions);
+            if (empty($item)) {
+                throw new NotFoundException(__d('bedita', 'Invalid path'));
+            }
+
+            $pathInfo['ids'][] = $item['id'];
+            $pathInfo['slugs'][] = $item['slug'];
+            $pathInfo['types'][] = $item['object_type_id'];
+            $parent = $item['id'];
+        }
+
+        return $pathInfo;
+    }
+
 }

--- a/plugins/BEdita/Core/src/Model/Table/TreesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TreesTable.php
@@ -21,6 +21,7 @@ use Cake\Core\Configure;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\TableSchemaInterface;
+use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\Query;
@@ -28,6 +29,7 @@ use Cake\ORM\Rule\IsUnique;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
+use Cake\Utility\Text;
 use Cake\Validation\Validator;
 
 /**
@@ -129,6 +131,9 @@ class TreesTable extends Table
             ->boolean('canonical');
 
         $validator
+            ->notEmptyString('slug');
+
+        $validator
             ->allowEmptyArray('params', null, static::jsonSchema(null) === true)
             ->requirePresence('params', static::jsonSchema(null) === true ? false : 'create')
             ->add('params', 'valid', [
@@ -168,6 +173,7 @@ class TreesTable extends Table
      */
     public function buildRules(RulesChecker $rules): RulesChecker
     {
+        $rules->add($rules->isUnique(['parent_id', 'slug']));
         $rules->add($rules->existsIn(['object_id'], 'Objects'));
         $rules->add($rules->existsIn(['root_id'], 'RootObjects'));
         $rules->add($rules->existsIn(
@@ -232,6 +238,27 @@ class TreesTable extends Table
         }
 
         return $rule($entity, ['repository' => $this]);
+    }
+
+    /**
+     * Generate unique `slug` if needed.
+     *
+     * @param \Cake\Event\EventInterface $event The event
+     * @param \Cake\Datasource\EntityInterface $entity The entity persisted
+     * @return void
+     */
+    public function beforeRules(EventInterface $event, EntityInterface $entity)
+    {
+        if (empty($entity->get('slug'))) {
+            $object = TableRegistry::getTableLocator()->get('Objects')->get($entity->get('object_id'));
+            $slug = mb_strtolower(Text::slug((string)$object->get('title') ?: $object->get('type')));
+            $slug = Text::truncate($slug, 254 - strlen((string)$entity->get('object_id')));
+            $entity->set('slug', sprintf('%s-%s', $slug, $entity->get('object_id')));
+        } elseif (!empty($entity->get('slug')) && $entity->isDirty('slug')) {
+            $slug = mb_strtolower(Text::slug((string)$entity->get('slug')));
+            $slug = Text::truncate($slug, 255);
+            $entity->set('slug', $slug);
+        }
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/TreesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TreesTable.php
@@ -449,5 +449,4 @@ class TreesTable extends Table
 
         return $pathInfo;
     }
-
 }

--- a/plugins/BEdita/Core/tests/Fixture/TreesFixture.php
+++ b/plugins/BEdita/Core/tests/Fixture/TreesFixture.php
@@ -39,6 +39,7 @@ class TreesFixture extends TestFixture
             'depth_level' => 0,
             'menu' => 0,
             'canonical' => 0,
+            'slug' => 'root-folder-11',
         ],
 
         // sub folder
@@ -52,6 +53,7 @@ class TreesFixture extends TestFixture
             'depth_level' => 1,
             'menu' => 1,
             'canonical' => 1,
+            'slug' => 'sub-folder-12',
         ],
 
         // document in root folder
@@ -65,6 +67,7 @@ class TreesFixture extends TestFixture
             'depth_level' => 1,
             'menu' => 1,
             'canonical' => 1,
+            'slug' => 'title-one-2',
         ],
 
         // profile in sub folder
@@ -78,6 +81,7 @@ class TreesFixture extends TestFixture
             'depth_level' => 2,
             'menu' => 1,
             'canonical' => 1,
+            'slug' => 'gustavo-supporto-profile-4',
         ],
 
         // another root folder
@@ -91,6 +95,7 @@ class TreesFixture extends TestFixture
             'depth_level' => 0,
             'menu' => 1,
             'canonical' => 0,
+            'slug' => 'another-root-folder-13',
         ],
     ];
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
@@ -275,6 +275,109 @@ class FolderTest extends TestCase
     }
 
     /**
+     * Data provider for `testGetSlugPath()`
+     *
+     * @return array
+     */
+    public function getSlugPathProvider()
+    {
+        return [
+            'root' => [
+                [[
+                    'id' => 11,
+                    'menu' => false,
+                    'params' => null,
+                    'slug' => 'root-folder-11',
+                ]],
+                11,
+            ],
+            'subfolder' => [
+                [
+                    [
+                        'id' => 11,
+                        'menu' => false,
+                        'params' => null,
+                        'slug' => 'root-folder-11',
+                    ],
+                    [
+                        'id' => 12,
+                        'menu' => true,
+                        'params' => null,
+                        'slug' => 'sub-folder-12',
+                    ],
+                ],
+                12,
+            ],
+            'object in subfolder' => [
+                [
+                    [
+                        'id' => 11,
+                        'menu' => false,
+                        'params' => null,
+                        'slug' => 'root-folder-11',
+                    ],
+                    [
+                        'id' => 12,
+                        'menu' => true,
+                        'params' => null,
+                        'slug' => 'sub-folder-12',
+                    ],
+                    [
+                        'id' => 4,
+                        'menu' => true,
+                        'params' => null,
+                        'slug' => 'gustavo-supporto-profile-4',
+                    ],
+                ],
+                4,
+            ],
+        ];
+    }
+
+    /**
+     * Test getter for `slug_path`
+     *
+     * @param array $expected The expected slug path parts
+     * @param int $id The folder id
+     * @return void
+     * @dataProvider getSlugPathProvider
+     * @covers ::_getSlugPath()
+     */
+    public function testGetSlugPath($expected, $id)
+    {
+        $folder = $this->Folders->get($id);
+        static::assertEquals($expected, $folder->slug_path);
+    }
+
+    /**
+     * Test that `slug_path` virtual property is null if folder id is empty.
+     *
+     * @return void
+     * @covers ::_getSlugPath()
+     */
+    public function testGetSlugPathNull()
+    {
+        $folder = $this->Folders->newEntity([]);
+        static::assertNull($folder->slug_path);
+    }
+
+    /**
+     * Test getter for `path` throws RuntimeException if folder is orphan.
+     *
+     * @return void
+     * @covers ::_getSlugPath()
+     */
+    public function testGetSlugPathOrphanFolder()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Folder "12" is not on the tree.');
+        TableRegistry::getTableLocator()->get('Trees')->deleteAll(['object_id' => 12]);
+        TableRegistry::getTableLocator()->get('Trees')->recover();
+
+        $this->Folders->get(12)->get('slug_path');
+    }
+
+    /**
      * Test empty perms.
      *
      * @return void

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -527,6 +527,7 @@ class JsonApiTraitTest extends TestCase
             'menu' => true,
             'canonical' => true,
             'params' => null,
+            'slug' => 'gustavo-supporto-profile-4',
         ];
         static::assertEquals($expected, Hash::get($child, 'meta.relation'));
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/TreesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/TreesTableTest.php
@@ -22,6 +22,7 @@ use Cake\Core\Configure;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Event\Event;
 use Cake\Http\Exception\BadRequestException;
+use Cake\Http\Exception\NotFoundException;
 use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Association\HasMany;
 use Cake\ORM\Behavior\TreeBehavior;
@@ -565,6 +566,7 @@ class TreesTableTest extends TestCase
      * @return void
      * @dataProvider findPathNodesProvider()
      * @covers ::findPathNodes()
+     * @covers ::getSchema())
      * @return void
      */
     public function testFindPathNodes($expected, array $options): void
@@ -700,5 +702,101 @@ class TreesTableTest extends TestCase
         } else {
             static::assertStringContainsString($expected, $result);
         }
+    }
+
+    /**
+     * Test `getPathInfo()` with a valid multi-level path.
+     *
+     * @return void
+     * @covers ::getPathInfo()
+     * @covers ::loadSlugsPath()
+     */
+    public function testGetPathInfoValid(): void
+    {
+        $result = $this->Trees->getPathInfo('root-folder-11/sub-folder-12');
+
+        static::assertIsArray($result, 'Result must be an array');
+        static::assertNotEmpty($result, 'Result should not be empty');
+        static::assertEquals([11, 12], $result['ids']);
+        static::assertEquals(['root-folder-11', 'sub-folder-12'], $result['slugs']);
+        static::assertArrayHasKey('types', $result, 'Array should have an `types` property');
+    }
+
+    /**
+     * Test `getPathInfo()` with a deeper valid path.
+     *
+     * @return void
+     * @covers ::getPathInfo()
+     * @covers ::loadSlugsPath()
+     */
+    public function testGetPathInfoDeepValid(): void
+    {
+        $result = $this->Trees->getPathInfo('root-folder-11/sub-folder-12/gustavo-supporto-profile-4');
+
+        static::assertIsArray($result, 'result must be an array');
+        static::assertNotEmpty($result, 'result should not be empty');
+        static::assertEquals([11, 12, 4], $result['ids']);
+        static::assertEquals(
+            ['root-folder-11', 'sub-folder-12', 'gustavo-supporto-profile-4'],
+            $result['slugs']
+        );
+        static::assertArrayHasKey('types', $result, 'array should have an `types` property');
+    }
+
+    /**
+     * Test `getPathInfo()` with a valid alternative root.
+     *
+     * @return void
+     * @covers ::getPathInfo()
+     * @covers ::loadSlugsPath()
+     */
+    public function testGetPathInfoAlternativeRoot(): void
+    {
+        $result = $this->Trees->getPathInfo('another-root-folder-13');
+
+        static::assertIsArray($result, 'result must be an array');
+        static::assertNotEmpty($result, 'result should not be empty');
+        static::assertEquals([13], $result['ids']);
+        static::assertEquals(['another-root-folder-13'], $result['slugs']);
+        static::assertArrayHasKey('types', $result, 'array should have an `types` property');
+    }
+
+    /**
+     * Test `getPathInfo()` with an invalid path.
+     *
+     * @return void
+     * @covers ::getPathInfo()
+     * @covers ::loadSlugsPath()
+     */
+    public function testGetPathInfoInvalid(): void
+    {
+        $this->expectException(NotFoundException::class);
+        $this->Trees->getPathInfo('this-is-not/a-valid-path');
+    }
+
+    /**
+     * Test `getPathInfo()` with a partially valid but non-existent full path.
+     *
+     * @return void
+     * @covers ::getPathInfo()
+     * @covers ::loadSlugsPath()
+     */
+    public function testGetPathInfoPartialInvalid(): void
+    {
+        $this->expectException(NotFoundException::class);
+        $this->Trees->getPathInfo('root-folder-11/waldo');
+    }
+
+    /**
+     * Test `getPathInfo()` with an empty path.
+     *
+     * @return void
+     * @covers ::getPathInfo()
+     * @covers ::loadSlugsPath()
+     */
+    public function testGetPathInfoEmpty(): void
+    {
+        $this->expectException(NotFoundException::class);
+        $this->Trees->getPathInfo('');
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/TreesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/TreesTableTest.php
@@ -20,6 +20,7 @@ use BEdita\Core\Model\Table\TreesTable;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Core\Configure;
 use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\Event\Event;
 use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Association\HasMany;
@@ -208,6 +209,91 @@ class TreesTableTest extends TestCase
         $entity->object_id = $objectId;
         $entity->parent_id = $parentId;
         static::assertEquals($expected, $this->Trees->isPositionUnique($entity));
+    }
+
+    /**
+     * Data provider for `testSlugPopulation()`.
+     *
+     * @return array[]
+     */
+    public function slugPopulationProvider()
+    {
+        return [
+            'no slug' => [
+                'title-example-3',
+                3,
+                '',
+                'title example',
+            ],
+            'no slug or title' => [
+                'documents-3',
+                3,
+                '',
+                '',
+            ],
+            'no slug, title special characters' => [
+                'asd-lol-rofl-3',
+                3,
+                '',
+                'asd@lol.rofl',
+            ],
+            'slug correct' => [
+                'slug-doc',
+                2,
+                'slug-doc',
+                'title example',
+            ],
+            'update no slug' => [
+                'title-example-2',
+                2,
+                '',
+                'title example',
+            ],
+            'update no slug or title' => [
+                'documents-2',
+                2,
+                '',
+                '',
+            ],
+            'update slug special characters' => [
+                'asd-lol-rofl',
+                2,
+                'asd@lol.rofl',
+                'title example',
+            ],
+            'update slug correct' => [
+                'slug-doc',
+                2,
+                'slug-doc',
+                'title example',
+            ],
+        ];
+    }
+
+    /**
+     * Test for slug generation in `beforeRules()`.
+     *
+     * @param $expected
+     * @param $objectId
+     * @param $slug
+     * @param $title
+     * @return void
+     * @dataProvider slugPopulationProvider
+     * @covers ::beforeRules()
+     */
+    public function testSlugPopulation($expected, $objectId, $slug, $title)
+    {
+        $this->fetchTable('Documents')
+            ->updateQuery()
+            ->set('title', $title)
+            ->where(['id' => $objectId])
+            ->execute();
+        $node = $this->Trees->newEntity([
+            'object_id' => $objectId,
+            'slug' => $slug,
+        ]);
+        $this->Trees->beforeRules(new Event('Model.beforeRules'), $node);
+        static::assertEquals($expected, $node->get('slug'));
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -43,7 +43,7 @@ Cache::drop('_bedita_object_types_');
 Cache::setConfig('_bedita_object_types_', ['className' => 'Null']);
 
 if (getenv('DEBUG_LOG_QUERIES')) {
-    ConnectionManager::get('test')->logQueries(true);
+    ConnectionManager::get('test')->enableQueryLogging();
     Log::setConfig('queries', [
         'className' => 'Console',
         'stream' => 'php://stdout',


### PR DESCRIPTION
This PR is for the transition from uname-based URLs to slug-based ones. These will allow to have multiple objects with the same "name" reachable from different paths. For example, `/hello/world` and `/good/morning/world` could reference different objects based on their paths even if the last piece of the URL is the same. This is currently not possible, since the path is built using the objects' unames and those must be unique across the whole database.

This PR adds a `slug` field to the `trees` table.

The migration also populates the new field with the current `uname` value.

A controller `TreeSlugs` has been added to handle `/tree_paths/*` routes, which work like the `/trees/*` ones and will replace them when the stransition will be complete (**TODO** tests for the controller).

This change should be backward-compatible.