### PR TITLE
Project model in multiple json files

### DIFF
--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -155,7 +155,7 @@ class ProjectModelCommand extends Command
     }
 
     /**
-     * Retrieve model file from `project-model` folder.
+     * Build model file from `project-model` folder, putting together all JSON files.
      * If the folder does not exist or is empty, returns null.
      *
      * @return string|null

--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -75,7 +75,26 @@ class ProjectModelCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
-        $file = $this->modelFilePath($args);
+        $file = null;
+        // try to build file from project-model json files, merging them
+        if (file_exists(CONFIG . DS . 'project-model')) {
+            $files = glob(CONFIG . DS . 'project-model' . DS . '*.json');
+            $json = [];
+            foreach ($files as $file) {
+                $basename = basename($file);
+                $name = str_replace('.json', '', $basename);
+                $content = file_get_contents($file);
+                $json[$name] = json_decode($content, true);
+            }
+            if (!empty($json)) {
+                $file = TMP . DS . 'project-model.json';
+                file_put_contents($file, json_encode($json, JSON_PRETTY_PRINT));
+            }
+            unset($json, $files, $basename, $name, $content);
+        }
+        if (empty($file)) {
+            $file = $this->modelFilePath($args);
+        }
         if (!file_exists($file)) {
             $io->error(sprintf('File not found %s', $file));
 

--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -171,7 +171,7 @@ class ProjectModelCommand extends Command
 
             return null;
         }
-        $file = null;
+        $projectModelFile = null;
         $json = [];
         foreach ($files as $file) {
             $name = str_replace('.json', '', basename($file));
@@ -181,12 +181,12 @@ class ProjectModelCommand extends Command
             }
         }
         if (!empty($json)) {
-            $file = TMP . DS . 'project-model.json';
-            file_put_contents($file, json_encode($json, JSON_PRETTY_PRINT));
+            $projectModelFile = TMP . DS . 'project-model.json';
+            file_put_contents($projectModelFile, json_encode($json, JSON_PRETTY_PRINT));
         }
         unset($json, $files, $name, $content);
 
-        return $file;
+        return $projectModelFile;
     }
 
     /**

--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -167,7 +167,6 @@ class ProjectModelCommand extends Command
         }
         $files = glob(CONFIG . DS . 'project-model' . DS . '*.json');
         if (empty($files)) {
-
             return null;
         }
         $projectModelFile = null;

--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -81,16 +81,17 @@ class ProjectModelCommand extends Command
             $files = glob(CONFIG . DS . 'project-model' . DS . '*.json');
             $json = [];
             foreach ($files as $file) {
-                $basename = basename($file);
-                $name = str_replace('.json', '', $basename);
+                $name = str_replace('.json', '', basename($file));
                 $content = file_get_contents($file);
-                $json[$name] = json_decode($content, true);
+                if ($content) {
+                    $json[$name] = json_decode($content, true);
+                }
             }
             if (!empty($json)) {
                 $file = TMP . DS . 'project-model.json';
                 file_put_contents($file, json_encode($json, JSON_PRETTY_PRINT));
             }
-            unset($json, $files, $basename, $name, $content);
+            unset($json, $files, $name, $content);
         }
         if (empty($file)) {
             $file = $this->modelFilePath($args);

--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -162,12 +162,11 @@ class ProjectModelCommand extends Command
      */
     protected function modelFileFromFolder(): ?string
     {
-        if (!file_exists(CONFIG . DS . 'project-model')) {
+        if (!is_dir(CONFIG . DS . 'project-model')) {
             return null;
         }
         $files = glob(CONFIG . DS . 'project-model' . DS . '*.json');
         if (empty($files)) {
-            unset($files);
 
             return null;
         }
@@ -177,14 +176,13 @@ class ProjectModelCommand extends Command
             $name = str_replace('.json', '', basename($file));
             $content = file_get_contents($file);
             if ($content) {
-                $json[$name] = json_decode($content, true);
+                $json[$name] = (array)json_decode($content, true);
             }
         }
         if (!empty($json)) {
             $projectModelFile = TMP . DS . 'project-model.json';
             file_put_contents($projectModelFile, json_encode($json, JSON_PRETTY_PRINT));
         }
-        unset($json, $files, $name, $content);
 
         return $projectModelFile;
     }

--- a/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
+++ b/plugins/BEdita/Core/src/Command/ProjectModelCommand.php
@@ -75,24 +75,7 @@ class ProjectModelCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
-        $file = null;
-        // try to build file from project-model json files, merging them
-        if (file_exists(CONFIG . DS . 'project-model')) {
-            $files = glob(CONFIG . DS . 'project-model' . DS . '*.json');
-            $json = [];
-            foreach ($files as $file) {
-                $name = str_replace('.json', '', basename($file));
-                $content = file_get_contents($file);
-                if ($content) {
-                    $json[$name] = json_decode($content, true);
-                }
-            }
-            if (!empty($json)) {
-                $file = TMP . DS . 'project-model.json';
-                file_put_contents($file, json_encode($json, JSON_PRETTY_PRINT));
-            }
-            unset($json, $files, $name, $content);
-        }
+        $file = $this->modelFileFromFolder();
         if (empty($file)) {
             $file = $this->modelFilePath($args);
         }
@@ -169,6 +152,41 @@ class ProjectModelCommand extends Command
             },
             $data
         );
+    }
+
+    /**
+     * Retrieve model file from `project-model` folder.
+     * If the folder does not exist or is empty, returns null.
+     *
+     * @return string|null
+     */
+    protected function modelFileFromFolder(): ?string
+    {
+        if (!file_exists(CONFIG . DS . 'project-model')) {
+            return null;
+        }
+        $files = glob(CONFIG . DS . 'project-model' . DS . '*.json');
+        if (empty($files)) {
+            unset($files);
+
+            return null;
+        }
+        $file = null;
+        $json = [];
+        foreach ($files as $file) {
+            $name = str_replace('.json', '', basename($file));
+            $content = file_get_contents($file);
+            if ($content) {
+                $json[$name] = json_decode($content, true);
+            }
+        }
+        if (!empty($json)) {
+            $file = TMP . DS . 'project-model.json';
+            file_put_contents($file, json_encode($json, JSON_PRETTY_PRINT));
+        }
+        unset($json, $files, $name, $content);
+
+        return $file;
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
@@ -220,4 +220,51 @@ class ProjectModelCommandTest extends TestCase
         ];
         $this->assertEquals($expected, $actual);
     }
+
+    /**
+     * Test modelFileFromFolder method
+     *
+     * @return void
+     * @covers ::modelFileFromFolder()
+     */
+    public function testModelFileFromFolder(): void
+    {
+        // CONFIG . DS . 'project-model' not exists
+        $folder = CONFIG . DS . 'project-model';
+        if (is_dir($folder)) {
+            rmdir($folder);
+        }
+        $cmd = new class () extends ProjectModelCommand
+        {
+            public function modelFileFromFolder(): ?string
+            {
+                return parent::modelFileFromFolder();
+            }
+        };
+        $this->assertNull($cmd->modelFileFromFolder());
+
+        // CONFIG . DS . 'project-model' exists but empty
+        $folder = CONFIG . DS . 'project-model';
+        if (!is_dir($folder)) {
+            mkdir($folder, 0777, true);
+        }
+        $this->assertNull($cmd->modelFileFromFolder());
+
+        // CONFIG . DS . 'project-model' exists and contains files
+        $file1 = $folder . DS . 'test1.json';
+        $file2 = $folder . DS . 'test2.json';
+        file_put_contents($file1, json_encode(['test1' => 'value1']));
+        file_put_contents($file2, json_encode(['test2' => 'value2']));
+        $expected = TMP . DS . 'project-model.json';
+        $result = $cmd->modelFileFromFolder();
+        $this->assertFileExists($expected);
+        $this->assertJsonStringEqualsJsonFile($expected, json_encode([
+            'test1' => ['test1' => 'value1'],
+            'test2' => ['test2' => 'value2'],
+        ]));
+        unlink($file1);
+        unlink($file2);
+        rmdir($folder);
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ProjectModelCommandTest.php
@@ -244,10 +244,7 @@ class ProjectModelCommandTest extends TestCase
         $this->assertNull($cmd->modelFileFromFolder());
 
         // CONFIG . DS . 'project-model' exists but empty
-        $folder = CONFIG . DS . 'project-model';
-        if (!is_dir($folder)) {
-            mkdir($folder, 0777, true);
-        }
+        mkdir($folder, 0777, true);
         $this->assertNull($cmd->modelFileFromFolder());
 
         // CONFIG . DS . 'project-model' exists and contains files


### PR DESCRIPTION
This PR resolves #2144 

Project model command check folder `config/project-model` (if any) json files, merge them in `TMP . DS . 'project-model.json`, to use it as project_model. If no folder is set, command behaves as before, using `project-model.json` (from `config` or from `--file` option).

![image](https://github.com/user-attachments/assets/4241b5a5-aa6c-4d94-9186-ece5087674a5)

