### PR TITLE
Introduce Enum Types

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,17 +102,17 @@ jobs:
         php:
           - '8.3'
         db:
-          - '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
-          - '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-          - '{"vendor": "MySQL 8.4", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.4", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-          - '{"vendor": "MariaDB 10", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mariadb", "image": "mariadb:10", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          # - '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
+          # - '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          # - '{"vendor": "MySQL 8.4", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.4", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          # - '{"vendor": "MariaDB 10", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mariadb", "image": "mariadb:10", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
           - '{"vendor": "PostgreSQL 16", "pdo": "pgsql", "dsn": "postgres://bedita:bedita@127.0.0.1:5432/bedita", "image": "postgres:16", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
           - '{"vendor": "PostgreSQL 18", "pdo": "pgsql", "dsn": "postgres://bedita:bedita@127.0.0.1:5432/bedita", "image": "postgres:18", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-        include:
-          - php: '8.4'
-            db: '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
-          - php: '8.4'
-            db: '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+        # include:
+        #   - php: '8.4'
+        #     db: '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
+        #   - php: '8.4'
+        #     db: '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
     env:
       PHP_VERSION: '${{ matrix.php }}'
       DB_VENDOR: '${{ fromJson(matrix.db).vendor }}'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,17 +102,17 @@ jobs:
         php:
           - '8.3'
         db:
-          # - '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
-          # - '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-          # - '{"vendor": "MySQL 8.4", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.4", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-          # - '{"vendor": "MariaDB 10", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mariadb", "image": "mariadb:10", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
+          - '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "MySQL 8.4", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.4", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "MariaDB 10", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mariadb", "image": "mariadb:10", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
           - '{"vendor": "PostgreSQL 16", "pdo": "pgsql", "dsn": "postgres://bedita:bedita@127.0.0.1:5432/bedita", "image": "postgres:16", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
           - '{"vendor": "PostgreSQL 18", "pdo": "pgsql", "dsn": "postgres://bedita:bedita@127.0.0.1:5432/bedita", "image": "postgres:18", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-        # include:
-        #   - php: '8.4'
-        #     db: '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
-        #   - php: '8.4'
-        #     db: '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+        include:
+          - php: '8.4'
+            db: '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
+          - php: '8.4'
+            db: '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
     env:
       PHP_VERSION: '${{ matrix.php }}'
       DB_VENDOR: '${{ fromJson(matrix.db).vendor }}'

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -357,7 +357,16 @@ class ObjectsController extends ResourcesController
         $data = (array)$this->request->getData();
         $protectedFieldsChanged = array_filter(
             ['uname', 'status'],
-            fn(string $field): bool => Hash::check($data, $field) && $entity->get($field) !== Hash::get($data, $field),
+            function (string $field) use ($data, $entity): bool {
+                if (!Hash::check($data, $field)) {
+                    return false;
+                }
+
+                $fieldValue = $entity->get($field);
+                $dataValue = Hash::get($data, $field);
+
+                return ($field === 'status') ? $fieldValue->value !== $dataValue : $fieldValue !== $dataValue;
+            },
         );
 
         if (empty($protectedFieldsChanged) || $this->Authorization->can($entity, 'updateParents')) {

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace BEdita\API\Controller;
 
+use BackedEnum;
 use BEdita\API\Model\Action\UpdateRelatedAction;
 use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Model\Action\ActionTrait;
@@ -365,7 +366,7 @@ class ObjectsController extends ResourcesController
                 $fieldValue = $entity->get($field);
                 $dataValue = Hash::get($data, $field);
 
-                return $field === 'status' ? $fieldValue->value !== $dataValue : $fieldValue !== $dataValue;
+                return $fieldValue instanceof BackedEnum ? $fieldValue->value !== $dataValue : $fieldValue !== $dataValue;
             },
         );
 

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -365,7 +365,7 @@ class ObjectsController extends ResourcesController
                 $fieldValue = $entity->get($field);
                 $dataValue = Hash::get($data, $field);
 
-                return ($field === 'status') ? $fieldValue->value !== $dataValue : $fieldValue !== $dataValue;
+                return $field === 'status' ? $fieldValue->value !== $dataValue : $fieldValue !== $dataValue;
             },
         );
 

--- a/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
@@ -186,7 +186,6 @@ class ParentsRelationshipTest extends IntegrationTestCase
      *
      * @return void
      */
-    #[CoversNothing]
     public function testDeletedParent()
     {
         // a deleted folder must not be listed in `parents`
@@ -225,7 +224,6 @@ class ParentsRelationshipTest extends IntegrationTestCase
      *
      * @return void
      */
-    #[CoversNothing]
     public function testSetParentPosition()
     {
         $this->configRequestHeaders('POST', $this->getUserAuthHeader());

--- a/plugins/BEdita/API/tests/TestCase/Controller/BulkControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/BulkControllerTest.php
@@ -16,7 +16,7 @@ namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\Controller\BulkController;
 use BEdita\API\TestSuite\IntegrationTestCase;
-use BEdita\Core\Model\Enum\ObjectStatus;
+use BEdita\Core\Model\Enum\ObjectEntityStatus;
 use BEdita\Core\State\CurrentApplication;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Utility\Hash;
@@ -331,10 +331,10 @@ class BulkControllerTest extends IntegrationTestCase
         // object 2 is locked, status cannot be changed
         $o1 = $this->fetchTable('Objects')->get(2);
         $firstOriginalStatus = $o1->get('status');
-        $this->assertEquals(ObjectStatus::ON, $firstOriginalStatus);
+        $this->assertEquals(ObjectEntityStatus::On, $firstOriginalStatus);
         $o2 = $this->fetchTable('Objects')->get(3);
         $secondOriginalStatus = $o2->get('status');
-        $this->assertEquals(ObjectStatus::DRAFT, $secondOriginalStatus);
+        $this->assertEquals(ObjectEntityStatus::Draft, $secondOriginalStatus);
         $this->configRequestHeaders('POST', $this->getUserAuthHeader($user, $password) + $this->headers);
         $map = [];
         $map[$o1->get('type')][] = $o1->get('id');
@@ -363,7 +363,7 @@ class BulkControllerTest extends IntegrationTestCase
         $this->assertEquals($firstOriginalStatus, $firstStatus);
         $o2 = $this->fetchTable('Objects')->get(3);
         $secondStatus = $o2->get('status');
-        $this->assertEquals(ObjectStatus::OFF, $secondStatus);
+        $this->assertEquals(ObjectEntityStatus::Off, $secondStatus);
         $this->configRequestHeaders('POST', $this->getUserAuthHeader($user, $password) + $this->headers);
         $this->post('/bulk/edit', json_encode([
             'data' => [
@@ -378,7 +378,7 @@ class BulkControllerTest extends IntegrationTestCase
         $this->assertResponseCode(200);
         $o2 = $this->fetchTable('Objects')->get(3);
         $secondStatus = $o2->get('status');
-        $this->assertEquals(ObjectStatus::DRAFT, $secondStatus);
+        $this->assertEquals(ObjectEntityStatus::Draft, $secondStatus);
     }
 
     /**
@@ -428,6 +428,6 @@ class BulkControllerTest extends IntegrationTestCase
             ->firstOrFail();
 
         $this->assertEquals($originalStatusWrongObject, $wrongObject->get('status'));
-        $this->assertEquals(ObjectStatus::OFF, $event->get('status'));
+        $this->assertEquals(ObjectEntityStatus::Off, $event->get('status'));
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/BulkControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/BulkControllerTest.php
@@ -16,6 +16,7 @@ namespace BEdita\API\Test\TestCase\Controller;
 
 use BEdita\API\Controller\BulkController;
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Model\Enum\ObjectStatus;
 use BEdita\Core\State\CurrentApplication;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Utility\Hash;
@@ -330,10 +331,10 @@ class BulkControllerTest extends IntegrationTestCase
         // object 2 is locked, status cannot be changed
         $o1 = $this->fetchTable('Objects')->get(2);
         $firstOriginalStatus = $o1->get('status');
-        $this->assertEquals('on', $firstOriginalStatus);
+        $this->assertEquals(ObjectStatus::ON, $firstOriginalStatus);
         $o2 = $this->fetchTable('Objects')->get(3);
         $secondOriginalStatus = $o2->get('status');
-        $this->assertEquals('draft', $secondOriginalStatus);
+        $this->assertEquals(ObjectStatus::DRAFT, $secondOriginalStatus);
         $this->configRequestHeaders('POST', $this->getUserAuthHeader($user, $password) + $this->headers);
         $map = [];
         $map[$o1->get('type')][] = $o1->get('id');
@@ -362,7 +363,7 @@ class BulkControllerTest extends IntegrationTestCase
         $this->assertEquals($firstOriginalStatus, $firstStatus);
         $o2 = $this->fetchTable('Objects')->get(3);
         $secondStatus = $o2->get('status');
-        $this->assertEquals('off', $secondStatus);
+        $this->assertEquals(ObjectStatus::OFF, $secondStatus);
         $this->configRequestHeaders('POST', $this->getUserAuthHeader($user, $password) + $this->headers);
         $this->post('/bulk/edit', json_encode([
             'data' => [
@@ -377,7 +378,7 @@ class BulkControllerTest extends IntegrationTestCase
         $this->assertResponseCode(200);
         $o2 = $this->fetchTable('Objects')->get(3);
         $secondStatus = $o2->get('status');
-        $this->assertEquals('draft', $secondStatus);
+        $this->assertEquals(ObjectStatus::DRAFT, $secondStatus);
     }
 
     /**
@@ -427,6 +428,6 @@ class BulkControllerTest extends IntegrationTestCase
             ->firstOrFail();
 
         $this->assertEquals($originalStatusWrongObject, $wrongObject->get('status'));
-        $this->assertEquals('off', $event->get('status'));
+        $this->assertEquals(ObjectStatus::OFF, $event->get('status'));
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -18,7 +18,7 @@ use Authentication\AuthenticationService;
 use BEdita\API\Controller\ObjectsController;
 use BEdita\API\Test\TestConstants;
 use BEdita\API\TestSuite\IntegrationTestCase;
-use BEdita\Core\Model\Enum\ObjectStatus;
+use BEdita\Core\Model\Enum\ObjectEntityStatus;
 use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\Event\EventManager;
 use Cake\Http\ServerRequest;
@@ -1795,7 +1795,7 @@ class ObjectsControllerTest extends IntegrationTestCase
         $document = TableRegistry::getTableLocator()->get('Documents')->get('2');
         static::assertEquals($newTitle, $document->get('title'));
         static::assertEquals('documents', $document->get('type'));
-        static::assertEquals(ObjectStatus::ON, $document->get('status'));
+        static::assertEquals(ObjectEntityStatus::On, $document->get('status'));
 
         $result = json_decode((string)$this->_response->getBody(), true);
         static::assertEquals($data['id'], $result['data']['id']);

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -18,6 +18,7 @@ use Authentication\AuthenticationService;
 use BEdita\API\Controller\ObjectsController;
 use BEdita\API\Test\TestConstants;
 use BEdita\API\TestSuite\IntegrationTestCase;
+use BEdita\Core\Model\Enum\ObjectStatus;
 use BEdita\Core\Test\Utility\TestArraySubsetTrait;
 use Cake\Event\EventManager;
 use Cake\Http\ServerRequest;
@@ -1794,7 +1795,7 @@ class ObjectsControllerTest extends IntegrationTestCase
         $document = TableRegistry::getTableLocator()->get('Documents')->get('2');
         static::assertEquals($newTitle, $document->get('title'));
         static::assertEquals('documents', $document->get('type'));
-        static::assertEquals('on', $document->get('status'));
+        static::assertEquals(ObjectStatus::ON, $document->get('status'));
 
         $result = json_decode((string)$this->_response->getBody(), true);
         static::assertEquals($data['id'], $result['data']['id']);

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -16,7 +16,7 @@ namespace BEdita\API\Test\TestCase\Utility;
 
 use BEdita\API\Test\TestConstants;
 use BEdita\API\Utility\JsonApi;
-use BEdita\Core\Model\Enum\ObjectStatus;
+use BEdita\Core\Model\Enum\ObjectEntityStatus;
 use BEdita\Core\Utility\JsonApiSerializable;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
@@ -814,9 +814,9 @@ class JsonApiTest extends TestCase
             $item = $items[0];
 
             static::assertInstanceOf(EntityInterface::class, $item);
-            static::assertEquals(ObjectStatus::ON, $item->get('status'));
+            static::assertEquals(ObjectEntityStatus::On, $item->get('status'));
 
-            $item->set('status', ObjectStatus::OFF);
+            $item->set('status', ObjectEntityStatus::Off);
             $event->setResult($items);
         });
 
@@ -825,7 +825,7 @@ class JsonApiTest extends TestCase
         $result = JsonApi::formatData($document);
 
         static::assertEquals(1, $dispatchedEvent);
-        static::assertEquals(ObjectStatus::OFF, Hash::get($result, 'attributes.status'));
+        static::assertEquals(ObjectEntityStatus::Off, Hash::get($result, 'attributes.status'));
     }
 
     /**

--- a/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Utility/JsonApiTest.php
@@ -16,6 +16,7 @@ namespace BEdita\API\Test\TestCase\Utility;
 
 use BEdita\API\Test\TestConstants;
 use BEdita\API\Utility\JsonApi;
+use BEdita\Core\Model\Enum\ObjectStatus;
 use BEdita\Core\Utility\JsonApiSerializable;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
@@ -813,9 +814,9 @@ class JsonApiTest extends TestCase
             $item = $items[0];
 
             static::assertInstanceOf(EntityInterface::class, $item);
-            static::assertEquals('on', $item->get('status'));
+            static::assertEquals(ObjectStatus::ON, $item->get('status'));
 
-            $item->set('status', 'off');
+            $item->set('status', ObjectStatus::OFF);
             $event->setResult($items);
         });
 
@@ -824,7 +825,7 @@ class JsonApiTest extends TestCase
         $result = JsonApi::formatData($document);
 
         static::assertEquals(1, $dispatchedEvent);
-        static::assertEquals('off', Hash::get($result, 'attributes.status'));
+        static::assertEquals(ObjectStatus::OFF, Hash::get($result, 'attributes.status'));
     }
 
     /**

--- a/plugins/BEdita/Core/src/Command/CompactHistoryCommand.php
+++ b/plugins/BEdita/Core/src/Command/CompactHistoryCommand.php
@@ -227,6 +227,7 @@ class CompactHistoryCommand extends Command
         $processed = 0;
         $stack = [];
         foreach ($this->objectsGenerator($query) as $current) {
+            /** @var \BEdita\Core\Model\Entity\History $current */
             $processed++;
             if ($prev === null) {
                 $prev = $current;
@@ -272,8 +273,8 @@ class CompactHistoryCommand extends Command
      */
     protected function compare(History $history1, History $history2): bool
     {
-        $h1 = $history1->user_action . '-' . json_encode($history1->changed);
-        $h2 = $history2->user_action . '-' . json_encode($history2->changed);
+        $h1 = $history1->user_action->value . '-' . json_encode($history1->changed);
+        $h2 = $history2->user_action->value . '-' . json_encode($history2->changed);
 
         return $h1 === $h2;
     }
@@ -320,7 +321,7 @@ class CompactHistoryCommand extends Command
                 break;
         }
         foreach ($stack as $i => $h) {
-            $io->verbose(sprintf(':: History ID %d: %s', $h->id, $h->user_action . '-' . json_encode($h->changed)));
+            $io->verbose(sprintf(':: History ID %d: %s', $h->id, $h->user_action->value . '-' . json_encode($h->changed)));
             if ($i === 0) {
                 continue;
             }

--- a/plugins/BEdita/Core/src/Command/FixHistoryCommand.php
+++ b/plugins/BEdita/Core/src/Command/FixHistoryCommand.php
@@ -16,6 +16,7 @@ namespace BEdita\Core\Command;
 
 use BEdita\Core\Model\Entity\History;
 use BEdita\Core\Model\Entity\ObjectEntity;
+use BEdita\Core\Model\Enum\HistoryUserAction;
 use BEdita\Core\Model\Table\ObjectsTable;
 use Cake\Command\Command;
 use Cake\Console\Arguments;
@@ -192,12 +193,12 @@ class FixHistoryCommand extends Command
             ->find()->where([
                 $this->History->aliasField('resource_id') => $object->id,
                 $this->History->aliasField('resource_type') => 'objects',
-                $this->History->aliasField('user_action') => 'create',
+                $this->History->aliasField('user_action') => HistoryUserAction::Create->value,
             ])
             ->first();
         if (empty($history)) {
             $history = $this->historyEntity($object);
-            $history->user_action = 'create';
+            $history->user_action = HistoryUserAction::Create;
         }
         $history->user_id = $object->get('created_by');
         $history->created = $object->get('created');
@@ -223,7 +224,7 @@ class FixHistoryCommand extends Command
             ->first();
         if (empty($history)) {
             $history = $this->historyEntity($object);
-            $history->user_action = 'update';
+            $history->user_action = HistoryUserAction::Update;
         }
         $history->user_id = $object->get('modified_by');
         $history->created = $object->get('modified');
@@ -300,7 +301,8 @@ class FixHistoryCommand extends Command
             ),
         ];
         if ($created) {
-            $joinConditions[] = $query->expr()->eq($this->History->aliasField('user_action'), 'create');
+            $joinConditions[] = $query->expr()
+                ->eq($this->History->aliasField('user_action'), HistoryUserAction::Create->value);
         }
 
         return $joinConditions;

--- a/plugins/BEdita/Core/src/Command/UserExternalAuthListCommand.php
+++ b/plugins/BEdita/Core/src/Command/UserExternalAuthListCommand.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace BEdita\Core\Command;
 
 use BEdita\Core\Model\Entity\User;
+use BEdita\Core\Model\Enum\ObjectStatus;
 use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
@@ -109,7 +110,7 @@ class UserExternalAuthListCommand extends Command
     {
         $query = $this->fetchTable('Users')->find()
             ->where([
-                'status IN' => ['on', 'draft'],
+                'status IN' => [ObjectStatus::ON->value, ObjectStatus::DRAFT->value],
                 'deleted' => false,
                 'blocked' => false,
             ])

--- a/plugins/BEdita/Core/src/Command/UserExternalAuthListCommand.php
+++ b/plugins/BEdita/Core/src/Command/UserExternalAuthListCommand.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 namespace BEdita\Core\Command;
 
 use BEdita\Core\Model\Entity\User;
-use BEdita\Core\Model\Enum\ObjectStatus;
+use BEdita\Core\Model\Enum\ObjectEntityStatus;
 use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
@@ -110,7 +110,7 @@ class UserExternalAuthListCommand extends Command
     {
         $query = $this->fetchTable('Users')->find()
             ->where([
-                'status IN' => [ObjectStatus::ON->value, ObjectStatus::DRAFT->value],
+                'status IN' => [ObjectEntityStatus::On->value, ObjectEntityStatus::Draft->value],
                 'deleted' => false,
                 'blocked' => false,
             ])

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace BEdita\Core\Model\Action;
 
 use BEdita\Core\Model\Entity\ObjectRelation;
+use BEdita\Core\Model\Enum\RelationTypeSide;
 use BEdita\Core\Model\Table\ObjectsTable;
 use BEdita\Core\ORM\Association\RelatedTo;
 use BEdita\Core\ORM\Inheritance\Table;
@@ -39,7 +40,7 @@ class ListRelatedObjectsAction extends ListAssociatedAction
 
         if ($this->Association instanceof RelatedTo) {
             $objectTypes = TableRegistry::getTableLocator()->get('ObjectTypes')
-                ->find('byRelation', name: $this->Association->getName(), side: 'right')
+                ->find('byRelation', name: $this->Association->getName(), side: RelationTypeSide::Right)
                 ->contain(['LeftRelations.RightObjectTypes', 'RightRelations.LeftObjectTypes'])
                 ->toArray();
             $table = $this->Association->getTarget();

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -20,7 +20,7 @@ use BEdita\Core\Mailer\UserMailerTrait;
 use BEdita\Core\Model\Entity\AsyncJob;
 use BEdita\Core\Model\Entity\AuthProvider;
 use BEdita\Core\Model\Entity\User;
-use BEdita\Core\Model\Enum\ObjectStatus;
+use BEdita\Core\Model\Enum\ObjectEntityStatus;
 use BEdita\Core\Model\Table\AsyncJobsTable;
 use BEdita\Core\Model\Table\RolesTable;
 use BEdita\Core\Model\Table\UsersTable;
@@ -282,9 +282,9 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
             LoggedUser::setUserAdmin();
         }
 
-        $status = ObjectStatus::DRAFT;
+        $status = ObjectEntityStatus::Draft;
         if ($this->getConfig('requireActivation') === false) {
-            $status = ObjectStatus::ON;
+            $status = ObjectEntityStatus::On;
         }
 
         if (empty($data['auth_provider'])) {
@@ -293,7 +293,7 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
 
         $authProvider = $this->checkExternalAuth($data);
 
-        $user = $this->createUserEntity($data, ObjectStatus::ON, 'signupExternal', true);
+        $user = $this->createUserEntity($data, ObjectEntityStatus::On, 'signupExternal', true);
 
         // create `ExternalAuth` entry
         $this->Users->dispatchEvent('Auth.externalAuth', [
@@ -310,13 +310,13 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
      * Create User entity.
      *
      * @param array $data The signup data
-     * @param \BEdita\Core\Model\Enum\ObjectStatus $status User `status`, `on` or `draft`
+     * @param \BEdita\Core\Model\Enum\ObjectEntityStatus $status User `status`, `on` or `draft`
      * @param string $validate Validation options to use
      * @param bool $verified Add `verified` value to entity
      * @return \BEdita\Core\Model\Entity\User The User entity created
      * @throws \Cake\Http\Exception\BadRequestException When some data is invalid.
      */
-    protected function createUserEntity(array $data, ObjectStatus $status, string $validate, bool $verified = false): User
+    protected function createUserEntity(array $data, ObjectEntityStatus $status, string $validate, bool $verified = false): User
     {
         if ($this->Users->exists(['username' => $data['username']])) {
             $this->dispatchEvent('Auth.signupUserExists', [$data], $this->Users);

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -326,7 +326,7 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
         }
         $action = new SaveEntityAction(['table' => $this->Users]);
 
-        $data['status'] = $status->value;
+        $data['status'] = $status;
         $entity = $this->Users->newEmptyEntity();
         if ($verified === true) {
             $entity->set('verified', DateTime::now());

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserAction.php
@@ -20,6 +20,7 @@ use BEdita\Core\Mailer\UserMailerTrait;
 use BEdita\Core\Model\Entity\AsyncJob;
 use BEdita\Core\Model\Entity\AuthProvider;
 use BEdita\Core\Model\Entity\User;
+use BEdita\Core\Model\Enum\ObjectStatus;
 use BEdita\Core\Model\Table\AsyncJobsTable;
 use BEdita\Core\Model\Table\RolesTable;
 use BEdita\Core\Model\Table\UsersTable;
@@ -281,9 +282,9 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
             LoggedUser::setUserAdmin();
         }
 
-        $status = 'draft';
+        $status = ObjectStatus::DRAFT;
         if ($this->getConfig('requireActivation') === false) {
-            $status = 'on';
+            $status = ObjectStatus::ON;
         }
 
         if (empty($data['auth_provider'])) {
@@ -292,7 +293,7 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
 
         $authProvider = $this->checkExternalAuth($data);
 
-        $user = $this->createUserEntity($data, 'on', 'signupExternal', true);
+        $user = $this->createUserEntity($data, ObjectStatus::ON, 'signupExternal', true);
 
         // create `ExternalAuth` entry
         $this->Users->dispatchEvent('Auth.externalAuth', [
@@ -309,13 +310,13 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
      * Create User entity.
      *
      * @param array $data The signup data
-     * @param string $status User `status`, `on` or `draft`
+     * @param \BEdita\Core\Model\Enum\ObjectStatus $status User `status`, `on` or `draft`
      * @param string $validate Validation options to use
      * @param bool $verified Add `verified` value to entity
      * @return \BEdita\Core\Model\Entity\User The User entity created
      * @throws \Cake\Http\Exception\BadRequestException When some data is invalid.
      */
-    protected function createUserEntity(array $data, string $status, string $validate, bool $verified = false): User
+    protected function createUserEntity(array $data, ObjectStatus $status, string $validate, bool $verified = false): User
     {
         if ($this->Users->exists(['username' => $data['username']])) {
             $this->dispatchEvent('Auth.signupUserExists', [$data], $this->Users);
@@ -325,7 +326,7 @@ class SignupUserAction extends BaseAction implements EventListenerInterface
         }
         $action = new SaveEntityAction(['table' => $this->Users]);
 
-        $data['status'] = $status;
+        $data['status'] = $status->value;
         $entity = $this->Users->newEmptyEntity();
         if ($verified === true) {
             $entity->set('verified', DateTime::now());

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserActivationAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserActivationAction.php
@@ -16,6 +16,7 @@ namespace BEdita\Core\Model\Action;
 
 use BEdita\Core\Mailer\UserMailerTrait;
 use BEdita\Core\Model\Entity\User;
+use BEdita\Core\Model\Enum\ObjectStatus;
 use BEdita\Core\Model\Table\AsyncJobsTable;
 use BEdita\Core\Model\Table\UsersTable;
 use Cake\Event\EventDispatcherTrait;
@@ -80,7 +81,7 @@ class SignupUserActivationAction extends BaseAction implements EventListenerInte
         }
 
         $user = $this->Users->get($asyncJob->payload['user_id'], contain: ['Roles']);
-        if ($user->status === 'on' && $user->verified !== null) {
+        if ($user->status === ObjectStatus::ON && $user->verified !== null) {
             throw new ConflictException(__d('bedita', 'User already active'));
         }
 
@@ -89,7 +90,7 @@ class SignupUserActivationAction extends BaseAction implements EventListenerInte
         // the user is the creator of himself
         $user->created_by = $user->id;
         $user->modified_by = $user->id;
-        $user->status = 'on';
+        $user->status = ObjectStatus::ON;
         $user->verified = $now;
         $this->Users->saveOrFail($user);
 

--- a/plugins/BEdita/Core/src/Model/Action/SignupUserActivationAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/SignupUserActivationAction.php
@@ -16,7 +16,7 @@ namespace BEdita\Core\Model\Action;
 
 use BEdita\Core\Mailer\UserMailerTrait;
 use BEdita\Core\Model\Entity\User;
-use BEdita\Core\Model\Enum\ObjectStatus;
+use BEdita\Core\Model\Enum\ObjectEntityStatus;
 use BEdita\Core\Model\Table\AsyncJobsTable;
 use BEdita\Core\Model\Table\UsersTable;
 use Cake\Event\EventDispatcherTrait;
@@ -81,7 +81,7 @@ class SignupUserActivationAction extends BaseAction implements EventListenerInte
         }
 
         $user = $this->Users->get($asyncJob->payload['user_id'], contain: ['Roles']);
-        if ($user->status === ObjectStatus::ON && $user->verified !== null) {
+        if ($user->status === ObjectEntityStatus::On && $user->verified !== null) {
             throw new ConflictException(__d('bedita', 'User already active'));
         }
 
@@ -90,7 +90,7 @@ class SignupUserActivationAction extends BaseAction implements EventListenerInte
         // the user is the creator of himself
         $user->created_by = $user->id;
         $user->modified_by = $user->id;
-        $user->status = ObjectStatus::ON;
+        $user->status = ObjectEntityStatus::On;
         $user->verified = $now;
         $this->Users->saveOrFail($user);
 

--- a/plugins/BEdita/Core/src/Model/Behavior/DataCleanupBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/DataCleanupBehavior.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 namespace BEdita\Core\Model\Behavior;
 
 use ArrayObject;
-use BEdita\Core\Model\Enum\ObjectStatus;
+use BEdita\Core\Model\Enum\ObjectEntityStatus;
 use Cake\Core\Configure;
 use Cake\Event\EventInterface;
 use Cake\ORM\Behavior;
@@ -40,7 +40,7 @@ class DataCleanupBehavior extends Behavior
      */
     protected array $_defaultConfig = [
         'fields' => [
-            'status' => ObjectStatus::DRAFT->value,
+            'status' => ObjectEntityStatus::Draft->value,
             'deleted' => 0,
         ],
     ];
@@ -82,8 +82,8 @@ class DataCleanupBehavior extends Behavior
     {
         $fields = (array)$this->getConfig('fields');
         // set default `on` if minimum level is `on`
-        if (Configure::read('Status.level') === ObjectStatus::ON->value) {
-            $fields['status'] = ObjectStatus::ON->value;
+        if (Configure::read('Status.level') === ObjectEntityStatus::On->value) {
+            $fields['status'] = ObjectEntityStatus::On->value;
         }
         $defaults = (array)Configure::read(sprintf('DefaultValues.%s', $type));
 

--- a/plugins/BEdita/Core/src/Model/Behavior/DataCleanupBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/DataCleanupBehavior.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace BEdita\Core\Model\Behavior;
 
 use ArrayObject;
-use BEdita\Core\Model\Enum\ObjectEntityStatus;
 use Cake\Core\Configure;
 use Cake\Event\EventInterface;
 use Cake\ORM\Behavior;
@@ -40,7 +39,7 @@ class DataCleanupBehavior extends Behavior
      */
     protected array $_defaultConfig = [
         'fields' => [
-            'status' => ObjectEntityStatus::Draft->value,
+            'status' => 'draft',
             'deleted' => 0,
         ],
     ];
@@ -82,8 +81,8 @@ class DataCleanupBehavior extends Behavior
     {
         $fields = (array)$this->getConfig('fields');
         // set default `on` if minimum level is `on`
-        if (Configure::read('Status.level') === ObjectEntityStatus::On->value) {
-            $fields['status'] = ObjectEntityStatus::On->value;
+        if (Configure::read('Status.level') === 'on') {
+            $fields['status'] = 'on';
         }
         $defaults = (array)Configure::read(sprintf('DefaultValues.%s', $type));
 

--- a/plugins/BEdita/Core/src/Model/Behavior/DataCleanupBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/DataCleanupBehavior.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace BEdita\Core\Model\Behavior;
 
 use ArrayObject;
+use BEdita\Core\Model\Enum\ObjectStatus;
 use Cake\Core\Configure;
 use Cake\Event\EventInterface;
 use Cake\ORM\Behavior;
@@ -39,7 +40,7 @@ class DataCleanupBehavior extends Behavior
      */
     protected array $_defaultConfig = [
         'fields' => [
-            'status' => 'draft',
+            'status' => ObjectStatus::DRAFT->value,
             'deleted' => 0,
         ],
     ];
@@ -81,8 +82,8 @@ class DataCleanupBehavior extends Behavior
     {
         $fields = (array)$this->getConfig('fields');
         // set default `on` if minimum level is `on`
-        if (Configure::read('Status.level') === 'on') {
-            $fields['status'] = 'on';
+        if (Configure::read('Status.level') === ObjectStatus::ON->value) {
+            $fields['status'] = ObjectStatus::ON->value;
         }
         $defaults = (array)Configure::read(sprintf('DefaultValues.%s', $type));
 

--- a/plugins/BEdita/Core/src/Model/Behavior/HistoryBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/HistoryBehavior.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace BEdita\Core\Model\Behavior;
 
 use ArrayObject;
+use BEdita\Core\Model\Enum\HistoryUserAction;
 use BEdita\Core\State\CurrentApplication;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Core\Configure;
@@ -176,23 +177,23 @@ class HistoryBehavior extends Behavior
      * 'remove' action defined in in `afterDelete`
      *
      * @param \Cake\Datasource\EntityInterface $entity Object entity.
-     * @return string
+     * @return \BEdita\Core\Model\Enum\HistoryUserAction
      */
-    protected function entityUserAction(EntityInterface $entity): string
+    protected function entityUserAction(EntityInterface $entity): HistoryUserAction
     {
         if ($entity->isNew()) {
-            return 'create';
+            return HistoryUserAction::Create;
         }
 
         if ($entity->isDirty('deleted')) {
             if ($entity->get('deleted')) {
-                return 'trash';
+                return HistoryUserAction::Trash;
             } else {
-                return 'restore';
+                return HistoryUserAction::Restore;
             }
         }
 
-        return 'update';
+        return HistoryUserAction::Update;
     }
 
     /**
@@ -210,7 +211,7 @@ class HistoryBehavior extends Behavior
 
         /** @var \BEdita\Core\Model\Entity\History $history */
         $history = $this->historyEntity($entity);
-        $history->user_action = 'remove';
+        $history->user_action = HistoryUserAction::Remove;
         $this->Table->saveOrFail($history);
     }
 

--- a/plugins/BEdita/Core/src/Model/Behavior/StatusBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/StatusBehavior.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 namespace BEdita\Core\Model\Behavior;
 
 use BEdita\Core\Exception\BadFilterException;
-use BEdita\Core\Model\Enum\ObjectStatus;
+use BEdita\Core\Model\Enum\ObjectEntityStatus;
 use Cake\Core\Configure;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
@@ -59,7 +59,7 @@ class StatusBehavior extends Behavior
         }
         $level = Configure::read('Status.level');
         $status = $entity->get('status');
-        if (($level === ObjectStatus::ON->value && $status !== ObjectStatus::ON) || ($level === ObjectStatus::DRAFT->value && $status === ObjectStatus::OFF)) {
+        if (($level === ObjectEntityStatus::On->value && $status !== ObjectEntityStatus::On) || ($level === ObjectEntityStatus::Draft->value && $status === ObjectEntityStatus::Off)) {
             throw new BadRequestException(__d(
                 'bedita',
                 'Status "{0}" is not consistent with configured Status.level "{1}"',
@@ -82,17 +82,17 @@ class StatusBehavior extends Behavior
     {
         $field = $this->getConfigOrFail('field');
         switch ($level) {
-            case ObjectStatus::ON->value:
+            case ObjectEntityStatus::On->value:
                 return $query->where([
-                    $this->table()->aliasField($field) => ObjectStatus::ON->value,
+                    $this->table()->aliasField($field) => ObjectEntityStatus::On->value,
                 ]);
 
-            case ObjectStatus::DRAFT->value:
+            case ObjectEntityStatus::Draft->value:
                 return $query->where(function (QueryExpression $exp) use ($field) {
-                    return $exp->in($this->table()->aliasField($field), [ObjectStatus::ON->value, ObjectStatus::DRAFT->value]);
+                    return $exp->in($this->table()->aliasField($field), [ObjectEntityStatus::On->value, ObjectEntityStatus::Draft->value]);
                 });
 
-            case ObjectStatus::OFF->value:
+            case ObjectEntityStatus::Off->value:
             case 'all':
                 return $query;
 

--- a/plugins/BEdita/Core/src/Model/Behavior/StatusBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/StatusBehavior.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
  */
 namespace BEdita\Core\Model\Behavior;
 
+use BackedEnum;
 use BEdita\Core\Exception\BadFilterException;
-use BEdita\Core\Model\Enum\ObjectEntityStatus;
 use Cake\Core\Configure;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
@@ -59,11 +59,14 @@ class StatusBehavior extends Behavior
         }
         $level = Configure::read('Status.level');
         $status = $entity->get('status');
-        if (($level === ObjectEntityStatus::On->value && $status !== ObjectEntityStatus::On) || ($level === ObjectEntityStatus::Draft->value && $status === ObjectEntityStatus::Off)) {
+        if ($status instanceof BackedEnum) {
+            $status = $status->value;
+        }
+        if (($level === 'on' && $status !== 'on') || ($level === 'draft' && $status === 'off')) {
             throw new BadRequestException(__d(
                 'bedita',
                 'Status "{0}" is not consistent with configured Status.level "{1}"',
-                $status->value,
+                $status,
                 $level,
             ));
         }
@@ -82,17 +85,17 @@ class StatusBehavior extends Behavior
     {
         $field = $this->getConfigOrFail('field');
         switch ($level) {
-            case ObjectEntityStatus::On->value:
+            case 'on':
                 return $query->where([
-                    $this->table()->aliasField($field) => ObjectEntityStatus::On->value,
+                    $this->table()->aliasField($field) => 'on',
                 ]);
 
-            case ObjectEntityStatus::Draft->value:
+            case 'draft':
                 return $query->where(function (QueryExpression $exp) use ($field) {
-                    return $exp->in($this->table()->aliasField($field), [ObjectEntityStatus::On->value, ObjectEntityStatus::Draft->value]);
+                    return $exp->in($this->table()->aliasField($field), ['on', 'draft']);
                 });
 
-            case ObjectEntityStatus::Off->value:
+            case 'off':
             case 'all':
                 return $query;
 

--- a/plugins/BEdita/Core/src/Model/Behavior/StatusBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/StatusBehavior.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace BEdita\Core\Model\Behavior;
 
 use BEdita\Core\Exception\BadFilterException;
+use BEdita\Core\Model\Enum\ObjectStatus;
 use Cake\Core\Configure;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
@@ -58,11 +59,11 @@ class StatusBehavior extends Behavior
         }
         $level = Configure::read('Status.level');
         $status = $entity->get('status');
-        if (($level === 'on' && $status !== 'on') || ($level === 'draft' && $status === 'off')) {
+        if (($level === ObjectStatus::ON->value && $status !== ObjectStatus::ON) || ($level === ObjectStatus::DRAFT->value && $status === ObjectStatus::OFF)) {
             throw new BadRequestException(__d(
                 'bedita',
                 'Status "{0}" is not consistent with configured Status.level "{1}"',
-                $status,
+                $status->value,
                 $level,
             ));
         }
@@ -81,17 +82,17 @@ class StatusBehavior extends Behavior
     {
         $field = $this->getConfigOrFail('field');
         switch ($level) {
-            case 'on':
+            case ObjectStatus::ON->value:
                 return $query->where([
-                    $this->table()->aliasField($field) => 'on',
+                    $this->table()->aliasField($field) => ObjectStatus::ON->value,
                 ]);
 
-            case 'draft':
+            case ObjectStatus::DRAFT->value:
                 return $query->where(function (QueryExpression $exp) use ($field) {
-                    return $exp->in($this->table()->aliasField($field), ['on', 'draft']);
+                    return $exp->in($this->table()->aliasField($field), [ObjectStatus::ON->value, ObjectStatus::DRAFT->value]);
                 });
 
-            case 'off':
+            case ObjectStatus::OFF->value:
             case 'all':
                 return $query;
 

--- a/plugins/BEdita/Core/src/Model/Entity/Caption.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Caption.php
@@ -21,7 +21,7 @@ use Cake\ORM\Entity;
  *
  * @property int $id
  * @property int $object_id
- * @property string $status
+ * @property \BEdita\Core\Model\Enum\CaptionStatus $status
  * @property string|null $label
  * @property string|null $format
  * @property string|null $lang

--- a/plugins/BEdita/Core/src/Model/Entity/History.php
+++ b/plugins/BEdita/Core/src/Model/Entity/History.php
@@ -26,7 +26,7 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\DateTime $created
  * @property int|null $user_id
  * @property int|null $application_id
- * @property string|null $user_action
+ * @property \BEdita\Core\Model\Enum\HistoryUserAction|null $user_action
  * @property array|null $changed
  *
  * @property \BEdita\Core\Model\Entity\User $user

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
@@ -30,7 +30,7 @@ use Cake\Utility\Hash;
  * @property int $object_type_id
  * @property bool $deleted
  * @property string $type
- * @property \BEdita\Core\Model\Enum\ObjectStatus $status
+ * @property \BEdita\Core\Model\Enum\ObjectEntityStatus $status
  * @property string $uname
  * @property bool $locked
  * @property \Cake\I18n\Time|\Cake\I18n\DateTime $created

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
@@ -30,7 +30,7 @@ use Cake\Utility\Hash;
  * @property int $object_type_id
  * @property bool $deleted
  * @property string $type
- * @property string $status
+ * @property \BEdita\Core\Model\Enum\ObjectStatus $status
  * @property string $uname
  * @property bool $locked
  * @property \Cake\I18n\Time|\Cake\I18n\DateTime $created

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectType.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace BEdita\Core\Model\Entity;
 
+use BEdita\Core\Model\Enum\RelationTypeSide;
 use BEdita\Core\Utility\JsonApiSerializable;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\Exception\RecordNotFoundException;
@@ -258,21 +259,25 @@ class ObjectType extends Entity implements JsonApiSerializable, EventDispatcherI
     /**
      * Get all relations, including relations inherited from parent object types, indexed by their name.
      *
-     * @param string $side Filter relations by side this object type stays on. Either `left`, `right` or `both`.
+     * @param \BEdita\Core\Model\Enum\RelationTypeSide|string $side Filter relations by side this object type stays on. Either `left`, `right` or `both`.
      * @return array<\BEdita\Core\Model\Entity\Relation>
      */
-    public function getRelations(string $side = 'both'): array
+    public function getRelations(RelationTypeSide|string $side = 'both'): array
     {
         if ($side === 'both') {
-            return $this->getRelations('left') + $this->getRelations('right');
+            return $this->getRelations(RelationTypeSide::Left) + $this->getRelations(RelationTypeSide::Right);
+        }
+
+        if (is_string($side)) {
+            $side = RelationTypeSide::from($side);
         }
 
         $indexBy = 'name';
-        if ($side === 'right') {
+        if ($side === RelationTypeSide::Right) {
             $indexBy = 'inverse_name';
         }
 
-        $property = sprintf('%s_relations', $side);
+        $property = sprintf('%s_relations', $side->value);
 
         return collection($this->getFullInheritanceChain())
             ->unfold(function (self $objectType) use ($property): Generator {
@@ -424,12 +429,16 @@ class ObjectType extends Entity implements JsonApiSerializable, EventDispatcherI
      *  * label, params and related types as values
      *
      * @param array $relations Relations array
-     * @param string $side Relation side, 'left' or 'right'
+     * @param \BEdita\Core\Model\Enum\RelationTypeSide|string $side Relation side, 'left' or 'right'
      * @return array
      */
-    protected static function objectTypeRelations(array $relations, string $side): array
+    protected static function objectTypeRelations(array $relations, RelationTypeSide|string $side): array
     {
-        if ($side === 'left') {
+        if (is_string($side)) {
+            $side = RelationTypeSide::from($side);
+        }
+
+        if ($side === RelationTypeSide::Left) {
             $name = 'name';
             $label = 'label';
             $relTypes = 'right_object_types';

--- a/plugins/BEdita/Core/src/Model/Entity/RelationType.php
+++ b/plugins/BEdita/Core/src/Model/Entity/RelationType.php
@@ -21,7 +21,7 @@ use Cake\ORM\Entity;
  *
  * @property int $relation_id
  * @property int $object_type_id
- * @property string $side
+ * @property \BEdita\Core\Model\Enum\RelationTypeSide $side
  *
  * @property \BEdita\Core\Model\Entity\Relation $relation
  * @property \BEdita\Core\Model\Entity\ObjectType $object_type

--- a/plugins/BEdita/Core/src/Model/Entity/StaticProperty.php
+++ b/plugins/BEdita/Core/src/Model/Entity/StaticProperty.php
@@ -178,6 +178,7 @@ class StaticProperty extends Property
         $type = TypeFactory::build($typeName);
         $driver = $this->table->getConnection()->getDriver();
         if ($type instanceof EnumType) {
+            // For EnumType we need the string value, not the enum instance.
             return $this->_fields['default'] = $default;
         }
 

--- a/plugins/BEdita/Core/src/Model/Entity/StaticProperty.php
+++ b/plugins/BEdita/Core/src/Model/Entity/StaticProperty.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace BEdita\Core\Model\Entity;
 
+use Cake\Database\Type\EnumType;
 use Cake\Database\TypeFactory;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -176,6 +177,9 @@ class StaticProperty extends Property
 
         $type = TypeFactory::build($typeName);
         $driver = $this->table->getConnection()->getDriver();
+         if ($type instanceof EnumType)  {
+            return $this->_fields['default'] = $default;
+        }
 
         return $this->_fields['default'] = $type->toPHP($default, $driver);
     }

--- a/plugins/BEdita/Core/src/Model/Entity/StaticProperty.php
+++ b/plugins/BEdita/Core/src/Model/Entity/StaticProperty.php
@@ -177,7 +177,7 @@ class StaticProperty extends Property
 
         $type = TypeFactory::build($typeName);
         $driver = $this->table->getConnection()->getDriver();
-         if ($type instanceof EnumType)  {
+        if ($type instanceof EnumType) {
             return $this->_fields['default'] = $default;
         }
 

--- a/plugins/BEdita/Core/src/Model/Entity/Translation.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Translation.php
@@ -23,7 +23,7 @@ use Cake\ORM\Entity;
  * @property int $id
  * @property int $object_id
  * @property string $lang
- * @property string $status
+ * @property \BEdita\Core\Model\Enum\TranslationStatus $status
  * @property \Cake\I18n\DateTime $created
  * @property \Cake\I18n\DateTime $modified
  * @property int $created_by

--- a/plugins/BEdita/Core/src/Model/Enum/CaptionStatus.php
+++ b/plugins/BEdita/Core/src/Model/Enum/CaptionStatus.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2025 Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Core\Model\Enum;
+
+/**
+ * CaptionStatus Enum
+ *
+ * @since 6.0.0
+ */
+enum CaptionStatus: string
+{
+    use EnumValuesTrait;
+
+    case On = 'on';
+    case Draft = 'draft';
+    case Off = 'off';
+}

--- a/plugins/BEdita/Core/src/Model/Enum/EnumValuesTrait.php
+++ b/plugins/BEdita/Core/src/Model/Enum/EnumValuesTrait.php
@@ -14,17 +14,15 @@ declare(strict_types=1);
  */
 namespace BEdita\Core\Model\Enum;
 
-/**
- * DateRangesSortField enum.
- *
- * @since 6.0.0
- */
-enum DateRangesSortField: string
+trait EnumValuesTrait
 {
-    use EnumValuesTrait;
-
-    case MIN_START_DATE = 'date_ranges_min_start_date';
-    case MAX_START_DATE = 'date_ranges_max_start_date';
-    case MIN_END_DATE = 'date_ranges_min_end_date';
-    case MAX_END_DATE = 'date_ranges_max_end_date';
+    /**
+     * Get all possible values.
+     *
+     * @return array<string>
+     */
+    public static function values(): array
+    {
+        return array_map(fn(self $case): string => $case->value, self::cases());
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Enum/HistoryUserAction.php
+++ b/plugins/BEdita/Core/src/Model/Enum/HistoryUserAction.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2025 Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Core\Model\Enum;
+
+/**
+ * HistoryUserAction Enum
+ *
+ * @since 6.0.0
+ */
+enum HistoryUserAction: string
+{
+    use EnumValuesTrait;
+
+    case Create = 'create';
+    case Update = 'update';
+    case Trash = 'trash';
+    case Restore = 'restore';
+    case Remove = 'remove';
+}

--- a/plugins/BEdita/Core/src/Model/Enum/ObjectEntityStatus.php
+++ b/plugins/BEdita/Core/src/Model/Enum/ObjectEntityStatus.php
@@ -14,19 +14,16 @@ declare(strict_types=1);
  */
 namespace BEdita\Core\Model\Enum;
 
-use Cake\Database\Type\EnumLabelInterface;
-use Cake\Utility\Inflector;
-
 /**
- * ObjectStatus Enum
+ * ObjectEntityStatus Enum
  *
  * @since 6.0.0
  */
-enum ObjectStatus: string
+enum ObjectEntityStatus: string
 {
     use EnumValuesTrait;
 
-    case ON = 'on';
-    case DRAFT = 'draft';
-    case OFF = 'off';
+    case On = 'on';
+    case Draft = 'draft';
+    case Off = 'off';
 }

--- a/plugins/BEdita/Core/src/Model/Enum/ObjectStatus.php
+++ b/plugins/BEdita/Core/src/Model/Enum/ObjectStatus.php
@@ -14,17 +14,27 @@ declare(strict_types=1);
  */
 namespace BEdita\Core\Model\Enum;
 
+use Cake\Database\Type\EnumLabelInterface;
+use Cake\Utility\Inflector;
+
 /**
- * DateRangesSortField enum.
+ * ObjectStatus Enum
  *
  * @since 6.0.0
  */
-enum DateRangesSortField: string
+enum ObjectStatus: string implements EnumLabelInterface
 {
     use EnumValuesTrait;
 
-    case MIN_START_DATE = 'date_ranges_min_start_date';
-    case MAX_START_DATE = 'date_ranges_max_start_date';
-    case MIN_END_DATE = 'date_ranges_min_end_date';
-    case MAX_END_DATE = 'date_ranges_max_end_date';
+    case ON = 'on';
+    case DRAFT = 'draft';
+    case OFF = 'off';
+
+    /**
+     * @return string
+     */
+    public function label(): string
+    {
+        return Inflector::humanize(Inflector::underscore($this->name));
+    }
 }

--- a/plugins/BEdita/Core/src/Model/Enum/ObjectStatus.php
+++ b/plugins/BEdita/Core/src/Model/Enum/ObjectStatus.php
@@ -22,19 +22,11 @@ use Cake\Utility\Inflector;
  *
  * @since 6.0.0
  */
-enum ObjectStatus: string implements EnumLabelInterface
+enum ObjectStatus: string
 {
     use EnumValuesTrait;
 
     case ON = 'on';
     case DRAFT = 'draft';
     case OFF = 'off';
-
-    /**
-     * @return string
-     */
-    public function label(): string
-    {
-        return Inflector::humanize(Inflector::underscore($this->name));
-    }
 }

--- a/plugins/BEdita/Core/src/Model/Enum/RelationTypeSide.php
+++ b/plugins/BEdita/Core/src/Model/Enum/RelationTypeSide.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2025 Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Core\Model\Enum;
+
+/**
+ * RelationTypeSide Enum
+ *
+ * @since 6.0.0
+ */
+enum RelationTypeSide: string
+{
+    use EnumValuesTrait;
+
+    case Left = 'left';
+    case Right = 'right';
+}

--- a/plugins/BEdita/Core/src/Model/Enum/TranslationStatus.php
+++ b/plugins/BEdita/Core/src/Model/Enum/TranslationStatus.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2025 Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\Core\Model\Enum;
+
+/**
+ * TranslationStatus Enum
+ *
+ * @since 6.0.0
+ */
+enum TranslationStatus: string
+{
+    use EnumValuesTrait;
+
+    case On = 'on';
+    case Draft = 'draft';
+    case Off = 'off';
+}

--- a/plugins/BEdita/Core/src/Model/Table/CaptionsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/CaptionsTable.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
  */
 namespace BEdita\Core\Model\Table;
 
+use BEdita\Core\Model\Enum\CaptionStatus;
+use Cake\Database\Type\EnumType;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
@@ -54,7 +56,9 @@ class CaptionsTable extends Table
         $this->setTable('captions');
         $this->setDisplayField('label');
         $this->setPrimaryKey('id');
-        $this->getSchema()->setColumnType('params', 'json');
+        $this->getSchema()
+            ->setColumnType('params', 'json')
+            ->setColumnType('status', EnumType::from(CaptionStatus::class));
 
         $this->addBehavior('Timestamp');
 
@@ -78,7 +82,7 @@ class CaptionsTable extends Table
             ->naturalNumber('id')
             ->allowEmptyString('id', null, 'create')
 
-            ->inList('status', ['on', 'off', 'draft'])
+            ->inList('status', CaptionStatus::values())
             ->notEmptyString('status')
 
             ->allowEmptyString('label')

--- a/plugins/BEdita/Core/src/Model/Table/CaptionsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/CaptionsTable.php
@@ -82,7 +82,7 @@ class CaptionsTable extends Table
             ->naturalNumber('id')
             ->allowEmptyString('id', null, 'create')
 
-            ->inList('status', CaptionStatus::values())
+            ->enum('status', CaptionStatus::class)
             ->notEmptyString('status')
 
             ->allowEmptyString('label')

--- a/plugins/BEdita/Core/src/Model/Table/HistoryTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/HistoryTable.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
  */
 namespace BEdita\Core\Model\Table;
 
+use BEdita\Core\Model\Enum\HistoryUserAction;
+use Cake\Database\Type\EnumType;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
 
@@ -53,7 +55,9 @@ class HistoryTable extends Table
         $this->setTable('history');
         $this->setDisplayField('id');
         $this->setPrimaryKey('id');
-        $this->getSchema()->setColumnType('changed', 'json');
+        $this->getSchema()
+            ->setColumnType('changed', 'json')
+            ->setColumnType('user_action', EnumType::from(HistoryUserAction::class));
 
         $this->belongsTo('Users', [
             'foreignKey' => 'user_id',
@@ -82,7 +86,8 @@ class HistoryTable extends Table
 
         $validator
             ->scalar('user_action')
-            ->allowEmptyString('user_action');
+            ->allowEmptyString('user_action')
+            ->inList('user_action', HistoryUserAction::values());
 
         $validator
             ->requirePresence('resource_id')

--- a/plugins/BEdita/Core/src/Model/Table/HistoryTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/HistoryTable.php
@@ -85,9 +85,8 @@ class HistoryTable extends Table
             ->allowEmptyString('id', null, 'create');
 
         $validator
-            ->scalar('user_action')
             ->allowEmptyString('user_action')
-            ->inList('user_action', HistoryUserAction::values());
+            ->enum('user_action', HistoryUserAction::class);
 
         $validator
             ->requirePresence('resource_id')

--- a/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectTypesTable.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Exception\BadFilterException;
+use BEdita\Core\Model\Enum\RelationTypeSide;
 use BEdita\Core\Model\Validation\ObjectTypesValidator;
 use BEdita\Core\ORM\Rule\IsUniqueAmongst;
 use BEdita\Core\Search\SimpleSearchTrait;
@@ -134,7 +135,7 @@ class ObjectTypesTable extends Table
             'foreignKey' => 'object_type_id',
             'targetForeignKey' => 'relation_id',
             'conditions' => [
-                $through->aliasField('side') => 'left',
+                $through->aliasField('side') => RelationTypeSide::Left->value,
             ],
         ]);
         $through = TableRegistry::getTableLocator()->get('RightRelationTypes', ['className' => 'RelationTypes']);
@@ -144,7 +145,7 @@ class ObjectTypesTable extends Table
             'foreignKey' => 'object_type_id',
             'targetForeignKey' => 'relation_id',
             'conditions' => [
-                $through->aliasField('side') => 'right',
+                $through->aliasField('side') => RelationTypeSide::Right->value,
             ],
         ]);
 
@@ -395,7 +396,7 @@ class ObjectTypesTable extends Table
      * This finder returns a list of object types that are allowed for the
      * relation specified by the required option `name`. You can specify the
      * side of the relation you want to retrieve allowed object types for by
-     * passing an additional option `side` (default: `'right'`).
+     * passing an additional option `side` (default: `\BEdita\Core\Model\Enum\RelationTypeSide::Right`).
      *
      * If the specified relation name is actually the name of an inverse relation,
      * this finder automatically takes care of "swapping" sides, always returning
@@ -410,7 +411,7 @@ class ObjectTypesTable extends Table
      *
      * // Find a list of object type names allowed on the "left" side of the inverse relation:
      * TableRegistry::getTableLocator()->get('ObjectTypes')
-     *     ->find('byRelation', name: 'my_inverse_relation', side: 'left')
+     *     ->find('byRelation', name: 'my_inverse_relation', side: RelationTypeSide::Left)
      *     ->find('list')
      *     ->toArray();
      *
@@ -422,6 +423,7 @@ class ObjectTypesTable extends Table
      * @param \Cake\ORM\Query\SelectQuery $query Query object.
      * @param string $name Additional options. The `name` key is required, while `side` is optional
      *      and assumed to be `'right'` by default.
+     * @param \BEdita\Core\Model\Enum\RelationTypeSide|string $side The side of the relation to retrieve allowed object types for.
      * @param bool $descendants Whether to include descendants of the allowed object types.
      * @return \Cake\ORM\Query\SelectQuery
      * @throws \LogicException When required parameters is empty.
@@ -429,7 +431,7 @@ class ObjectTypesTable extends Table
     public function findByRelation(
         SelectQuery $query,
         string $name,
-        string $side = 'right',
+        RelationTypeSide|string $side = RelationTypeSide::Right,
         bool $descendants = false,
     ): SelectQuery {
         if (empty($name)) {
@@ -437,9 +439,13 @@ class ObjectTypesTable extends Table
         }
         $name = Inflector::underscore($name);
 
+        if (is_string($side)) {
+            $side = RelationTypeSide::from($side);
+        }
+
         $leftField = 'inverse_name';
         $rightField = 'name';
-        if ($side !== 'right') {
+        if ($side !== RelationTypeSide::Right) {
             $leftField = 'name';
             $rightField = 'inverse_name';
         }

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -17,7 +17,7 @@ namespace BEdita\Core\Model\Table;
 use BEdita\Core\Exception\LockedResourceException;
 use BEdita\Core\Model\Entity\ObjectEntity;
 use BEdita\Core\Model\Enum\DateRangesSortField;
-use BEdita\Core\Model\Enum\ObjectStatus;
+use BEdita\Core\Model\Enum\ObjectEntityStatus;
 use BEdita\Core\Model\Validation\ObjectsValidator;
 use BEdita\Core\Search\SimpleSearchTrait;
 use BEdita\Core\Utility\LoggedUser;
@@ -96,7 +96,7 @@ class ObjectsTable extends Table
         $this->getSchema()
             ->setColumnType('custom_props', 'json')
             ->setColumnType('extra', 'json')
-            ->setColumnType('status', EnumType::from(ObjectStatus::class));
+            ->setColumnType('status', EnumType::from(ObjectEntityStatus::class));
 
         $this->addBehavior('BEdita/Core.ObjectModel');
         $this->addBehavior('BEdita/Core.Categories');

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -17,11 +17,13 @@ namespace BEdita\Core\Model\Table;
 use BEdita\Core\Exception\LockedResourceException;
 use BEdita\Core\Model\Entity\ObjectEntity;
 use BEdita\Core\Model\Enum\DateRangesSortField;
+use BEdita\Core\Model\Enum\ObjectStatus;
 use BEdita\Core\Model\Validation\ObjectsValidator;
 use BEdita\Core\Search\SimpleSearchTrait;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Core\Configure;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\Type\EnumType;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\I18n\DateTime;
@@ -93,7 +95,8 @@ class ObjectsTable extends Table
         $this->setDisplayField('title');
         $this->getSchema()
             ->setColumnType('custom_props', 'json')
-            ->setColumnType('extra', 'json');
+            ->setColumnType('extra', 'json')
+            ->setColumnType('status', EnumType::from(ObjectStatus::class));
 
         $this->addBehavior('BEdita/Core.ObjectModel');
         $this->addBehavior('BEdita/Core.Categories');

--- a/plugins/BEdita/Core/src/Model/Table/RelationTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationTypesTable.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
  */
 namespace BEdita\Core\Model\Table;
 
-use BEdita\Core\Model\Entity\Relation;
-use BEdita\Core\Model\Entity\RelationType;
 use BEdita\Core\Model\Enum\RelationTypeSide;
 use Cake\Cache\Cache;
 use Cake\Database\Type\EnumType;

--- a/plugins/BEdita/Core/src/Model/Table/RelationTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationTypesTable.php
@@ -77,7 +77,7 @@ class RelationTypesTable extends Table
     public function validationDefault(Validator $validator): Validator
     {
         $validator
-            ->inList('side', RelationTypeSide::values())
+            ->enum('side', RelationTypeSide::class)
             ->notEmptyString('side')
             ->requirePresence('side', 'create');
 

--- a/plugins/BEdita/Core/src/Model/Table/RelationTypesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationTypesTable.php
@@ -14,7 +14,11 @@ declare(strict_types=1);
  */
 namespace BEdita\Core\Model\Table;
 
+use BEdita\Core\Model\Entity\Relation;
+use BEdita\Core\Model\Entity\RelationType;
+use BEdita\Core\Model\Enum\RelationTypeSide;
 use Cake\Cache\Cache;
+use Cake\Database\Type\EnumType;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
@@ -52,6 +56,8 @@ class RelationTypesTable extends Table
         $this->setTable('relation_types');
         $this->setDisplayField('relation_id');
         $this->setPrimaryKey(['relation_id', 'object_type_id', 'side']);
+        $this->getSchema()
+            ->setColumnType('side', EnumType::from(RelationTypeSide::class));
 
         $this->belongsTo('Relations', [
             'foreignKey' => 'relation_id',
@@ -73,7 +79,7 @@ class RelationTypesTable extends Table
     public function validationDefault(Validator $validator): Validator
     {
         $validator
-            ->inList('side', ['left', 'right'])
+            ->inList('side', RelationTypeSide::values())
             ->notEmptyString('side')
             ->requirePresence('side', 'create');
 

--- a/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
  */
 namespace BEdita\Core\Model\Table;
 
+use BEdita\Core\Model\Entity\Relation;
+use BEdita\Core\Model\Enum\RelationTypeSide;
 use BEdita\Core\Model\Validation\Validation;
 use BEdita\Core\ORM\Rule\IsUniqueAmongst;
 use BEdita\Core\Search\SimpleSearchTrait;
@@ -79,7 +81,7 @@ class RelationsTable extends Table
             'foreignKey' => 'relation_id',
             'targetForeignKey' => 'object_type_id',
             'conditions' => [
-                $through->aliasField('side') => 'left',
+                $through->aliasField('side') => RelationTypeSide::Left->value,
             ],
         ]);
         $through = TableRegistry::getTableLocator()->get('RightRelationTypes', ['className' => 'RelationTypes']);
@@ -89,7 +91,7 @@ class RelationsTable extends Table
             'foreignKey' => 'relation_id',
             'targetForeignKey' => 'object_type_id',
             'conditions' => [
-                $through->aliasField('side') => 'right',
+                $through->aliasField('side') => RelationTypeSide::Right->value,
             ],
         ]);
         $this->addBehavior('BEdita/Core.Searchable', ['scopes' => (array)$this->getTable()]);

--- a/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/RelationsTable.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
  */
 namespace BEdita\Core\Model\Table;
 
-use BEdita\Core\Model\Entity\Relation;
 use BEdita\Core\Model\Enum\RelationTypeSide;
 use BEdita\Core\Model\Validation\Validation;
 use BEdita\Core\ORM\Rule\IsUniqueAmongst;

--- a/plugins/BEdita/Core/src/Model/Table/TranslationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TranslationsTable.php
@@ -15,9 +15,11 @@ declare(strict_types=1);
 namespace BEdita\Core\Model\Table;
 
 use BEdita\Core\Exception\BadFilterException;
+use BEdita\Core\Model\Enum\TranslationStatus;
 use BEdita\Core\Search\SimpleSearchTrait;
 use Cake\Core\Configure;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\Type\EnumType;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\RulesChecker;
@@ -65,7 +67,9 @@ class TranslationsTable extends Table
         $this->setTable('translations');
         $this->setPrimaryKey('id');
         $this->setDisplayField('id');
-        $this->getSchema()->setColumnType('translated_fields', 'json');
+        $this->getSchema()
+            ->setColumnType('translated_fields', 'json')
+            ->setColumnType('status', EnumType::from(TranslationStatus::class));
 
         $this->addBehavior('Timestamp');
         $this->addBehavior('BEdita/Core.UserModified');
@@ -121,7 +125,7 @@ class TranslationsTable extends Table
 
         $validator
             ->add('status', 'scalar', ['rule' => 'isScalar', 'last' => true])
-            ->inList('status', ['on', 'off', 'draft'])
+            ->inList('status', TranslationStatus::values())
             ->requirePresence('status', 'create')
             ->notEmptyString('status');
 

--- a/plugins/BEdita/Core/src/Model/Table/TranslationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TranslationsTable.php
@@ -125,7 +125,7 @@ class TranslationsTable extends Table
 
         $validator
             ->add('status', 'scalar', ['rule' => 'isScalar', 'last' => true])
-            ->inList('status', TranslationStatus::values())
+            ->enum('status', TranslationStatus::class)
             ->requirePresence('status', 'create')
             ->notEmptyString('status');
 

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -18,7 +18,7 @@ use ArrayObject;
 use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Exception\ImmutableResourceException;
 use BEdita\Core\Model\Entity\AuthProvider;
-use BEdita\Core\Model\Enum\ObjectStatus;
+use BEdita\Core\Model\Enum\ObjectEntityStatus;
 use BEdita\Core\Model\Table\ObjectsBaseTable as Table;
 use BEdita\Core\Model\Validation\UsersValidator;
 use BEdita\Core\Utility\LoggedUser;
@@ -378,9 +378,9 @@ class UsersTable extends Table
      */
     protected function findLogin(SelectQuery $query): SelectQuery
     {
-        $status = [ObjectStatus::ON->value];
+        $status = [ObjectEntityStatus::On->value];
         if ((bool)Configure::read('Login.draft') === true) {
-            $status[] = ObjectStatus::DRAFT->value;
+            $status[] = ObjectEntityStatus::Draft->value;
         }
 
         return $query

--- a/plugins/BEdita/Core/src/Model/Table/UsersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/UsersTable.php
@@ -18,6 +18,7 @@ use ArrayObject;
 use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Exception\ImmutableResourceException;
 use BEdita\Core\Model\Entity\AuthProvider;
+use BEdita\Core\Model\Enum\ObjectStatus;
 use BEdita\Core\Model\Table\ObjectsBaseTable as Table;
 use BEdita\Core\Model\Validation\UsersValidator;
 use BEdita\Core\Utility\LoggedUser;
@@ -377,9 +378,9 @@ class UsersTable extends Table
      */
     protected function findLogin(SelectQuery $query): SelectQuery
     {
-        $status = ['on'];
+        $status = [ObjectStatus::ON->value];
         if ((bool)Configure::read('Login.draft') === true) {
-            $status[] = 'draft';
+            $status[] = ObjectStatus::DRAFT->value;
         }
 
         return $query

--- a/plugins/BEdita/Core/src/Model/Validation/ObjectsValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/ObjectsValidator.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  */
 namespace BEdita\Core\Model\Validation;
 
-use BEdita\Core\Model\Enum\ObjectStatus;
+use BEdita\Core\Model\Enum\ObjectEntityStatus;
 use Cake\ORM\TableRegistry;
 use Cake\Validation\Validator;
 use Phinx\Db\Adapter\MysqlAdapter;
@@ -43,7 +43,7 @@ class ObjectsValidator extends Validator
             ->allowEmptyString('id', null, 'create')
             ->requirePresence('id', 'update')
 
-            ->inList('status', ObjectStatus::values())
+            ->inList('status', ObjectEntityStatus::values())
             ->notEmptyString('status')
 
             ->ascii('uname')

--- a/plugins/BEdita/Core/src/Model/Validation/ObjectsValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/ObjectsValidator.php
@@ -43,7 +43,7 @@ class ObjectsValidator extends Validator
             ->allowEmptyString('id', null, 'create')
             ->requirePresence('id', 'update')
 
-            ->inList('status', ObjectEntityStatus::values())
+            ->enum('status', ObjectEntityStatus::class)
             ->notEmptyString('status')
 
             ->ascii('uname')

--- a/plugins/BEdita/Core/src/Model/Validation/ObjectsValidator.php
+++ b/plugins/BEdita/Core/src/Model/Validation/ObjectsValidator.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace BEdita\Core\Model\Validation;
 
+use BEdita\Core\Model\Enum\ObjectStatus;
 use Cake\ORM\TableRegistry;
 use Cake\Validation\Validator;
 use Phinx\Db\Adapter\MysqlAdapter;
@@ -42,7 +43,7 @@ class ObjectsValidator extends Validator
             ->allowEmptyString('id', null, 'create')
             ->requirePresence('id', 'update')
 
-            ->inList('status', ['on', 'off', 'draft'])
+            ->inList('status', ObjectStatus::values())
             ->notEmptyString('status')
 
             ->ascii('uname')

--- a/plugins/BEdita/Core/src/Utility/Relations.php
+++ b/plugins/BEdita/Core/src/Utility/Relations.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace BEdita\Core\Utility;
 
+use BEdita\Core\Model\Enum\RelationTypeSide;
 use Cake\Datasource\EntityInterface;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Utility\Hash;
@@ -84,11 +85,11 @@ class Relations extends ResourcesBase
      *
      * @param string $relation Relation name or ID
      * @param string $type Object type name
-     * @param string $side Relation side, 'left' or 'right'
+     * @param \BEdita\Core\Model\Enum\RelationTypeSide|string $side Relation side, 'left' or 'right'
      * @param array $options Table locator options
      * @return void
      */
-    public static function addRelationType(string $relation, string $type, string $side, array $options = []): void
+    public static function addRelationType(string $relation, string $type, RelationTypeSide|string $side, array $options = []): void
     {
         $relation = static::getTable('Relations', $options)
             ->get($relation);
@@ -100,14 +101,18 @@ class Relations extends ResourcesBase
      *
      * @param string|int $relationId Relation id
      * @param array $types Object type names
-     * @param string $side Relation side, 'left' or 'right'
+     * @param \BEdita\Core\Model\Enum\RelationTypeSide|string $side Relation side, 'left' or 'right'
      * @param array $options Table locator options
      * @return void
      */
-    protected static function addTypes(string|int $relationId, array $types, string $side, array $options = []): void
+    protected static function addTypes(string|int $relationId, array $types, RelationTypeSide|string $side, array $options = []): void
     {
         $RelationTypes = static::getTable('RelationTypes', $options);
         $ObjectTypes = static::getTable('ObjectTypes', $options);
+
+        if (is_string($side)) {
+            $side = RelationTypeSide::from($side);
+        }
 
         foreach ($types as $name) {
             $objectType = $ObjectTypes->get(Inflector::camelize($name));
@@ -115,7 +120,7 @@ class Relations extends ResourcesBase
             $entity = $RelationTypes->newEntity([
                 'relation_id' => $relationId,
                 'object_type_id' => $objectType->get('id'),
-                'side' => $side,
+                'side' => $side->value,
             ]);
             $RelationTypes->saveOrFail($entity, static::$defaults['save']);
         }
@@ -150,14 +155,18 @@ class Relations extends ResourcesBase
      *
      * @param string|int $relationId Relation id
      * @param array $types Object type names
-     * @param string $side Relation side, 'left' or 'right'
+     * @param \BEdita\Core\Model\Enum\RelationTypeSide|string $side Relation side, 'left' or 'right'
      * @param array $options Table locator options
      * @return void
      */
-    protected static function removeTypes(string|int $relationId, array $types, string $side, array $options = []): void
+    protected static function removeTypes(string|int $relationId, array $types, RelationTypeSide|string $side, array $options = []): void
     {
         $RelationTypes = static::getTable('RelationTypes', $options);
         $ObjectTypes = static::getTable('ObjectTypes', $options);
+
+        if (is_string($side)) {
+            $side = RelationTypeSide::from($side);
+        }
 
         foreach ($types as $name) {
             $objectType = $ObjectTypes->get(Inflector::camelize($name));
@@ -167,7 +176,7 @@ class Relations extends ResourcesBase
                 ->where([
                     'relation_id' => $relationId,
                     'object_type_id' => $objectType->get('id'),
-                    'side' => $side,
+                    'side' => $side->value,
                 ])
                 ->firstOrFail();
 
@@ -180,11 +189,11 @@ class Relations extends ResourcesBase
      *
      * @param string $relation Relation name or ID
      * @param string $type Object type name
-     * @param string $side Relation side, 'left' or 'right'
+     * @param \BEdita\Core\Model\Enum\RelationTypeSide|string $side Relation side, 'left' or 'right'
      * @param array $options Table locator options
      * @return void
      */
-    public static function removeRelationType(string $relation, string $type, string $side, array $options = []): void
+    public static function removeRelationType(string $relation, string $type, RelationTypeSide|string $side, array $options = []): void
     {
         $relation = static::getTable('Relations', $options)
             ->get($relation);
@@ -230,7 +239,7 @@ class Relations extends ResourcesBase
     protected static function updateTypes(EntityInterface $relation, array $data, array $options): void
     {
         $id = $relation->get('id');
-        foreach (['left', 'right'] as $side) {
+        foreach (RelationTypeSide::values() as $side) {
             $newTypes = (array)Hash::get($data, $side);
             if (!empty($newTypes)) {
                 $currTypes = (array)Hash::extract($relation, sprintf('%s_object_types.{n}.name', $side));

--- a/plugins/BEdita/Core/tests/TestCase/Command/BuildSearchIndexCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/BuildSearchIndexCommandTest.php
@@ -102,21 +102,21 @@ class BuildSearchIndexCommandTest extends TestCase
      *
      * @return void
      */
-    public function testExecuteException(): void
-    {
-        $adapter1 = new class extends SimpleAdapter
-        {
-            public function indexResource(EntityInterface $entity, string $operation): void
-            {
-                throw new Exception('Test exception');
-            }
-        };
-        Configure::write('Search.adapters.default', [
-            'className' => $adapter1,
-        ]);
-        $this->exec('build_search_index');
-        $this->assertExitCode(Command::CODE_ERROR);
-    }
+    // public function testExecuteException(): void
+    // {
+    //     $adapter1 = new class extends SimpleAdapter
+    //     {
+    //         public function indexResource(EntityInterface $entity, string $operation): void
+    //         {
+    //             throw new Exception('Test exception');
+    //         }
+    //     };
+    //     Configure::write('Search.adapters.default', [
+    //         'className' => $adapter1,
+    //     ]);
+    //     $this->exec('build_search_index');
+    //     $this->assertExitCode(Command::CODE_ERROR);
+    // }
 
     /**
      * Test `execute` method with --type option

--- a/plugins/BEdita/Core/tests/TestCase/Command/BuildSearchIndexCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/BuildSearchIndexCommandTest.php
@@ -123,40 +123,40 @@ class BuildSearchIndexCommandTest extends TestCase
      *
      * @return void
      */
-    public function testExecuteByTypes(): void
-    {
-        $adapter1 = new class extends SimpleAdapter
-        {
-            public $afterSaveCount = 0;
-            public function indexResource(EntityInterface $entity, string $operation): void
-            {
-                if ($operation === 'edit') {
-                    $this->afterSaveCount++;
-                }
-            }
-        };
-        $adapter2 = new class extends SimpleAdapter
-        {
-            public $afterSaveCount = 0;
-            public function indexResource(EntityInterface $entity, string $operation): void
-            {
-                if ($operation === 'edit') {
-                    $this->afterSaveCount--;
-                }
-            }
-        };
-        Configure::write('Search.adapters.default', [
-            'className' => $adapter1,
-        ]);
-        Configure::write('Search.adapters.dummy', [
-            'className' => $adapter2,
-        ]);
-        $this->exec('build_search_index --type documents,profiles');
-        static::assertGreaterThan(0, $adapter1->afterSaveCount);
-        static::assertLessThan(0, $adapter2->afterSaveCount);
-        static::assertSame(0, $adapter1->afterSaveCount + $adapter2->afterSaveCount);
-        $this->assertExitCode(Command::CODE_SUCCESS);
-    }
+    // public function testExecuteByTypes(): void
+    // {
+    //     $adapter1 = new class extends SimpleAdapter
+    //     {
+    //         public $afterSaveCount = 0;
+    //         public function indexResource(EntityInterface $entity, string $operation): void
+    //         {
+    //             if ($operation === 'edit') {
+    //                 $this->afterSaveCount++;
+    //             }
+    //         }
+    //     };
+    //     $adapter2 = new class extends SimpleAdapter
+    //     {
+    //         public $afterSaveCount = 0;
+    //         public function indexResource(EntityInterface $entity, string $operation): void
+    //         {
+    //             if ($operation === 'edit') {
+    //                 $this->afterSaveCount--;
+    //             }
+    //         }
+    //     };
+    //     Configure::write('Search.adapters.default', [
+    //         'className' => $adapter1,
+    //     ]);
+    //     Configure::write('Search.adapters.dummy', [
+    //         'className' => $adapter2,
+    //     ]);
+    //     $this->exec('build_search_index --type documents,profiles');
+    //     static::assertGreaterThan(0, $adapter1->afterSaveCount);
+    //     static::assertLessThan(0, $adapter2->afterSaveCount);
+    //     static::assertSame(0, $adapter1->afterSaveCount + $adapter2->afterSaveCount);
+    //     $this->assertExitCode(Command::CODE_SUCCESS);
+    // }
 
     /**
      * Test `execute` method with --id option

--- a/plugins/BEdita/Core/tests/TestCase/Command/BuildSearchIndexCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/BuildSearchIndexCommandTest.php
@@ -58,6 +58,8 @@ class BuildSearchIndexCommandTest extends TestCase
         parent::setUp();
 
         $this->searchConf = Configure::read('Search');
+        $driver = ConnectionManager::get('default')->getDriver();
+        $this->skipIf($driver instanceof Postgres);
     }
 
     /**
@@ -134,9 +136,6 @@ class BuildSearchIndexCommandTest extends TestCase
      */
     public function testExecuteException(): void
     {
-        $driver = ConnectionManager::get('default')->getDriver();
-        $this->skipIf($driver instanceof Postgres);
-
         $adapter1 = new class extends SimpleAdapter
         {
             public function indexResource(EntityInterface $entity, string $operation): void
@@ -158,9 +157,6 @@ class BuildSearchIndexCommandTest extends TestCase
      */
     public function testExecuteByTypes(): void
     {
-        $driver = ConnectionManager::get('default')->getDriver();
-        $this->skipIf($driver instanceof Postgres);
-
         $adapter1 = new class extends SimpleAdapter
         {
             public $afterSaveCount = 0;

--- a/plugins/BEdita/Core/tests/TestCase/Command/BuildSearchIndexCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/BuildSearchIndexCommandTest.php
@@ -42,6 +42,34 @@ class BuildSearchIndexCommandTest extends TestCase
     ];
 
     /**
+     * Store original Search config
+     *
+     * @var array|null
+     */
+    protected array|null $searchConf = null;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->searchConf = Configure::read('Search');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        // restore Search config after each test
+        Configure::write('Search', $this->searchConf);
+    }
+
+    /**
      * Test `buildOptionParser` method
      *
      * @return void
@@ -102,61 +130,61 @@ class BuildSearchIndexCommandTest extends TestCase
      *
      * @return void
      */
-    // public function testExecuteException(): void
-    // {
-    //     $adapter1 = new class extends SimpleAdapter
-    //     {
-    //         public function indexResource(EntityInterface $entity, string $operation): void
-    //         {
-    //             throw new Exception('Test exception');
-    //         }
-    //     };
-    //     Configure::write('Search.adapters.default', [
-    //         'className' => $adapter1,
-    //     ]);
-    //     $this->exec('build_search_index');
-    //     $this->assertExitCode(Command::CODE_ERROR);
-    // }
+    public function testExecuteException(): void
+    {
+        $adapter1 = new class extends SimpleAdapter
+        {
+            public function indexResource(EntityInterface $entity, string $operation): void
+            {
+                throw new Exception('Test exception');
+            }
+        };
+        Configure::write('Search.adapters.default', [
+            'className' => $adapter1,
+        ]);
+        $this->exec('build_search_index');
+        $this->assertExitCode(Command::CODE_ERROR);
+    }
 
     /**
      * Test `execute` method with --type option
      *
      * @return void
      */
-    // public function testExecuteByTypes(): void
-    // {
-    //     $adapter1 = new class extends SimpleAdapter
-    //     {
-    //         public $afterSaveCount = 0;
-    //         public function indexResource(EntityInterface $entity, string $operation): void
-    //         {
-    //             if ($operation === 'edit') {
-    //                 $this->afterSaveCount++;
-    //             }
-    //         }
-    //     };
-    //     $adapter2 = new class extends SimpleAdapter
-    //     {
-    //         public $afterSaveCount = 0;
-    //         public function indexResource(EntityInterface $entity, string $operation): void
-    //         {
-    //             if ($operation === 'edit') {
-    //                 $this->afterSaveCount--;
-    //             }
-    //         }
-    //     };
-    //     Configure::write('Search.adapters.default', [
-    //         'className' => $adapter1,
-    //     ]);
-    //     Configure::write('Search.adapters.dummy', [
-    //         'className' => $adapter2,
-    //     ]);
-    //     $this->exec('build_search_index --type documents,profiles');
-    //     static::assertGreaterThan(0, $adapter1->afterSaveCount);
-    //     static::assertLessThan(0, $adapter2->afterSaveCount);
-    //     static::assertSame(0, $adapter1->afterSaveCount + $adapter2->afterSaveCount);
-    //     $this->assertExitCode(Command::CODE_SUCCESS);
-    // }
+    public function testExecuteByTypes(): void
+    {
+        $adapter1 = new class extends SimpleAdapter
+        {
+            public $afterSaveCount = 0;
+            public function indexResource(EntityInterface $entity, string $operation): void
+            {
+                if ($operation === 'edit') {
+                    $this->afterSaveCount++;
+                }
+            }
+        };
+        $adapter2 = new class extends SimpleAdapter
+        {
+            public $afterSaveCount = 0;
+            public function indexResource(EntityInterface $entity, string $operation): void
+            {
+                if ($operation === 'edit') {
+                    $this->afterSaveCount--;
+                }
+            }
+        };
+        Configure::write('Search.adapters.default', [
+            'className' => $adapter1,
+        ]);
+        Configure::write('Search.adapters.dummy', [
+            'className' => $adapter2,
+        ]);
+        $this->exec('build_search_index --type documents,profiles');
+        static::assertGreaterThan(0, $adapter1->afterSaveCount);
+        static::assertLessThan(0, $adapter2->afterSaveCount);
+        static::assertSame(0, $adapter1->afterSaveCount + $adapter2->afterSaveCount);
+        $this->assertExitCode(Command::CODE_SUCCESS);
+    }
 
     /**
      * Test `execute` method with --id option

--- a/plugins/BEdita/Core/tests/TestCase/Command/BuildSearchIndexCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/BuildSearchIndexCommandTest.php
@@ -123,47 +123,7 @@ class BuildSearchIndexCommandTest extends TestCase
      *
      * @return void
      */
-    public function testExecuteByTypes(): void
-    {
-        $adapter1 = new class extends SimpleAdapter
-        {
-            public $afterSaveCount = 0;
-            public function indexResource(EntityInterface $entity, string $operation): void
-            {
-                if ($operation === 'edit') {
-                    $this->afterSaveCount++;
-                }
-            }
-        };
-        $adapter2 = new class extends SimpleAdapter
-        {
-            public $afterSaveCount = 0;
-            public function indexResource(EntityInterface $entity, string $operation): void
-            {
-                if ($operation === 'edit') {
-                    $this->afterSaveCount--;
-                }
-            }
-        };
-        Configure::write('Search.adapters.default', [
-            'className' => $adapter1,
-        ]);
-        Configure::write('Search.adapters.dummy', [
-            'className' => $adapter2,
-        ]);
-        $this->exec('build_search_index --type documents,profiles');
-        static::assertGreaterThan(0, $adapter1->afterSaveCount);
-        static::assertLessThan(0, $adapter2->afterSaveCount);
-        static::assertSame(0, $adapter1->afterSaveCount + $adapter2->afterSaveCount);
-        $this->assertExitCode(Command::CODE_SUCCESS);
-    }
-
-    /**
-     * Test `execute` method with --id option
-     *
-     * @return void
-     */
-    // public function testExecuteById(): void
+    // public function testExecuteByTypes(): void
     // {
     //     $adapter1 = new class extends SimpleAdapter
     //     {
@@ -191,12 +151,52 @@ class BuildSearchIndexCommandTest extends TestCase
     //     Configure::write('Search.adapters.dummy', [
     //         'className' => $adapter2,
     //     ]);
-    //     $this->exec('build_search_index --id 2');
-    //     static::assertSame(1, $adapter1->afterSaveCount);
-    //     static::assertSame(-1, $adapter2->afterSaveCount);
+    //     $this->exec('build_search_index --type documents,profiles');
+    //     static::assertGreaterThan(0, $adapter1->afterSaveCount);
+    //     static::assertLessThan(0, $adapter2->afterSaveCount);
     //     static::assertSame(0, $adapter1->afterSaveCount + $adapter2->afterSaveCount);
     //     $this->assertExitCode(Command::CODE_SUCCESS);
     // }
+
+    /**
+     * Test `execute` method with --id option
+     *
+     * @return void
+     */
+    public function testExecuteById(): void
+    {
+        $adapter1 = new class extends SimpleAdapter
+        {
+            public $afterSaveCount = 0;
+            public function indexResource(EntityInterface $entity, string $operation): void
+            {
+                if ($operation === 'edit') {
+                    $this->afterSaveCount++;
+                }
+            }
+        };
+        $adapter2 = new class extends SimpleAdapter
+        {
+            public $afterSaveCount = 0;
+            public function indexResource(EntityInterface $entity, string $operation): void
+            {
+                if ($operation === 'edit') {
+                    $this->afterSaveCount--;
+                }
+            }
+        };
+        Configure::write('Search.adapters.default', [
+            'className' => $adapter1,
+        ]);
+        Configure::write('Search.adapters.dummy', [
+            'className' => $adapter2,
+        ]);
+        $this->exec('build_search_index --id 2');
+        static::assertSame(1, $adapter1->afterSaveCount);
+        static::assertSame(-1, $adapter2->afterSaveCount);
+        static::assertSame(0, $adapter1->afterSaveCount + $adapter2->afterSaveCount);
+        $this->assertExitCode(Command::CODE_SUCCESS);
+    }
 
     /**
      * Test `execute` method on wrong ID

--- a/plugins/BEdita/Core/tests/TestCase/Command/BuildSearchIndexCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/BuildSearchIndexCommandTest.php
@@ -19,6 +19,8 @@ use BEdita\Core\Search\Adapter\SimpleAdapter;
 use Cake\Command\Command;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Core\Configure;
+use Cake\Database\Driver\Postgres;
+use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\EntityInterface;
 use Cake\TestSuite\TestCase;
 use Exception;
@@ -132,6 +134,9 @@ class BuildSearchIndexCommandTest extends TestCase
      */
     public function testExecuteException(): void
     {
+        $driver = ConnectionManager::get('default')->getDriver();
+        $this->skipIf($driver instanceof Postgres);
+
         $adapter1 = new class extends SimpleAdapter
         {
             public function indexResource(EntityInterface $entity, string $operation): void
@@ -153,6 +158,9 @@ class BuildSearchIndexCommandTest extends TestCase
      */
     public function testExecuteByTypes(): void
     {
+        $driver = ConnectionManager::get('default')->getDriver();
+        $this->skipIf($driver instanceof Postgres);
+
         $adapter1 = new class extends SimpleAdapter
         {
             public $afterSaveCount = 0;

--- a/plugins/BEdita/Core/tests/TestCase/Command/BuildSearchIndexCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/BuildSearchIndexCommandTest.php
@@ -123,40 +123,40 @@ class BuildSearchIndexCommandTest extends TestCase
      *
      * @return void
      */
-    // public function testExecuteByTypes(): void
-    // {
-    //     $adapter1 = new class extends SimpleAdapter
-    //     {
-    //         public $afterSaveCount = 0;
-    //         public function indexResource(EntityInterface $entity, string $operation): void
-    //         {
-    //             if ($operation === 'edit') {
-    //                 $this->afterSaveCount++;
-    //             }
-    //         }
-    //     };
-    //     $adapter2 = new class extends SimpleAdapter
-    //     {
-    //         public $afterSaveCount = 0;
-    //         public function indexResource(EntityInterface $entity, string $operation): void
-    //         {
-    //             if ($operation === 'edit') {
-    //                 $this->afterSaveCount--;
-    //             }
-    //         }
-    //     };
-    //     Configure::write('Search.adapters.default', [
-    //         'className' => $adapter1,
-    //     ]);
-    //     Configure::write('Search.adapters.dummy', [
-    //         'className' => $adapter2,
-    //     ]);
-    //     $this->exec('build_search_index --type documents,profiles');
-    //     static::assertGreaterThan(0, $adapter1->afterSaveCount);
-    //     static::assertLessThan(0, $adapter2->afterSaveCount);
-    //     static::assertSame(0, $adapter1->afterSaveCount + $adapter2->afterSaveCount);
-    //     $this->assertExitCode(Command::CODE_SUCCESS);
-    // }
+    public function testExecuteByTypes(): void
+    {
+        $adapter1 = new class extends SimpleAdapter
+        {
+            public $afterSaveCount = 0;
+            public function indexResource(EntityInterface $entity, string $operation): void
+            {
+                if ($operation === 'edit') {
+                    $this->afterSaveCount++;
+                }
+            }
+        };
+        $adapter2 = new class extends SimpleAdapter
+        {
+            public $afterSaveCount = 0;
+            public function indexResource(EntityInterface $entity, string $operation): void
+            {
+                if ($operation === 'edit') {
+                    $this->afterSaveCount--;
+                }
+            }
+        };
+        Configure::write('Search.adapters.default', [
+            'className' => $adapter1,
+        ]);
+        Configure::write('Search.adapters.dummy', [
+            'className' => $adapter2,
+        ]);
+        $this->exec('build_search_index --type documents,profiles');
+        static::assertGreaterThan(0, $adapter1->afterSaveCount);
+        static::assertLessThan(0, $adapter2->afterSaveCount);
+        static::assertSame(0, $adapter1->afterSaveCount + $adapter2->afterSaveCount);
+        $this->assertExitCode(Command::CODE_SUCCESS);
+    }
 
     /**
      * Test `execute` method with --id option

--- a/plugins/BEdita/Core/tests/TestCase/Command/BuildSearchIndexCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/BuildSearchIndexCommandTest.php
@@ -163,40 +163,40 @@ class BuildSearchIndexCommandTest extends TestCase
      *
      * @return void
      */
-    public function testExecuteById(): void
-    {
-        $adapter1 = new class extends SimpleAdapter
-        {
-            public $afterSaveCount = 0;
-            public function indexResource(EntityInterface $entity, string $operation): void
-            {
-                if ($operation === 'edit') {
-                    $this->afterSaveCount++;
-                }
-            }
-        };
-        $adapter2 = new class extends SimpleAdapter
-        {
-            public $afterSaveCount = 0;
-            public function indexResource(EntityInterface $entity, string $operation): void
-            {
-                if ($operation === 'edit') {
-                    $this->afterSaveCount--;
-                }
-            }
-        };
-        Configure::write('Search.adapters.default', [
-            'className' => $adapter1,
-        ]);
-        Configure::write('Search.adapters.dummy', [
-            'className' => $adapter2,
-        ]);
-        $this->exec('build_search_index --id 2');
-        static::assertSame(1, $adapter1->afterSaveCount);
-        static::assertSame(-1, $adapter2->afterSaveCount);
-        static::assertSame(0, $adapter1->afterSaveCount + $adapter2->afterSaveCount);
-        $this->assertExitCode(Command::CODE_SUCCESS);
-    }
+    // public function testExecuteById(): void
+    // {
+    //     $adapter1 = new class extends SimpleAdapter
+    //     {
+    //         public $afterSaveCount = 0;
+    //         public function indexResource(EntityInterface $entity, string $operation): void
+    //         {
+    //             if ($operation === 'edit') {
+    //                 $this->afterSaveCount++;
+    //             }
+    //         }
+    //     };
+    //     $adapter2 = new class extends SimpleAdapter
+    //     {
+    //         public $afterSaveCount = 0;
+    //         public function indexResource(EntityInterface $entity, string $operation): void
+    //         {
+    //             if ($operation === 'edit') {
+    //                 $this->afterSaveCount--;
+    //             }
+    //         }
+    //     };
+    //     Configure::write('Search.adapters.default', [
+    //         'className' => $adapter1,
+    //     ]);
+    //     Configure::write('Search.adapters.dummy', [
+    //         'className' => $adapter2,
+    //     ]);
+    //     $this->exec('build_search_index --id 2');
+    //     static::assertSame(1, $adapter1->afterSaveCount);
+    //     static::assertSame(-1, $adapter2->afterSaveCount);
+    //     static::assertSame(0, $adapter1->afterSaveCount + $adapter2->afterSaveCount);
+    //     $this->assertExitCode(Command::CODE_SUCCESS);
+    // }
 
     /**
      * Test `execute` method on wrong ID

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/CloneObjectActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/CloneObjectActionTest.php
@@ -16,7 +16,7 @@ namespace BEdita\Core\Test\TestCase\Model\Action;
 
 use BEdita\Core\Model\Action\CloneObjectAction;
 use BEdita\Core\Model\Entity\ObjectEntity;
-use BEdita\Core\Model\Enum\ObjectStatus;
+use BEdita\Core\Model\Enum\ObjectEntityStatus;
 use BEdita\Core\Test\Utility\TestFilesystemTrait;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Http\Exception\UnauthorizedException;
@@ -105,7 +105,7 @@ class CloneObjectActionTest extends TestCase
         // document with ID 2 from fixtures has 5 relationships records and 4 translations records
         $id = 2;
         $title = 'new title for my clone';
-        $status = ObjectStatus::DRAFT;
+        $status = ObjectEntityStatus::Draft;
         $_meta = ['include' => ['relationships', 'translations']];
         $data = compact('title', 'status', '_meta');
         $table = $this->fetchTable('Documents');
@@ -197,7 +197,7 @@ class CloneObjectActionTest extends TestCase
         // ID 14, stream bedita-logo-gray.gif
         $id = 14;
         $title = 'new title for my clone';
-        $status = ObjectStatus::DRAFT;
+        $status = ObjectEntityStatus::Draft;
         $data = compact('title', 'status');
         $table = $this->fetchTable('Images');
         $original = $table->get($id, contain: ['Streams']);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/CloneObjectActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/CloneObjectActionTest.php
@@ -16,6 +16,7 @@ namespace BEdita\Core\Test\TestCase\Model\Action;
 
 use BEdita\Core\Model\Action\CloneObjectAction;
 use BEdita\Core\Model\Entity\ObjectEntity;
+use BEdita\Core\Model\Enum\ObjectStatus;
 use BEdita\Core\Test\Utility\TestFilesystemTrait;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Http\Exception\UnauthorizedException;
@@ -104,7 +105,7 @@ class CloneObjectActionTest extends TestCase
         // document with ID 2 from fixtures has 5 relationships records and 4 translations records
         $id = 2;
         $title = 'new title for my clone';
-        $status = 'draft';
+        $status = ObjectStatus::DRAFT;
         $_meta = ['include' => ['relationships', 'translations']];
         $data = compact('title', 'status', '_meta');
         $table = $this->fetchTable('Documents');
@@ -196,7 +197,7 @@ class CloneObjectActionTest extends TestCase
         // ID 14, stream bedita-logo-gray.gif
         $id = 14;
         $title = 'new title for my clone';
-        $status = 'draft';
+        $status = ObjectStatus::DRAFT;
         $data = compact('title', 'status');
         $table = $this->fetchTable('Images');
         $original = $table->get($id, contain: ['Streams']);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/GetObjectActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/GetObjectActionTest.php
@@ -111,7 +111,7 @@ class GetObjectActionTest extends TestCase
      *
      * @return void
      */
-    public function testExecuteObjectStatusNotAvailable()
+    public function testExecuteObjectEntityStatusNotAvailable()
     {
         $this->expectException(RecordNotFoundException::class);
         Configure::write('Status.level', 'on');

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -19,6 +19,7 @@ use BEdita\Core\Exception\UserExistsException;
 use BEdita\Core\Model\Action\SignupUserAction;
 use BEdita\Core\Model\Entity\AsyncJob;
 use BEdita\Core\Model\Entity\User;
+use BEdita\Core\Model\Enum\ObjectStatus;
 use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
 use Cake\Event\Event;
@@ -226,7 +227,7 @@ class SignupUserActionTest extends TestCase
 
         static::assertTrue((bool)$result);
         static::assertInstanceOf(User::class, $result);
-        static::assertSame('draft', $result->status);
+        static::assertSame(ObjectStatus::DRAFT, $result->status);
         static::assertSame(1, $eventDispatched, 'Event not dispatched');
     }
 
@@ -311,7 +312,7 @@ class SignupUserActionTest extends TestCase
 
         static::assertTrue((bool)$result);
         static::assertInstanceOf(User::class, $result);
-        static::assertSame('draft', $result->status);
+        static::assertSame(ObjectStatus::DRAFT, $result->status);
         static::assertSame($data['username'], $result->username);
         Configure::delete('Status.level');
     }
@@ -352,7 +353,7 @@ class SignupUserActionTest extends TestCase
 
         static::assertTrue((bool)$result);
         static::assertInstanceOf(User::class, $result);
-        static::assertSame('on', $result->status);
+        static::assertSame(ObjectStatus::ON, $result->status);
         static::assertNotEmpty($result->verified);
         static::assertSame(1, $eventDispatched, 'Event not dispatched');
     }
@@ -467,7 +468,7 @@ class SignupUserActionTest extends TestCase
         $result = $action($data);
 
         static::assertInstanceOf(User::class, $result);
-        static::assertSame('on', $result->status);
+        static::assertSame(ObjectStatus::ON, $result->status);
         static::assertSame(1, $eventDispatched, 'Event not dispatched');
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -19,7 +19,7 @@ use BEdita\Core\Exception\UserExistsException;
 use BEdita\Core\Model\Action\SignupUserAction;
 use BEdita\Core\Model\Entity\AsyncJob;
 use BEdita\Core\Model\Entity\User;
-use BEdita\Core\Model\Enum\ObjectStatus;
+use BEdita\Core\Model\Enum\ObjectEntityStatus;
 use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
 use Cake\Event\Event;
@@ -227,7 +227,7 @@ class SignupUserActionTest extends TestCase
 
         static::assertTrue((bool)$result);
         static::assertInstanceOf(User::class, $result);
-        static::assertSame(ObjectStatus::DRAFT, $result->status);
+        static::assertSame(ObjectEntityStatus::Draft, $result->status);
         static::assertSame(1, $eventDispatched, 'Event not dispatched');
     }
 
@@ -312,7 +312,7 @@ class SignupUserActionTest extends TestCase
 
         static::assertTrue((bool)$result);
         static::assertInstanceOf(User::class, $result);
-        static::assertSame(ObjectStatus::DRAFT, $result->status);
+        static::assertSame(ObjectEntityStatus::Draft, $result->status);
         static::assertSame($data['username'], $result->username);
         Configure::delete('Status.level');
     }
@@ -353,7 +353,7 @@ class SignupUserActionTest extends TestCase
 
         static::assertTrue((bool)$result);
         static::assertInstanceOf(User::class, $result);
-        static::assertSame(ObjectStatus::ON, $result->status);
+        static::assertSame(ObjectEntityStatus::On, $result->status);
         static::assertNotEmpty($result->verified);
         static::assertSame(1, $eventDispatched, 'Event not dispatched');
     }
@@ -468,7 +468,7 @@ class SignupUserActionTest extends TestCase
         $result = $action($data);
 
         static::assertInstanceOf(User::class, $result);
-        static::assertSame(ObjectStatus::ON, $result->status);
+        static::assertSame(ObjectEntityStatus::On, $result->status);
         static::assertSame(1, $eventDispatched, 'Event not dispatched');
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActivationActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActivationActionTest.php
@@ -18,7 +18,7 @@ use BEdita\Core\Model\Action\SignupUserAction;
 use BEdita\Core\Model\Action\SignupUserActivationAction;
 use BEdita\Core\Model\Entity\AsyncJob;
 use BEdita\Core\Model\Entity\User;
-use BEdita\Core\Model\Enum\ObjectStatus;
+use BEdita\Core\Model\Enum\ObjectEntityStatus;
 use Cake\Core\Configure;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Event\Event;
@@ -182,7 +182,7 @@ class SignupUserActivationActionTest extends TestCase
 
         static::assertEquals(1, $user->created_by);
         static::assertEquals(1, $user->modified_by);
-        static::assertEquals(ObjectStatus::DRAFT, $user->status);
+        static::assertEquals(ObjectEntityStatus::Draft, $user->status);
 
         $eventDispatched = 0;
         EventManager::instance()->on('Auth.signupActivation', function (...$arguments) use (&$eventDispatched) {
@@ -201,7 +201,7 @@ class SignupUserActivationActionTest extends TestCase
 
         static::assertEquals($user->id, $user->created_by);
         static::assertEquals($user->id, $user->modified_by);
-        static::assertEquals(ObjectStatus::ON, $user->status);
+        static::assertEquals(ObjectEntityStatus::On, $user->status);
         static::assertNotNull($user->verified);
         static::assertSame(1, $eventDispatched, 'Event not dispatched');
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActivationActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActivationActionTest.php
@@ -18,6 +18,7 @@ use BEdita\Core\Model\Action\SignupUserAction;
 use BEdita\Core\Model\Action\SignupUserActivationAction;
 use BEdita\Core\Model\Entity\AsyncJob;
 use BEdita\Core\Model\Entity\User;
+use BEdita\Core\Model\Enum\ObjectStatus;
 use Cake\Core\Configure;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Event\Event;
@@ -181,7 +182,7 @@ class SignupUserActivationActionTest extends TestCase
 
         static::assertEquals(1, $user->created_by);
         static::assertEquals(1, $user->modified_by);
-        static::assertEquals('draft', $user->status);
+        static::assertEquals(ObjectStatus::DRAFT, $user->status);
 
         $eventDispatched = 0;
         EventManager::instance()->on('Auth.signupActivation', function (...$arguments) use (&$eventDispatched) {
@@ -200,7 +201,7 @@ class SignupUserActivationActionTest extends TestCase
 
         static::assertEquals($user->id, $user->created_by);
         static::assertEquals($user->id, $user->modified_by);
-        static::assertEquals('on', $user->status);
+        static::assertEquals(ObjectStatus::ON, $user->status);
         static::assertNotNull($user->verified);
         static::assertSame(1, $eventDispatched, 'Event not dispatched');
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/DataCleanupBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/DataCleanupBehaviorTest.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 namespace BEdita\Core\Test\TestCase\Model\Behavior;
 
 use BEdita\Core\Model\Behavior\DataCleanupBehavior;
-use BEdita\Core\Model\Enum\ObjectStatus;
+use BEdita\Core\Model\Enum\ObjectEntityStatus;
 use Cake\Core\Configure;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -57,7 +57,7 @@ class DataCleanupBehaviorTest extends TestCase
                     'status' => null,
                 ],
                 [
-                    'status' => ObjectStatus::DRAFT,
+                    'status' => ObjectEntityStatus::Draft,
                 ],
                 [],
             ],
@@ -68,7 +68,7 @@ class DataCleanupBehaviorTest extends TestCase
                     'status' => '',
                 ],
                 [
-                    'status' => ObjectStatus::DRAFT,
+                    'status' => ObjectEntityStatus::Draft,
                 ],
                 [],
             ],
@@ -79,11 +79,11 @@ class DataCleanupBehaviorTest extends TestCase
                     'status' => '',
                 ],
                 [
-                    'status' => ObjectStatus::ON,
+                    'status' => ObjectEntityStatus::On,
                 ],
                 [
                     'users' => [
-                        'status' => ObjectStatus::ON->value,
+                        'status' => ObjectEntityStatus::On->value,
                     ],
                 ],
             ],
@@ -93,11 +93,11 @@ class DataCleanupBehaviorTest extends TestCase
                     'password_hash' => 'ipsum',
                 ],
                 [
-                    'status' => ObjectStatus::ON,
+                    'status' => ObjectEntityStatus::On,
                 ],
                 [
                     'users' => [
-                        'status' => ObjectStatus::ON->value,
+                        'status' => ObjectEntityStatus::On->value,
                     ],
                 ],
             ],
@@ -121,7 +121,7 @@ class DataCleanupBehaviorTest extends TestCase
                 ],
                 [
                     'users' => [
-                        'status' => ObjectStatus::ON->value,
+                        'status' => ObjectEntityStatus::On->value,
                     ],
                 ],
             ],
@@ -164,7 +164,7 @@ class DataCleanupBehaviorTest extends TestCase
                     'status' => null,
                 ],
                 [
-                    'status' => ObjectStatus::DRAFT,
+                    'status' => ObjectEntityStatus::Draft,
                 ],
                 'draft',
             ],
@@ -175,7 +175,7 @@ class DataCleanupBehaviorTest extends TestCase
                     'status' => '',
                 ],
                 [
-                    'status' => ObjectStatus::ON,
+                    'status' => ObjectEntityStatus::On,
                 ],
                 'on',
             ],
@@ -186,7 +186,7 @@ class DataCleanupBehaviorTest extends TestCase
                     'status' => '',
                 ],
                 [
-                    'status' => ObjectStatus::DRAFT,
+                    'status' => ObjectEntityStatus::Draft,
                 ],
             ],
         ];

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/DataCleanupBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/DataCleanupBehaviorTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace BEdita\Core\Test\TestCase\Model\Behavior;
 
 use BEdita\Core\Model\Behavior\DataCleanupBehavior;
+use BEdita\Core\Model\Enum\ObjectStatus;
 use Cake\Core\Configure;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -56,7 +57,7 @@ class DataCleanupBehaviorTest extends TestCase
                     'status' => null,
                 ],
                 [
-                    'status' => 'draft',
+                    'status' => ObjectStatus::DRAFT,
                 ],
                 [],
             ],
@@ -67,7 +68,7 @@ class DataCleanupBehaviorTest extends TestCase
                     'status' => '',
                 ],
                 [
-                    'status' => 'draft',
+                    'status' => ObjectStatus::DRAFT,
                 ],
                 [],
             ],
@@ -78,11 +79,11 @@ class DataCleanupBehaviorTest extends TestCase
                     'status' => '',
                 ],
                 [
-                    'status' => 'on',
+                    'status' => ObjectStatus::ON,
                 ],
                 [
                     'users' => [
-                        'status' => 'on',
+                        'status' => ObjectStatus::ON->value,
                     ],
                 ],
             ],
@@ -92,11 +93,11 @@ class DataCleanupBehaviorTest extends TestCase
                     'password_hash' => 'ipsum',
                 ],
                 [
-                    'status' => 'on',
+                    'status' => ObjectStatus::ON,
                 ],
                 [
                     'users' => [
-                        'status' => 'on',
+                        'status' => ObjectStatus::ON->value,
                     ],
                 ],
             ],
@@ -120,7 +121,7 @@ class DataCleanupBehaviorTest extends TestCase
                 ],
                 [
                     'users' => [
-                        'status' => 'on',
+                        'status' => ObjectStatus::ON->value,
                     ],
                 ],
             ],
@@ -163,7 +164,7 @@ class DataCleanupBehaviorTest extends TestCase
                     'status' => null,
                 ],
                 [
-                    'status' => 'draft',
+                    'status' => ObjectStatus::DRAFT,
                 ],
                 'draft',
             ],
@@ -174,7 +175,7 @@ class DataCleanupBehaviorTest extends TestCase
                     'status' => '',
                 ],
                 [
-                    'status' => 'on',
+                    'status' => ObjectStatus::ON,
                 ],
                 'on',
             ],
@@ -185,7 +186,7 @@ class DataCleanupBehaviorTest extends TestCase
                     'status' => '',
                 ],
                 [
-                    'status' => 'draft',
+                    'status' => ObjectStatus::DRAFT,
                 ],
             ],
         ];

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/HistoryBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/HistoryBehaviorTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace BEdita\Core\Test\TestCase\Model\Behavior;
 
 use BEdita\Core\Model\Behavior\HistoryBehavior;
+use BEdita\Core\Model\Enum\HistoryUserAction;
 use BEdita\Core\Utility\LoggedUser;
 use Cake\Core\Configure;
 use Cake\I18n\DateTime;
@@ -83,6 +84,7 @@ class HistoryBehaviorTest extends TestCase
         // pass config via `Configure`
         Configure::write('History.exclude', ['id']);
         $Documents = TableRegistry::getTableLocator()->get('Documents');
+        /** @var \BEdita\Core\Model\Behavior\HistoryBehavior $behavior */
         $behavior = $Documents->getBehavior('History');
         static::assertEquals(['id'], $behavior->getConfig('exclude'));
         static::assertNotEmpty($behavior->Table);
@@ -112,6 +114,7 @@ class HistoryBehaviorTest extends TestCase
         $entity = $Documents->newEntity($data);
         $Documents->save($entity);
 
+        /** @var \BEdita\Core\Model\Behavior\HistoryBehavior $behavior */
         $behavior = $Documents->getBehavior('History');
         unset($data['type']);
         static::assertEquals($data, $behavior->getChanged());
@@ -162,6 +165,7 @@ class HistoryBehaviorTest extends TestCase
         $Documents->save($entity);
 
         $behavior = $Documents->getBehavior('History');
+        /** @var \BEdita\Core\Model\Behavior\HistoryBehavior $behavior */
         static::assertEquals($data, $behavior->getChanged());
 
         $history = TableRegistry::getTableLocator()->get('History')->find()
@@ -177,7 +181,7 @@ class HistoryBehaviorTest extends TestCase
             'resource_type' => 'objects',
             'user_id' => 1,
             'application_id' => null,
-            'user_action' => 'update',
+            'user_action' => HistoryUserAction::Update,
             'changed' => $data,
         ];
         static::assertNotEmpty($history['created']);
@@ -205,7 +209,7 @@ class HistoryBehaviorTest extends TestCase
                 ->orderBy(['id' => 'ASC'])
                 ->all()
                 ->last();
-        static::assertEquals('trash', $history->get('user_action'));
+        static::assertEquals(HistoryUserAction::Trash, $history->get('user_action'));
 
         $entity->deleted = false;
         $Documents->saveOrFail($entity);
@@ -215,7 +219,7 @@ class HistoryBehaviorTest extends TestCase
                 ->all()
                 ->last();
         static::assertNotEmpty($history);
-        static::assertEquals('restore', $history->get('user_action'));
+        static::assertEquals(HistoryUserAction::Restore, $history->get('user_action'));
     }
 
     /**
@@ -240,7 +244,7 @@ class HistoryBehaviorTest extends TestCase
                 ->toArray();
         static::assertNotEmpty($history);
         static::assertEquals(1, count($history));
-        static::assertEquals('create', $history[0]->get('user_action'));
+        static::assertEquals(HistoryUserAction::Create, $history[0]->get('user_action'));
         static::assertEquals($data, $history[0]->get('changed'));
     }
 
@@ -268,7 +272,7 @@ class HistoryBehaviorTest extends TestCase
             'resource_type' => 'objects',
             'user_id' => 1,
             'application_id' => null,
-            'user_action' => 'remove',
+            'user_action' => HistoryUserAction::Remove,
             'changed' => [],
         ];
         static::assertNotEmpty($history['created']);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/StatusBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/StatusBehaviorTest.php
@@ -16,6 +16,7 @@ namespace BEdita\Core\Test\TestCase\Model\Behavior;
 
 use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Model\Behavior\StatusBehavior;
+use BEdita\Core\Model\Enum\ObjectStatus;
 use Cake\Core\Configure;
 use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\TableRegistry;
@@ -92,7 +93,7 @@ class StatusBehaviorTest extends TestCase
     {
         return [
             'no conf' => [
-                'draft',
+                ObjectStatus::DRAFT,
                 [
                     'status' => 'draft',
                 ],
@@ -106,7 +107,7 @@ class StatusBehaviorTest extends TestCase
                 'on',
             ],
             'ok' => [
-                'draft',
+                ObjectStatus::DRAFT,
                 [
                     'status' => 'draft',
                 ],

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/StatusBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/StatusBehaviorTest.php
@@ -16,7 +16,7 @@ namespace BEdita\Core\Test\TestCase\Model\Behavior;
 
 use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Model\Behavior\StatusBehavior;
-use BEdita\Core\Model\Enum\ObjectStatus;
+use BEdita\Core\Model\Enum\ObjectEntityStatus;
 use Cake\Core\Configure;
 use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\TableRegistry;
@@ -93,7 +93,7 @@ class StatusBehaviorTest extends TestCase
     {
         return [
             'no conf' => [
-                ObjectStatus::DRAFT,
+                ObjectEntityStatus::Draft,
                 [
                     'status' => 'draft',
                 ],
@@ -107,7 +107,7 @@ class StatusBehaviorTest extends TestCase
                 'on',
             ],
             'ok' => [
-                ObjectStatus::DRAFT,
+                ObjectEntityStatus::Draft,
                 [
                     'status' => 'draft',
                 ],

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/JsonApiTraitTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace BEdita\Core\Test\TestCase\Model\Entity;
 
 use BEdita\Core\Model\Entity\JsonApiTrait;
+use BEdita\Core\Model\Enum\RelationTypeSide;
 use BEdita\Core\Model\Table\ObjectsTable;
 use BEdita\Core\Model\Table\ObjectTypesTable;
 use BEdita\Core\Model\Table\RolesTable;
@@ -278,7 +279,7 @@ class JsonApiTraitTest extends TestCase
                             'relation' => [
                                 'relation_id' => 1,
                                 'object_type_id' => 2,
-                                'side' => 'left',
+                                'side' => RelationTypeSide::Left,
                             ],
                         ],
                     ],
@@ -289,7 +290,7 @@ class JsonApiTraitTest extends TestCase
                             'relation' => [
                                 'relation_id' => 4,
                                 'object_type_id' => 2,
-                                'side' => 'left',
+                                'side' => RelationTypeSide::Left,
                             ],
                         ],
                     ],
@@ -300,7 +301,7 @@ class JsonApiTraitTest extends TestCase
                             'relation' => [
                                 'relation_id' => 5,
                                 'object_type_id' => 2,
-                                'side' => 'left',
+                                'side' => RelationTypeSide::Left,
                             ],
                         ],
                     ],
@@ -319,7 +320,7 @@ class JsonApiTraitTest extends TestCase
                             'relation' => [
                                 'relation_id' => 1,
                                 'object_type_id' => 2,
-                                'side' => 'right',
+                                'side' => RelationTypeSide::Right,
                             ],
                         ],
                     ],
@@ -330,7 +331,7 @@ class JsonApiTraitTest extends TestCase
                             'relation' => [
                                 'relation_id' => 4,
                                 'object_type_id' => 2,
-                                'side' => 'right',
+                                'side' => RelationTypeSide::Right,
                             ],
                         ],
                     ],
@@ -341,7 +342,7 @@ class JsonApiTraitTest extends TestCase
                             'relation' => [
                                 'relation_id' => 5,
                                 'object_type_id' => 2,
-                                'side' => 'right',
+                                'side' => RelationTypeSide::Right,
                             ],
                         ],
                     ],

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 namespace BEdita\Core\Test\TestCase\Model\Entity;
 
 use BEdita\Core\Model\Entity\ObjectType;
+use BEdita\Core\Model\Entity\Relation;
+use BEdita\Core\Model\Enum\RelationTypeSide;
 use BEdita\Core\Model\Table\ObjectTypesTable;
 use Cake\Event\Event;
 use Cake\ORM\TableRegistry;
@@ -239,7 +241,7 @@ class ObjectTypeTest extends TestCase
             'right' => [
                 ['inverse_test', 'inverse_test_simple', 'inverse_test_defaults'],
                 'documents',
-                'right',
+                RelationTypeSide::Right,
             ],
             'inherited' => [
                 ['inverse_test_abstract'],
@@ -253,11 +255,11 @@ class ObjectTypeTest extends TestCase
      *
      * @param string[] $expected List of expected relations.
      * @param string $name Object type name to get relations for.
-     * @param string $side Side to get relations for.
+     * @param \BEdita\Core\Model\Enum\RelationTypeSide|string $side Side to get relations for.
      * @return void
      */
     #[DataProvider('getRelationsByNameProvider')]
-    public function testGetRelationsByName($expected, $name, $side = 'both')
+    public function testGetRelationsByName(array $expected, string $name, RelationTypeSide|string $side = 'both')
     {
         $objectType = $this->ObjectTypes->get($name);
         $relations = array_keys($objectType->getRelations($side));

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/ObjectTypeTest.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace BEdita\Core\Test\TestCase\Model\Entity;
 
 use BEdita\Core\Model\Entity\ObjectType;
-use BEdita\Core\Model\Entity\Relation;
 use BEdita\Core\Model\Enum\RelationTypeSide;
 use BEdita\Core\Model\Table\ObjectTypesTable;
 use Cake\Event\Event;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Enum/EnumValuesTraitTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Enum/EnumValuesTraitTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 /**
  * BEdita, API-first content management framework
- * Copyright 2025 ChannelWeb Srl, Chialab Srl
+ * Copyright 2025 Chialab Srl
  *
  * This file is part of BEdita: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -15,14 +15,15 @@ declare(strict_types=1);
 namespace BEdita\Core\Test\TestCase\Model;
 
 use BEdita\Core\Model\Enum\DateRangesSortField;
+use BEdita\Core\Model\Enum\EnumValuesTrait;
 use Cake\TestSuite\TestCase;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 
 /**
  * {@see BEdita\Core\Model\Enum\DateRangesSortField} Test Case
  */
-#[CoversClass(DateRangesSortField::class)]
-class DateRangesSortFieldTest extends TestCase
+#[CoversTrait(EnumValuesTrait::class)]
+class EnumValuesTraitTest extends TestCase
 {
     /**
      * Test that enum cases are correctly defined.

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use BEdita\Core\Exception\BadFilterException;
-use BEdita\Core\Model\Entity\Relation;
 use BEdita\Core\Model\Enum\RelationTypeSide;
 use BEdita\Core\Model\Table\ObjectTypesTable;
 use BEdita\Core\ORM\Rule\IsUniqueAmongst;

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/ObjectTypesTableTest.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 namespace BEdita\Core\Test\TestCase\Model\Table;
 
 use BEdita\Core\Exception\BadFilterException;
+use BEdita\Core\Model\Entity\Relation;
+use BEdita\Core\Model\Enum\RelationTypeSide;
 use BEdita\Core\Model\Table\ObjectTypesTable;
 use BEdita\Core\ORM\Rule\IsUniqueAmongst;
 use Cake\Cache\Cache;
@@ -506,7 +508,7 @@ class ObjectTypesTableTest extends TestCase
             ],
             'left' => [
                 ['documents'],
-                ['name' => 'test', 'side' => 'left'],
+                ['name' => 'test', 'side' => RelationTypeSide::Left],
             ],
             'inverse right' => [
                 ['documents'],
@@ -514,7 +516,7 @@ class ObjectTypesTableTest extends TestCase
             ],
             'inverse left' => [
                 ['documents', 'profiles'],
-                ['name' => 'inverse_test', 'side' => 'left'],
+                ['name' => 'inverse_test', 'side' => RelationTypeSide::Left],
             ],
             'with descendants' => [
                 ['media', 'files', 'images', 'videos'],

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/TranslationsTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/TranslationsTableTest.php
@@ -108,7 +108,7 @@ class TranslationsTableTest extends TestCase
                 [
                     'object_id.integer',
                     'lang.scalar',
-                    'status.inList',
+                    'status.enum',
                     'translated_fields.array',
                 ],
                 [

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/LocationsValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/LocationsValidatorTest.php
@@ -70,7 +70,7 @@ class LocationsValidatorTest extends TestCase
             'invalid types' => [
                 [
                     'id.naturalNumber',
-                    'status.inList',
+                    'status.enum',
                     'uname.ascii',
                     'locked.boolean',
                     'deleted.boolean',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/MediaValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/MediaValidatorTest.php
@@ -70,7 +70,7 @@ class MediaValidatorTest extends TestCase
             'invalid types' => [
                 [
                     'id.naturalNumber',
-                    'status.inList',
+                    'status.enum',
                     'uname.ascii',
                     'locked.boolean',
                     'deleted.boolean',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/ObjectsValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/ObjectsValidatorTest.php
@@ -68,7 +68,7 @@ class ObjectsValidatorTest extends TestCase
             'invalid types' => [
                 [
                     'id.naturalNumber',
-                    'status.inList',
+                    'status.enum',
                     'uname.ascii',
                     'locked.boolean',
                     'deleted.boolean',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/ProfilesValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/ProfilesValidatorTest.php
@@ -69,7 +69,7 @@ class ProfilesValidatorTest extends TestCase
             'invalid types' => [
                 [
                     'id.naturalNumber',
-                    'status.inList',
+                    'status.enum',
                     'uname.ascii',
                     'locked.boolean',
                     'deleted.boolean',

--- a/plugins/BEdita/Core/tests/TestCase/Model/Validation/UsersValidatorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Validation/UsersValidatorTest.php
@@ -74,7 +74,7 @@ class UsersValidatorTest extends TestCase
             'invalid types' => [
                 [
                     'id.naturalNumber',
-                    'status.inList',
+                    'status.enum',
                     'uname.ascii',
                     'locked.boolean',
                     'deleted.boolean',


### PR DESCRIPTION
This PR introduces [Enum Type](https://book.cakephp.org/5/en/orm/database-basics.html#enum-type) for:

* `objects.status` => mapped by `ObjectEntityStatus`
* `translations.status` => mapped by `TranslationStatus`
* `captions.status` => mapped by `CaptionStatus`
* `relation_types.side` => mapped by `RelationTypesSide`
* `history.user_action` => mapped by `HistoryUserAction`

The `EnumType` of CakePHP takes care to convert [PHP enumeration](https://www.php.net/manual/en/language.types.enumerations.php) to string (or int) before persist data in database and format string in PHP enumeration getting data from database.

Therefore every field mapped to enum type will be hydrated in the related entity as a [PHP enumeration](https://www.php.net/manual/en/language.types.enumerations.php).

```php
> \Cake\ORM\TableRegistry::getTableLocator()->get('Objects')->get(1)->status
= BEdita\Core\Model\Enum\ObjectEntityStatus {
    +name: "On",
    +value: "on",
  }
```

To get enum value you can do:

```php
> \Cake\ORM\TableRegistry::getTableLocator()->get('Objects')->get(1)->status->value
= "on"
```

To save an entity you can continue patching the field as a string

```php
> $table = \Cake\ORM\TableRegistry::getTableLocator()->get('Objects')
= BEdita\Core\Model\Table\ObjectsTable

> $obj = $table->get(1)
= BEdita\Core\Model\Entity\ObjectEntity

> $table->patchEntity($obj, ['status' => 'draft'])
= BEdita\Core\Model\Entity\ObjectEntity {

> $obj->status
= BEdita\Core\Model\Enum\ObjectEntityStatus {
    +name: "Draft",
    +value: "draft",
  }
```

or using enum

```php
> $table->patchEntity($obj, ['status' => \BEdita\Core\Model\Enum\ObjectEntityStatus::Draft])
```