### PR TITLE
Add PostgreSQL support in custom props finder

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/CustomPropertiesFilterTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/CustomPropertiesFilterTest.php
@@ -17,6 +17,7 @@ namespace BEdita\API\Test\IntegrationTest;
 use BEdita\API\TestSuite\IntegrationTestCase;
 use BEdita\Core\Test\Utility\TestFilesystemTrait;
 use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Postgres;
 use Cake\Datasource\ConnectionManager;
 use Cake\Utility\Hash;
 
@@ -41,7 +42,8 @@ class CustomPropertiesFilterTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $this->skipUnless(ConnectionManager::get('default')->getDriver() instanceof Mysql);
+        $driver = ConnectionManager::get('default')->getDriver();
+        $this->skipUnless(($driver instanceof Mysql) || ($driver instanceof Postgres));
         $this->filesystemSetup();
     }
 

--- a/plugins/BEdita/Core/config/Migrations/20251006090244_CustomPropsJson.php
+++ b/plugins/BEdita/Core/config/Migrations/20251006090244_CustomPropsJson.php
@@ -21,14 +21,13 @@ class CustomPropsJson extends AbstractMigration
             // For PostgreSQL, use raw SQL with explicit casting
             $this->execute('ALTER TABLE objects ALTER COLUMN custom_props TYPE jsonb USING custom_props::jsonb');
         } else {
-            // For other databases, use Phinx changeColumn
-            $json = 'text';
-            if (in_array('json', $columnTypes)) {
-                $json = 'json';
+            // For other databases having a 'json' column type, use Phinx changeColumn
+            if (!in_array('json', $columnTypes)) {
+                return;
             }
 
             $this->table('objects')
-                ->changeColumn('custom_props', $json, [
+                ->changeColumn('custom_props', 'json', [
                     'comment' => 'object custom properties (JSON format)',
                     'default' => null,
                     'null' => true,

--- a/plugins/BEdita/Core/config/Migrations/20251006090244_CustomPropsJson.php
+++ b/plugins/BEdita/Core/config/Migrations/20251006090244_CustomPropsJson.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\AbstractMigration;
+
+/**
+ * Migration to change `objects.custom_props` column type from TEXT to JSON/JSONB.
+ * Uses JSON for MySQL/MariaDB and JSONB for PostgreSQL for better performance.
+ */
+class CustomPropsJson extends AbstractMigration
+{
+    /**
+     * @inheritDoc
+     */
+    public function up(): void
+    {
+        $adapterType = $this->getAdapter()->getAdapterType();
+        $columnTypes = $this->getAdapter()->getColumnTypes();
+
+        if ($adapterType === 'pgsql' && in_array('jsonb', $columnTypes)) {
+            // For PostgreSQL, use raw SQL with explicit casting
+            $this->execute('ALTER TABLE objects ALTER COLUMN custom_props TYPE jsonb USING custom_props::jsonb');
+        } else {
+            // For other databases, use Phinx changeColumn
+            $json = 'text';
+            if (in_array('json', $columnTypes)) {
+                $json = 'json';
+            }
+
+            $this->table('objects')
+                ->changeColumn('custom_props', $json, [
+                    'comment' => 'object custom properties (JSON format)',
+                    'default' => null,
+                    'null' => true,
+                ])
+                ->update();
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function down(): void
+    {
+        // Revert back to TEXT type for all databases
+        $this->table('objects')
+            ->changeColumn('custom_props', 'text', [
+                'comment' => 'object custom properties (JSON format)',
+                'default' => null,
+                'length' => null,
+                'null' => true,
+            ])
+            ->update();
+    }
+}

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -364,6 +364,7 @@ class CustomPropertiesBehavior extends Behavior
 
                         // Use ->> operator directly on JSON column
                         [$key, $type] = $query->getConnection()->cast($key, 'string');
+
                         return $query->expr()->eq(
                             sprintf('%s->>%s', $field, $query->getConnection()->getDriver()->quote($key, $type)),
                             $compareValue

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -349,18 +349,17 @@ class CustomPropertiesBehavior extends Behavior
                             ),
                             new FunctionExpression('JSON_UNQUOTE', [json_encode($value)]) // trick to normalize values compared
                         );
-                    } else {
-                        // PostgreSQL syntax with native JSON column using ->> operator
-                        // For PostgreSQL's ->> operator, we need to handle value formatting correctly
-                        $compareValue = is_string($value) ? $value : json_encode($value); // Use json_encode to handle formatting
-                        [$key, $type] = $query->getConnection()->cast($key, 'string');
-
-                        // Use ->> operator directly on JSON column
-                        return $query->expr()->eq(
-                            sprintf('%s->>%s', $field, $query->getConnection()->getDriver()->quote($key, $type)),
-                            $compareValue
-                        );
                     }
+                    // PostgreSQL syntax with native JSON column using ->> operator
+                    // For PostgreSQL's ->> operator, we need to handle value formatting correctly
+                    $compareValue = is_string($value) ? $value : json_encode($value); // Use json_encode to handle formatting
+                    [$key, $type] = $query->getConnection()->cast($key, 'string');
+
+                    // Use ->> operator directly on JSON column
+                    return $query->expr()->eq(
+                        sprintf('%s->>%s', $field, $query->getConnection()->getDriver()->quote($key, $type)),
+                        $compareValue
+                    );
                 },
                 array_keys($options),
                 $options

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -363,8 +363,9 @@ class CustomPropertiesBehavior extends Behavior
                         }
 
                         // Use ->> operator directly on JSON column
+                        [$key, $type] = $query->getConnection()->cast($key, 'string');
                         return $query->expr()->eq(
-                            sprintf('%s->>%s', $field, $query->getConnection()->quote($key)),
+                            sprintf('%s->>%s', $field, $query->getConnection()->getDriver()->quote($key, $type)),
                             $compareValue
                         );
                     }

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -352,19 +352,10 @@ class CustomPropertiesBehavior extends Behavior
                     } else {
                         // PostgreSQL syntax with native JSON column using ->> operator
                         // For PostgreSQL's ->> operator, we need to handle value formatting correctly
-                        if (is_string($value)) {
-                            $compareValue = $value; // For strings, compare directly without JSON encoding quotes
-                        } elseif (is_bool($value)) {
-                            $compareValue = $value ? 'true' : 'false'; // Boolean values as strings
-                        } elseif (is_null($value)) {
-                            $compareValue = 'null'; // Null as string
-                        } else {
-                            $compareValue = (string)$value; // Numbers and other scalars as strings
-                        }
-
-                        // Use ->> operator directly on JSON column
+                        $compareValue = is_string($value) ? $value : json_encode($value); // Use json_encode to handle formatting
                         [$key, $type] = $query->getConnection()->cast($key, 'string');
 
+                        // Use ->> operator directly on JSON column
                         return $query->expr()->eq(
                             sprintf('%s->>%s', $field, $query->getConnection()->getDriver()->quote($key, $type)),
                             $compareValue

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -20,6 +20,7 @@ use BEdita\Core\Model\Entity\ObjectEntity;
 use BEdita\Core\Model\Validation\Validation;
 use Cake\Collection\CollectionInterface;
 use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Postgres;
 use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
@@ -309,9 +310,10 @@ class CustomPropertiesBehavior extends Behavior
      */
     public function findCustomProp(Query $query, array $options): Query
     {
-        // for now we handle just MySQL
-        if (!($query->getConnection()->getDriver() instanceof Mysql)) {
-            throw new BadFilterException(__d('bedita', 'customProp finder isn\'t supported for datasource'));
+        $driver = $query->getConnection()->getDriver();
+        // Check if driver is supported
+        if (!($driver instanceof Mysql) && !($driver instanceof Postgres)) {
+            throw new BadFilterException(__d('bedita', 'customProp finder isn\'t supported for this datasource'));
         }
 
         $available = $this->getAvailable();
@@ -328,23 +330,44 @@ class CustomPropertiesBehavior extends Behavior
         }
         unset($value);
 
-        return $query->where(function (QueryExpression $exp, Query $query) use ($options) {
+        return $query->where(function (QueryExpression $exp, Query $query) use ($options, $driver) {
             $field = $this->table()->aliasField($this->getConfig('field'));
 
             return $exp->and(array_map(
-                function ($key, $value) use ($field, $query) {
-                    return $query->expr()->eq(
-                        new FunctionExpression(
-                            'JSON_UNQUOTE',
-                            [
-                                new FunctionExpression(
-                                    'JSON_EXTRACT',
-                                    [$field => 'identifier', sprintf('$.%s', $key)]
-                                ),
-                            ]
-                        ),
-                        new FunctionExpression('JSON_UNQUOTE', [json_encode($value)]) // trick to normalize values compared
-                    );
+                function ($key, $value) use ($field, $query, $driver) {
+                    if ($driver instanceof Mysql) {
+                        // MySQL syntax using JSON_EXTRACT and JSON_UNQUOTE
+                        return $query->expr()->eq(
+                            new FunctionExpression(
+                                'JSON_UNQUOTE',
+                                [
+                                    new FunctionExpression(
+                                        'JSON_EXTRACT',
+                                        [$field => 'identifier', sprintf('$.%s', $key)]
+                                    ),
+                                ]
+                            ),
+                            new FunctionExpression('JSON_UNQUOTE', [json_encode($value)]) // trick to normalize values compared
+                        );
+                    } else {
+                        // PostgreSQL syntax with native JSON column using ->> operator
+                        // For PostgreSQL's ->> operator, we need to handle value formatting correctly
+                        if (is_string($value)) {
+                            $compareValue = $value; // For strings, compare directly without JSON encoding quotes
+                        } elseif (is_bool($value)) {
+                            $compareValue = $value ? 'true' : 'false'; // Boolean values as strings
+                        } elseif (is_null($value)) {
+                            $compareValue = 'null'; // Null as string
+                        } else {
+                            $compareValue = (string)$value; // Numbers and other scalars as strings
+                        }
+
+                        // Use ->> operator directly on JSON column
+                        return $query->expr()->eq(
+                            sprintf('%s->>%s', $field, $query->getConnection()->quote($key)),
+                            $compareValue
+                        );
+                    }
                 },
                 array_keys($options),
                 $options

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/ListEntitiesActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/ListEntitiesActionTest.php
@@ -18,6 +18,7 @@ namespace BEdita\Core\Test\TestCase\Model\Action;
 use BEdita\Core\Model\Action\ListEntitiesAction;
 use BEdita\Core\ORM\Inheritance\Table;
 use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Postgres;
 use Cake\Datasource\ConnectionManager;
 use Cake\I18n\FrozenTime;
 use Cake\ORM\Query;
@@ -258,7 +259,8 @@ class ListEntitiesActionTest extends TestCase
      */
     public function testFilterCustomProp(): void
     {
-        $this->skipUnless(ConnectionManager::get('default')->getDriver() instanceof Mysql);
+        $driver = ConnectionManager::get('default')->getDriver();
+        $this->skipUnless(($driver instanceof Mysql) || ($driver instanceof Postgres));
 
         $table = $this->getTableLocator()->get('Files');
         $action = new ListEntitiesAction(compact('table'));

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
@@ -588,7 +588,7 @@ class CustomPropertiesBehaviorTest extends TestCase
         $driver = $connection->getDriver();
         if (!($driver instanceof Mysql) && !($driver instanceof Postgres)) {
             $this->expectException(BadFilterException::class);
-            $this->expectExceptionMessage('customProp finder isn\'t supported for datasource');
+            $this->expectExceptionMessage('customProp finder isn\'t supported for this datasource');
         } elseif ($expected instanceof \Exception) {
             $this->expectException(get_class($expected));
             $this->expectExceptionMessage($expected->getMessage());
@@ -618,7 +618,7 @@ class CustomPropertiesBehaviorTest extends TestCase
         $driver = $connection->getDriver();
         if (!($driver instanceof Mysql) && !($driver instanceof Postgres)) {
             $this->expectException(BadFilterException::class);
-            $this->expectExceptionMessage('customProp finder isn\'t supported for datasource');
+            $this->expectExceptionMessage('customProp finder isn\'t supported for this datasource');
         }
 
         $Profiles = $this->getTableLocator()->get('Profiles');

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
@@ -19,6 +19,7 @@ use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Test\Utility\TestFilesystemTrait;
 use Cake\Collection\CollectionInterface;
 use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Postgres;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -584,7 +585,8 @@ class CustomPropertiesBehaviorTest extends TestCase
     public function testFindCustomProp($expected, string $tableName, array $options): void
     {
         $connection = ConnectionManager::get('default');
-        if (!$connection->getDriver() instanceof Mysql) {
+        $driver = $connection->getDriver();
+        if (!($driver instanceof Mysql) && !($driver instanceof Postgres)) {
             $this->expectException(BadFilterException::class);
             $this->expectExceptionMessage('customProp finder isn\'t supported for datasource');
         } elseif ($expected instanceof \Exception) {
@@ -613,7 +615,8 @@ class CustomPropertiesBehaviorTest extends TestCase
     public function testFindCustomPropInteger(): void
     {
         $connection = ConnectionManager::get('default');
-        if (!$connection->getDriver() instanceof Mysql) {
+        $driver = $connection->getDriver();
+        if (!($driver instanceof Mysql) && !($driver instanceof Postgres)) {
             $this->expectException(BadFilterException::class);
             $this->expectExceptionMessage('customProp finder isn\'t supported for datasource');
         }


### PR DESCRIPTION
This pull request adds support for PostgreSQL in handling custom properties stored as JSON, alongside existing MySQL support. It updates both the database migration logic and the application code to ensure correct querying and filtering of JSON custom properties in both databases. The test suite is also updated to validate functionality for PostgreSQL.

* Added a new migration to change the `objects.custom_props` column type from `TEXT` to `JSONB` for PostgreSQL and to `JSON` for MySQL/MariaDB, improving performance and native JSON support.
* Updated `CustomPropertiesBehavior` to support custom property filtering for PostgreSQL, using the  `->>` operator. 
* Modified integration and unit tests
