### PR TITLE
Validate entity before saving in `Resources::create`

### DIFF
--- a/plugins/BEdita/Core/src/Utility/Resources.php
+++ b/plugins/BEdita/Core/src/Utility/Resources.php
@@ -128,13 +128,13 @@ class Resources extends ResourcesBase
             $defaults = (array)Hash::get(static::$defaults, $type);
             $item = array_merge($defaults, $item);
             $resource = $Table->newEntity($item);
-            foreach ($item as $k => $v) {
-                $resource->set($k, $v);
-            }
             if ($resource->hasErrors()) {
                 throw new InvalidArgumentException(
                     __('Invalid resource data') . ': ' . json_encode($resource->getErrors())
                 );
+            }
+            foreach ($item as $k => $v) {
+                $resource->set($k, $v);
             }
             $result[] = $Table->saveOrFail($resource, static::$defaults['save']);
         }

--- a/plugins/BEdita/Core/src/Utility/Resources.php
+++ b/plugins/BEdita/Core/src/Utility/Resources.php
@@ -19,6 +19,7 @@ use Cake\Datasource\EntityInterface;
 use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\Table;
 use Cake\Utility\Hash;
+use InvalidArgumentException;
 
 /**
  * Utility class to resources creation/update/removal in migrations, shell scripts and similar scenarios
@@ -127,6 +128,12 @@ class Resources extends ResourcesBase
             $resource = $Table->newEmptyEntity();
             $defaults = (array)Hash::get(static::$defaults, $type);
             $item = array_merge($defaults, $item);
+            $resource = $Table->newEntity($item);
+            if ($resource->hasErrors()) {
+                throw new InvalidArgumentException(
+                    __('Invalid resource data') . ': ' . json_encode($resource->getErrors())
+                );
+            }
             foreach ($item as $k => $v) {
                 $resource->set($k, $v);
             }

--- a/plugins/BEdita/Core/src/Utility/Resources.php
+++ b/plugins/BEdita/Core/src/Utility/Resources.php
@@ -128,13 +128,13 @@ class Resources extends ResourcesBase
             $defaults = (array)Hash::get(static::$defaults, $type);
             $item = array_merge($defaults, $item);
             $resource = $Table->newEntity($item);
+            foreach ($item as $k => $v) {
+                $resource->set($k, $v);
+            }
             if ($resource->hasErrors()) {
                 throw new InvalidArgumentException(
                     __('Invalid resource data') . ': ' . json_encode($resource->getErrors())
                 );
-            }
-            foreach ($item as $k => $v) {
-                $resource->set($k, $v);
             }
             $result[] = $Table->saveOrFail($resource, static::$defaults['save']);
         }

--- a/plugins/BEdita/Core/src/Utility/Resources.php
+++ b/plugins/BEdita/Core/src/Utility/Resources.php
@@ -125,7 +125,6 @@ class Resources extends ResourcesBase
         $result = [];
 
         foreach ($data as $item) {
-            $resource = $Table->newEmptyEntity();
             $defaults = (array)Hash::get(static::$defaults, $type);
             $item = array_merge($defaults, $item);
             $resource = $Table->newEntity($item);

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
@@ -232,7 +232,23 @@ class ResourcesTest extends TestCase
      *
      * @covers ::create()
      */
-    public function testCreateInvalidName(): void
+    public function testCreateInvalidCategory(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid resource data: {"name":{"regex":"The provided value is invalid"}}');
+        Resources::create('categories', [
+            [
+                'name' => 'società',
+            ],
+        ]);
+    }
+
+    /**
+     * Test `create` method with invalid name.
+     *
+     * @covers ::create()
+     */
+    public function testCreateInvalidRole(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid resource data: {"name":{"regex":"The provided value is invalid"}}');

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ResourcesTest.php
@@ -21,6 +21,7 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
+use InvalidArgumentException;
 
 /**
  * {@see \BEdita\Core\Utility\Resources} Test Case
@@ -68,7 +69,7 @@ class ResourcesTest extends TestCase
                 'roles',
                 [
                     [
-                        'name' => 'new role',
+                        'name' => 'new_role',
                     ],
                 ],
             ],
@@ -76,7 +77,7 @@ class ResourcesTest extends TestCase
                 'applications',
                 [
                     [
-                        'name' => 'new app',
+                        'name' => 'new_app',
                     ],
                 ],
             ],
@@ -224,6 +225,22 @@ class ResourcesTest extends TestCase
     {
         $result = Resources::create($type, $data);
         static::assertEquals(count($data), count($result));
+    }
+
+    /**
+     * Test `create` method with invalid name.
+     *
+     * @covers ::create()
+     */
+    public function testCreateInvalidName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid resource data: {"name":{"regex":"The provided value is invalid"}}');
+        Resources::create('roles', [
+            [
+                'name' => 'invalid name',
+            ],
+        ]);
     }
 
     /**


### PR DESCRIPTION
When saving resources (for example on `bin/cake project_model`) the function `Resource::create` is called.

This provides a fix in the above function, by using entity validation before saving resource.