### PR TITLE
PHP_VERSION 8.3 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PHP_VERSION=8.2
+ARG PHP_VERSION=8.3
 FROM chialab/php:${PHP_VERSION}-apache
 LABEL author="dev@chialab.io"
 


### PR DESCRIPTION
This updates PHP_VERSION used in `Dockerfile` from 8.2 to 8.3.