### PR TITLE
Base url in Filesystem configuration

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -441,12 +441,14 @@ return [
         'default' => [
             'className' => 'BEdita/Core.Local',
             'path' => WWW_ROOT . '_files',
-            'url' => env('FILESYSTEM_DEFAULT_URL', null),
+            'baseUrl' => env('FILESYSTEM_DEFAULT_BASE_URL', null),
+            'url' => env('FILESYSTEM_DEFAULT_URL', null), // this will override baseUrl if set
         ],
         'thumbnails' => [
             'className' => 'BEdita/Core.Local',
             'path' => WWW_ROOT . '_files' . DS . 'thumbs',
-            'url' => env('FILESYSTEM_THUMBNAILS_URL', null),
+            'baseUrl' => env('FILESYSTEM_THUMBNAILS_BASE_URL', null),
+            'url' => env('FILESYSTEM_THUMBNAILS_URL', null), // this will override baseUrl if set
         ],
     ],
 

--- a/config/app.php
+++ b/config/app.php
@@ -441,14 +441,14 @@ return [
         'default' => [
             'className' => 'BEdita/Core.Local',
             'path' => WWW_ROOT . '_files',
-            'baseUrl' => env('FILESYSTEM_DEFAULT_BASE_URL', null),
-            'url' => env('FILESYSTEM_DEFAULT_URL', null), // this will override baseUrl if set
+            'baseUrl' => env('FILESYSTEM_DEFAULT_BASE_URL', null), // string
+            'url' => env('FILESYSTEM_DEFAULT_URL', null), // dsn
         ],
         'thumbnails' => [
             'className' => 'BEdita/Core.Local',
             'path' => WWW_ROOT . '_files' . DS . 'thumbs',
-            'baseUrl' => env('FILESYSTEM_THUMBNAILS_BASE_URL', null),
-            'url' => env('FILESYSTEM_THUMBNAILS_URL', null), // this will override baseUrl if set
+            'baseUrl' => env('FILESYSTEM_THUMBNAILS_BASE_URL', null), // string
+            'url' => env('FILESYSTEM_THUMBNAILS_URL', null), // dsn
         ],
     ],
 


### PR DESCRIPTION
This PR fixes the Filesystem configuration providing a `baseUrl` key, with value from environment variable `FILESYSTEM_DEFAULT_BASE_URL` (and `FILESYSTEM_THUMBNAILS_BASE_URL`).

Tests: https://github.com/bedita/bedita/actions/runs/18776491778