### PR TITLE
Sorting children by publish start falls back to creation date

### DIFF
--- a/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
@@ -298,9 +298,9 @@ class ListAssociatedAction extends BaseAction
      *
      * @param \Cake\ORM\Association $association Association
      * @param  mixed $primaryKey Primary key
-     * @return array
+     * @return \Cake\Database\ExpressionInterface|array<string, 'asc' | 'desc'>
      */
-    protected function sort(Association $association, $primaryKey): array
+    protected function sort(Association $association, $primaryKey)
     {
         if ($association->getName() === 'Children') {
             return (array)TableRegistry::getTableLocator()->get('Folders')->getSort($primaryKey);

--- a/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
@@ -16,9 +16,12 @@ declare(strict_types=1);
 namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Model\Entity\Folder;
+use Cake\Database\Expression\FunctionExpression;
+use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
+use Cake\Log\Log;
 use Cake\ORM\Query;
 use Cake\ORM\Rule\ValidCount;
 use Cake\ORM\RulesChecker;
@@ -320,25 +323,42 @@ class FoldersTable extends ObjectsTable
      * Get sort by object ID.
      * Default 'Trees.tree_left' => 'asc'
      *
-     * @param int $id The tree object ID
-     * @return array
+     * @param \BEdita\Core\Model\Entity\Folder|string|int $folder The tree object ID
+     * @return \Cake\Database\ExpressionInterface|array<string, 'asc' | 'desc'>
      */
-    public function getSort(int $id): array
+    public function getSort($folder)
     {
-        /** @var \BEdita\Core\Model\Entity\Folder $entity */
-        $entity = $this->get($id);
-        $order = $entity->get('children_order');
-        if (empty($order) || $order === 'position') {
-            return ['Trees.tree_left' => 'asc'];
-        }
-        if ($order === '-position') {
-            return ['Trees.tree_left' => 'desc'];
-        }
-        $sign = substr($order, 0, 1);
-        $direction = $sign === '-' ? 'desc' : 'asc';
-        $field = $sign === '-' ? substr($order, 1) : $order;
-        $key = sprintf('Children.%s', $field);
+        $entity = $folder instanceof Folder ? $folder : $this->get($folder);
+        $order = $entity->get('children_order') ?: 'position';
 
-        return [$key => $direction];
+        [$field, $direction] = substr($order, 0, 1) === '-' ? [substr($order, 1), 'DESC'] : [$order, 'ASC'];
+        switch ($field) {
+            case 'position':
+                return [$this->Children->junction()->aliasField('tree_left') => $direction];
+
+            case 'publish_start':
+                return new OrderClauseExpression(
+                    new FunctionExpression(
+                        'COALESCE',
+                        [
+                            $this->Children->aliasField('publish_start') => 'identifier',
+                            $this->Children->aliasField('created') => 'identifier',
+                        ],
+                        ['timestamp', 'timestamp'],
+                        'timestamp',
+                    ),
+                    $direction,
+                );
+
+            case 'title':
+            case 'created':
+            case 'modified':
+                return [$this->Children->aliasField($field) => $direction];
+
+            default:
+                Log::warning(sprintf('Malformed property `children_order` "%s" for children sorting of folder #%d, defaulting to tree position', $order, $folder->id));
+
+                return [$this->Children->junction()->aliasField('tree_left') => 'ASC'];
+        }
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
@@ -18,7 +18,11 @@ namespace BEdita\Core\Test\TestCase\Model\Table;
 use BEdita\Core\Model\Entity\ObjectType;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Core\Configure;
+use Cake\Database\Expression\FunctionExpression;
+use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\ExpressionInterface;
+use Cake\Database\ValueBinder;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -539,74 +543,125 @@ class FoldersTableTest extends TestCase
             'Order position Trees.tree_left asc' => [
                 11,
                 'position',
-                ['Trees.tree_left' => 'asc'],
+                ['Trees.tree_left' => 'ASC'],
             ],
             'Order -position Trees.tree_left desc' => [
                 11,
                 '-position',
-                ['Trees.tree_left' => 'desc'],
+                ['Trees.tree_left' => 'DESC'],
             ],
             'Order title Children.title asc' => [
                 11,
                 'title',
-                ['Children.title' => 'asc'],
+                ['Children.title' => 'ASC'],
             ],
             'Order -title Children.title desc' => [
                 11,
                 '-title',
-                ['Children.title' => 'desc'],
+                ['Children.title' => 'DESC'],
             ],
             'Order created Children.created asc' => [
                 11,
                 'created',
-                ['Children.created' => 'asc'],
+                ['Children.created' => 'ASC'],
             ],
             'Order -created Children.created desc' => [
                 11,
                 '-created',
-                ['Children.created' => 'desc'],
+                ['Children.created' => 'DESC'],
             ],
             'Order modified Children.modified asc' => [
                 11,
                 'modified',
-                ['Children.modified' => 'asc'],
+                ['Children.modified' => 'ASC'],
             ],
             'Order -modified Children.modified desc' => [
                 11,
                 '-modified',
-                ['Children.modified' => 'desc'],
+                ['Children.modified' => 'DESC'],
             ],
             'Order publish_start Children.publish_start asc' => [
                 11,
                 'publish_start',
-                ['Children.publish_start' => 'asc'],
+                new OrderClauseExpression(new FunctionExpression('COALESCE', ['Children.publish_start' => 'identifier', 'Children.created' => 'identifier']), 'ASC'),
             ],
             'Order -publish_start Children.publish_start desc' => [
                 11,
                 '-publish_start',
-                ['Children.publish_start' => 'desc'],
+                new OrderClauseExpression(new FunctionExpression('COALESCE', ['Children.publish_start' => 'identifier', 'Children.created' => 'identifier']), 'DESC'),
             ],
             'Default order Trees.tree_left asc' => [
                 11,
                 null,
-                ['Trees.tree_left' => 'asc'],
+                ['Trees.tree_left' => 'ASC'],
             ],
         ];
     }
 
     /**
-     * Test `getSort` method.
+     * Test {@see \BEdita\Core\Model\Table\FoldersTable::getSort()} method.
      *
+     * @param int $id Folder ID.
+     * @param string|null $order Value of `children_order` property.
+     * @param \Cake\Database\ExpressionInterface|array<string, string> Expected order.
      * @return void
      * @dataProvider getSortProvider()
      * @covers ::getSort()
      */
-    public function testGetSort(int $id, ?string $order, array $expected): void
+    public function testGetSort(int $id, ?string $order, $expected): void
     {
         $folder = $this->Folders->get($id);
-        $folder = $this->Folders->patchEntity($folder, ['children_order' => $order]);
-        $this->Folders->save($folder);
+        $folder->set('children_order', $order);
+        $this->Folders->saveOrFail($folder);
+
         $actual = $this->Folders->getSort($id);
-        static::assertSame($expected, $actual);
+
+        if ($expected instanceof ExpressionInterface) {
+            $binder = $this->Folders->selectQuery()->getValueBinder();
+            static::assertInstanceOf(ExpressionInterface::class, $actual);
+            static::assertSame($expected->sql($binder), $actual->sql($binder));
+        } else {
+            static::assertSame($expected, $actual);
+        }
+    }
+
+    /**
+     * Test {@see \BEdita\Core\Model\Table\FoldersTable::getSort()} method reading the order directly from the entity.
+     *
+     * @param int $id Folder ID.
+     * @param string|null $order Value of `children_order` property.
+     * @param \Cake\Database\ExpressionInterface|array<string, string> Expected order.
+     * @return void
+     * @dataProvider getSortProvider()
+     * @covers ::getSort()
+     */
+    public function testGetSortFolder(int $id, ?string $order, $expected): void
+    {
+        $folder = $this->Folders->get($id);
+        $folder->set('children_order', $order);
+
+        $actual = $this->Folders->getSort($folder);
+
+        if ($expected instanceof ExpressionInterface) {
+            static::assertInstanceOf(ExpressionInterface::class, $actual);
+            static::assertSame($expected->sql(new ValueBinder()), $actual->sql(new ValueBinder()));
+        } else {
+            static::assertSame($expected, $actual);
+        }
+    }
+
+    /**
+     * Test {@see \BEdita\Core\Model\Table\FoldersTable::getSort()} method with an invalid field for `children_order`.
+     *
+     * @return void
+     * @covers ::getSort()
+     * @testWith ["invalid_field"]
+     *           ["-uname"]
+     */
+    public function testGetSortInvalidField(string $order): void
+    {
+        $actual = $this->Folders->getSort($this->Folders->newEmptyEntity()->set('children_order', $order));
+
+        static::assertSame(['Trees.tree_left' => 'ASC'], $actual);
     }
 }


### PR DESCRIPTION
This PR introduces a fallback for children sorting when it is set to `publish_start`. Previously, objects without a publication start date were placed at the end of the pack and their relative order was unpredictable. After this change, when publication start date is missing we assume the object creation date. This makes sorting predictable and should cover more cases as they're intended.