### PR TITLE
Let History obfuscate `old_password`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
     },
     "conflict": {
         "enqueue/dsn": "!=0.10.19",
+        "enqueue/enqueue": "!=0.10.24",
         "enqueue/simple-client": "!=0.10.19",
         "symfony/console": "^7",
         "symfony/filesystem": "^7"

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "dereuromark/cakephp-ide-helper": "^1.17"
     },
     "conflict": {
-        "enqueue/simple-client": "!=0.10.25",
+        "enqueue/simple-client": "!=0.10.19",
         "symfony/console": "^7",
         "symfony/filesystem": "^7"
     },

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "dereuromark/cakephp-ide-helper": "^1.17"
     },
     "conflict": {
+        "enqueue/dsn": "!=0.10.19",
         "enqueue/simple-client": "!=0.10.19",
         "symfony/console": "^7",
         "symfony/filesystem": "^7"

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "dereuromark/cakephp-ide-helper": "^1.17"
     },
     "conflict": {
+        "enqueue/simple-client": "!=0.10.25",
         "symfony/console": "^7",
         "symfony/filesystem": "^7"
     },

--- a/plugins/BEdita/Core/src/Model/Behavior/HistoryBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/HistoryBehavior.php
@@ -48,6 +48,7 @@ class HistoryBehavior extends Behavior
         ],
         'obfuscate' => [
             'password' => '*****',
+            'old_password' => '*****',
         ],
         'resource_type' => 'objects',
         'implementedFinders' => [


### PR DESCRIPTION
This PR fixes a problem in `HistoryBehavior`: `old_password` is not obfuscated.

Suggested sql query to update properly history data:
```sql
BEGIN;

UPDATE history
SET changed = JSON_REPLACE(changed, '$.old_password', '*****')
WHERE resource_type = 'objects'
  AND user_action = 'update'
  AND changed->'$.old_password';

ROLLBACK;
```