### PR TITLE
Fix pass ObjectType entity to ListObjectsAction in /bulk endpoint

### DIFF
--- a/plugins/BEdita/API/src/Controller/BulkController.php
+++ b/plugins/BEdita/API/src/Controller/BulkController.php
@@ -109,7 +109,7 @@ class BulkController extends JsonBaseController
                 continue;
             }
             $typesTable = $this->fetchTable(Inflector::camelize($type));
-            $action = new ListObjectsAction(['table' => $typesTable, 'objectType' => $type]);
+            $action = new ListObjectsAction(['table' => $typesTable, 'objectType' => $objectType]);
             $query = $action();
             $entities = $query
                 ->where([sprintf('%s.id IN', $typesTable->getAlias()) => $map[$type]])

--- a/plugins/BEdita/API/tests/TestCase/Controller/BulkControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/BulkControllerTest.php
@@ -26,17 +26,6 @@ use Cake\Utility\Hash;
 class BulkControllerTest extends IntegrationTestCase
 {
     /**
-     * Fixtures
-     *
-     * @var array
-     */
-    protected $fixtures = [
-        'plugin.BEdita/Core.Objects',
-        'plugin.BEdita/Core.Endpoints',
-        'plugin.BEdita/Core.EndpointPermissions',
-    ];
-
-    /**
      * Backup of original endpoint permissions
      *
      * @var array
@@ -400,5 +389,56 @@ class BulkControllerTest extends IntegrationTestCase
         $o2 = $this->fetchTable('Objects')->get(3);
         $secondStatus = $o2->get('status');
         $this->assertEquals('draft', $secondStatus);
+    }
+
+    /**
+     * Test that trying to save in bulk data referred to a wrong id for an object type then it is ignored.
+     *
+     * @return void
+     * @covers ::edit()
+     */
+    public function testWrongObjectType(): void
+    {
+        $eventId = 9;
+        $documentId = 3;
+        $wrongObject = $this->fetchTable('Documents')
+            ->find('type', ['documents'])
+            ->where(['id' => $documentId])
+            ->firstOrFail();
+        $originalStatusWrongObject = $wrongObject->get('status');
+
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader('first user', 'password1') + $this->headers);
+        $this->post('/bulk/edit', json_encode([
+            'data' => [
+                'attributes' => [
+                    'status' => 'off',
+                ],
+                'objects' => [
+                    'events' => [$documentId, $eventId], // 3 is id of document => can't edit it as event
+                ],
+            ],
+        ]));
+        $this->assertResponseCode(200);
+
+        // check response content
+        $response = (array)json_decode((string)$this->_response->getBody(), true);
+        $response = (array)Hash::get($response, 'data');
+        $this->assertArrayHasKey('saved', $response);
+        $this->assertArrayHasKey('errors', $response);
+        $this->assertCount(1, Hash::get($response, 'saved')); // just one object save, the wrong one was skipped
+        $this->assertCount(0, Hash::get($response, 'errors'));
+        $this->assertEquals($eventId, Hash::get($response, 'saved.0'));
+
+        $wrongObject = $this->fetchTable('Documents')
+            ->find('type', ['documents'])
+            ->where(['id' => $documentId])
+            ->firstOrFail();
+        $event = $this->fetchTable('Events')
+            ->find('type', ['events'])
+            ->where(['id' => $eventId])
+            ->firstOrFail();
+
+        $this->assertEquals($originalStatusWrongObject, $wrongObject->get('status'));
+        $this->assertEquals('off', $event->get('status'));
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/BulkControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/BulkControllerTest.php
@@ -41,14 +41,24 @@ class BulkControllerTest extends IntegrationTestCase
      *
      * @var array
      */
-    protected $originalEndpointPermissions = [];
+    protected array $originalEndpointPermissions = [];
 
     /**
      * Backup of original object permissions
      *
      * @var array
      */
-    protected $originalObjectPermissions = [];
+    protected array $originalObjectPermissions = [];
+
+    /**
+     * Request headers
+     *
+     * @var array
+     */
+    protected array $headers = [
+        'Content-Type' => 'application/json',
+        'Accept' => 'application/json',
+    ];
 
     /**
      * Set up method
@@ -103,7 +113,7 @@ class BulkControllerTest extends IntegrationTestCase
      */
     public function testIndex404(): void
     {
-        $this->configRequestHeaders('GET', $this->getUserAuthHeader());
+        $this->configRequestHeaders('GET', $this->getUserAuthHeader() + $this->headers);
         $this->get('/bulk');
         $this->assertResponseCode(404);
     }
@@ -116,11 +126,11 @@ class BulkControllerTest extends IntegrationTestCase
      */
     public function testIndex405(): void
     {
-        $this->configRequestHeaders('GET', $this->getUserAuthHeader());
+        $this->configRequestHeaders('GET', $this->getUserAuthHeader() + $this->headers);
         $this->get('/bulk/edit');
         $this->assertResponseCode(405);
 
-        $this->configRequestHeaders('POST', $this->getUserAuthHeader());
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader() + $this->headers);
         $this->post('/bulk/something');
         $this->assertResponseCode(405);
     }
@@ -152,7 +162,7 @@ class BulkControllerTest extends IntegrationTestCase
     public function testEditAbstractType(): void
     {
         // try to edit object 1 of abstract type 'objects'
-        $this->configRequestHeaders('POST', $this->getUserAuthHeader('first user', 'password1'));
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader('first user', 'password1') + $this->headers);
         $this->post('/bulk/edit', json_encode([
             'data' => [
                 'attributes' => [
@@ -230,7 +240,7 @@ class BulkControllerTest extends IntegrationTestCase
         $this->assertEquals(0, $permission->get('permission'), 'Permission should be 0 (block)');
 
         // try to edit object 3 with user that is not admin
-        $this->configRequestHeaders('POST', $this->getUserAuthHeader('second user', 'password2'));
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader('second user', 'password2') + $this->headers);
         $this->post('/bulk/edit', json_encode([
             'data' => [
                 'attributes' => [
@@ -306,7 +316,7 @@ class BulkControllerTest extends IntegrationTestCase
         $this->assertEquals(['first role'], $perms['roles']);
 
         // Try to edit with user that doesn't have permissions (second user, role 2)
-        $this->configRequestHeaders('POST', $this->getUserAuthHeader('second user', 'password2'));
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader('second user', 'password2') + $this->headers);
         $this->post('/bulk/edit', json_encode([
             'data' => [
                 'attributes' => [
@@ -346,7 +356,7 @@ class BulkControllerTest extends IntegrationTestCase
         $o2 = $this->fetchTable('Objects')->get(3);
         $secondOriginalStatus = $o2->get('status');
         $this->assertEquals('draft', $secondOriginalStatus);
-        $this->configRequestHeaders('POST', $this->getUserAuthHeader($user, $password));
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader($user, $password) + $this->headers);
         $map = [];
         $map[$o1->get('type')][] = $o1->get('id');
         $map[$o2->get('type')][] = $o2->get('id');
@@ -375,7 +385,7 @@ class BulkControllerTest extends IntegrationTestCase
         $o2 = $this->fetchTable('Objects')->get(3);
         $secondStatus = $o2->get('status');
         $this->assertEquals('off', $secondStatus);
-        $this->configRequestHeaders('POST', $this->getUserAuthHeader($user, $password));
+        $this->configRequestHeaders('POST', $this->getUserAuthHeader($user, $password) + $this->headers);
         $this->post('/bulk/edit', json_encode([
             'data' => [
                 'attributes' => [


### PR DESCRIPTION
This PR fixes an issue calling `ListObjectsAction` with wrong parameter in bulk edit action.
It was passed a string instead of `ObjectEntity` bypassing the subsequent `find('type')`.

Without this fix it was possible to edit object props of wrong object type. For example you could set `status = 'off'` of all objects also if request payload specify the type.

An unit test is added to verify that behavior. Moreover tests are improved passing the right headers for content type negotiation.