### PR TITLE
Cakephp queue 1.1

### DIFF
--- a/plugins/BEdita/Core/composer.json
+++ b/plugins/BEdita/Core/composer.json
@@ -24,7 +24,7 @@
         "php": ">=7.4",
         "cakephp/cakephp": "~4.5.0",
         "cakephp/migrations": "^3.5.2",
-        "cakephp/queue": "^0.1.11",
+        "cakephp/queue": "^1.1",
         "league/flysystem": "^2.4.5",
         "league/glide": "^2.2.2",
         "robmorgan/phinx": "^0.12.10",


### PR DESCRIPTION
This PR updates the dependency of cakephp queue from 0.1 to 1.1.

This shold resolve the annoying issue `error: [LogicException] Processor was not found. processorName: "Cake\Queue\Queue\Processor********"` in some enviroments, by appling [this patch](https://github.com/cakephp/queue/pull/127).

