### PR TITLE
Sort of children association

### DIFF
--- a/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListAssociatedAction.php
@@ -17,6 +17,7 @@ namespace BEdita\Core\Model\Action;
 
 use Cake\Collection\CollectionInterface;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\ExpressionInterface;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\Exception\InvalidPrimaryKeyException;
 use Cake\Datasource\Exception\RecordNotFoundException;
@@ -302,10 +303,14 @@ class ListAssociatedAction extends BaseAction
      */
     protected function sort(Association $association, $primaryKey)
     {
+        $sort = $association->getSort();
         if ($association->getName() === 'Children') {
-            return (array)TableRegistry::getTableLocator()->get('Folders')->getSort($primaryKey);
+            $sort = TableRegistry::getTableLocator()->get('Folders')->getSort($primaryKey);
+        }
+        if ($sort instanceof ExpressionInterface) {
+            return $sort;
         }
 
-        return (array)$association->getSort();
+        return (array)$sort;
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListAssociatedActionTest.php
@@ -40,6 +40,8 @@ class ListAssociatedActionTest extends TestCase
         'plugin.BEdita/Core.FakeTags',
         'plugin.BEdita/Core.FakeArticlesTags',
         'plugin.BEdita/Core.ObjectTypes',
+        'plugin.BEdita/Core.PropertyTypes',
+        'plugin.BEdita/Core.Properties',
         'plugin.BEdita/Core.Relations',
         'plugin.BEdita/Core.RelationTypes',
         'plugin.BEdita/Core.Objects',
@@ -282,5 +284,28 @@ class ListAssociatedActionTest extends TestCase
         $result = json_decode(json_encode($result->toArray()), true);
         static::assertEquals('Sub Folder', $result[0]['title']);
         static::assertEquals('title one', $result[1]['title']);
+    }
+
+    /**
+     * Test `sort` method with publish start sorting, which uses a query function.
+     *
+     * @return void
+     * @covers ::sort()
+     */
+    public function testSortWithPublishStart()
+    {
+        // Set children order
+        $Folders = TableRegistry::getTableLocator()->get('Folders');
+        $folder = $Folders->get(11);
+        $folder->set('children_order', 'publish_start');
+        $Folders->saveOrFail($folder);
+
+        // association Children
+        $association = $Folders->getAssociation('Children');
+        $action = new ListAssociatedAction(compact('association'));
+        $result = $action(['primaryKey' => 11]);
+        $result = json_decode(json_encode($result->toArray()), true);
+        static::assertEquals('title one', $result[0]['title']);
+        static::assertEquals('Sub Folder', $result[1]['title']);
     }
 }


### PR DESCRIPTION
The sort part of the query in `ListAssociatedAction` is always cast to array, but in some cases it may actually be a query function (see https://github.com/bedita/bedita/pull/2134).