### PR TITLE
Add support for 'nin' operator in fieldsFilter

### DIFF
--- a/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
+++ b/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
@@ -85,15 +85,28 @@ trait QueryFilterTrait
                 }
 
                 $in = [];
+                $nin = [];
                 foreach ($conditions as $operator => $value) {
                     if (is_numeric($operator)) {
                         $in[] = $value;
                         continue;
                     }
-                    $exp = $this->operatorExpression($exp, $operator, $field, $value);
+
+                    switch ($operator) {
+                        case 'nin':
+                            $nin = is_string($value) ? explode(',', $value) : (array)$value;
+                            break;
+
+                        default:
+                            $exp = $this->operatorExpression($exp, $operator, $field, $value);
+                    }
                 }
+
                 if (!empty($in)) {
                     $exp = $exp->in($field, $in);
+                }
+                if (!empty($nin)) {
+                    $exp = $exp->notIn($field, $nin);
                 }
             }
 

--- a/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
+++ b/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
@@ -85,28 +85,17 @@ trait QueryFilterTrait
                 }
 
                 $in = [];
-                $nin = [];
                 foreach ($conditions as $operator => $value) {
                     if (is_numeric($operator)) {
                         $in[] = $value;
                         continue;
                     }
 
-                    switch ($operator) {
-                        case 'nin':
-                            $nin = is_string($value) ? explode(',', $value) : (array)$value;
-                            break;
-
-                        default:
-                            $exp = $this->operatorExpression($exp, $operator, $field, $value);
-                    }
+                    $exp = $this->operatorExpression($exp, $operator, $field, $value);
                 }
 
                 if (!empty($in)) {
                     $exp = $exp->in($field, $in);
-                }
-                if (!empty($nin)) {
-                    $exp = $exp->notIn($field, $nin);
                 }
             }
 
@@ -161,6 +150,16 @@ trait QueryFilterTrait
             case 'ge':
             case '>=':
                 $exp = $exp->gte($field, $value);
+                break;
+            case 'notin':
+            case 'nin':
+                $values = is_string($value) ? explode(',', $value) : (array)$value;
+                $exp = $exp->notIn($field, $values);
+                break;
+
+            case 'in':
+                $values = is_string($value) ? explode(',', $value) : (array)$value;
+                $exp = $exp->in($field, $values);
                 break;
 
             case 'null':

--- a/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
@@ -168,6 +168,12 @@ class QueryFilterTraitTest extends TestCase
                 ],
                 1,
             ],
+            'ninCatEagle' => [
+                [
+                    'name' => ['nin' => ['cat', 'eagle']],
+                ],
+                1,
+            ],
         ];
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
@@ -174,6 +174,18 @@ class QueryFilterTraitTest extends TestCase
                 ],
                 1,
             ],
+            'notInCombined' => [
+                [
+                    'name' => ['eagle', 'bat', 'nin' => ['cat', 'koala'], 'lt' => 'f'],
+                ],
+                1,
+            ],
+            'inCatKoala' => [
+                [
+                    'name' => ['in' => ['cat', 'koala']],
+                ],
+                2,
+            ],
         ];
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/QueryFilterTraitTest.php
@@ -186,6 +186,13 @@ class QueryFilterTraitTest extends TestCase
                 ],
                 2,
             ],
+            'separateInClausesForEachField' => [
+                [
+                    'name' => ['koala', 'eagle'],
+                    'legs' => [4,5,6,7],
+                ],
+                1,
+            ],
         ];
     }
 


### PR DESCRIPTION
Implements the `nin` (not in) operator in `fieldsFilter`.

This allows users to write filters like `filter[field][nin]=x,y,z`, which internally maps to a `NOT IN` condition on the specified field.

The change is covered by unit tests under `QueryFilterTraitTest`.