### PR TITLE
Add auth providers and external auth endpoints for admin

### DIFF
--- a/plugins/BEdita/API/config/routes.php
+++ b/plugins/BEdita/API/config/routes.php
@@ -30,6 +30,8 @@ return function (RouteBuilder $routes) {
         ];
         $adminControllers = [
             'applications',
+            'auth_providers',
+            'external_auth',
             'async_jobs',
             'config',
             'endpoints',

--- a/plugins/BEdita/API/postman/BE5.postman_collection.json
+++ b/plugins/BEdita/API/postman/BE5.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "250fd7c1-413e-4ba1-b07f-c05ad5230a6c",
+		"_postman_id": "582503df-130c-43a4-b347-8b5c472eb959",
 		"name": "BEdita 5 Core API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "6916583"
+		"_exporter_id": "14877423"
 	},
 	"item": [
 		{
@@ -8169,6 +8169,263 @@
 					"response": []
 				},
 				{
+					"name": "Create auth provider",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var responseJSON;",
+									"try {",
+									"    responseJSON = JSON.parse(responseBody); ",
+									"    tests[\"Status code is 201\"] = responseCode.code === 201;",
+									"    tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';",
+									"    if (responseJSON && responseJSON.data && responseJSON.data.id) {",
+									"        postman.setEnvironmentVariable(\"adminResourceId\", responseJSON.data.id);",
+									"    }",
+									"} catch (e) {",
+									"    tests[\"Error in parsing response\"] = e;",
+									"}"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.api+json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/vnd.api+json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}"
+							},
+							{
+								"key": "X-Api-Key",
+								"value": "{{apiKey}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"data\": {\n        \"type\": \"auth_providers\",\n        \"attributes\": {\n            \"name\": \"my-very-first-app\"\n        }\n    }\n}"
+						},
+						"url": {
+							"raw": "{{be4Url}}/admin/auth_providers",
+							"host": [
+								"{{be4Url}}"
+							],
+							"path": [
+								"admin",
+								"auth_providers"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Modify auth provider",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"tests[\"Status code is 200\"] = responseCode.code === 200;",
+									"tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"value": "application/vnd.api+json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}"
+							},
+							{
+								"key": "X-Api-Key",
+								"value": "{{apiKey}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"data\": {\n        \"id\": \"{{adminResourceId}}\",\n        \"type\": \"applications\",\n        \"attributes\": {\n            \"name\": \"new-app-name\",\n            \"description\": \"New application description\"\n        }\n    }\n}"
+						},
+						"url": {
+							"raw": "{{be4Url}}/admin/auth_providers/{{adminResourceId}}",
+							"host": [
+								"{{be4Url}}"
+							],
+							"path": [
+								"admin",
+								"auth_providers",
+								"{{adminResourceId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET single auth provider",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"if (responseCode.code === 200) {",
+									"    tests[\"Status equals 200\"] = true;",
+									"} else if (responseCode.code === 404) {",
+									"    tests[\"Status code is 404\"] = true;",
+									"}",
+									"tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.api+json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}"
+							},
+							{
+								"key": "X-Api-Key",
+								"value": "{{apiKey}}"
+							}
+						],
+						"url": {
+							"raw": "{{be4Url}}/admin/auth_providers/{{adminResourceId}}",
+							"host": [
+								"{{be4Url}}"
+							],
+							"path": [
+								"admin",
+								"auth_providers",
+								"{{adminResourceId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET auth providers",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"tests[\"Status code is 200\"] = responseCode.code === 200;",
+									"tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.api+json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}"
+							},
+							{
+								"key": "X-Api-Key",
+								"value": "{{apiKey}}"
+							}
+						],
+						"url": {
+							"raw": "{{be4Url}}/admin/auth_providers",
+							"host": [
+								"{{be4Url}}"
+							],
+							"path": [
+								"admin",
+								"auth_providers"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete auth provider",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"tests[\"Status code is 204\"] = responseCode.code === 204;",
+									"tests[\"Body matches string\"] = responseBody === \"\";",
+									"postman.setEnvironmentVariable(\"adminResourceId\",\"\");"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.api+json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}"
+							},
+							{
+								"key": "X-Api-Key",
+								"value": "{{apiKey}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{be4Url}}/admin/auth_providers/{{adminResourceId}}",
+							"host": [
+								"{{be4Url}}"
+							],
+							"path": [
+								"admin",
+								"auth_providers",
+								"{{adminResourceId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Create async job",
 					"event": [
 						{
@@ -8917,6 +9174,262 @@
 							"path": [
 								"admin",
 								"endpoints",
+								"{{adminResourceId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create external auth",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var responseJSON;",
+									"try {",
+									"    responseJSON = JSON.parse(responseBody); ",
+									"    tests[\"Status code is 201\"] = responseCode.code === 201;",
+									"    tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';",
+									"    if (responseJSON && responseJSON.data && responseJSON.data.id) {",
+									"        postman.setEnvironmentVariable(\"adminResourceId\", responseJSON.data.id);",
+									"    }",
+									"} catch (e) {",
+									"    tests[\"Error in parsing response\"] = e;",
+									"}"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.api+json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/vnd.api+json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}"
+							},
+							{
+								"key": "X-Api-Key",
+								"value": "{{apiKey}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"data\": {\n        \"type\": \"external_auth\",\n        \"attributes\": {\n            \"user_id\": 1,\n            \"auth_provider_id\": {{adminResourceId}},\n            \"provider_username\": \"id\"\n        }\n    }\n}"
+						},
+						"url": {
+							"raw": "{{be4Url}}/admin/external_auth",
+							"host": [
+								"{{be4Url}}"
+							],
+							"path": [
+								"admin",
+								"external_auth"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET single external auth",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"if (responseCode.code === 200) {",
+									"    tests[\"Status equals 200\"] = true;",
+									"} else if (responseCode.code === 404) {",
+									"    tests[\"Status code is 404\"] = true;",
+									"}",
+									"tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.api+json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}"
+							},
+							{
+								"key": "X-Api-Key",
+								"value": "{{apiKey}}"
+							}
+						],
+						"url": {
+							"raw": "{{be4Url}}/admin/external_auth/{{adminResourceId}}",
+							"host": [
+								"{{be4Url}}"
+							],
+							"path": [
+								"admin",
+								"external_auth",
+								"{{adminResourceId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET external auths",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"tests[\"Status code is 200\"] = responseCode.code === 200;",
+									"tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.api+json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}"
+							},
+							{
+								"key": "X-Api-Key",
+								"value": "{{apiKey}}"
+							}
+						],
+						"url": {
+							"raw": "{{be4Url}}/admin/external_auth",
+							"host": [
+								"{{be4Url}}"
+							],
+							"path": [
+								"admin",
+								"external_auth"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Modify external auth",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"tests[\"Status code is 200\"] = responseCode.code === 200;",
+									"tests[\"Content-Type is correct\"] = postman.getResponseHeader(\"Content-Type\") === 'application/vnd.api+json';"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"value": "application/vnd.api+json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}"
+							},
+							{
+								"key": "X-Api-Key",
+								"value": "{{apiKey}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"data\": {\n        \"id\": \"{{adminResourceId}}\",\n        \"type\": \"applications\",\n        \"attributes\": {\n            \"name\": \"new-app-name\",\n            \"description\": \"New application description\"\n        }\n    }\n}"
+						},
+						"url": {
+							"raw": "{{be4Url}}/admin/external_auth/{{adminResourceId}}",
+							"host": [
+								"{{be4Url}}"
+							],
+							"path": [
+								"admin",
+								"external_auth",
+								"{{adminResourceId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete external auth",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"tests[\"Status code is 204\"] = responseCode.code === 204;",
+									"tests[\"Body matches string\"] = responseBody === \"\";",
+									"postman.setEnvironmentVariable(\"adminResourceId\", \"\");"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/vnd.api+json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}"
+							},
+							{
+								"key": "X-Api-Key",
+								"value": "{{apiKey}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{be4Url}}/admin/external_auth/{{adminResourceId}}",
+							"host": [
+								"{{be4Url}}"
+							],
+							"path": [
+								"admin",
+								"external_auth",
 								"{{adminResourceId}}"
 							]
 						}

--- a/plugins/BEdita/API/src/Controller/Admin/AuthProvidersController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/AuthProvidersController.php
@@ -18,7 +18,7 @@ namespace BEdita\API\Controller\Admin;
 /**
  * Controller for `/admin/auth_providers` endpoint.
  *
- * @since 4.0.0
+ * @since 5.38.0
  * @property \BEdita\Core\Model\Table\AuthProviders $AuthProviders
  */
 class AuthProvidersController extends AdminController

--- a/plugins/BEdita/API/src/Controller/Admin/AuthProvidersController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/AuthProvidersController.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 /**
  * BEdita, API-first content management framework
- * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ * Copyright 2025 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published

--- a/plugins/BEdita/API/src/Controller/Admin/AuthProvidersController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/AuthProvidersController.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\API\Controller\Admin;
+
+/**
+ * Controller for `/admin/auth_providers` endpoint.
+ *
+ * @since 4.0.0
+ * @property \BEdita\Core\Model\Table\AuthProviders $AuthProviders
+ */
+class AuthProvidersController extends AdminController
+{
+    /**
+     * @inheritDoc
+     */
+    public $defaultTable = 'AuthProviders';
+}

--- a/plugins/BEdita/API/src/Controller/Admin/ExternalAuthController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/ExternalAuthController.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 /**
  * BEdita, API-first content management framework
- * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ * Copyright 2025 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -18,7 +18,7 @@ namespace BEdita\API\Controller\Admin;
 /**
  * Controller for `/admin/external_auth` endpoint.
  *
- * @since 4.0.0
+ * @since 5.38.0
  * @property \BEdita\Core\Model\Table\ExternalAuth $ExternalAuth
  */
 class ExternalAuthController extends AdminController

--- a/plugins/BEdita/API/src/Controller/Admin/ExternalAuthController.php
+++ b/plugins/BEdita/API/src/Controller/Admin/ExternalAuthController.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2017 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\API\Controller\Admin;
+
+/**
+ * Controller for `/admin/external_auth` endpoint.
+ *
+ * @since 4.0.0
+ * @property \BEdita\Core\Model\Table\ExternalAuth $ExternalAuth
+ */
+class ExternalAuthController extends AdminController
+{
+    /**
+     * @inheritDoc
+     */
+    public $defaultTable = 'ExternalAuth';
+}

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/AuthProvidersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/AuthProvidersControllerTest.php
@@ -1,0 +1,403 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\API\Test\TestCase\Controller\Admin;
+
+use BEdita\API\TestSuite\IntegrationTestCase;
+use Cake\Core\Configure;
+use Cake\ORM\TableRegistry;
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+
+/**
+ * @coversDefaultClass \BEdita\API\Controller\Admin\AuthProvidersController
+ */
+class AuthProvidersControllerTest extends IntegrationTestCase
+{
+    use ArraySubsetAsserts;
+
+    /**
+     * Test `index` method with user not admin.
+     *
+     * @return void
+     * @covers ::index()
+     * @covers ::initialize()
+     */
+    public function testIndexNoAdmin()
+    {
+        $this->configRequestHeaders();
+        $this->get('/admin/auth_providers');
+        $this->assertResponseCode(401);
+        $this->assertContentType('application/vnd.api+json');
+    }
+
+    /**
+     * Test `index` method.
+     *
+     * @return void
+     * @covers ::index()
+     * @covers ::initialize()
+     */
+    public function testIndex()
+    {
+        // auth as admin
+        $fullBaseUrl = Configure::read('App.fullBaseUrl');
+        if (empty($fullBaseUrl)) {
+            Configure::write('App.fullBaseUrl', 'http://api.example.com');
+        }
+        $expected = [
+            'data' => [
+                [
+                    'id' => '1',
+                    'type' => 'auth_providers',
+                    'attributes' => [
+                        'name' => 'example',
+                        'auth_class' => 'BEdita/API.OAuth2',
+                        'url' => 'https://example.com/oauth2',
+                        'params' => ['provider_username_field' => 'owner_id'],
+                        'enabled' => true,
+                        'created' => '2018-04-07T12:51:27+00:00',
+                        'modified' => '2018-04-07T12:51:27+00:00',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/admin/auth_providers/1',
+                    ],
+                ],
+                [
+                    'id' => '2',
+                    'type' => 'auth_providers',
+                    'attributes' => [
+                        'name' => 'uuid',
+                        'auth_class' => 'BEdita/API.Uuid',
+                        'url' => null,
+                        'params' => ['status' => 'on'],
+                        'enabled' => true,
+                        'created' => '2018-04-07T12:51:27+00:00',
+                        'modified' => '2018-04-07T12:51:27+00:00',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/admin/auth_providers/2',
+                    ],
+                ],
+                [
+                    'id' => '3',
+                    'type' => 'auth_providers',
+                    'attributes' => [
+                        'name' => 'linkedout',
+                        'auth_class' => 'BEdita/API.OAuth2',
+                        'url' => 'https://out.example.com/oauth2',
+                        'params' => ['provider_username_field' => 'owner_id'],
+                        'enabled' => false,
+                        'created' => '2018-04-07T12:51:27+00:00',
+                        'modified' => '2018-04-07T12:51:27+00:00',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/admin/auth_providers/3',
+                    ],
+                ],
+                [
+                    'id' => '4',
+                    'type' => 'auth_providers',
+                    'attributes' => [
+                        'name' => 'otp',
+                        'auth_class' => 'BEdita/API.OTP',
+                        'url' => null,
+                        'params' => ['expiry' => '+5 minutes'],
+                        'enabled' => true,
+                        'created' => '2018-04-07T12:51:27+00:00',
+                        'modified' => '2018-04-07T12:51:27+00:00',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/admin/auth_providers/4',
+                    ],
+                ],
+            ],
+            'links' => [
+                'self' => 'http://api.example.com/admin/auth_providers',
+                'home' => 'http://api.example.com/home',
+                'first' => 'http://api.example.com/admin/auth_providers',
+                'last' => 'http://api.example.com/admin/auth_providers',
+                'prev' => null,
+                'next' => null,
+            ],
+            'meta' => [
+                'pagination' => [
+                    'count' => 4,
+                    'page' => 1,
+                    'page_count' => 1,
+                    'page_items' => 4,
+                    'page_size' => 20,
+                ],
+            ],
+        ];
+
+        $this->configRequestHeaders('GET', $this->getUserAuthHeader());
+        $this->get('/admin/auth_providers');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test index method.
+     *
+     * @return void
+     * @covers ::resource()
+     * @covers ::initialize()
+     */
+    public function testEmpty()
+    {
+        $expected = [
+            'data' => [],
+            'links' => [
+                'self' => 'http://api.example.com/admin/auth_providers',
+                'home' => 'http://api.example.com/home',
+                'first' => 'http://api.example.com/admin/auth_providers',
+                'last' => 'http://api.example.com/admin/auth_providers',
+                'prev' => null,
+                'next' => null,
+            ],
+            'meta' => [
+                'pagination' => [
+                    'count' => 0,
+                    'page' => 1,
+                    'page_count' => 1,
+                    'page_items' => 0,
+                    'page_size' => 20,
+                ],
+            ],
+        ];
+
+        TableRegistry::getTableLocator()->get('ExternalAuth')->deleteAll([]);
+        TableRegistry::getTableLocator()->get('AuthProviders')->deleteAll([]);
+
+        $this->configRequestHeaders('GET', $this->getUserAuthHeader());
+        $this->get('/admin/auth_providers');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test view method.
+     *
+     * @return void
+     * @covers ::resource()
+     * @covers ::initialize()
+     */
+    public function testSingle()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/admin/auth_providers/1',
+                'home' => 'http://api.example.com/home',
+            ],
+            'data' => [
+                'id' => '1',
+                'type' => 'auth_providers',
+                'attributes' => [
+                    'name' => 'example',
+                    'auth_class' => 'BEdita/API.OAuth2',
+                    'url' => 'https://example.com/oauth2',
+                    'params' => ['provider_username_field' => 'owner_id'],
+                    'enabled' => true,
+                    'created' => '2018-04-07T12:51:27+00:00',
+                    'modified' => '2018-04-07T12:51:27+00:00',
+                ],
+
+            ],
+        ];
+
+        $this->configRequestHeaders('GET', $this->getUserAuthHeader());
+        $this->get('/admin/auth_providers/1');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test view method.
+     *
+     * @return void
+     * @covers ::resource()
+     * @covers ::initialize()
+     * @covers \BEdita\API\Error\ExceptionRenderer
+     */
+    public function testMissing()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/admin/auth_providers/99',
+                'home' => 'http://api.example.com/home',
+            ],
+            'error' => [
+                'status' => '404',
+            ],
+        ];
+
+        $this->configRequestHeaders('GET', $this->getUserAuthHeader());
+        $this->get('/admin/auth_providers/99');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(404);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertArrayNotHasKey('data', $result);
+        static::assertArrayHasKey('links', $result);
+        static::assertArrayHasKey('error', $result);
+        static::assertEquals($expected['links'], $result['links']);
+        static::assertArraySubset($expected['error'], $result['error']);
+        static::assertArrayHasKey('title', $result['error']);
+        static::assertNotEmpty($result['error']['title']);
+    }
+
+    /**
+     * Test add method.
+     *
+     * @return void
+     * @covers ::index()
+     * @covers ::initialize()
+     * @covers ::resourceUrl()
+     */
+    public function testAdd()
+    {
+        $data = [
+            'type' => 'auth_providers',
+            'attributes' => [
+                'name' => 'oauth2',
+            ],
+        ];
+
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $this->post('/admin/auth_providers', json_encode(compact('data')));
+
+        $this->assertResponseCode(201);
+        $this->assertContentType('application/vnd.api+json');
+
+        $application = TableRegistry::getTableLocator()->get('auth_providers')
+            ->find()
+            ->order(['id' => 'DESC'])
+            ->first();
+
+        $this->assertHeader('Location', 'http://api.example.com/admin/auth_providers/' . $application->id);
+
+        $expected = array_merge(['id' => $application->id], $data['attributes']);
+        static::assertArraySubset($expected, $application->toArray());
+    }
+
+    /**
+     * Test add method with invalid data.
+     *
+     * @return void
+     * @covers ::index()
+     * @covers ::initialize()
+     */
+    public function testAddAlreadyExist()
+    {
+        $data = [
+            'type' => 'auth_providers',
+            'attributes' => [
+                'name' => 'example',
+            ],
+        ];
+
+        $auth_providers = TableRegistry::getTableLocator()->get('auth_providers');
+        $count = $auth_providers->find()->count();
+
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $this->post('/admin/auth_providers', json_encode(compact('data')));
+
+        $this->assertResponseCode(400);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals($count, $auth_providers->find()->count());
+    }
+
+    /**
+     * Test edit method.
+     *
+     * @return void
+     * @covers ::resource()
+     * @covers ::initialize()
+     */
+    public function testEdit()
+    {
+        $data = [
+            'id' => '1',
+            'type' => 'auth_providers',
+            'attributes' => [
+                'name' => 'otp2',
+            ],
+        ];
+
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $this->patch('/admin/auth_providers/1', json_encode(compact('data')));
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        $auth_providers = TableRegistry::getTableLocator()->get('auth_providers');
+        $entity = $auth_providers->get(1);
+        static::assertEquals('otp2', $entity->get('name'));
+    }
+
+    /**
+     * Test edit method with ID conflict.
+     *
+     * @return void
+     * @covers ::resource()
+     * @covers ::initialize()
+     */
+    public function testEditConflict()
+    {
+        $data = [
+            'id' => '1',
+            'type' => 'auth_providers',
+            'attributes' => [
+                'name' => 'otp',
+            ],
+        ];
+
+        $auth_providers = TableRegistry::getTableLocator()->get('auth_providers');
+        $expected = $auth_providers->get(1)->get('name');
+
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $this->patch('/admin/auth_providers/2', json_encode(compact('data')));
+
+        $this->assertResponseCode(409);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals($expected, $auth_providers->get(1)->get('name'));
+    }
+
+    /**
+     * Test delete method.
+     *
+     * @return void
+     * @covers ::resource()
+     * @covers ::initialize()
+     */
+    public function testDelete()
+    {
+        $this->configRequestHeaders('DELETE', $this->getUserAuthHeader());
+        $this->delete('/admin/auth_providers/2');
+
+        $this->assertResponseCode(204);
+        $this->assertResponseEmpty();
+        static::assertFalse(TableRegistry::getTableLocator()->get('auth_providers')->exists(['id' => 2]));
+    }
+}

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/AuthProvidersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/AuthProvidersControllerTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 /**
  * BEdita, API-first content management framework
- * Copyright 2023 ChannelWeb Srl, Chialab Srl
+ * Copyright 2025 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -67,11 +67,13 @@ class AuthProvidersControllerTest extends IntegrationTestCase
                         'url' => 'https://example.com/oauth2',
                         'params' => ['provider_username_field' => 'owner_id'],
                         'enabled' => true,
-                        'created' => '2018-04-07T12:51:27+00:00',
-                        'modified' => '2018-04-07T12:51:27+00:00',
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/admin/auth_providers/1',
+                    ],
+                    'meta' => [
+                        'created' => '2018-04-07T12:51:27+00:00',
+                        'modified' => '2018-04-07T12:51:27+00:00',
                     ],
                 ],
                 [
@@ -83,12 +85,14 @@ class AuthProvidersControllerTest extends IntegrationTestCase
                         'url' => null,
                         'params' => ['status' => 'on'],
                         'enabled' => true,
-                        'created' => '2018-04-07T12:51:27+00:00',
-                        'modified' => '2018-04-07T12:51:27+00:00',
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/admin/auth_providers/2',
                     ],
+                    'meta' => [
+                        'created' => '2018-04-07T12:51:27+00:00',
+                        'modified' => '2018-04-07T12:51:27+00:00',
+                    ]
                 ],
                 [
                     'id' => '3',
@@ -99,11 +103,13 @@ class AuthProvidersControllerTest extends IntegrationTestCase
                         'url' => 'https://out.example.com/oauth2',
                         'params' => ['provider_username_field' => 'owner_id'],
                         'enabled' => false,
-                        'created' => '2018-04-07T12:51:27+00:00',
-                        'modified' => '2018-04-07T12:51:27+00:00',
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/admin/auth_providers/3',
+                    ],
+                    'meta' => [
+                        'created' => '2018-04-07T12:51:27+00:00',
+                        'modified' => '2018-04-07T12:51:27+00:00',
                     ],
                 ],
                 [
@@ -115,11 +121,13 @@ class AuthProvidersControllerTest extends IntegrationTestCase
                         'url' => null,
                         'params' => ['expiry' => '+5 minutes'],
                         'enabled' => true,
-                        'created' => '2018-04-07T12:51:27+00:00',
-                        'modified' => '2018-04-07T12:51:27+00:00',
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/admin/auth_providers/4',
+                    ],
+                    'meta' => [
+                        'created' => '2018-04-07T12:51:27+00:00',
+                        'modified' => '2018-04-07T12:51:27+00:00',
                     ],
                 ],
             ],
@@ -216,10 +224,11 @@ class AuthProvidersControllerTest extends IntegrationTestCase
                     'url' => 'https://example.com/oauth2',
                     'params' => ['provider_username_field' => 'owner_id'],
                     'enabled' => true,
+                ],
+                'meta' => [
                     'created' => '2018-04-07T12:51:27+00:00',
                     'modified' => '2018-04-07T12:51:27+00:00',
                 ],
-
             ],
         ];
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/AuthProvidersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/AuthProvidersControllerTest.php
@@ -92,7 +92,7 @@ class AuthProvidersControllerTest extends IntegrationTestCase
                     'meta' => [
                         'created' => '2018-04-07T12:51:27+00:00',
                         'modified' => '2018-04-07T12:51:27+00:00',
-                    ]
+                    ],
                 ],
                 [
                     'id' => '3',

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/ExternalAuthControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/ExternalAuthControllerTest.php
@@ -222,7 +222,7 @@ class ExternalAuthControllerTest extends IntegrationTestCase
                 'meta' => [
                     'created' => '2018-04-07T12:51:27+00:00',
                     'modified' => '2018-04-07T12:51:27+00:00',
-                ]
+                ],
             ],
         ];
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/ExternalAuthControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/ExternalAuthControllerTest.php
@@ -1,0 +1,399 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2023 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\API\Test\TestCase\Controller\Admin;
+
+use BEdita\API\TestSuite\IntegrationTestCase;
+use Cake\Core\Configure;
+use Cake\ORM\TableRegistry;
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+
+/**
+ * @coversDefaultClass \BEdita\API\Controller\Admin\ExternalAuthController
+ */
+class ExternalAuthControllerTest extends IntegrationTestCase
+{
+    use ArraySubsetAsserts;
+
+    /**
+     * Test `index` method with user not admin.
+     *
+     * @return void
+     * @covers ::index()
+     * @covers ::initialize()
+     */
+    public function testIndexNoAdmin()
+    {
+        $this->configRequestHeaders();
+        $this->get('/admin/external_auth');
+        $this->assertResponseCode(401);
+        $this->assertContentType('application/vnd.api+json');
+    }
+
+    /**
+     * Test `index` method.
+     *
+     * @return void
+     * @covers ::index()
+     * @covers ::initialize()
+     */
+    public function testIndex()
+    {
+        // auth as admin
+        $fullBaseUrl = Configure::read('App.fullBaseUrl');
+        if (empty($fullBaseUrl)) {
+            Configure::write('App.fullBaseUrl', 'http://api.example.com');
+        }
+        $expected = [
+            'data' => [
+                [
+                    'id' => '1',
+                    'type' => 'external_auth',
+                    'attributes' => [
+                        'user_id' => 1,
+                        'auth_provider_id' => 1,
+                        'params' => null,
+                        'provider_username' => 'first_user',
+                        'created' => '2018-04-07T12:51:27+00:00',
+                        'modified' => '2018-04-07T12:51:27+00:00',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/admin/external_auth/1',
+                    ],
+                ],
+                [
+                    'id' => '2',
+                    'type' => 'external_auth',
+                    'attributes' => [
+                        'user_id' => 5,
+                        'auth_provider_id' => 2,
+                        'params' => null,
+                        'provider_username' => '17fec0fa-068a-4d7c-8283-da91d47cef7d',
+                        'created' => '2018-04-07T12:51:27+00:00',
+                        'modified' => '2018-04-07T12:51:27+00:00',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/admin/external_auth/2',
+                    ],
+                ],
+                [
+                    'id' => '3',
+                    'type' => 'external_auth',
+                    'attributes' => [
+                        'user_id' => 5,
+                        'auth_provider_id' => 3,
+                        'params' => null,
+                        'provider_username' => 'disabled_auth_provider',
+                        'created' => '2020-10-26T17:16:27+00:00',
+                        'modified' => '2020-10-26T17:16:27+00:00',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/admin/external_auth/3',
+                    ],
+                ],
+                [
+                    'id' => '4',
+                    'type' => 'external_auth',
+                    'attributes' => [
+                        'user_id' => 20,
+                        'auth_provider_id' => 1,
+                        'params' => null,
+                        'provider_username' => 'third_user',
+                        'created' => '2018-04-10T12:51:27+00:00',
+                        'modified' => '2018-04-10T12:51:27+00:00',
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/admin/external_auth/4',
+                    ],
+                ],
+            ],
+            'links' => [
+                'self' => 'http://api.example.com/admin/external_auth',
+                'home' => 'http://api.example.com/home',
+                'first' => 'http://api.example.com/admin/external_auth',
+                'last' => 'http://api.example.com/admin/external_auth',
+                'prev' => null,
+                'next' => null,
+            ],
+            'meta' => [
+                'pagination' => [
+                    'count' => 4,
+                    'page' => 1,
+                    'page_count' => 1,
+                    'page_items' => 4,
+                    'page_size' => 20,
+                ],
+            ],
+        ];
+
+        $this->configRequestHeaders('GET', $this->getUserAuthHeader());
+        $this->get('/admin/external_auth');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test index method.
+     *
+     * @return void
+     * @covers ::resource()
+     * @covers ::initialize()
+     */
+    public function testEmpty()
+    {
+        $expected = [
+            'data' => [],
+            'links' => [
+                'self' => 'http://api.example.com/admin/external_auth',
+                'home' => 'http://api.example.com/home',
+                'first' => 'http://api.example.com/admin/external_auth',
+                'last' => 'http://api.example.com/admin/external_auth',
+                'prev' => null,
+                'next' => null,
+            ],
+            'meta' => [
+                'pagination' => [
+                    'count' => 0,
+                    'page' => 1,
+                    'page_count' => 1,
+                    'page_items' => 0,
+                    'page_size' => 20,
+                ],
+            ],
+        ];
+
+        TableRegistry::getTableLocator()->get('ExternalAuth')->deleteAll([]);
+
+        $this->configRequestHeaders('GET', $this->getUserAuthHeader());
+        $this->get('/admin/external_auth');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test view method.
+     *
+     * @return void
+     * @covers ::resource()
+     * @covers ::initialize()
+     */
+    public function testSingle()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/admin/external_auth/1',
+                'home' => 'http://api.example.com/home',
+            ],
+            'data' => [
+                'id' => '1',
+                'type' => 'external_auth',
+                'attributes' => [
+                    'user_id' => 1,
+                    'auth_provider_id' => 1,
+                    'params' => null,
+                    'provider_username' => 'first_user',
+                    'created' => '2018-04-07T12:51:27+00:00',
+                    'modified' => '2018-04-07T12:51:27+00:00',
+                ],
+
+            ],
+        ];
+
+        $this->configRequestHeaders('GET', $this->getUserAuthHeader());
+        $this->get('/admin/external_auth/1');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test view method.
+     *
+     * @return void
+     * @covers ::resource()
+     * @covers ::initialize()
+     * @covers \BEdita\API\Error\ExceptionRenderer
+     */
+    public function testMissing()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/admin/external_auth/99',
+                'home' => 'http://api.example.com/home',
+            ],
+            'error' => [
+                'status' => '404',
+            ],
+        ];
+
+        $this->configRequestHeaders('GET', $this->getUserAuthHeader());
+        $this->get('/admin/external_auth/99');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(404);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertArrayNotHasKey('data', $result);
+        static::assertArrayHasKey('links', $result);
+        static::assertArrayHasKey('error', $result);
+        static::assertEquals($expected['links'], $result['links']);
+        static::assertArraySubset($expected['error'], $result['error']);
+        static::assertArrayHasKey('title', $result['error']);
+        static::assertNotEmpty($result['error']['title']);
+    }
+
+    /**
+     * Test add method.
+     *
+     * @return void
+     * @covers ::index()
+     * @covers ::initialize()
+     * @covers ::resourceUrl()
+     */
+    public function testAdd()
+    {
+        $data = [
+            'type' => 'external_auth',
+            'attributes' => [
+                'user_id' => 1,
+                'auth_provider_id' => 2,
+                'provider_username' => 'new_user',
+            ],
+        ];
+
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $this->post('/admin/external_auth', json_encode(compact('data')));
+
+        $this->assertResponseCode(201);
+        $this->assertContentType('application/vnd.api+json');
+
+        $application = TableRegistry::getTableLocator()->get('external_auth')
+            ->find()
+            ->order(['id' => 'DESC'])
+            ->first();
+
+        $this->assertHeader('Location', 'http://api.example.com/admin/external_auth/' . $application->id);
+
+        $expected = array_merge(['id' => $application->id], $data['attributes']);
+        static::assertArraySubset($expected, $application->toArray());
+    }
+
+    /**
+     * Test add method with invalid data.
+     *
+     * @return void
+     * @covers ::index()
+     * @covers ::initialize()
+     */
+    public function testAddAlreadyExist()
+    {
+        $data = [
+            'type' => 'external_auth',
+            'attributes' => [
+                'name' => 'example',
+            ],
+        ];
+
+        $external_auth = TableRegistry::getTableLocator()->get('external_auth');
+        $count = $external_auth->find()->count();
+
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $this->post('/admin/external_auth', json_encode(compact('data')));
+
+        $this->assertResponseCode(400);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals($count, $external_auth->find()->count());
+    }
+
+    /**
+     * Test edit method.
+     *
+     * @return void
+     * @covers ::resource()
+     * @covers ::initialize()
+     */
+    public function testEdit()
+    {
+        $data = [
+            'id' => '1',
+            'type' => 'external_auth',
+            'attributes' => [
+                'provider_username' => 'new name',
+            ],
+        ];
+
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $this->patch('/admin/external_auth/1', json_encode(compact('data')));
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        $external_auth = TableRegistry::getTableLocator()->get('external_auth');
+        $entity = $external_auth->get(1);
+        static::assertEquals('new name', $entity->get('provider_username'));
+    }
+
+    /**
+     * Test edit method with ID conflict.
+     *
+     * @return void
+     * @covers ::resource()
+     * @covers ::initialize()
+     */
+    public function testEditConflict()
+    {
+        $data = [
+            'id' => '1',
+            'type' => 'external_auth',
+            'attributes' => [
+                'name' => 'new name',
+            ],
+        ];
+
+        $external_auth = TableRegistry::getTableLocator()->get('external_auth');
+        $expected = $external_auth->get(1)->get('name');
+
+        $this->configRequestHeaders('PATCH', $this->getUserAuthHeader());
+        $this->patch('/admin/external_auth/2', json_encode(compact('data')));
+
+        $this->assertResponseCode(409);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals($expected, $external_auth->get(1)->get('name'));
+    }
+
+    /**
+     * Test delete method.
+     *
+     * @return void
+     * @covers ::resource()
+     * @covers ::initialize()
+     */
+    public function testDelete()
+    {
+        $this->configRequestHeaders('DELETE', $this->getUserAuthHeader());
+        $this->delete('/admin/external_auth/2');
+
+        $this->assertResponseCode(204);
+        $this->assertResponseEmpty();
+        static::assertFalse(TableRegistry::getTableLocator()->get('external_auth')->exists(['id' => 2]));
+    }
+}

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/ExternalAuthControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/ExternalAuthControllerTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 /**
  * BEdita, API-first content management framework
- * Copyright 2023 ChannelWeb Srl, Chialab Srl
+ * Copyright 2025 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -66,11 +66,13 @@ class ExternalAuthControllerTest extends IntegrationTestCase
                         'auth_provider_id' => 1,
                         'params' => null,
                         'provider_username' => 'first_user',
-                        'created' => '2018-04-07T12:51:27+00:00',
-                        'modified' => '2018-04-07T12:51:27+00:00',
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/admin/external_auth/1',
+                    ],
+                    'meta' => [
+                        'created' => '2018-04-07T12:51:27+00:00',
+                        'modified' => '2018-04-07T12:51:27+00:00',
                     ],
                 ],
                 [
@@ -81,11 +83,13 @@ class ExternalAuthControllerTest extends IntegrationTestCase
                         'auth_provider_id' => 2,
                         'params' => null,
                         'provider_username' => '17fec0fa-068a-4d7c-8283-da91d47cef7d',
-                        'created' => '2018-04-07T12:51:27+00:00',
-                        'modified' => '2018-04-07T12:51:27+00:00',
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/admin/external_auth/2',
+                    ],
+                    'meta' => [
+                        'created' => '2018-04-07T12:51:27+00:00',
+                        'modified' => '2018-04-07T12:51:27+00:00',
                     ],
                 ],
                 [
@@ -96,11 +100,13 @@ class ExternalAuthControllerTest extends IntegrationTestCase
                         'auth_provider_id' => 3,
                         'params' => null,
                         'provider_username' => 'disabled_auth_provider',
-                        'created' => '2020-10-26T17:16:27+00:00',
-                        'modified' => '2020-10-26T17:16:27+00:00',
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/admin/external_auth/3',
+                    ],
+                    'meta' => [
+                        'created' => '2020-10-26T17:16:27+00:00',
+                        'modified' => '2020-10-26T17:16:27+00:00',
                     ],
                 ],
                 [
@@ -111,11 +117,13 @@ class ExternalAuthControllerTest extends IntegrationTestCase
                         'auth_provider_id' => 1,
                         'params' => null,
                         'provider_username' => 'third_user',
-                        'created' => '2018-04-10T12:51:27+00:00',
-                        'modified' => '2018-04-10T12:51:27+00:00',
                     ],
                     'links' => [
                         'self' => 'http://api.example.com/admin/external_auth/4',
+                    ],
+                    'meta' => [
+                        'created' => '2018-04-10T12:51:27+00:00',
+                        'modified' => '2018-04-10T12:51:27+00:00',
                     ],
                 ],
             ],
@@ -210,10 +218,11 @@ class ExternalAuthControllerTest extends IntegrationTestCase
                     'auth_provider_id' => 1,
                     'params' => null,
                     'provider_username' => 'first_user',
+                ],
+                'meta' => [
                     'created' => '2018-04-07T12:51:27+00:00',
                     'modified' => '2018-04-07T12:51:27+00:00',
-                ],
-
+                ]
             ],
         ];
 

--- a/plugins/BEdita/Core/src/Model/Entity/AuthProvider.php
+++ b/plugins/BEdita/Core/src/Model/Entity/AuthProvider.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace BEdita\Core\Model\Entity;
 
+use BEdita\Core\Utility\JsonApiSerializable;
 use Cake\Core\Configure;
 use Cake\Database\Expression\QueryExpression;
 use Cake\ORM\Entity;
@@ -37,8 +38,10 @@ use Cake\Utility\Text;
  * @property \BEdita\Core\Model\Entity\ExternalAuth[] $external_auth
  * @since 4.0.0
  */
-class AuthProvider extends Entity
+class AuthProvider extends Entity implements JsonApiSerializable
 {
+    use JsonApiAdminTrait;
+
     /**
      * @inheritDoc
      */

--- a/plugins/BEdita/Core/src/Model/Entity/AuthProvider.php
+++ b/plugins/BEdita/Core/src/Model/Entity/AuthProvider.php
@@ -48,6 +48,8 @@ class AuthProvider extends Entity implements JsonApiSerializable
     protected $_accessible = [
         '*' => true,
         'id' => false,
+        'created' => false,
+        'modified' => false,
     ];
 
     /**

--- a/plugins/BEdita/Core/src/Model/Entity/ExternalAuth.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ExternalAuth.php
@@ -42,5 +42,7 @@ class ExternalAuth extends Entity implements JsonApiSerializable
     protected $_accessible = [
         '*' => true,
         'id' => false,
+        'created' => false,
+        'modified' => false,
     ];
 }

--- a/plugins/BEdita/Core/src/Model/Entity/ExternalAuth.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ExternalAuth.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace BEdita\Core\Model\Entity;
 
+use BEdita\Core\Utility\JsonApiSerializable;
 use Cake\ORM\Entity;
 
 /**
@@ -31,8 +32,10 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\Time $modified
  * @since 4.0.0
  */
-class ExternalAuth extends Entity
+class ExternalAuth extends Entity implements JsonApiSerializable
 {
+    use JsonApiAdminTrait;
+
     /**
      * @inheritDoc
      */


### PR DESCRIPTION
This PR introduces new endpoints for managing auth providers and external auth, accessible only to admin users:
- `[GET, POST, PATCH, DELETE] /admin/auth_providers`
- `[GET, POST, PATCH, DELETE] /admin/external_auth`