### PR TITLE
feat: include join data of related entities

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -3224,10 +3224,24 @@ class ObjectsControllerTest extends IntegrationTestCase
                             [
                                 'id' => '4',
                                 'type' => 'profiles',
+                                'meta' => [
+                                    'relation' => [
+                                        'priority' => 1,
+                                        'inv_priority' => 2,
+                                        'params' => null,
+                                    ],
+                                ],
                             ],
                             [
                                 'id' => '3',
                                 'type' => 'documents',
+                                'meta' => [
+                                    'relation' => [
+                                        'priority' => 2,
+                                        'inv_priority' => 1,
+                                        'params' => null,
+                                    ],
+                                ],
                             ],
                         ],
                     ],
@@ -3438,6 +3452,213 @@ class ObjectsControllerTest extends IntegrationTestCase
 
         $this->configRequestHeaders();
         $this->get('/documents/2?include=test,inverse_test');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test that relationships include join data.
+     *
+     * @return void
+     * @coversNothing This is an integration test for {@see \BEdita\Core\Model\Entity\JsonApiTrait::jsonApiSerialize()}
+     */
+    public function testIncludeJoinData()
+    {
+        $expected = [
+            'data' => [
+                'id' => '2',
+                'type' => 'documents',
+                'attributes' => [
+                    'status' => 'on',
+                    'uname' => 'title-one',
+                    'title' => 'title one',
+                    'description' => 'description here',
+                    'body' => 'body here',
+                    'extra' => [
+                        'abstract' => 'abstract here',
+                        'list' => ['one', 'two', 'three'],
+                    ],
+                    'categories' => [
+                        [
+                            'name' => 'first-cat',
+                            'labels' => ['default' => 'First category'],
+                            'params' => '100',
+                            'label' => 'First category',
+                        ],
+                        [
+                            'name' => 'second-cat',
+                            'labels' => ['default' => 'Second category'],
+                            'params' => null,
+                            'label' => 'Second category',
+                        ],
+                    ],
+                    'lang' => 'en',
+                    'publish_start' => '2016-05-13T07:09:23+00:00',
+                    'publish_end' => '2016-05-13T07:09:23+00:00',
+                    'another_title' => null,
+                    'another_description' => null,
+                ],
+                'meta' => [
+                    'locked' => true,
+                    'created_by' => 1,
+                    'modified_by' => 1,
+                    'created' => '2016-05-13T07:09:23+00:00',
+                    'modified' => '2016-05-13T07:09:23+00:00',
+                    'published' => '2016-05-13T07:09:23+00:00',
+                ],
+                'relationships' => [
+                    'test' => [
+                        'links' => [
+                            'self' => 'http://api.example.com/documents/2/relationships/test',
+                            'related' => 'http://api.example.com/documents/2/test',
+                        ],
+                    ],
+                    'inverse_test' => [
+                        'links' => [
+                            'self' => 'http://api.example.com/documents/2/relationships/inverse_test',
+                            'related' => 'http://api.example.com/documents/2/inverse_test',
+                        ],
+                    ],
+                    'parents' => [
+                        'links' => [
+                            'self' => 'http://api.example.com/documents/2/relationships/parents',
+                            'related' => 'http://api.example.com/documents/2/parents',
+                        ],
+                    ],
+                    'translations' => [
+                        'links' => [
+                            'self' => 'http://api.example.com/documents/2/relationships/translations',
+                            'related' => 'http://api.example.com/documents/2/translations',
+                        ],
+                    ],
+                    'test_simple' => [
+                        'links' => [
+                            'self' => 'http://api.example.com/documents/2/relationships/test_simple',
+                            'related' => 'http://api.example.com/documents/2/test_simple',
+                        ],
+                        'data' => [
+                            [
+                                'id' => '4',
+                                'type' => 'profiles',
+                                'meta' => [
+                                    'relation' => [
+                                        'priority' => 1,
+                                        'inv_priority' => 1,
+                                        'params' => ['name' => 'John'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'test_defaults' => [
+                        'links' => [
+                            'self' => 'http://api.example.com/documents/2/relationships/test_defaults',
+                            'related' => 'http://api.example.com/documents/2/test_defaults',
+                        ],
+                    ],
+                    'inverse_test_simple' => [
+                        'links' => [
+                            'self' => 'http://api.example.com/documents/2/relationships/inverse_test_simple',
+                            'related' => 'http://api.example.com/documents/2/inverse_test_simple',
+                        ],
+                        'data' => [],
+                    ],
+                    'inverse_test_defaults' => [
+                        'links' => [
+                            'self' => 'http://api.example.com/documents/2/relationships/inverse_test_defaults',
+                            'related' => 'http://api.example.com/documents/2/inverse_test_defaults',
+                        ],
+                    ],
+                ],
+            ],
+            'included' => [
+                [
+                    'id' => '4',
+                    'type' => 'profiles',
+                    'attributes' => [
+                        'status' => 'on',
+                        'uname' => 'gustavo-supporto',
+                        'title' => 'Gustavo Supporto profile',
+                        'description' => 'Some description about Gustavo',
+                        'body' => null,
+                        'extra' => null,
+                        'lang' => 'en',
+                        'publish_start' => null,
+                        'publish_end' => null,
+                    ],
+                    'meta' => [
+                        'locked' => false,
+                        'created' => '2016-05-13T07:09:23+00:00',
+                        'modified' => '2016-05-13T07:09:23+00:00',
+                        'published' => null,
+                        'created_by' => 1,
+                        'modified_by' => 1,
+                        'relation' => [
+                            'priority' => 1,
+                            'inv_priority' => 1,
+                            'params' => ['name' => 'John'],
+                        ],
+                    ],
+                    'links' => [
+                        'self' => 'http://api.example.com/profiles/4',
+                    ],
+                    'relationships' => [
+                        'inverse_test' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/profiles/4/inverse_test',
+                                'self' => 'http://api.example.com/profiles/4/relationships/inverse_test',
+                            ],
+                        ],
+                        'parents' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/profiles/4/parents',
+                                'self' => 'http://api.example.com/profiles/4/relationships/parents',
+                            ],
+                        ],
+                        'translations' => [
+                            'links' => [
+                                'related' => 'http://api.example.com/profiles/4/translations',
+                                'self' => 'http://api.example.com/profiles/4/relationships/translations',
+                            ],
+                        ],
+                        'inverse_test_simple' => [
+                            'links' => [
+                                'self' => 'http://api.example.com/profiles/4/relationships/inverse_test_simple',
+                                'related' => 'http://api.example.com/profiles/4/inverse_test_simple',
+                            ],
+                        ],
+                        'inverse_test_defaults' => [
+                            'links' => [
+                                'self' => 'http://api.example.com/profiles/4/relationships/inverse_test_defaults',
+                                'related' => 'http://api.example.com/profiles/4/inverse_test_defaults',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'meta' => [
+                'schema' => [
+                    'documents' => [
+                        '$id' => 'http://api.example.com/model/schema/documents',
+                        'revision' => TestConstants::SCHEMA_REVISIONS['documents'],
+                    ],
+                    'profiles' => [
+                        '$id' => 'http://api.example.com/model/schema/profiles',
+                        'revision' => TestConstants::SCHEMA_REVISIONS['profiles'],
+                    ],
+                ],
+            ],
+            'links' => [
+                'self' => 'http://api.example.com/documents/2?include=test_simple%2Cinverse_test_simple',
+                'home' => 'http://api.example.com/home',
+            ],
+        ];
+
+        $this->configRequestHeaders();
+        $this->get('/documents/2?include=test_simple,inverse_test_simple');
         $result = json_decode((string)$this->_response->getBody(), true);
 
         $this->assertResponseCode(200);

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -430,10 +430,24 @@ class JsonApiTest extends TestCase
                                 [
                                     'id' => '4',
                                     'type' => 'profiles',
+                                    'meta' => [
+                                        'relation' => [
+                                            'priority' => 1,
+                                            'inv_priority' => 2,
+                                            'params' => null,
+                                        ],
+                                    ],
                                 ],
                                 [
                                     'id' => '3',
                                     'type' => 'documents',
+                                    'meta' => [
+                                        'relation' => [
+                                            'priority' => 2,
+                                            'inv_priority' => 1,
+                                            'params' => null,
+                                        ],
+                                    ],
                                 ],
                             ],
                         ],

--- a/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
+++ b/plugins/BEdita/Core/src/Model/Entity/JsonApiTrait.php
@@ -314,7 +314,7 @@ trait JsonApiTrait
                 ));
             }
 
-            $data[] = $item->jsonApiSerialize(JsonApiSerializable::JSONAPIOPT_EXCLUDE_ATTRIBUTES | JsonApiSerializable::JSONAPIOPT_EXCLUDE_META | JsonApiSerializable::JSONAPIOPT_EXCLUDE_LINKS | JsonApiSerializable::JSONAPIOPT_EXCLUDE_RELATIONSHIPS);
+            $data[] = $item->jsonApiSerialize(JsonApiSerializable::JSONAPIOPT_EXCLUDE_ATTRIBUTES | JsonApiSerializable::JSONAPIOPT_EXCLUDE_META | JsonApiSerializable::JSONAPIOPT_EXCLUDE_LINKS | JsonApiSerializable::JSONAPIOPT_EXCLUDE_RELATIONSHIPS | JsonApiSerializable::JSONAPIOPT_INCLUDE_JOIN_DATA);
         }
 
         return $single ? $data[0] : $data;
@@ -453,6 +453,8 @@ trait JsonApiTrait
         }
         if (($options & JsonApiSerializable::JSONAPIOPT_EXCLUDE_META) === 0) {
             $meta = $this->getMeta();
+        } elseif (($options & JsonApiSerializable::JSONAPIOPT_INCLUDE_JOIN_DATA) > 0) {
+            $meta = array_filter(['relation' => $this->joinData()]);
         }
         if (($options & JsonApiSerializable::JSONAPIOPT_EXCLUDE_LINKS) === 0) {
             $links = $this->getLinks();

--- a/plugins/BEdita/Core/src/Utility/JsonApiSerializable.php
+++ b/plugins/BEdita/Core/src/Utility/JsonApiSerializable.php
@@ -51,6 +51,11 @@ interface JsonApiSerializable
     public const JSONAPIOPT_EXCLUDE_RELATIONSHIPS = 8;
 
     /**
+     * Tell JSON API serializer to include `relationships` join data from resource.
+     */
+    public const JSONAPIOPT_INCLUDE_JOIN_DATA = 16;
+
+    /**
      * Tell JSON API serializer to exclude all (`attributes`, `meta`, `links`, `relationships`) from resource
      *
      * @var int

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -40,6 +40,13 @@ class JsonApiTraitTest extends TestCase
     public $ObjectTypes;
 
     /**
+     * Helper table.
+     *
+     * @var \BEdita\Core\Model\Table\ObjectsTable
+     */
+    public $Documents;
+
+    /**
      * Fixtures
      *
      * @var array
@@ -76,6 +83,7 @@ class JsonApiTraitTest extends TestCase
 
         $this->Roles = TableRegistry::getTableLocator()->get('Roles');
         $this->ObjectTypes = TableRegistry::getTableLocator()->get('ObjectTypes');
+        $this->Documents = TableRegistry::getTableLocator()->get('Documents');
 
         $this->loadPlugins(['BEdita/API' => ['routes' => true]]);
     }
@@ -276,14 +284,35 @@ class JsonApiTraitTest extends TestCase
                     [
                         'id' => '1',
                         'type' => 'relations',
+                        'meta' => [
+                            'relation' => [
+                                'relation_id' => 1,
+                                'object_type_id' => 2,
+                                'side' => 'left',
+                            ],
+                        ],
                     ],
                     [
                         'id' => '4',
                         'type' => 'relations',
+                        'meta' => [
+                            'relation' => [
+                                'relation_id' => 4,
+                                'object_type_id' => 2,
+                                'side' => 'left',
+                            ],
+                        ],
                     ],
                     [
                         'id' => '5',
                         'type' => 'relations',
+                        'meta' => [
+                            'relation' => [
+                                'relation_id' => 5,
+                                'object_type_id' => 2,
+                                'side' => 'left',
+                            ],
+                        ],
                     ],
                 ],
                 'links' => [
@@ -296,14 +325,35 @@ class JsonApiTraitTest extends TestCase
                     [
                         'id' => '1',
                         'type' => 'relations',
+                        'meta' => [
+                            'relation' => [
+                                'relation_id' => 1,
+                                'object_type_id' => 2,
+                                'side' => 'right',
+                            ],
+                        ],
                     ],
                     [
                         'id' => '4',
                         'type' => 'relations',
+                        'meta' => [
+                            'relation' => [
+                                'relation_id' => 4,
+                                'object_type_id' => 2,
+                                'side' => 'right',
+                            ],
+                        ],
                     ],
                     [
                         'id' => '5',
                         'type' => 'relations',
+                        'meta' => [
+                            'relation' => [
+                                'relation_id' => 5,
+                                'object_type_id' => 2,
+                                'side' => 'right',
+                            ],
+                        ],
                     ],
                 ],
                 'links' => [
@@ -323,7 +373,7 @@ class JsonApiTraitTest extends TestCase
             ],
         ];
 
-        $objectType = $this->ObjectTypes->get(2, ['contain' => ['Parent', 'RightRelations', 'LeftRelations']])->jsonApiSerialize();
+        $objectType = $this->ObjectTypes->get(2, ['contain' => ['Parent', 'RightRelations', 'LeftRelations']])->jsonApiSerialize(JsonApiSerializable::JSONAPIOPT_EXCLUDE_META);
 
         $relationships = $objectType['relationships'];
         $included = $objectType['included'];
@@ -674,6 +724,30 @@ class JsonApiTraitTest extends TestCase
         $role = json_decode(json_encode($role), true);
 
         static::assertEquals($expected, $role);
+    }
+
+    /**
+     * Test that JSON API serializer includes relationships' join data.
+     *
+     * @return void
+     * @covers ::jsonApiSerialize()
+     */
+    public function testSerializeJoinData()
+    {
+        $expected = [
+            'id' => '4',
+            'type' => 'profiles',
+            'meta' => [
+                'relation' => [
+                    'priority' => 1,
+                    'inv_priority' => 1,
+                    'params' => ['name' => 'John'],
+                ],
+            ],
+        ];
+
+        $document = $this->Documents->get(2, ['contain' => ['TestSimple']])->jsonApiSerialize();
+        static::assertEquals($expected, (array)Hash::extract($document, 'relationships.test_simple.data.0'));
     }
 
     /**


### PR DESCRIPTION
When fetching objects from a list endpoint while including one or more relationships  (ex. `GET /documents?include=has_media`), the related objects are exposed in the `included` property of the response, but the relation's metadata (join data) is exposed only for the first related object:

```json
{
  "data": [
    {
      "id": "17",
      "type": "documents",
      "attributes": { ... },
      "meta": { ... },
      "relationships": {
        "has_media": {
          "data": [{ "id": "101", "type": "media" }]
        }
      }
    },
    {
      "id": "42",
      "type": "documents",
      "attributes": { ... },
      "meta": { ... },
      "relationships": {
        "has_media": {
          "data": [{ "id": "101", "type": "media" }]
        }
      }
    }
  ],
  "included": [
    {
      "id": "101",
      "type": "media",
      "attributes": { ... },
      "meta": {
        ...
        "relation": {
          ...
          "params": { "my_custom_relation_parameter": "Parameter for document 17" }
        }
      }
    }
  ]
}
```
This PR exposes the relation metadata for each related object in `data.[*].relationships.[relation].data.[*].meta`:

```json
{
  "data": [
    {
      "id": "17",
      "type": "documents",
      "attributes": { ... },
      "meta": { ... },
      "relationships": {
        "has_media": {
          "data": [{
            "id": "101",
            "type": "media",
            "meta": {
              "relation": {
                "params": { "my_custom_relation_parameter": "Parameter for document 17" }
              }
            }
          }]
        }
      }
    },
    {
      "id": "42",
      "type": "documents",
      "attributes": { ... },
      "meta": { ... },
      "relationships": {
        "has_media": {
          "data": [{
            "id": "101",
            "type": "media",
            "meta": {
              "relation": {
                "params": { "my_custom_relation_parameter": "Parameter for document 42" }
              }
            }
          }]
        }
      }
    }
  ],
  "included": [
    {
      "id": "101",
      "type": "media",
      "attributes": { ... },
      "meta": {
        ...
        "relation": {
          ...
          "params": { "my_custom_relation_parameter": "Parameter for document 17" }
        }
      }
    }
  ]
}
```