### PR TITLE
Fix and remove deprecations in migrations and seeds

### DIFF
--- a/plugins/BEdita/Core/config/Migrations/20160930083942_Alpha.php
+++ b/plugins/BEdita/Core/config/Migrations/20160930083942_Alpha.php
@@ -1,11 +1,11 @@
 <?php
 use Authentication\PasswordHasher\LegacyPasswordHasher;
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Database schema for Alpha release.
  */
-class Alpha extends AbstractMigration
+class Alpha extends BaseMigration
 {
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20170104171725_DeleteTrash.php
+++ b/plugins/BEdita/Core/config/Migrations/20170104171725_DeleteTrash.php
@@ -1,12 +1,12 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Use dedicated column for deleted objects.
  *
  * @see https://github.com/bedita/bedita/issues/1027
  */
-class DeleteTrash extends AbstractMigration
+class DeleteTrash extends BaseMigration
 {
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20170128124506_AddPropertiesCreatedModified.php
+++ b/plugins/BEdita/Core/config/Migrations/20170128124506_AddPropertiesCreatedModified.php
@@ -1,7 +1,7 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class AddPropertiesCreatedModified extends AbstractMigration
+class AddPropertiesCreatedModified extends BaseMigration
 {
 
     public function up()

--- a/plugins/BEdita/Core/config/Migrations/20170128124743_AddPropertiesLabelDescEnabledList.php
+++ b/plugins/BEdita/Core/config/Migrations/20170128124743_AddPropertiesLabelDescEnabledList.php
@@ -1,10 +1,10 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Add label, description, enabled and list view columns to `properties` table.
  */
-class AddPropertiesLabelDescEnabledList extends AbstractMigration
+class AddPropertiesLabelDescEnabledList extends BaseMigration
 {
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20170211120349_AllowPermissionsOnAllEndpoints.php
+++ b/plugins/BEdita/Core/config/Migrations/20170211120349_AllowPermissionsOnAllEndpoints.php
@@ -1,12 +1,12 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Allow `null` value in column `endpoint_permissions.endpoint_id`.
  *
  * @see https://github.com/bedita/bedita/issues/968
  */
-class AllowPermissionsOnAllEndpoints extends AbstractMigration
+class AllowPermissionsOnAllEndpoints extends BaseMigration
 {
 
     /**
@@ -17,7 +17,7 @@ class AllowPermissionsOnAllEndpoints extends AbstractMigration
         $this->table('endpoint_permissions')
             ->dropForeignKey(
                 'endpoint_id'
-            )            
+            )
             ->update();
 
         $this->table('endpoint_permissions')

--- a/plugins/BEdita/Core/config/Migrations/20170222170901_LocationsTable.php
+++ b/plugins/BEdita/Core/config/Migrations/20170222170901_LocationsTable.php
@@ -11,9 +11,9 @@
  *
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class LocationsTable extends AbstractMigration
+class LocationsTable extends BaseMigration
 {
     public bool $autoId = false;
 

--- a/plugins/BEdita/Core/config/Migrations/20170301144829_RemovePluralized.php
+++ b/plugins/BEdita/Core/config/Migrations/20170301144829_RemovePluralized.php
@@ -1,11 +1,11 @@
 <?php
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Make pluralized form the most significant column for `object_types` table.
  */
-class RemovePluralized extends AbstractMigration
+class RemovePluralized extends BaseMigration
 {
     /**
      * @inheritDoc

--- a/plugins/BEdita/Core/config/Migrations/20170307123150_CreateDateRanges.php
+++ b/plugins/BEdita/Core/config/Migrations/20170307123150_CreateDateRanges.php
@@ -1,8 +1,8 @@
 <?php
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class CreateDateRanges extends AbstractMigration
+class CreateDateRanges extends BaseMigration
 {
     public bool $autoId = false;
 

--- a/plugins/BEdita/Core/config/Migrations/20170309100413_AddAssociations.php
+++ b/plugins/BEdita/Core/config/Migrations/20170309100413_AddAssociations.php
@@ -1,12 +1,12 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Add `associations` column to `object_types` table.
  *
  * @see https://github.com/bedita/bedita/pull/1138
  */
-class AddAssociations extends AbstractMigration
+class AddAssociations extends BaseMigration
 {
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20170327145820_ChangeApplicationDescription.php
+++ b/plugins/BEdita/Core/config/Migrations/20170327145820_ChangeApplicationDescription.php
@@ -1,7 +1,7 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class ChangeApplicationDescription extends AbstractMigration
+class ChangeApplicationDescription extends BaseMigration
 {
 
     public function up()

--- a/plugins/BEdita/Core/config/Migrations/20170428100034_AddAsyncJobsTable.php
+++ b/plugins/BEdita/Core/config/Migrations/20170428100034_AddAsyncJobsTable.php
@@ -1,10 +1,10 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Add `async_jobs` table.
  */
-class AddAsyncJobsTable extends AbstractMigration
+class AddAsyncJobsTable extends BaseMigration
 {
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20170502183205_MakeAuthProvidersSettingsNullable.php
+++ b/plugins/BEdita/Core/config/Migrations/20170502183205_MakeAuthProvidersSettingsNullable.php
@@ -1,10 +1,10 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Make `auth_providers.url` and `auth_providers.params` columns nullable.
  */
-class MakeAuthProvidersSettingsNullable extends AbstractMigration
+class MakeAuthProvidersSettingsNullable extends BaseMigration
 {
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20170526152012_AddUserVerifiedField.php
+++ b/plugins/BEdita/Core/config/Migrations/20170526152012_AddUserVerifiedField.php
@@ -11,14 +11,14 @@
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Add `verified` field to `users` table.
  *
  * @since 4.0.0
  */
-class AddUserVerifiedField extends AbstractMigration
+class AddUserVerifiedField extends BaseMigration
 {
     /**
      * {@inheritdoc}

--- a/plugins/BEdita/Core/config/Migrations/20170607114052_AddIdVatNumbers.php
+++ b/plugins/BEdita/Core/config/Migrations/20170607114052_AddIdVatNumbers.php
@@ -11,14 +11,14 @@
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Add VAT ID number to `profiles` table.
  *
  * @since 4.0.0
  */
-class AddIdVatNumbers extends AbstractMigration
+class AddIdVatNumbers extends BaseMigration
 {
     /**
      * {@inheritdoc}

--- a/plugins/BEdita/Core/config/Migrations/20170618121702_AddStreamsTable.php
+++ b/plugins/BEdita/Core/config/Migrations/20170618121702_AddStreamsTable.php
@@ -11,14 +11,14 @@
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Refactor `media` table and add `streams` table.
  *
  * @since 4.0.0
  */
-class AddStreamsTable extends AbstractMigration
+class AddStreamsTable extends BaseMigration
 {
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20170721103804_MoveWidthHeightDurationToStreams.php
+++ b/plugins/BEdita/Core/config/Migrations/20170721103804_MoveWidthHeightDurationToStreams.php
@@ -11,14 +11,14 @@
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Move `width`, `height` and `duration` from `media` to `streams`. Add `provider_extra` to `media`.
  *
  * @since 4.0.0
  */
-class MoveWidthHeightDurationToStreams extends AbstractMigration
+class MoveWidthHeightDurationToStreams extends BaseMigration
 {
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20170824132927_AddCustomProps.php
+++ b/plugins/BEdita/Core/config/Migrations/20170824132927_AddCustomProps.php
@@ -11,14 +11,14 @@
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Add `custom_props` field to `objects` table.
  *
  * @since 4.0.0
  */
-class AddCustomProps extends AbstractMigration
+class AddCustomProps extends BaseMigration
 {
     /**
      * {@inheritdoc}

--- a/plugins/BEdita/Core/config/Migrations/20170825083904_AddHidden.php
+++ b/plugins/BEdita/Core/config/Migrations/20170825083904_AddHidden.php
@@ -1,12 +1,12 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Add `hidden` column to `object_types` table.
  *
  * @see https://github.com/bedita/bedita/1328
  */
-class AddHidden extends AbstractMigration
+class AddHidden extends BaseMigration
 {
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20170826231544_OnDeleteCascadePropertiesConstraint.php
+++ b/plugins/BEdita/Core/config/Migrations/20170826231544_OnDeleteCascadePropertiesConstraint.php
@@ -11,14 +11,14 @@
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Change constraints of `properties` table enabling ON DELETE CASCADE
  *
  * @since 4.0.0
  */
-class OnDeleteCascadePropertiesConstraint extends AbstractMigration
+class OnDeleteCascadePropertiesConstraint extends BaseMigration
 {
 
     public function up()

--- a/plugins/BEdita/Core/config/Migrations/20170826231544_OnDeleteCascadePropertiesConstraint.php
+++ b/plugins/BEdita/Core/config/Migrations/20170826231544_OnDeleteCascadePropertiesConstraint.php
@@ -23,10 +23,14 @@ class OnDeleteCascadePropertiesConstraint extends BaseMigration
 
     public function up()
     {
-        $this->table('properties')
-            ->dropForeignKey([], 'properties_objtype_fk')
-            ->dropForeignKey([], 'properties_proptype_fk')
-            ->update();
+        // SQLite does not support drop foreign keys
+        if ($this->getAdapter()->getAdapterType() !== 'sqlite') {
+            $this->table('properties')
+                ->dropForeignKey([], 'properties_objtype_fk')
+                ->dropForeignKey([], 'properties_proptype_fk')
+                ->update();
+            return;
+        }
 
         $this->table('properties')
             ->addForeignKey(

--- a/plugins/BEdita/Core/config/Migrations/20171005105447_ObjectTypesInheritance.php
+++ b/plugins/BEdita/Core/config/Migrations/20171005105447_ObjectTypesInheritance.php
@@ -1,7 +1,7 @@
 <?php
 
 use Cake\ORM\Table;
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Add inheritance to object types.
@@ -9,7 +9,7 @@ use Migrations\AbstractMigration;
  * This migration class also fixes tree information (left and right indexes, as prescribed by Nested-Set Model)
  * in order to make things work as expected from the very beginning.
  */
-class ObjectTypesInheritance extends AbstractMigration
+class ObjectTypesInheritance extends BaseMigration
 {
 
     /**
@@ -96,11 +96,10 @@ class ObjectTypesInheritance extends AbstractMigration
             ->update();
 
         // Populate tree data. We'll be using a clean CakePHP table object to be able to use Tree behavior.
-        /* @var \Migrations\CakeAdapter $adapter */
         $adapter = $this->getAdapter();
         $table = new Table([
             'table' => 'object_types',
-            'connection' => $adapter->getCakeConnection(),
+            'connection' => $adapter->getConnection(),
         ]);
 
         $table->updateAll( // "objects" and "media" are abstract.

--- a/plugins/BEdita/Core/config/Migrations/20171017154522_UniqueSingular.php
+++ b/plugins/BEdita/Core/config/Migrations/20171017154522_UniqueSingular.php
@@ -11,14 +11,14 @@
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Modify `object_types.singular` to be unique.
  *
  * @since 4.0.0
  */
-class UniqueSingular extends AbstractMigration
+class UniqueSingular extends BaseMigration
 {
     /**
      * {@inheritdoc}

--- a/plugins/BEdita/Core/config/Migrations/20171018161702_CoreMediaTypes.php
+++ b/plugins/BEdita/Core/config/Migrations/20171018161702_CoreMediaTypes.php
@@ -11,14 +11,14 @@
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Add `videos`, `audio` and `files` core media types.
  *
  * @since 4.0.0
  */
-class CoreMediaTypes extends AbstractMigration
+class CoreMediaTypes extends BaseMigration
 {
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20171027164507_DefaultApplication.php
+++ b/plugins/BEdita/Core/config/Migrations/20171027164507_DefaultApplication.php
@@ -12,14 +12,14 @@
  */
 
 use BEdita\Core\Model\Table\ApplicationsTable;
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Create a default application if missing.
  *
  * @since 4.0.0
  */
-class DefaultApplication extends AbstractMigration
+class DefaultApplication extends BaseMigration
 {
     /**
      * {@inheritdoc}

--- a/plugins/BEdita/Core/config/Migrations/20171030185447_MediaTypesInheritance.php
+++ b/plugins/BEdita/Core/config/Migrations/20171030185447_MediaTypesInheritance.php
@@ -1,13 +1,13 @@
 <?php
 
 use Cake\ORM\Table;
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Add inheritance info to `videos`, `audio` and `files`.
  *
  */
-class MediaTypesInheritance extends AbstractMigration
+class MediaTypesInheritance extends BaseMigration
 {
     /**
      * {@inheritDoc}
@@ -15,11 +15,10 @@ class MediaTypesInheritance extends AbstractMigration
     public function up()
     {
         // Populate tree data. We'll be using a clean CakePHP table object to be able to use Tree behavior.
-        /* @var \Migrations\CakeAdapter $adapter */
         $adapter = $this->getAdapter();
         $table = new Table([
             'table' => 'object_types',
-            'connection' => $adapter->getCakeConnection(),
+            'connection' => $adapter->getConnection(),
         ]);
 
         $table->updateAll( // `videos`, `audio` and `files` inherit from `media`.

--- a/plugins/BEdita/Core/config/Migrations/20171031155829_UsersInheritance.php
+++ b/plugins/BEdita/Core/config/Migrations/20171031155829_UsersInheritance.php
@@ -1,12 +1,12 @@
 <?php
 
 use Cake\ORM\Table;
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Fix `users` inheritance => from `objects` instead of `profiles`.
  */
-class UsersInheritance extends AbstractMigration
+class UsersInheritance extends BaseMigration
 {
     /**
      * {@inheritDoc}
@@ -16,7 +16,7 @@ class UsersInheritance extends AbstractMigration
         // Using a clean CakePHP table object to use Tree behavior.
         $table = new Table([
             'table' => 'object_types',
-            'connection' => $this->getAdapter()->getCakeConnection(),
+            'connection' => $this->getAdapter()->getConnection(),
         ]);
 
         $table->updateAll(

--- a/plugins/BEdita/Core/config/Migrations/20171104185428_ObjectTypesKey.php
+++ b/plugins/BEdita/Core/config/Migrations/20171104185428_ObjectTypesKey.php
@@ -1,12 +1,12 @@
 <?php
 
 use Cake\ORM\Table;
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Fix `object_type_id` foreign key index.
  */
-class ObjectTypesKey extends AbstractMigration
+class ObjectTypesKey extends BaseMigration
 {
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/config/Migrations/20171109094654_AddDefaultPropertyTypes.php
+++ b/plugins/BEdita/Core/config/Migrations/20171109094654_AddDefaultPropertyTypes.php
@@ -1,10 +1,10 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Add default property types.
  */
-class AddDefaultPropertyTypes extends AbstractMigration
+class AddDefaultPropertyTypes extends BaseMigration
 {
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20171110095938_AddCoreEnabledCreatedModified.php
+++ b/plugins/BEdita/Core/config/Migrations/20171110095938_AddCoreEnabledCreatedModified.php
@@ -1,12 +1,12 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Add `core_type`, `created`, `modified`, `enabled` columns to `object_types`.
  *
  * @see https://github.com/bedita/bedita/1366
  */
-class AddCoreEnabledCreatedModified extends AbstractMigration
+class AddCoreEnabledCreatedModified extends BaseMigration
 {
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/config/Migrations/20180131171902_FoldersType.php
+++ b/plugins/BEdita/Core/config/Migrations/20180131171902_FoldersType.php
@@ -12,14 +12,14 @@
  */
 
 use Cake\ORM\Table;
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Add `folders` core media type.
  *
  * @since 4.0.0
  */
-class FoldersType extends AbstractMigration
+class FoldersType extends BaseMigration
 {
 
     /**
@@ -47,7 +47,7 @@ class FoldersType extends AbstractMigration
         $adapter = $this->getAdapter();
         $table = new Table([
             'table' => 'object_types',
-            'connection' => $adapter->getCakeConnection(),
+            'connection' => $adapter->getConnection(),
         ]);
         // Now let's fix NSM (nested-set model) left and right indexes from tree data.
         $table->addBehavior('BEdita/Core.Tree', [
@@ -67,7 +67,7 @@ class FoldersType extends AbstractMigration
         $adapter = $this->getAdapter();
         $table = new Table([
             'table' => 'object_types',
-            'connection' => $adapter->getCakeConnection(),
+            'connection' => $adapter->getConnection(),
         ]);
         $table->addBehavior('Tree', [
             'left' => 'tree_left',

--- a/plugins/BEdita/Core/config/Migrations/20180208104214_AddTreesParentNodeId.php
+++ b/plugins/BEdita/Core/config/Migrations/20180208104214_AddTreesParentNodeId.php
@@ -1,5 +1,5 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Migration for:
@@ -10,7 +10,7 @@ use Migrations\AbstractMigration;
  *
  * @since 4.0.0
  */
-class AddTreesParentNodeId extends AbstractMigration
+class AddTreesParentNodeId extends BaseMigration
 {
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20180405182946_AddAuthProvidersClass.php
+++ b/plugins/BEdita/Core/config/Migrations/20180405182946_AddAuthProvidersClass.php
@@ -1,12 +1,12 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Add `auth_class`, `enabled`, `creaeted` and `modified` columns to `auth_providers` table.
  *
  * @see https://github.com/bedita/bedita/1429
  */
-class AddAuthProvidersClass extends AbstractMigration
+class AddAuthProvidersClass extends BaseMigration
 {
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/config/Migrations/20180507095822_DeleteRestrict.php
+++ b/plugins/BEdita/Core/config/Migrations/20180507095822_DeleteRestrict.php
@@ -1,5 +1,4 @@
 <?php
-use Cake\Auth\WeakPasswordHasher;
 use Migrations\BaseMigration;
 
 /**

--- a/plugins/BEdita/Core/config/Migrations/20180507095822_DeleteRestrict.php
+++ b/plugins/BEdita/Core/config/Migrations/20180507095822_DeleteRestrict.php
@@ -1,12 +1,12 @@
 <?php
 use Cake\Auth\WeakPasswordHasher;
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Replace `CASCADE` with `RESTRICT` on `objects.created_by`, `objects.modified_by`, `objects.object_type_id`
  * delete condition
  */
-class DeleteRestrict extends AbstractMigration
+class DeleteRestrict extends BaseMigration
 {
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/config/Migrations/20180525181318_AddConfigApplicationId.php
+++ b/plugins/BEdita/Core/config/Migrations/20180525181318_AddConfigApplicationId.php
@@ -1,12 +1,12 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Add `config.application_id`.
  *
  * @see https://github.com/bedita/bedita/1486
  */
-class AddConfigApplicationId extends AbstractMigration
+class AddConfigApplicationId extends BaseMigration
 {
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/config/Migrations/20180614080050_AddTranslationsTable.php
+++ b/plugins/BEdita/Core/config/Migrations/20180614080050_AddTranslationsTable.php
@@ -11,12 +11,12 @@
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Migration class to create `translations` table.
  */
-class AddTranslationsTable extends AbstractMigration
+class AddTranslationsTable extends BaseMigration
 {
     /**
      * @inheritDoc

--- a/plugins/BEdita/Core/config/Migrations/20180731202144_DateAndDateTime.php
+++ b/plugins/BEdita/Core/config/Migrations/20180731202144_DateAndDateTime.php
@@ -1,10 +1,10 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Add `datetime` and update `date` property types.
  */
-class DateAndDateTime extends AbstractMigration
+class DateAndDateTime extends BaseMigration
 {
 
     /**

--- a/plugins/BEdita/Core/config/Migrations/20180911142444_AddUserTokensTable.php
+++ b/plugins/BEdita/Core/config/Migrations/20180911142444_AddUserTokensTable.php
@@ -1,10 +1,10 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Add `user_tokens` table
  */
-class AddUserTokensTable extends AbstractMigration
+class AddUserTokensTable extends BaseMigration
 {
     /**
      * @inheritDoc

--- a/plugins/BEdita/Core/config/Migrations/20180918153133_RemoveUniqueEmail.php
+++ b/plugins/BEdita/Core/config/Migrations/20180918153133_RemoveUniqueEmail.php
@@ -1,10 +1,10 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Remove unique `profiles.email` index and add non-unique index
  */
-class RemoveUniqueEmail extends AbstractMigration
+class RemoveUniqueEmail extends BaseMigration
 {
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/config/Migrations/20190824171023_NameSingularComments.php
+++ b/plugins/BEdita/Core/config/Migrations/20190824171023_NameSingularComments.php
@@ -1,8 +1,8 @@
 <?php
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class NameSingularComments extends AbstractMigration
+class NameSingularComments extends BaseMigration
 {
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/config/Migrations/20190923161150_History.php
+++ b/plugins/BEdita/Core/config/Migrations/20190923161150_History.php
@@ -1,8 +1,8 @@
 <?php
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class History extends AbstractMigration
+class History extends BaseMigration
 {
     /**
      * @inheritDoc

--- a/plugins/BEdita/Core/config/Migrations/20191125163135_AddObjectCategories.php
+++ b/plugins/BEdita/Core/config/Migrations/20191125163135_AddObjectCategories.php
@@ -1,8 +1,8 @@
 <?php
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class AddObjectCategories extends AbstractMigration
+class AddObjectCategories extends BaseMigration
 {
     public bool $autoId = false;
 

--- a/plugins/BEdita/Core/config/Migrations/20191202181949_CorePropertyTypes.php
+++ b/plugins/BEdita/Core/config/Migrations/20191202181949_CorePropertyTypes.php
@@ -1,7 +1,7 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class CorePropertyTypes extends AbstractMigration
+class CorePropertyTypes extends BaseMigration
 {
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/config/Migrations/20200429070603_LinksTable.php
+++ b/plugins/BEdita/Core/config/Migrations/20200429070603_LinksTable.php
@@ -1,8 +1,8 @@
 <?php
 use Cake\ORM\Table;
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class LinksTable extends AbstractMigration
+class LinksTable extends BaseMigration
 {
     /**
      * {@inheritDoc}
@@ -92,7 +92,7 @@ class LinksTable extends AbstractMigration
     {
         $table = new Table([
             'table' => 'object_types',
-            'connection' => $this->getAdapter()->getCakeConnection(),
+            'connection' => $this->getAdapter()->getConnection(),
         ]);
         $table->addBehavior('BEdita/Core.Tree', [
             'left' => 'tree_left',

--- a/plugins/BEdita/Core/config/Migrations/20200505052558_PublicationsTable.php
+++ b/plugins/BEdita/Core/config/Migrations/20200505052558_PublicationsTable.php
@@ -1,9 +1,8 @@
 <?php
-use BEdita\Core\Utility\Resources;
 use Cake\ORM\Table;
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class PublicationsTable extends AbstractMigration
+class PublicationsTable extends BaseMigration
 {
     /**
      * {@inheritDoc}
@@ -99,7 +98,7 @@ class PublicationsTable extends AbstractMigration
     {
         $table = new Table([
             'table' => 'object_types',
-            'connection' => $this->getAdapter()->getCakeConnection(),
+            'connection' => $this->getAdapter()->getConnection(),
         ]);
         $table->addBehavior('BEdita/Core.Tree', [
             'left' => 'tree_left',

--- a/plugins/BEdita/Core/config/Migrations/20200514142029_AddTreesCanonical.php
+++ b/plugins/BEdita/Core/config/Migrations/20200514142029_AddTreesCanonical.php
@@ -1,10 +1,10 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
 /**
  * Add `trees.canonical` https://github.com/bedita/bedita/issues/1690
  */
-class AddTreesCanonical extends AbstractMigration
+class AddTreesCanonical extends BaseMigration
 {
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/config/Migrations/20200519114349_StreamsUriLimit.php
+++ b/plugins/BEdita/Core/config/Migrations/20200519114349_StreamsUriLimit.php
@@ -11,9 +11,9 @@
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class StreamsUriLimit extends AbstractMigration
+class StreamsUriLimit extends BaseMigration
 {
     /**
      * {@inheritdoc}

--- a/plugins/BEdita/Core/config/Migrations/20200708142319_ConfigChangePrimaryKey.php
+++ b/plugins/BEdita/Core/config/Migrations/20200708142319_ConfigChangePrimaryKey.php
@@ -1,8 +1,8 @@
 <?php
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class ConfigChangePrimaryKey extends AbstractMigration
+class ConfigChangePrimaryKey extends BaseMigration
 {
     /**
      * @inheritDoc

--- a/plugins/BEdita/Core/config/Migrations/20200729161955_ExtraMySQLSize.php
+++ b/plugins/BEdita/Core/config/Migrations/20200729161955_ExtraMySQLSize.php
@@ -11,13 +11,13 @@
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 use Phinx\Db\Adapter\MysqlAdapter;
 
 /**
  * Increase `objects.extra` column size to 16MB (on MySQL only)
  */
-class ExtraMySQLSize extends AbstractMigration
+class ExtraMySQLSize extends BaseMigration
 {
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/config/Migrations/20200903081010_OverrideProperties.php
+++ b/plugins/BEdita/Core/config/Migrations/20200903081010_OverrideProperties.php
@@ -1,12 +1,13 @@
 <?php
 use BEdita\Core\Utility\Resources;
-use Migrations\AbstractMigration;
+use Cake\Cache\Cache;
+use Migrations\BaseMigration;
 
 /**
  * New column `properties.is_static` to override property type of static property
  * New core property type `plain_text`
  */
-class OverrideProperties extends AbstractMigration
+class OverrideProperties extends BaseMigration
 {
     protected $create = [
         'property_types' => [
@@ -38,8 +39,17 @@ class OverrideProperties extends AbstractMigration
 
         Resources::save(
             ['create' => $this->create],
-            ['connection' => $this->getAdapter()->getCakeConnection()]
+            ['connection' => $this->getAdapter()->getConnection()]
         );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function postFlightCheck(): void
+    {
+        parent::postFlightCheck();
+        Cache::clearAll();
     }
 
     /**
@@ -53,7 +63,7 @@ class OverrideProperties extends AbstractMigration
 
         Resources::save(
             ['remove' => $this->create],
-            ['connection' => $this->getAdapter()->getCakeConnection()]
+            ['connection' => $this->getAdapter()->getConnection()]
         );
     }
 }

--- a/plugins/BEdita/Core/config/Migrations/20210304171244_AddAsyncJobsTableIndex.php
+++ b/plugins/BEdita/Core/config/Migrations/20210304171244_AddAsyncJobsTableIndex.php
@@ -1,8 +1,8 @@
 <?php
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class AddAsyncJobsTableIndex extends AbstractMigration
+class AddAsyncJobsTableIndex extends BaseMigration
 {
     /**
      * Change Method.

--- a/plugins/BEdita/Core/config/Migrations/20210910111921_AddStreamMetadata.php
+++ b/plugins/BEdita/Core/config/Migrations/20210910111921_AddStreamMetadata.php
@@ -1,7 +1,7 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class AddStreamMetadata extends AbstractMigration
+class AddStreamMetadata extends BaseMigration
 {
     /**
     * {@inheritDoc}

--- a/plugins/BEdita/Core/config/Migrations/20211005174753_ApplicationClientSecret.php
+++ b/plugins/BEdita/Core/config/Migrations/20211005174753_ApplicationClientSecret.php
@@ -1,7 +1,7 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class ApplicationClientSecret extends AbstractMigration
+class ApplicationClientSecret extends BaseMigration
 {
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/config/Migrations/20211015112939_PrivateStream.php
+++ b/plugins/BEdita/Core/config/Migrations/20211015112939_PrivateStream.php
@@ -1,7 +1,7 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class PrivateStream extends AbstractMigration
+class PrivateStream extends BaseMigration
 {
     /**
      * Change Method.

--- a/plugins/BEdita/Core/config/Migrations/20211111102130_TreeMenuOff.php
+++ b/plugins/BEdita/Core/config/Migrations/20211111102130_TreeMenuOff.php
@@ -1,7 +1,7 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class TreeMenuOff extends AbstractMigration
+class TreeMenuOff extends BaseMigration
 {
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/config/Migrations/20211125105831_PasswordCreated.php
+++ b/plugins/BEdita/Core/config/Migrations/20211125105831_PasswordCreated.php
@@ -1,7 +1,7 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class PasswordCreated extends AbstractMigration
+class PasswordCreated extends BaseMigration
 {
     /**
      * Change Method.

--- a/plugins/BEdita/Core/config/Migrations/20211126070240_ProfilePseudonym.php
+++ b/plugins/BEdita/Core/config/Migrations/20211126070240_ProfilePseudonym.php
@@ -1,7 +1,7 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class ProfilePseudonym extends AbstractMigration
+class ProfilePseudonym extends BaseMigration
 {
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/config/Migrations/20220316140137_CreateTagsTable.php
+++ b/plugins/BEdita/Core/config/Migrations/20220316140137_CreateTagsTable.php
@@ -1,13 +1,13 @@
 <?php
 
 use Cake\Database\Expression\QueryExpression;
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 use Phinx\Db\Adapter\MysqlAdapter;
 
 /**
  * Split tags and categories into their own tables.
  */
-class CreateTagsTable extends AbstractMigration
+class CreateTagsTable extends BaseMigration
 {
     /**
      * @inheritDoc

--- a/plugins/BEdita/Core/config/Migrations/20220325142752_AddUserPreferences.php
+++ b/plugins/BEdita/Core/config/Migrations/20220325142752_AddUserPreferences.php
@@ -1,7 +1,7 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class AddUserPreferences extends AbstractMigration
+class AddUserPreferences extends BaseMigration
 {
     /**
      * Change Method.

--- a/plugins/BEdita/Core/config/Migrations/20220725115913_IncreaseLinksUrlMaxLength.php
+++ b/plugins/BEdita/Core/config/Migrations/20220725115913_IncreaseLinksUrlMaxLength.php
@@ -1,7 +1,7 @@
 <?php
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class IncreaseLinksUrlMaxLength extends AbstractMigration
+class IncreaseLinksUrlMaxLength extends BaseMigration
 {
     /**
      * @inheritDoc

--- a/plugins/BEdita/Core/config/Migrations/20221026152339_ReadOnlyCustomProps.php
+++ b/plugins/BEdita/Core/config/Migrations/20221026152339_ReadOnlyCustomProps.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class ReadOnlyCustomProps extends AbstractMigration
+class ReadOnlyCustomProps extends BaseMigration
 {
     /**
      * @inheritDoc

--- a/plugins/BEdita/Core/config/Migrations/20221206063119_AddChildrenOrder.php
+++ b/plugins/BEdita/Core/config/Migrations/20221206063119_AddChildrenOrder.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
  * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
  */
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class AddChildrenOrder extends AbstractMigration
+class AddChildrenOrder extends BaseMigration
 {
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/config/Migrations/20230124110617_UpdateChildrenOrder.php
+++ b/plugins/BEdita/Core/config/Migrations/20230124110617_UpdateChildrenOrder.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
  */
 
 use Cake\ORM\Table;
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class UpdateChildrenOrder extends AbstractMigration
+class UpdateChildrenOrder extends BaseMigration
 {
     /**
      * Data for migration.
@@ -57,11 +57,10 @@ class UpdateChildrenOrder extends AbstractMigration
      */
     public function up(): void
     {
-        /** @var \Migrations\CakeAdapter $adapter */
         $adapter = $this->getAdapter();
         $table = new Table([
             'table' => 'property_types',
-            'connection' => $adapter->getCakeConnection(),
+            'connection' => $adapter->getConnection(),
         ]);
         $table->updateAll(
             [
@@ -78,11 +77,10 @@ class UpdateChildrenOrder extends AbstractMigration
      */
     public function down(): void
     {
-        /** @var \Migrations\CakeAdapter $adapter */
         $adapter = $this->getAdapter();
         $table = new Table([
             'table' => 'property_types',
-            'connection' => $adapter->getCakeConnection(),
+            'connection' => $adapter->getConnection(),
         ]);
         $table->updateAll(
             [

--- a/plugins/BEdita/Core/config/Migrations/20230209112747_ObjectTypeTranslatable.php
+++ b/plugins/BEdita/Core/config/Migrations/20230209112747_ObjectTypeTranslatable.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class ObjectTypeTranslatable extends AbstractMigration
+class ObjectTypeTranslatable extends BaseMigration
 {
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/config/Migrations/20230321112607_AddRolePriority.php
+++ b/plugins/BEdita/Core/config/Migrations/20230321112607_AddRolePriority.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class AddRolePriority extends AbstractMigration
+class AddRolePriority extends BaseMigration
 {
     /**
      * @inheritDoc

--- a/plugins/BEdita/Core/config/Migrations/20230327104919_ChangeObjectsDescriptionBodySize.php
+++ b/plugins/BEdita/Core/config/Migrations/20230327104919_ChangeObjectsDescriptionBodySize.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 use Phinx\Db\Adapter\MysqlAdapter;
 
-class ChangeObjectsDescriptionBodySize extends AbstractMigration
+class ChangeObjectsDescriptionBodySize extends BaseMigration
 {
     /**
      * Up Method.

--- a/plugins/BEdita/Core/config/Migrations/20230329121236_UpdateObjectPermissions.php
+++ b/plugins/BEdita/Core/config/Migrations/20230329121236_UpdateObjectPermissions.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class UpdateObjectPermissions extends AbstractMigration
+class UpdateObjectPermissions extends BaseMigration
 {
     /**
      * @inheritDoc

--- a/plugins/BEdita/Core/config/Migrations/20230508074242_AddAsyncJobsResults.php
+++ b/plugins/BEdita/Core/config/Migrations/20230508074242_AddAsyncJobsResults.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class AddAsyncJobsResults extends AbstractMigration
+class AddAsyncJobsResults extends BaseMigration
 {
     /**
      * @inheritDoc

--- a/plugins/BEdita/Core/config/Migrations/20230519093954_AsyncJobsEndpointAdminOnly.php
+++ b/plugins/BEdita/Core/config/Migrations/20230519093954_AsyncJobsEndpointAdminOnly.php
@@ -2,9 +2,9 @@
 declare(strict_types=1);
 
 use BEdita\Core\Model\Table\RolesTable;
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class AsyncJobsEndpointAdminOnly extends AbstractMigration
+class AsyncJobsEndpointAdminOnly extends BaseMigration
 {
     /**
      * @inheritDoc

--- a/plugins/BEdita/Core/config/Migrations/20230829072020_UpdateDateRanges.php
+++ b/plugins/BEdita/Core/config/Migrations/20230829072020_UpdateDateRanges.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class UpdateDateRanges extends AbstractMigration
+class UpdateDateRanges extends BaseMigration
 {
     /**
      * @inheritDoc

--- a/plugins/BEdita/Core/config/Migrations/20231215123326_AddCreatedIndexToHistory.php
+++ b/plugins/BEdita/Core/config/Migrations/20231215123326_AddCreatedIndexToHistory.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class AddCreatedIndexToHistory extends AbstractMigration
+class AddCreatedIndexToHistory extends BaseMigration
 {
     /**
      * @inheritDoc

--- a/plugins/BEdita/Core/config/Migrations/20240227155754_AddIndexesToAsyncJobs.php
+++ b/plugins/BEdita/Core/config/Migrations/20240227155754_AddIndexesToAsyncJobs.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class AddIndexesToAsyncJobs extends AbstractMigration
+class AddIndexesToAsyncJobs extends BaseMigration
 {
     /**
      * @inheritDoc

--- a/plugins/BEdita/Core/config/Migrations/20240314101914_AddNsmMultiColumnIndex.php
+++ b/plugins/BEdita/Core/config/Migrations/20240314101914_AddNsmMultiColumnIndex.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class AddNsmMultiColumnIndex extends AbstractMigration
+class AddNsmMultiColumnIndex extends BaseMigration
 {
     /**
      * @inheritDoc

--- a/plugins/BEdita/Core/config/Migrations/20240409130149_CategoriesLabels.php
+++ b/plugins/BEdita/Core/config/Migrations/20240409130149_CategoriesLabels.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class CategoriesLabels extends AbstractMigration
+class CategoriesLabels extends BaseMigration
 {
     /**
      * @inheritDoc

--- a/plugins/BEdita/Core/config/Migrations/20240409130155_TagsLabels.php
+++ b/plugins/BEdita/Core/config/Migrations/20240409130155_TagsLabels.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class TagsLabels extends AbstractMigration
+class TagsLabels extends BaseMigration
 {
     /**
      * @inheritDoc

--- a/plugins/BEdita/Core/config/Migrations/20240626123658_UpdateProperties.php
+++ b/plugins/BEdita/Core/config/Migrations/20240626123658_UpdateProperties.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class UpdateProperties extends AbstractMigration
+class UpdateProperties extends BaseMigration
 {
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/config/Migrations/20240919124057_ConfigContents.php
+++ b/plugins/BEdita/Core/config/Migrations/20240919124057_ConfigContents.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 use Phinx\Db\Adapter\MysqlAdapter;
 
-class ConfigContents extends AbstractMigration
+class ConfigContents extends BaseMigration
 {
     /**
      * {@inheritDoc}

--- a/plugins/BEdita/Core/config/Migrations/20240930121402_TreesAddParams.php
+++ b/plugins/BEdita/Core/config/Migrations/20240930121402_TreesAddParams.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class TreesAddParams extends AbstractMigration
+class TreesAddParams extends BaseMigration
 {
     /**
      * Change Method.

--- a/plugins/BEdita/Core/config/Migrations/20241021145530_CreateCaptions.php
+++ b/plugins/BEdita/Core/config/Migrations/20241021145530_CreateCaptions.php
@@ -1,13 +1,13 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 use Phinx\Db\Adapter\MysqlAdapter;
 
 /**
  * Migration for `captions` table.
  */
-class CreateCaptions extends AbstractMigration
+class CreateCaptions extends BaseMigration
 {
     public bool $autoId = false;
 

--- a/plugins/BEdita/Core/config/Migrations/20250224101936_TreesAddSlug.php
+++ b/plugins/BEdita/Core/config/Migrations/20250224101936_TreesAddSlug.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class TreesAddSlug extends AbstractMigration
+class TreesAddSlug extends BaseMigration
 {
     /**
      * @return void

--- a/plugins/BEdita/Core/config/Migrations/20250318131739_TreesSlugNotNullable.php
+++ b/plugins/BEdita/Core/config/Migrations/20250318131739_TreesSlugNotNullable.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Query;
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class TreesSlugNotNullable extends AbstractMigration
+class TreesSlugNotNullable extends BaseMigration
 {
     /**
      * @inheritDoc

--- a/plugins/BEdita/Core/config/Seeds/AdminFromEnvSeed.php
+++ b/plugins/BEdita/Core/config/Seeds/AdminFromEnvSeed.php
@@ -1,29 +1,27 @@
 <?php
-use Cake\Auth\WeakPasswordHasher;
-use Migrations\AbstractSeed;
+use Authentication\PasswordHasher\LegacyPasswordHasher;
+use Migrations\BaseSeed;
 
 /**
  * Updates main admin user from env vars:
  *  - 'username' => BEDITA_ADMIN_USR
  *  - 'password' => BEDITA_ADMIN_PWD
  */
-class AdminFromEnvSeed extends AbstractSeed
+class AdminFromEnvSeed extends BaseSeed
 {
     /**
      * {@inheritDoc}
      */
-    public function run()
+    public function run(): void
     {
         $username = getenv('BEDITA_ADMIN_USR');
         $password = getenv('BEDITA_ADMIN_PWD');
         if (empty($username) || empty($password)) {
-            echo "Mandatory environment variables missing: BEDITA_ADMIN_USR, BEDITA_ADMIN_PWD\n";
-            echo 'No data seeded!';
-
-            return -1;
+            $this->io->error('Mandatory environment variables missing: BEDITA_ADMIN_USR, BEDITA_ADMIN_PWD');
+            $this->io->abort('No data seeded!');
         }
 
-        $hash = (new WeakPasswordHasher(['hashType' => 'md5']))->hash($password);
+        $hash = (new LegacyPasswordHasher(['hashType' => 'md5']))->hash('password1');
         $query = sprintf("UPDATE users set username='%s', password_hash='%s' WHERE id=1", $username, $hash);
         $this->query($query);
     }

--- a/plugins/BEdita/Core/config/Seeds/ApplicationFromEnvSeed.php
+++ b/plugins/BEdita/Core/config/Seeds/ApplicationFromEnvSeed.php
@@ -1,7 +1,7 @@
 <?php
 
 use Cake\Utility\Text;
-use Migrations\AbstractSeed;
+use Migrations\BaseSeed;
 
 /**
  * Create new application from env vars:
@@ -14,26 +14,24 @@ use Migrations\AbstractSeed;
  *  - If an application `name` with same value (BEDITA_APP_NAME or `manager`)
  * is found an hash suffix is added.
  */
-class ApplicationFromEnvSeed extends AbstractSeed
+class ApplicationFromEnvSeed extends BaseSeed
 {
 
     /**
      * {@inheritDoc}
      */
-    public function run()
+    public function run(): void
     {
         $apiKey = getenv('BEDITA_API_KEY');
         if (empty($apiKey)) {
-            echo "Mandatory environment variable missing: BEDITA_API_KEY\n";
-            echo 'No data seeded!';
-
-            return -1;
+            $this->io->error('Mandatory environment variable missing: BEDITA_API_KEY');
+            $this->io->abort('No data seeded!');
         }
-        $appName = getenv('BEDITA_APP_NAME') ? getenv('BEDITA_APP_NAME') : 'manager';
 
+        $appName = getenv('BEDITA_APP_NAME') ? getenv('BEDITA_APP_NAME') : 'manager';
         $appRow = $this->fetchAll(sprintf("SELECT id FROM applications where api_key='%s'", $apiKey));
         if (!empty($appRow)) {
-            return 0;
+            return;
         }
 
         $row = [

--- a/plugins/BEdita/Core/config/Seeds/InitialSeed.php
+++ b/plugins/BEdita/Core/config/Seeds/InitialSeed.php
@@ -1,10 +1,10 @@
 <?php
-use Migrations\AbstractSeed;
+use Migrations\BaseSeed;
 
 /**
  * Initial seed.
  */
-class InitialSeed extends AbstractSeed
+class InitialSeed extends BaseSeed
 {
     /**
      * Run Method.
@@ -16,7 +16,7 @@ class InitialSeed extends AbstractSeed
      *
      * @return void
      */
-    public function run()
+    public function run(): void
     {
     }
 }

--- a/plugins/BEdita/Core/src/Migration/ResourcesMigration.php
+++ b/plugins/BEdita/Core/src/Migration/ResourcesMigration.php
@@ -15,16 +15,17 @@ declare(strict_types=1);
 namespace BEdita\Core\Migration;
 
 use BEdita\Core\Utility\Resources;
+use Cake\Cache\Cache;
 use Cake\Database\Connection;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
-use Migrations\AbstractMigration;
-use Migrations\Table;
+use Migrations\BaseMigration;
+use Migrations\Db\Table;
 use ReflectionClass;
 use RuntimeException;
 use Symfony\Component\Yaml\Yaml;
 
-abstract class ResourcesMigration extends AbstractMigration
+abstract class ResourcesMigration extends BaseMigration
 {
     /**
      * Read YAML migration data
@@ -71,6 +72,15 @@ abstract class ResourcesMigration extends AbstractMigration
     }
 
     /**
+     * @inheritDoc
+     */
+    public function postFlightCheck(): void
+    {
+        parent::postFlightCheck();
+        Cache::clearAll();
+    }
+
+    /**
      * Extract column related data from input array, then:
      *  - perform table columns removal
      *  - perform internal resources migrations
@@ -106,7 +116,7 @@ abstract class ResourcesMigration extends AbstractMigration
      */
     protected function getConnection(): Connection
     {
-        return $this->getAdapter()->getCakeConnection();
+        return $this->getAdapter()->getConnection();
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
@@ -108,10 +108,13 @@ class ObjectTypesTable extends Table
         $this->setTable('object_types');
         $this->setPrimaryKey('id');
         $this->setDisplayField('name');
-        $this->getSchema()
+        $tableSchema = $this->getSchema();
+        $tableSchema
             ->setColumnType('associations', 'json')
-            ->setColumnType('hidden', 'json')
-            ->setColumnType('translation_rules', 'json');
+            ->setColumnType('hidden', 'json');
+        if ($tableSchema->hasColumn('translation_rules')) {
+            $tableSchema->setColumnType('translation_rules', 'json');
+        }
 
         $this->hasMany('Objects', [
             'foreignKey' => 'object_type_id',

--- a/plugins/BEdita/Core/tests/TestCase/Migration/Migrations/TestColumns.php
+++ b/plugins/BEdita/Core/tests/TestCase/Migration/Migrations/TestColumns.php
@@ -18,7 +18,7 @@ use BEdita\Core\Migration\ResourcesMigration;
 use BEdita\Core\Test\TestCase\Migration\MockMigrationsTable;
 use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
-use Migrations\Table;
+use Migrations\Db\Table;
 
 class TestColumns extends ResourcesMigration
 {

--- a/plugins/BEdita/Core/tests/TestCase/Migration/MockMigrationsTable.php
+++ b/plugins/BEdita/Core/tests/TestCase/Migration/MockMigrationsTable.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  */
 namespace BEdita\Core\Test\TestCase\Migration;
 
-use Migrations\Table;
+use Migrations\Db\Table;
 
 class MockMigrationsTable extends Table
 {

--- a/plugins/BEdita/Core/tests/TestCase/Migration/ResourcesMigrationTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Migration/ResourcesMigrationTest.php
@@ -50,7 +50,7 @@ class ResourcesMigrationTest extends TestCase
      */
     public function testUp(): void
     {
-        $migration = new TestAdd('test', 20241220102400);
+        $migration = new TestAdd(20241220102400);
 
         $migration->up();
 
@@ -69,7 +69,7 @@ class ResourcesMigrationTest extends TestCase
         $objectType = $ObjectTypes->newEntity(['name' => 'foos', 'singular' => 'foo']);
         $ObjectTypes->saveOrFail($objectType);
 
-        $migration = new TestAdd('test', 20241220102400);
+        $migration = new TestAdd(20241220102400);
 
         $migration->down();
 
@@ -87,7 +87,7 @@ class ResourcesMigrationTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('YAML file not found');
 
-        $migration = new TestMissing('test', 20241220102400);
+        $migration = new TestMissing(20241220102400);
         $migration->up();
     }
 
@@ -100,7 +100,7 @@ class ResourcesMigrationTest extends TestCase
     {
         MockMigrationsTable::$calls = [];
 
-        $migration = new TestColumns('test', 20241220102400);
+        $migration = new TestColumns(20241220102400);
         $migration->up();
 
         $expected = [
@@ -160,7 +160,7 @@ class ResourcesMigrationTest extends TestCase
     {
         MockMigrationsTable::$calls = [];
 
-        $migration = new TestColumns('test', 20241220102400);
+        $migration = new TestColumns(20241220102400);
         $migration->down();
 
         $expected = [


### PR DESCRIPTION
This PR removes deprecations from migrations and seeds.

Moreover a couple of fixes was required:

- A fix to `ResourcesMigrations` was required since it internally uses `TableLocator` leaving the cache dirty and exposing subsequent `ResourcesMigrations` to use not aligned tables.
To fix that issue a `Clear::cache()` was done overriden `postFlightCheck()` method. The same method was overriden into migrations using `BEdita\Core\Utlity\Resources::save()`.
- Since previously `cakephp/migrations` using `Phinx` as backend skipped SQLite when trying to drop foreign keys while now it throws an exception, a migration is slightly modified to skip SQLite in that situation.


