### PR TITLE
Use object's uname as default slug unless one was passed

### DIFF
--- a/plugins/BEdita/Core/config/Migrations/20250224101936_TreesAddSlug.php
+++ b/plugins/BEdita/Core/config/Migrations/20250224101936_TreesAddSlug.php
@@ -25,29 +25,6 @@ class TreesAddSlug extends AbstractMigration
                 ],
             )
             ->update();
-
-        $this->getQueryBuilder()
-            ->update('trees')
-            ->set(
-                'slug',
-                $this->getQueryBuilder()
-                    ->select('objects.uname')
-                    ->from('objects')
-                    ->where(
-                        fn (QueryExpression $exp): QueryExpression => $exp
-                            ->equalFields('objects.id', 'trees.object_id')
-                    ),
-            )
-            ->where(fn (QueryExpression $exp): QueryExpression => $exp->isNull('slug'))
-            ->execute();
-
-        $this->table('trees')
-            ->changeColumn('slug', 'string', [
-                'comment' => 'URL-friendly name of an object',
-                'default' => null,
-                'null' => true,
-            ])
-            ->update();
     }
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20250318131739_TreesSlugNotNullable.php
+++ b/plugins/BEdita/Core/config/Migrations/20250318131739_TreesSlugNotNullable.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+use Cake\Database\Expression\QueryExpression;
+use Migrations\AbstractMigration;
+
+class TreesSlugNotNullable extends AbstractMigration
+{
+    /**
+     * @inheritDoc
+     */
+    public function up(): void
+    {
+        $this->getQueryBuilder()
+            ->update('trees')
+            ->set(
+                'slug',
+                $this->getQueryBuilder()
+                    ->select('objects.uname')
+                    ->from('objects')
+                    ->where(
+                        fn (QueryExpression $exp): QueryExpression => $exp
+                            ->equalFields('objects.id', 'trees.object_id')
+                    ),
+            )
+            ->where(fn (QueryExpression $exp): QueryExpression => $exp->isNull('slug'))
+            ->execute();
+
+        $this->table('trees')
+            ->changeColumn('slug', 'string', [
+                'comment' => 'URL-friendly name of an object',
+                'default' => null,
+                'null' => false,
+            ])
+            ->update();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function down(): void
+    {
+        $this->table('trees')
+            ->changeColumn('slug', 'string', [
+                'comment' => 'URL-friendly name of an object',
+                'default' => null,
+                'null' => true,
+            ])
+            ->update();
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Table/TreesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TreesTable.php
@@ -29,18 +29,17 @@ use Cake\ORM\Query;
 use Cake\ORM\Rule\IsUnique;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
-use Cake\ORM\TableRegistry;
 use Cake\Utility\Text;
 use Cake\Validation\Validator;
 
 /**
  * Trees Model
  *
- * @property \Cake\ORM\Association\BelongsTo $Objects
- * @property \Cake\ORM\Association\BelongsTo $ParentObjects
- * @property \Cake\ORM\Association\BelongsTo $RootObjects
- * @property \Cake\ORM\Association\BelongsTo $ParentNode
- * @property \Cake\ORM\Association\HasMany $ChildNodes
+ * @property \Cake\ORM\Association\BelongsTo|\BEdita\Core\Model\Table\ObjectsTable $Objects
+ * @property \Cake\ORM\Association\BelongsTo|\BEdita\Core\Model\Table\ObjectsTable $ParentObjects
+ * @property \Cake\ORM\Association\BelongsTo|\BEdita\Core\Model\Table\ObjectsTable $RootObjects
+ * @property \Cake\ORM\Association\BelongsTo|\BEdita\Core\Model\Table\TreesTable $ParentNode
+ * @property \Cake\ORM\Association\HasMany|\BEdita\Core\Model\Table\TreesTable $ChildNodes
  * @method \BEdita\Core\Model\Entity\Tree get($primaryKey, $options = [])
  * @method \BEdita\Core\Model\Entity\Tree newEntity($data = null, array $options = [])
  * @method \BEdita\Core\Model\Entity\Tree[] newEntities(array $data, array $options = [])
@@ -251,10 +250,7 @@ class TreesTable extends Table
     public function beforeRules(EventInterface $event, EntityInterface $entity)
     {
         if (empty($entity->get('slug'))) {
-            $object = TableRegistry::getTableLocator()->get('Objects')->get($entity->get('object_id'));
-            $slug = mb_strtolower(Text::slug((string)$object->get('title') ?: $object->get('type')));
-            $slug = Text::truncate($slug, 254 - strlen((string)$entity->get('object_id')));
-            $entity->set('slug', sprintf('%s-%s', $slug, $entity->get('object_id')));
+            $entity->set('slug', $this->Objects->get($entity->get('object_id'))->uname);
         } elseif (!empty($entity->get('slug')) && $entity->isDirty('slug')) {
             $slug = mb_strtolower(Text::slug((string)$entity->get('slug')));
             $slug = Text::truncate($slug, 255);
@@ -335,7 +331,7 @@ class TreesTable extends Table
     {
         static $foldersType = null;
         if ($foldersType === null) {
-            $foldersType = TableRegistry::getTableLocator()->get('ObjectTypes')->get('folders')->id;
+            $foldersType = $this->Objects->ObjectTypes->get('folders')->id;
         }
 
         return $this->Objects->exists([

--- a/plugins/BEdita/Core/tests/TestCase/Command/TreeCheckCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/TreeCheckCommandTest.php
@@ -145,6 +145,7 @@ class TreeCheckCommandTest extends TestCase
             $this->Trees->newEntity([
                 'object_id' => 12,
                 'parent_id' => null,
+                'slug' => 'foo-bar',
             ]),
             ['checkRules' => false]
         );
@@ -174,6 +175,7 @@ class TreeCheckCommandTest extends TestCase
             $this->Trees->newEntity([
                 'object_id' => 2,
                 'parent_id' => null,
+                'slug' => 'foo-bar',
             ]),
             ['checkRules' => false]
         );
@@ -202,6 +204,7 @@ class TreeCheckCommandTest extends TestCase
             $this->Trees->newEntity([
                 'object_id' => 4,
                 'parent_id' => 2,
+                'slug' => 'foo-bar',
             ]),
             ['checkRules' => false]
         );
@@ -239,6 +242,7 @@ class TreeCheckCommandTest extends TestCase
             $this->Trees->newEntity([
                 'object_id' => 2,
                 'parent_id' => 11,
+                'slug' => 'foo-bar',
             ]),
             ['checkRules' => false]
         );

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/TreesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/TreesTableTest.php
@@ -217,56 +217,48 @@ class TreesTableTest extends TestCase
      *
      * @return array[]
      */
-    public function slugPopulationProvider()
+    public function slugPopulationProvider(): array
     {
         return [
             'no slug' => [
-                'title-example-3',
+                'title-two',
                 3,
                 '',
-                'title example',
             ],
             'no slug or title' => [
-                'documents-3',
+                'title-two',
                 3,
-                '',
                 '',
             ],
             'no slug, title special characters' => [
-                'asd-lol-rofl-3',
+                'title-two',
                 3,
                 '',
-                'asd@lol.rofl',
             ],
             'slug correct' => [
                 'slug-doc',
                 2,
                 'slug-doc',
-                'title example',
             ],
             'update no slug' => [
-                'title-example-2',
+                'title-one',
                 2,
                 '',
-                'title example',
             ],
             'update no slug or title' => [
-                'documents-2',
+                'title-one',
                 2,
-                '',
                 '',
             ],
             'update slug special characters' => [
                 'asd-lol-rofl',
                 2,
                 'asd@lol.rofl',
-                'title example',
             ],
             'update slug correct' => [
                 'slug-doc',
                 2,
                 'slug-doc',
-                'title example',
             ],
         ];
     }
@@ -274,21 +266,15 @@ class TreesTableTest extends TestCase
     /**
      * Test for slug generation in `beforeRules()`.
      *
-     * @param $expected
-     * @param $objectId
-     * @param $slug
-     * @param $title
+     * @param string $expected Expected slug.
+     * @param int $objectId Object ID.
+     * @param string|null $slug Slug set on tree node.
      * @return void
-     * @dataProvider slugPopulationProvider
+     * @dataProvider slugPopulationProvider()
      * @covers ::beforeRules()
      */
-    public function testSlugPopulation($expected, $objectId, $slug, $title)
+    public function testSlugPopulation(string $expected, int $objectId, ?string $slug = null): void
     {
-        $this->fetchTable('Documents')
-            ->updateQuery()
-            ->set('title', $title)
-            ->where(['id' => $objectId])
-            ->execute();
         $node = $this->Trees->newEntity([
             'object_id' => $objectId,
             'slug' => $slug,


### PR DESCRIPTION
This PR fixes a forward compatibility problem with the newly introduced slugs.

First of all, the previous migration did not set the `trees.slug` column as non-nullable. Thus, a new migration has been added to re-execute the query that sets slugs as objects' unames and then sets the column as not-nullable. Such steps have now been removed from the previous migration as they're no longer needed there:

- any system where the existing migration has already been run would still need to run the new migration
- any system where the existing migration has not yet been run would run both migrations anyway

Next, the default behavior for slugs has been changed from a URL-friendly string derived from the object's title to the object's uname. This ensures that, unless somebody willingly chooses a `slug` that is different from the object's uname for a specific tree position, the tree path derived from unames and the tree path derived from slugs are exactly the same for every object.
This is particularly sensible for existing applications that are currently serving contents based on the unames path but at some point are planning to switch to slugs paths.