### PR TITLE
Project model config content as json

### DIFF
--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -88,6 +88,19 @@ class ProjectModelCommand extends Command
 
             return self::CODE_ERROR;
         }
+        // adjust project config content, if needed
+        if (isset($project['config'])) {
+            $project['config'] = array_map(
+                function ($item) {
+                    if (is_array($item['content'])) {
+                        return ['content' => json_encode($item['content'])];
+                    }
+
+                    return $item;
+                },
+                Hash::get($project, 'config', [])
+            );
+        }
 
         if ($args->getOption('cache-clear')) {
             Cache::clearAll();

--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -92,11 +92,7 @@ class ProjectModelCommand extends Command
         if (isset($project['config'])) {
             $project['config'] = array_map(
                 function ($item) {
-                    if (is_array($item['content'])) {
-                        return ['content' => json_encode($item['content'])];
-                    }
-
-                    return $item;
+                    return is_array($item['content']) ? ['content' => json_encode($item['content'])] : $item;
                 },
                 Hash::get($project, 'config', [])
             );

--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -91,9 +91,7 @@ class ProjectModelCommand extends Command
         // adjust project config content, if needed
         if (isset($project['config'])) {
             $project['config'] = array_map(
-                function ($item) {
-                    return is_array($item['content']) ? ['content' => json_encode($item['content'])] : $item;
-                },
+                fn ($item) => is_array($item['content']) ? ['content' => json_encode($item['content'])] : $item,
                 Hash::get($project, 'config', [])
             );
         }

--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -90,10 +90,7 @@ class ProjectModelCommand extends Command
         }
         // adjust project config content, if needed
         if (isset($project['config'])) {
-            $project['config'] = array_map(
-                fn ($item) => is_array($item['content']) ? ['content' => json_encode($item['content'])] : $item,
-                Hash::get($project, 'config', [])
-            );
+            $project['config'] = $this->prepareContent($project['config']);
         }
 
         if ($args->getOption('cache-clear')) {
@@ -132,6 +129,26 @@ class ProjectModelCommand extends Command
         }
 
         return null;
+    }
+
+    /**
+     * Set content to string if is an array, in model data.
+     *
+     * @param array $data Data to prepare.
+     * @return array
+     */
+    protected function prepareContent(array $data): array
+    {
+        return array_map(
+            function ($item) {
+                if (is_array($item['content'])) {
+                    $item['content'] = json_encode($item['content']);
+                }
+
+                return $item;
+            },
+            $data
+        );
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
@@ -189,4 +189,35 @@ class ProjectModelCommandTest extends TestCase
         $this->assertOutputContains('Cache cleared');
         $this->assertExitSuccess();
     }
+
+    /**
+     * Test prepareContent method
+     *
+     * @return void
+     * @covers ::prepareContent()
+     */
+    public function testPrepareContent(): void
+    {
+        $cmd = new class () extends ProjectModelCommand
+        {
+            public function prepareContent(array $data): array
+            {
+                return parent::prepareContent($data);
+            }
+        };
+        $data = [
+            [
+                'name' => 'test',
+                'content' => ['sample' => 'something'],
+            ],
+        ];
+        $actual = $cmd->prepareContent($data);
+        $expected = [
+            [
+                'name' => 'test',
+                'content' => '{"sample":"something"}',
+            ],
+        ];
+        $this->assertEquals($expected, $actual);
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -486,7 +486,16 @@ class ProjectModelTest extends TestCase
                 'label' => 'Disabled category',
             ],
         ],
-        'config' => [],
+        'config' => [
+            [
+                'name' => 'sample_config',
+                'description' => 'Sample configuration',
+                'content' => [
+                    'setting1' => 'value1',
+                    'setting2' => 'value2',
+                ],
+            ],
+        ],
     ];
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -486,16 +486,7 @@ class ProjectModelTest extends TestCase
                 'label' => 'Disabled category',
             ],
         ],
-        'config' => [
-            [
-                'name' => 'sample_config',
-                'description' => 'Sample configuration',
-                'content' => [
-                    'setting1' => 'value1',
-                    'setting2' => 'value2',
-                ],
-            ],
-        ],
+        'config' => [],
     ];
 
     /**


### PR DESCRIPTION
This PR provides the possibility to set `content` as json in project_model instead of a string, for config data.
Example:
```
{
    "config": [
        {
            "name": "Properties",
            "context": "app",
            "content": {
                // ...
            }
        }
    ]
}
```