### PR TITLE
Remove rdohms/phpunit-arraysubset-asserts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
         "phpstan/phpdoc-parser": "^1.7",
         "cakephp/repl": "^2.0.1",
         "phpunit/phpunit": "^10.5.5 || ^11.1.3 || ^12.1",
-        "dms/phpunit-arraysubset-asserts": "^0.5",
         "bedita/dev-tools": "^3.1.1",
         "phpstan/phpstan": "^1.7.1",
         "phpstan/extension-installer": "^1.0",

--- a/plugins/BEdita/API/tests/IntegrationTest/NewObjectTypesTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/NewObjectTypesTest.php
@@ -15,15 +15,15 @@ declare(strict_types=1);
 namespace BEdita\API\Test\IntegrationTest;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\ORM\TableRegistry;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * Test new object types creation, along with objects implementations
  */
 class NewObjectTypesTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * @inheritDoc

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/AdminControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/AdminControllerTest.php
@@ -15,14 +15,14 @@ declare(strict_types=1);
 namespace BEdita\API\Test\TestCase\Controller\Admin;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\Admin\AdminController
  */
 class AdminControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Test unauthorized response for unauthenticated calls.

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/ApplicationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/ApplicationsControllerTest.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/ApplicationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/ApplicationsControllerTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
  *
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
-
 namespace BEdita\API\Test\TestCase\Controller\Admin;
 
 use BEdita\API\Test\TestConstants;

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/ApplicationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/ApplicationsControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -12,19 +13,20 @@ declare(strict_types=1);
  *
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
+
 namespace BEdita\API\Test\TestCase\Controller\Admin;
 
 use BEdita\API\Test\TestConstants;
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\ORM\TableRegistry;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\Admin\ApplicationsController
  */
 class ApplicationsControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Test index method.

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/AsyncJobsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/AsyncJobsControllerTest.php
@@ -15,16 +15,16 @@ declare(strict_types=1);
 namespace BEdita\API\Test\TestCase\Controller\Admin;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Text;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\Admin\AsyncJobsController
  */
 class AsyncJobsControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Test index method.

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/AuthProvidersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/AuthProvidersControllerTest.php
@@ -15,16 +15,16 @@ declare(strict_types=1);
 namespace BEdita\API\Test\TestCase\Controller\Admin;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\Core\Configure;
 use Cake\ORM\TableRegistry;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\Admin\AuthProvidersController
  */
 class AuthProvidersControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Test `index` method with user not admin.

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/EndpointsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/EndpointsControllerTest.php
@@ -15,15 +15,15 @@ declare(strict_types=1);
 namespace BEdita\API\Test\TestCase\Controller\Admin;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\ORM\TableRegistry;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\Admin\EndpointsController
  */
 class EndpointsControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Test index method.

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/ExternalAuthControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/ExternalAuthControllerTest.php
@@ -15,16 +15,16 @@ declare(strict_types=1);
 namespace BEdita\API\Test\TestCase\Controller\Admin;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\Core\Configure;
 use Cake\ORM\TableRegistry;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\Admin\ExternalAuthController
  */
 class ExternalAuthControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Test `index` method with user not admin.

--- a/plugins/BEdita/API/tests/TestCase/Controller/AppControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AppControllerTest.php
@@ -22,9 +22,9 @@ use BEdita\API\Controller\AppController;
 use BEdita\API\Policy\EndpointPolicy;
 use BEdita\API\Test\TestConstants;
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\Core\Configure;
 use Cake\Http\ServerRequest;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Exception;
 
 /**
@@ -32,7 +32,7 @@ use Exception;
  */
 class AppControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Test API meta info header.

--- a/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
@@ -15,15 +15,15 @@ declare(strict_types=1);
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\ORM\TableRegistry;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\AsyncJobsController
  */
 class AsyncJobsControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Test index method on GET.

--- a/plugins/BEdita/API/tests/TestCase/Controller/Component/UploadComponentTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Component/UploadComponentTest.php
@@ -15,17 +15,17 @@ declare(strict_types=1);
 namespace BEdita\API\Test\TestCase\Controller\Component;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use BEdita\Core\Test\Utility\TestFilesystemTrait;
 use Cake\Utility\Hash;
 use Cake\Validation\Validation;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\Component\UploadComponent
  */
 class UploadComponentTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
     use TestFilesystemTrait;
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/FoldersControllerTest.php
@@ -16,18 +16,18 @@ namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\Test\TestConstants;
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Collection\Collection;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\FoldersController
  */
 class FoldersControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Folders table.

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/ObjectTypesControllerTest.php
@@ -15,16 +15,16 @@ declare(strict_types=1);
 namespace BEdita\API\Test\TestCase\Controller\Model;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\Model\ObjectTypesController
  */
 class ObjectTypesControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Fixtures

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertiesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertiesControllerTest.php
@@ -15,15 +15,15 @@ declare(strict_types=1);
 namespace BEdita\API\Test\TestCase\Controller\Model;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\ORM\TableRegistry;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\Model\PropertiesController
  */
 class PropertiesControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Fixtures

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/PropertyTypesControllerTest.php
@@ -15,15 +15,15 @@ declare(strict_types=1);
 namespace BEdita\API\Test\TestCase\Controller\Model;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\ORM\TableRegistry;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\Model\PropertyTypesController
  */
 class PropertyTypesControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Fixtures

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/RelationsControllerTest.php
@@ -15,9 +15,9 @@ declare(strict_types=1);
 namespace BEdita\API\Test\TestCase\Controller\Model;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use stdClass;
 
 /**
@@ -25,7 +25,7 @@ use stdClass;
  */
 class RelationsControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Test index method.

--- a/plugins/BEdita/API/tests/TestCase/Controller/Model/SchemaControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Model/SchemaControllerTest.php
@@ -16,7 +16,7 @@ namespace BEdita\API\Test\TestCase\Controller\Model;
 
 use BEdita\API\Test\TestConstants;
 use BEdita\API\TestSuite\IntegrationTestCase;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 
 /**
  * {@see \BEdita\API\Controller\Model\SchemaController} Test Case
@@ -25,7 +25,7 @@ use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
  */
 class SchemaControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Fixtures

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -18,18 +18,18 @@ use Authentication\AuthenticationService;
 use BEdita\API\Controller\ObjectsController;
 use BEdita\API\Test\TestConstants;
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\Event\EventManager;
 use Cake\Http\ServerRequest;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\ObjectsController
  */
 class ObjectsControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Fixtures

--- a/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ResourcesControllerTest.php
@@ -15,15 +15,15 @@ declare(strict_types=1);
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\Event\EventManager;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\ResourcesController
  */
 class ResourcesControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Test relationships method to list existing relationships.

--- a/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
@@ -16,15 +16,15 @@ namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\Test\TestConstants;
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\ORM\TableRegistry;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\RolesController
  */
 class RolesControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Test index method.

--- a/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/SignupControllerTest.php
@@ -15,19 +15,19 @@ declare(strict_types=1);
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\Core\Configure;
 use Cake\I18n\DateTime;
 use Cake\Mailer\TransportFactory;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\SignupController
  */
 class SignupControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Fixtures

--- a/plugins/BEdita/API/tests/TestCase/Controller/StreamsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/StreamsControllerTest.php
@@ -15,16 +15,16 @@ declare(strict_types=1);
 namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use BEdita\Core\Test\Utility\TestFilesystemTrait;
 use Cake\Validation\Validation;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\StreamsController
  */
 class StreamsControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
     use TestFilesystemTrait;
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Controller/TrashControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/TrashControllerTest.php
@@ -16,16 +16,16 @@ namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\Test\TestConstants;
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\ORM\TableRegistry;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\TrashController
  */
 class TrashControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Objects table instance.

--- a/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/UsersControllerTest.php
@@ -16,15 +16,15 @@ namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\Test\TestConstants;
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\ORM\TableRegistry;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * @coversDefaultClass \BEdita\API\Controller\UsersController
  */
 class UsersControllerTest extends IntegrationTestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Test index method.

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/AsyncGeneratorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/Thumbnail/AsyncGeneratorTest.php
@@ -16,17 +16,17 @@ namespace BEdita\Core\Test\TestCase\Filesystem\Thumbnail;
 
 use BEdita\Core\Filesystem\Thumbnail;
 use BEdita\Core\Filesystem\Thumbnail\AsyncGenerator;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\I18n\DateTime;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * @coversDefaultClass \BEdita\Core\Filesystem\Thumbnail\AsyncGenerator
  */
 class AsyncGeneratorTest extends TestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Fixtures.

--- a/plugins/BEdita/Core/tests/TestCase/Job/Service/ThumbnailServiceTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/Service/ThumbnailServiceTest.php
@@ -21,7 +21,6 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Text;
 use Exception;
-use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
 
 /**
  * @coversDefaultClass \BEdita\Core\Job\Service\ThumbnailService

--- a/plugins/BEdita/Core/tests/TestCase/Job/Service/ThumbnailServiceTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/Service/ThumbnailServiceTest.php
@@ -110,7 +110,7 @@ class ThumbnailServiceTest extends TestCase
         return [
             'ok' => [
                 true,
-                static::once(),
+                fn (self $testCase) => $testCase->once(),
                 [
                     'uuid' => 'e5afe167-7341-458d-a1e6-042e8791b0fe',
                     'generator' => 'test',
@@ -121,7 +121,7 @@ class ThumbnailServiceTest extends TestCase
             ],
             'not found' => [
                 true,
-                static::never(),
+                fn (self $testCase) => $testCase->never(),
                 [
                     'uuid' => Text::uuid(), // This UUID does not exist.
                     'generator' => 'test',
@@ -132,7 +132,7 @@ class ThumbnailServiceTest extends TestCase
             ],
             'error' => [
                 false,
-                static::once(),
+                fn (self $testCase) => $testCase->once(),
                 [
                     'uuid' => 'e5afe167-7341-458d-a1e6-042e8791b0fe',
                     'generator' => 'test',
@@ -149,21 +149,21 @@ class ThumbnailServiceTest extends TestCase
      * Test `run` method.
      *
      * @param bool $expected Expected result.
-     * @param \PHPUnit\Framework\MockObject\Rule\InvocationOrder $count Invocation count of base generator method.
+     * @param callable $count Callable that returns InvokedCountMatcher of base generator method.
      * @param array $payload Async job payload.
      * @param bool $shouldThrow Should the base generator throw an exception when invoked?
      * @return void
      * @dataProvider runProvider()
      * @covers ::run()
      */
-    public function testRun($expected, InvocationOrder $count, array $payload, $shouldThrow = false)
+    public function testRun($expected, callable $count, array $payload, $shouldThrow = false)
     {
         $stream = $this->Streams->find()->where(['uuid' => $payload['uuid']])->first();
 
         $generator = $this->getMockBuilder(ThumbnailGenerator::class)
             ->onlyMethods(['generate'])
             ->getMockForAbstractClass();
-        $method = $generator->expects($count)
+        $method = $generator->expects($count($this))
             ->method('generate')
             ->with($stream, $payload['options']);
         if ($shouldThrow) {

--- a/plugins/BEdita/Core/tests/TestCase/Mailer/Transport/AsyncJobsTransportTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Mailer/Transport/AsyncJobsTransportTest.php
@@ -15,19 +15,19 @@ declare(strict_types=1);
 namespace BEdita\Core\Test\TestCase\Mailer\Transport;
 
 use BEdita\Core\Job\Service\MailService;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\Mailer\Mailer;
 use Cake\Mailer\TransportFactory;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * @coversDefaultClass \BEdita\Core\Mailer\Transport\AsyncJobsTransport
  */
 class AsyncJobsTransportTest extends TestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Fixtures

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UserModifiedBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UserModifiedBehaviorTest.php
@@ -15,10 +15,10 @@ declare(strict_types=1);
 namespace BEdita\Core\Test\TestCase\Model\Behavior;
 
 use BEdita\Core\Model\Entity\ObjectEntity;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use UnexpectedValueException;
 
 /**
@@ -28,7 +28,7 @@ use UnexpectedValueException;
  */
 class UserModifiedBehaviorTest extends TestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Fixtures

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/FolderTest.php
@@ -280,7 +280,7 @@ class FolderTest extends TestCase
      *
      * @return array
      */
-    public function getSlugPathProvider()
+    public static function getSlugPathProvider()
     {
         return [
             'root' => [

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/StaticPropertyTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/StaticPropertyTest.php
@@ -19,10 +19,10 @@ use BEdita\Core\Model\Entity\StaticProperty;
 use BEdita\Core\Model\Table\PropertiesTable;
 use BEdita\Core\Model\Table\StreamsTable;
 use BEdita\Core\Model\Table\UsersTable;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * {@see \BEdita\Core\Model\Entity\StaticProperty} Test Case
@@ -31,7 +31,7 @@ use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
  */
 class StaticPropertyTest extends TestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Test subject's table

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/StaticPropertiesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/StaticPropertiesTableTest.php
@@ -16,11 +16,11 @@ namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use BEdita\Core\Model\Entity\StaticProperty;
 use BEdita\Core\Model\Table\ObjectTypesTable;
+use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\Cache\Cache;
 use Cake\Database\Schema\TableSchema;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 /**
  * {@see \BEdita\Core\Model\Table\StaticPropertiesTable} Test Case
@@ -29,7 +29,7 @@ use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
  */
 class StaticPropertiesTableTest extends TestCase
 {
-    use ArraySubsetAsserts;
+    use TestArraySubsetTrait;
 
     /**
      * Test subject

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/TreesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/TreesTableTest.php
@@ -216,7 +216,7 @@ class TreesTableTest extends TestCase
      *
      * @return array[]
      */
-    public function slugPopulationProvider(): array
+    public static function slugPopulationProvider(): array
     {
         return [
             'no slug' => [

--- a/plugins/BEdita/Core/tests/Utility/TestArraySubsetTrait.php
+++ b/plugins/BEdita/Core/tests/Utility/TestArraySubsetTrait.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Core\Test\Utility;
+
+/**
+ * Trait to add assert
+ */
+trait TestArraySubsetTrait
+{
+    /**
+     * Assert that an array is a subset of another array.
+     *
+     * @param array $subset The subset to check.
+     * @param array $array The array to check against.
+     * @param string $message Optional message to display on failure.
+     * @return void
+     */
+    public static function assertArraySubset(array $subset, array $array, string $message = ''): void
+    {
+        foreach ($subset as $key => $value) {
+            self::assertArrayHasKey($key, $array, $message);
+            self::assertEquals($value, $array[$key], $message);
+        }
+    }
+}

--- a/plugins/BEdita/Core/tests/Utility/TestArraySubsetTrait.php
+++ b/plugins/BEdita/Core/tests/Utility/TestArraySubsetTrait.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 /**
  * BEdita, API-first content management framework
- * Copyright 2020 ChannelWeb Srl, Chialab Srl
+ * Copyright 2025 ChannelWeb Srl, Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published

--- a/plugins/BEdita/Core/tests/Utility/TestArraySubsetTrait.php
+++ b/plugins/BEdita/Core/tests/Utility/TestArraySubsetTrait.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 namespace BEdita\Core\Test\Utility;
 
 /**
- * Trait to add assert
+ * Trait to add `assertArraySubset()` method to test cases.
  */
 trait TestArraySubsetTrait
 {


### PR DESCRIPTION
This PR removes [rdohms/phpunit-arraysubset-asserts](https://github.com/rdohms/phpunit-arraysubset-asserts) package replacing it with a simplified utility method `\BEdita\Core\Test\Utility\TestArraySubsetTrait::assertArraySubset(array $subset, array $array, string $message = '')`.

This was done since rdohms/phpunit-arraysubset-asserts doesn't support PHPUnit 11+, there is a [PR](https://github.com/rdohms/phpunit-arraysubset-asserts/pull/86) but it seems that package is not actived maintained.

For our use I think that method is enough and after that we can update PHPUnit version.