### PR TITLE
Add `?sort=published` for objects, to sort by `publish_start ?? created`

### DIFF
--- a/plugins/BEdita/API/src/Datasource/JsonApiPaginator.php
+++ b/plugins/BEdita/API/src/Datasource/JsonApiPaginator.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 namespace BEdita\API\Datasource;
 
 use BEdita\Core\Model\Table\ObjectsTable;
+use Cake\Database\Expression\FunctionExpression;
+use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Datasource\Paging\NumericPaginator;
 use Cake\Datasource\QueryInterface;
 use Cake\Datasource\RepositoryInterface;
@@ -91,6 +93,24 @@ class JsonApiPaginator extends NumericPaginator
             unset($options['order']);
             if (in_array($options['sort'], ObjectsTable::DATERANGES_SORT_FIELDS)) {
                 $options['sortableFields'] = [$options['sort']];
+            }
+
+            $sortableFields = $this->getSortableFields($options);
+            $canSortField = fn (string $field): bool => $sortableFields === null || in_array($field, $sortableFields, true);
+            if ($options['sort'] === 'published' && $canSortField('publish_start')) {
+                $options['order'] = new OrderClauseExpression(
+                    new FunctionExpression(
+                        'COALESCE',
+                        [
+                            $object->getAlias() . '.publish_start' => 'identifier',
+                            $object->getAlias() . '.created' => 'identifier',
+                        ],
+                        ['timestamp', 'timestamp'],
+                        'timestamp',
+                    ),
+                    $options['direction'] ?? 'asc',
+                );
+                unset($options['sort'], $options['direction']);
             }
         }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -1047,6 +1047,219 @@ class ObjectsControllerTest extends IntegrationTestCase
     }
 
     /**
+     * Test index method.
+     *
+     * @return void
+     * @covers ::index()
+     * @covers ::initialize()
+     * @covers ::addCount()
+     * @covers ::prepareFilter()
+     * @covers ::prepareInclude()
+     */
+    public function testIndexSortPublished()
+    {
+        $expected = [
+            'links' => [
+                'self' => 'http://api.example.com/documents?sort=published',
+                'home' => 'http://api.example.com/home',
+                'first' => 'http://api.example.com/documents?sort=published',
+                'last' => 'http://api.example.com/documents?sort=published',
+                'prev' => null,
+                'next' => null,
+            ],
+            'meta' => [
+                'pagination' => [
+                    'count' => 2,
+                    'page' => 1,
+                    'page_count' => 1,
+                    'page_items' => 2,
+                    'page_size' => 20,
+                ],
+                'schema' => [
+                    'documents' => [
+                        '$id' => 'http://api.example.com/model/schema/documents',
+                        'revision' => TestConstants::SCHEMA_REVISIONS['documents'],
+                    ],
+                ],
+            ],
+            'data' => [
+                [
+                    'id' => '3',
+                    'type' => 'documents',
+                    'attributes' => [
+                        'status' => 'draft',
+                        'uname' => 'title-two',
+                        'title' => 'title two',
+                        'description' => 'description here',
+                        'body' => 'body here',
+                        'extra' => null,
+                        'lang' => null,
+                        'publish_start' => null,
+                        'publish_end' => null,
+                        'categories' => [],
+                        'another_title' => null,
+                        'another_description' => null,
+                    ],
+                    'meta' => [
+                        'locked' => false,
+                        'created' => '2016-05-12T07:09:23+00:00',
+                        'modified' => '2016-05-13T08:30:00+00:00',
+                        'published' => null,
+                        'created_by' => 1,
+                        'modified_by' => 5,
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/documents/3',
+                    ],
+                    'relationships' => [
+                        'test' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/documents/3/test',
+                                'self' => 'http://api.example.com/documents/3/relationships/test',
+                            ],
+                        ],
+                        'inverse_test' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/documents/3/inverse_test',
+                                'self' => 'http://api.example.com/documents/3/relationships/inverse_test',
+                            ],
+                        ],
+                        'parents' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/documents/3/parents',
+                                'self' => 'http://api.example.com/documents/3/relationships/parents',
+                            ],
+                        ],
+                        'translations' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/documents/3/translations',
+                                'self' => 'http://api.example.com/documents/3/relationships/translations',
+                            ],
+                        ],
+                        'test_simple' => [
+                            'links' => [
+                                'self' => 'http://api.example.com/documents/3/relationships/test_simple',
+                                'related' => 'http://api.example.com/documents/3/test_simple',
+                            ],
+                        ],
+                        'test_defaults' => [
+                            'links' => [
+                                'self' => 'http://api.example.com/documents/3/relationships/test_defaults',
+                                'related' => 'http://api.example.com/documents/3/test_defaults',
+                            ],
+                        ],
+                        'inverse_test_simple' => [
+                            'links' => [
+                                'self' => 'http://api.example.com/documents/3/relationships/inverse_test_simple',
+                                'related' => 'http://api.example.com/documents/3/inverse_test_simple',
+                            ],
+                        ],
+                        'inverse_test_defaults' => [
+                            'links' => [
+                                'self' => 'http://api.example.com/documents/3/relationships/inverse_test_defaults',
+                                'related' => 'http://api.example.com/documents/3/inverse_test_defaults',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'id' => '2',
+                    'type' => 'documents',
+                    'attributes' => [
+                        'status' => 'on',
+                        'uname' => 'title-one',
+                        'title' => 'title one',
+                        'description' => 'description here',
+                        'body' => 'body here',
+                        'extra' => [
+                            'abstract' => 'abstract here',
+                            'list' => ['one', 'two', 'three'],
+                        ],
+                        'lang' => 'en',
+                        'publish_start' => '2016-05-13T07:09:23+00:00',
+                        'publish_end' => '2016-05-13T07:09:23+00:00',
+                        'categories' => [
+                            ['name' => 'first-cat', 'labels' => ['default' => 'First category'], 'params' => '100', 'label' => 'First category'],
+                            ['name' => 'second-cat', 'labels' => ['default' => 'Second category'], 'params' => null, 'label' => 'Second category'],
+                        ],
+                        'another_title' => null,
+                        'another_description' => null,
+                    ],
+                    'meta' => [
+                        'locked' => true,
+                        'created' => '2016-05-13T07:09:23+00:00',
+                        'modified' => '2016-05-13T07:09:23+00:00',
+                        'published' => '2016-05-13T07:09:23+00:00',
+                        'created_by' => 1,
+                        'modified_by' => 1,
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/documents/2',
+                    ],
+                    'relationships' => [
+                        'test' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/documents/2/test',
+                                'self' => 'http://api.example.com/documents/2/relationships/test',
+                            ],
+                        ],
+                        'inverse_test' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/documents/2/inverse_test',
+                                'self' => 'http://api.example.com/documents/2/relationships/inverse_test',
+                            ],
+                        ],
+                        'parents' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/documents/2/parents',
+                                'self' => 'http://api.example.com/documents/2/relationships/parents',
+                            ],
+                        ],
+                        'translations' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/documents/2/translations',
+                                'self' => 'http://api.example.com/documents/2/relationships/translations',
+                            ],
+                        ],
+                        'test_simple' => [
+                            'links' => [
+                                'self' => 'http://api.example.com/documents/2/relationships/test_simple',
+                                'related' => 'http://api.example.com/documents/2/test_simple',
+                            ],
+                        ],
+                        'test_defaults' => [
+                            'links' => [
+                                'self' => 'http://api.example.com/documents/2/relationships/test_defaults',
+                                'related' => 'http://api.example.com/documents/2/test_defaults',
+                            ],
+                        ],
+                        'inverse_test_simple' => [
+                            'links' => [
+                                'self' => 'http://api.example.com/documents/2/relationships/inverse_test_simple',
+                                'related' => 'http://api.example.com/documents/2/inverse_test_simple',
+                            ],
+                        ],
+                        'inverse_test_defaults' => [
+                            'links' => [
+                                'self' => 'http://api.example.com/documents/2/relationships/inverse_test_defaults',
+                                'related' => 'http://api.example.com/documents/2/inverse_test_defaults',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->configRequestHeaders();
+        $this->get('/documents?sort=published');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals($expected, $result);
+    }
+
+    /**
      * Test index method on DELETE.
      *
      * @return void

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -1060,10 +1060,10 @@ class ObjectsControllerTest extends IntegrationTestCase
     {
         $expected = [
             'links' => [
-                'self' => 'http://api.example.com/documents?sort=published',
+                'self' => 'http://api.example.com/documents?sort=-published',
                 'home' => 'http://api.example.com/home',
-                'first' => 'http://api.example.com/documents?sort=published',
-                'last' => 'http://api.example.com/documents?sort=published',
+                'first' => 'http://api.example.com/documents?sort=-published',
+                'last' => 'http://api.example.com/documents?sort=-published',
                 'prev' => null,
                 'next' => null,
             ],
@@ -1176,7 +1176,7 @@ class ObjectsControllerTest extends IntegrationTestCase
                             'list' => ['one', 'two', 'three'],
                         ],
                         'lang' => 'en',
-                        'publish_start' => '2016-05-13T07:09:23+00:00',
+                        'publish_start' => '2015-01-01T00:00:00+00:00',
                         'publish_end' => '2016-05-13T07:09:23+00:00',
                         'categories' => [
                             ['name' => 'first-cat', 'labels' => ['default' => 'First category'], 'params' => '100', 'label' => 'First category'],
@@ -1250,8 +1250,10 @@ class ObjectsControllerTest extends IntegrationTestCase
             ],
         ];
 
+        $this->fetchTable('Documents')->updateAll(['publish_start' => '2015-01-01 00:00:00'], ['id' => 2]);
+
         $this->configRequestHeaders();
-        $this->get('/documents?sort=published');
+        $this->get('/documents?sort=-published');
         $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->assertResponseCode(200);

--- a/plugins/BEdita/API/tests/TestCase/Datasource/JsonApiPaginatorTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Datasource/JsonApiPaginatorTest.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 namespace BEdita\API\Test\TestCase\Datasource;
 
 use BEdita\API\Datasource\JsonApiPaginator;
+use Cake\Database\Expression\FunctionExpression;
+use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -120,6 +122,20 @@ class JsonApiPaginatorTest extends TestCase
             'special' => [
                 ['date_ranges_max_end_date' => 'desc'],
                 '-date_ranges_max_end_date',
+            ],
+            'published desc' => [
+                new OrderClauseExpression(
+                    new FunctionExpression('COALESCE', ['Roles.publish_start' => 'identifier', 'Roles.created' => 'identifier'], ['timestamp', 'timestamp'], 'timestamp'),
+                    'desc',
+                ),
+                '-published',
+            ],
+            'published asc' => [
+                new OrderClauseExpression(
+                    new FunctionExpression('COALESCE', ['Roles.publish_start' => 'identifier', 'Roles.created' => 'identifier'], ['timestamp', 'timestamp'], 'timestamp'),
+                    'asc',
+                ),
+                'published',
             ],
             'multipleFields' => [
                 new BadRequestException('Unsupported sorting field'),


### PR DESCRIPTION
This PR adds a custom sorting option for tables that allow sorting by `publish_start` to make it possible to sort by `COALESCE(publish_start, created)`. This is useful in conjunction with `filter[ancestor]` to sort all descendants in a publication by their publication date and find the latest.
