### PR TITLE
Enable operators on custom properties filters

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,8 +104,10 @@ jobs:
         db:
           - '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
           - '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-          - '{"vendor": "MariaDB", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mariadb", "image": "mariadb:10", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
-          - '{"vendor": "PostgreSQL", "pdo": "pgsql", "dsn": "postgres://bedita:bedita@127.0.0.1:5432/bedita", "image": "postgres:14", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "MySQL 8.4", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.4", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "MariaDB 10", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mariadb", "image": "mariadb:10", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "PostgreSQL 16", "pdo": "pgsql", "dsn": "postgres://bedita:bedita@127.0.0.1:5432/bedita", "image": "postgres:16", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - '{"vendor": "PostgreSQL 18", "pdo": "pgsql", "dsn": "postgres://bedita:bedita@127.0.0.1:5432/bedita", "image": "postgres:18", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
         include:
           - php: '8.4'
             db: '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'

--- a/plugins/BEdita/API/tests/IntegrationTest/CustomPropertiesFilterTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/CustomPropertiesFilterTest.php
@@ -100,7 +100,7 @@ class CustomPropertiesFilterTest extends IntegrationTestCase
                 ['5'],
                 '/users?filter[another_username]=synapse,batman',
             ],
-            'string witj operator' => [
+            'string with operator' => [
                 ['5'],
                 '/users?filter[another_username][eq]=synapse',
             ],

--- a/plugins/BEdita/API/tests/IntegrationTest/CustomPropertiesFilterTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/CustomPropertiesFilterTest.php
@@ -84,9 +84,25 @@ class CustomPropertiesFilterTest extends IntegrationTestCase
                 ['14', '16'],
                 '/files?filter[media_property]=0',
             ],
+            'integer' => [
+                ['4'],
+                '/profiles?filter[number_of_friends]=42',
+            ],
+            'integer with operator' => [
+                ['4'],
+                '/profiles?filter[number_of_friends][gt]=10',
+            ],
             'string' => [
                 ['5'],
                 '/users?filter[another_username]=synapse',
+            ],
+            'string with multiple values' => [
+                ['5'],
+                '/users?filter[another_username]=synapse,batman',
+            ],
+            'string witj operator' => [
+                ['5'],
+                '/users?filter[another_username][eq]=synapse',
             ],
             'string no results' => [
                 [],
@@ -105,6 +121,7 @@ class CustomPropertiesFilterTest extends IntegrationTestCase
     #[DataProvider('filterProvider')]
     public function testFilter(array $expected, $url): void
     {
+        $this->prepareCustomProps($url);
         $this->configRequestHeaders();
         $this->get($url);
 
@@ -115,6 +132,27 @@ class CustomPropertiesFilterTest extends IntegrationTestCase
         sort($expected);
         sort($ids);
         static::assertEquals($expected, $ids);
+    }
+
+    /**
+     * Prepare custom properties for testing.
+     *
+     * @param string $url Url.
+     * @return void
+     */
+    protected function prepareCustomProps(string $url): void
+    {
+        $tableName = ucfirst(substr($url, 1, strpos($url, '?') - 1));
+        $table = $this->getTableLocator()->get($tableName);
+        $entity = null;
+        if ($tableName === 'Profiles') {
+            $entity = $table->get(4);
+            $entity->set('number_of_friends', 42);
+        }
+        if (empty($entity)) {
+            return;
+        }
+        $table->saveOrFail($entity);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -361,8 +361,8 @@ class CustomPropertiesBehavior extends Behavior
      *
      * ```
      * [
-     *     <expressionProperty1> => [<operator> => <expressionValue>],
-     *     <expressionProperty2> => [<operator> => <expressionValue>],
+     *     <expressionProperty1> => [<operator1> => <expressionValue1>],
+     *     <expressionProperty2> => [<operator2> => <expressionValue2>],
      * ]
      * ...
      *

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -429,7 +429,7 @@ class CustomPropertiesBehavior extends Behavior
      * @param object $driver Database driver.
      * @return mixed
      */
-    protected function expressionField(string $field, string $key, object $driver): mixed
+    protected function expressionField(string $field, string $key, object $driver): FunctionExpression|string
     {
         if ($driver instanceof Mysql) {
             return new FunctionExpression(

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -340,17 +340,18 @@ class CustomPropertiesBehavior extends Behavior
             throw new BadFilterException(__d('bedita', 'Invalid data'));
         }
 
-        $field = $this->table()->aliasField($this->getConfig('field'));
-        $conditions = $this->setupConditions($options, $field, $driver);
+        $conditions = $this->setupConditions($options, $driver);
 
-        return $query->where(function (QueryExpression $exp) use ($conditions, $query) {
+        return $query->where(function (QueryExpression $exp) use ($conditions, $query, $driver) {
 
-            return $exp->and(array_map(function ($key) use ($conditions, $query) {
+            return $exp->and(array_map(function ($key) use ($conditions, $query, $driver) {
+                $field = $this->table()->aliasField($this->getConfig('field'));
+                $fieldExp = $this->expressionField($field, $key, $driver);
                 $operation = $conditions[$key];
                 $operator = key($operation);
                 $value = $operation[$operator];
 
-                return $this->operatorExpression($query->newExpr(), $operator, $key, $value);
+                return $this->operatorExpression($query->newExpr(), $operator, $fieldExp, $value);
             }, array_keys($conditions)));
         });
     }
@@ -361,35 +362,33 @@ class CustomPropertiesBehavior extends Behavior
      *
      * ```
      * [
-     *     <expressionProperty1> => [<operator1> => <expressionValue1>],
-     *     <expressionProperty2> => [<operator2> => <expressionValue2>],
+     *     <property1> => [<operator1> => <expressionValue1>],
+     *     <property2> => [<operator2> => <expressionValue2>],
      * ]
      * ...
      *
-     * Where `<expressionPropertyN>` and `<expressionValueN>` are database driver specific expressions.
+     * Where `<expressionValue1>` and `<expressionValue2>` are database driver specific expressions.
      *
      * @param array $options Filter options.
-     * @param string $field Field name.
      * @param object $driver Database driver.
      * @return array
      */
-    protected function setupConditions(array $options, string $field, object $driver): array
+    protected function setupConditions(array $options, object $driver): array
     {
         $conditions = [];
         $available = $this->getAvailable();
-        foreach ($options as $prop => $value) {
-            $key = $this->expressionField($field, $prop, $driver);
-            /** @var \BEdita\Core\Model\Entity\Property $property */
-            $property = Hash::get($available, $prop);
-            $schema = [];
-            if ($property && $property->property_type) {
-                $schema = (array)$property->property_type->params;
-            }
+        foreach ($options as $key => $value) {
             if ($value === null) {
                 $conditions[$key] = ['null' => null];
                 continue;
             }
             $in = [];
+            /** @var \BEdita\Core\Model\Entity\Property $property */
+            $property = Hash::get($available, $key);
+            $schema = [];
+            if ($property && $property->property_type) {
+                $schema = (array)$property->property_type->params;
+            }
 
             if (!is_array($value)) {
                 if (is_string($value) && strpos($value, ',') !== false) {
@@ -459,10 +458,11 @@ class CustomPropertiesBehavior extends Behavior
     protected function expressionValue(mixed $value, array $schema, object $driver): mixed
     {
         $value = $this->formatValue($value, $schema);
+        $value = is_string($value) ? $value : json_encode($value);
         if ($driver instanceof Mysql) {
-            return new FunctionExpression('JSON_UNQUOTE', [json_encode($value)]);
+            return new FunctionExpression('JSON_UNQUOTE', [$value]);
         }
 
-        return is_string($value) ? $value : json_encode($value);
+        return $value;
     }
 }

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -427,7 +427,7 @@ class CustomPropertiesBehavior extends Behavior
      * @param string $field Field name.
      * @param string $key Property name.
      * @param object $driver Database driver.
-     * @return mixed
+     * @return \Cake\Database\Expression\FunctionExpression|string
      */
     protected function expressionField(string $field, string $key, object $driver): FunctionExpression|string
     {
@@ -453,9 +453,9 @@ class CustomPropertiesBehavior extends Behavior
      * @param mixed $value Property value.
      * @param array $schema Property JSON Schema.
      * @param object $driver Database driver.
-     * @return mixed
+     * @return \Cake\Database\Expression\FunctionExpression|string
      */
-    protected function expressionValue(mixed $value, array $schema, object $driver): mixed
+    protected function expressionValue(mixed $value, array $schema, object $driver): FunctionExpression|string
     {
         $value = $this->formatValue($value, $schema);
         $value = is_string($value) ? $value : json_encode($value);

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -357,7 +357,7 @@ class CustomPropertiesBehavior extends Behavior
 
     /**
      * Setup conditions for custom properties filtering.
-     * An array of conditions is returned whit this structure:
+     * An array of conditions is returned with this structure:
      *
      * ```
      * [
@@ -404,9 +404,12 @@ class CustomPropertiesBehavior extends Behavior
                     $in[] = $this->expressionValue($v, $schema, $driver);
                     continue;
                 }
-                $expValue = $this->expressionValue($v, $schema, $driver);
-                if ($operator == 'in' || $operator == 'notin' || $operator == 'nin') {
-                    $expValue = is_array($v) ? $v : [$v];
+
+                if ($operator === 'in' || $operator === 'notin' || $operator === 'nin') {
+                    $v = is_array($v) ? $v : [$v];
+                    $expValue = array_map(fn($i) => $this->expressionValue($i, $schema, $driver), $v);
+                } else {
+                    $expValue = $this->expressionValue($v, $schema, $driver);
                 }
                 $conditions[$key] = [$operator => $expValue];
             }
@@ -427,7 +430,7 @@ class CustomPropertiesBehavior extends Behavior
      * @param object $driver Database driver.
      * @return mixed
      */
-    protected function expressionField(string $field, string $key, object $driver)
+    protected function expressionField(string $field, string $key, object $driver): mixed
     {
         if ($driver instanceof Mysql) {
             return new FunctionExpression(
@@ -453,11 +456,11 @@ class CustomPropertiesBehavior extends Behavior
      * @param object $driver Database driver.
      * @return mixed
      */
-    protected function expressionValue(mixed $value, array $schema, object $driver)
+    protected function expressionValue(mixed $value, array $schema, object $driver): mixed
     {
         $value = $this->formatValue($value, $schema);
         if ($driver instanceof Mysql) {
-            return  new FunctionExpression('JSON_UNQUOTE', [json_encode($value)]);
+            return new FunctionExpression('JSON_UNQUOTE', [json_encode($value)]);
         }
 
         return is_string($value) ? $value : json_encode($value);

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -18,6 +18,7 @@ use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\Model\Entity\ObjectEntity;
 use BEdita\Core\Model\Entity\ObjectType;
 use BEdita\Core\Model\Validation\Validation;
+use BEdita\Core\ORM\QueryFilterTrait;
 use Cake\Collection\CollectionInterface;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Postgres;
@@ -37,6 +38,8 @@ use Cake\Utility\Hash;
  */
 class CustomPropertiesBehavior extends Behavior
 {
+    use QueryFilterTrait;
+
     /**
      * @inheritDoc
      */
@@ -337,47 +340,126 @@ class CustomPropertiesBehavior extends Behavior
             throw new BadFilterException(__d('bedita', 'Invalid data'));
         }
 
-        foreach ($options as $key => &$value) {
-            /** @var \BEdita\Core\Model\Entity\Property $property */
-            $property = Hash::get($available, $key);
-            $value = $this->formatValue($value, $property->property_type->params);
-        }
-        unset($value);
+        $field = $this->table()->aliasField($this->getConfig('field'));
+        $conditions = $this->setupConditions($options, $field, $driver);
 
-        return $query->where(function (QueryExpression $exp, SelectQuery $query) use ($options, $driver) {
-            $field = $this->table()->aliasField($this->getConfig('field'));
+        return $query->where(function (QueryExpression $exp) use ($conditions, $query) {
 
-            return $exp->and(array_map(
-                function ($key, $value) use ($field, $query, $driver) {
-                    if ($driver instanceof Mysql) {
-                        // MySQL syntax using JSON_EXTRACT and JSON_UNQUOTE
-                        return $query->expr()->eq(
-                            new FunctionExpression(
-                                'JSON_UNQUOTE',
-                                [
-                                    new FunctionExpression(
-                                        'JSON_EXTRACT',
-                                        [$field => 'identifier', sprintf('$.%s', $key)],
-                                    ),
-                                ],
-                            ),
-                            new FunctionExpression('JSON_UNQUOTE', [json_encode($value)]), // trick to normalize values compared
-                        );
-                    }
+            return $exp->and(array_map(function ($key) use ($conditions, $query) {
+                $operation = $conditions[$key];
+                $operator = key($operation);
+                $value = $operation[$operator];
 
-                    // PostgreSQL syntax with native JSON column using ->> operator
-                    // For PostgreSQL's ->> operator, we need to handle value formatting correctly
-                    $compareValue = is_string($value) ? $value : json_encode($value); // Use json_encode to handle formatting
-
-                    // Use ->> operator directly on JSON column
-                    return $query->expr()->eq(
-                        sprintf('%s->>%s', $field, $query->getConnection()->getDriver()->quote($key)),
-                        $compareValue,
-                    );
-                },
-                array_keys($options),
-                $options,
-            ));
+                return $this->operatorExpression($query->newExpr(), $operator, $key, $value);
+            }, array_keys($conditions)));
         });
+    }
+
+    /**
+     * Setup conditions for custom properties filtering.
+     * An array of conditions is returned whit this structure:
+     *
+     * ```
+     * [
+     *     <expressionProperty1> => [<operator> => <expressionValue>],
+     *     <expressionProperty2> => [<operator> => <expressionValue>],
+     * ]
+     * ...
+     *
+     * Where `<expressionPropertyN>` and `<expressionValueN>` are database driver specific expressions.
+     *
+     * @param array $options Filter options.
+     * @param string $field Field name.
+     * @param object $driver Database driver.
+     * @return array
+     */
+    protected function setupConditions(array $options, string $field, object $driver): array
+    {
+        $conditions = [];
+        $available = $this->getAvailable();
+        foreach ($options as $prop => $value) {
+            $key = $this->expressionField($field, $prop, $driver);
+            /** @var \BEdita\Core\Model\Entity\Property $property */
+            $property = Hash::get($available, $prop);
+            $schema = [];
+            if ($property && $property->property_type) {
+                $schema = (array)$property->property_type->params;
+            }
+            if ($value === null) {
+                $conditions[$key] = ['null' => null];
+                continue;
+            }
+            $in = [];
+
+            if (!is_array($value)) {
+                if (is_string($value) && strpos($value, ',') !== false) {
+                    $value = explode(',', $value);
+                } else {
+                    $conditions[$key] = ['eq' => $this->expressionValue($value, $schema, $driver)];
+                    continue;
+                }
+            }
+            foreach ($value as $operator => $v) {
+                if (is_numeric($operator)) {
+                    $in[] = $this->expressionValue($v, $schema, $driver);
+                    continue;
+                }
+                $expValue = $this->expressionValue($v, $schema, $driver);
+                if ($operator == 'in' || $operator == 'notin' || $operator == 'nin') {
+                    $expValue = is_array($v) ? $v : [$v];
+                }
+                $conditions[$key] = [$operator => $expValue];
+            }
+
+            if (!empty($in)) {
+                $conditions[$key] = ['in' => $in];
+            }
+        }
+
+        return $conditions;
+    }
+
+    /**
+     * Get expression for a property field.
+     *
+     * @param string $field Field name.
+     * @param string $key Property name.
+     * @param object $driver Database driver.
+     * @return mixed
+     */
+    protected function expressionField(string $field, string $key, object $driver)
+    {
+        if ($driver instanceof Mysql) {
+            return new FunctionExpression(
+                'JSON_UNQUOTE',
+                [
+                    new FunctionExpression(
+                        'JSON_EXTRACT',
+                        [$field => 'identifier', sprintf('$.%s', $key)],
+                    ),
+                ],
+            );
+        }
+
+        // Postgres field
+        return sprintf('%s->>%s', $field, $driver->quote($key));
+    }
+
+    /**
+     * Get expression value for a property value.
+     *
+     * @param mixed $value Property value.
+     * @param array $schema Property JSON Schema.
+     * @param object $driver Database driver.
+     * @return mixed
+     */
+    protected function expressionValue(mixed $value, array $schema, object $driver)
+    {
+        $value = $this->formatValue($value, $schema);
+        if ($driver instanceof Mysql) {
+            return  new FunctionExpression('JSON_UNQUOTE', [json_encode($value)]);
+        }
+
+        return is_string($value) ? $value : json_encode($value);
     }
 }

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -379,7 +379,7 @@ class CustomPropertiesBehavior extends Behavior
         $available = $this->getAvailable();
         foreach ($options as $key => $value) {
             if ($value === null) {
-                $conditions[$key] = ['null' => null];
+                $conditions[$key] = ['null' => true];
                 continue;
             }
             $in = [];

--- a/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
+++ b/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
@@ -110,11 +110,11 @@ trait QueryFilterTrait
      *
      * @param \Cake\Database\Expression\QueryExpression $exp Current query expression
      * @param string $operator Filter operator
-     * @param string $field Filter field
+     * @param mixed $field Filter field
      * @param mixed $value Filter value
      * @return \Cake\Database\Expression\QueryExpression Operator query expression
      */
-    protected function operatorExpression(QueryExpression $exp, string $operator, string $field, mixed $value): QueryExpression
+    public function operatorExpression(QueryExpression $exp, string $operator, mixed $field, mixed $value): QueryExpression
     {
         switch ($operator) {
             case 'eq':

--- a/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
+++ b/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
@@ -16,6 +16,7 @@ namespace BEdita\Core\ORM;
 
 use Cake\Database\Expression\ComparisonExpression;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\ExpressionInterface;
 use Cake\ORM\Query\SelectQuery;
 
 /**
@@ -110,7 +111,7 @@ trait QueryFilterTrait
      *
      * @param \Cake\Database\Expression\QueryExpression $exp Current query expression
      * @param string $operator Filter operator
-     * @param mixed $field Filter field
+     * @param \Cake\Database\ExpressionInterface|string $field Filter field
      * @param mixed $value Filter value
      * @return \Cake\Database\Expression\QueryExpression Operator query expression
      */

--- a/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
+++ b/plugins/BEdita/Core/src/ORM/QueryFilterTrait.php
@@ -114,7 +114,7 @@ trait QueryFilterTrait
      * @param mixed $value Filter value
      * @return \Cake\Database\Expression\QueryExpression Operator query expression
      */
-    public function operatorExpression(QueryExpression $exp, string $operator, mixed $field, mixed $value): QueryExpression
+    public function operatorExpression(QueryExpression $exp, string $operator, ExpressionInterface|string $field, mixed $value): QueryExpression
     {
         switch ($operator) {
             case 'eq':

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
@@ -514,6 +514,37 @@ class CustomPropertiesBehaviorTest extends TestCase
                 'Users',
                 ['another_username' => 'synapse'],
             ],
+            'filter operator string' => [
+                [],
+                'Users',
+                ['another_username' => ['ne' => 'synapse']],
+            ],
+            'filter integer' => [
+                [4],
+                'Profiles',
+                ['number_of_friends' => 42],
+            ],
+            'filter integer operator gt' => [
+                [4],
+                'Profiles',
+                ['number_of_friends' => ['gt' => 17]],
+            ],
+            'filter integer operator lt' => [
+                [],
+                'Profiles',
+                ['number_of_friends' => ['lt' => 10]],
+            ],
+            'filter integer operator in' => [
+                [4],
+                'Profiles',
+                ['number_of_friends' => ['in' => [12, 24, 42]]],
+            ],
+            'filter integer with array' => [
+                [4],
+                'Profiles',
+                ['number_of_friends' => [12, 24, 42]],
+            ],
+
             'filter bool true' => [
                 [10],
                 'Files',
@@ -567,6 +598,7 @@ class CustomPropertiesBehaviorTest extends TestCase
             $this->expectException(get_class($expected));
             $this->expectExceptionMessage($expected->getMessage());
         }
+        $this->prepareCustomProps($tableName);
 
         $result = $this->getTableLocator()
             ->get($tableName)
@@ -581,36 +613,22 @@ class CustomPropertiesBehaviorTest extends TestCase
     }
 
     /**
-     * Test custom prop finder for integer property.
+     * Prepare custom properties for testing.
      *
+     * @param string $tableName Table name.
      * @return void
      */
-    public function testFindCustomPropInteger(): void
+    protected function prepareCustomProps(string $tableName): void
     {
-        $connection = ConnectionManager::get('default');
-        $driver = $connection->getDriver();
-        if (!($driver instanceof Mysql) && !($driver instanceof Postgres)) {
-            $this->expectException(BadFilterException::class);
-            $this->expectExceptionMessage('customProp finder isn\'t supported for this datasource');
+        $table = $this->getTableLocator()->get($tableName);
+        $entity = null;
+        if ($tableName === 'Profiles') {
+            $entity = $table->get(4);
+            $entity->set('number_of_friends', 42);
         }
-
-        $Profiles = $this->getTableLocator()->get('Profiles');
-        $profile = $Profiles->find()->first();
-        $profile->set('number_of_friends', 10);
-        $Profiles->saveOrFail($profile);
-
-        $result = $Profiles->find('customProp', value: ['number_of_friends' => 10])
-            ->find('list')
-            ->orderByAsc('id')
-            ->toArray();
-
-        static::assertEquals([$profile->id], array_keys($result));
-
-        $result = $Profiles->find('customProp', number_of_friends: '10')
-            ->find('list')
-            ->orderByAsc('id')
-            ->toArray();
-
-        static::assertEquals([$profile->id], array_keys($result));
+        if (empty($entity)) {
+            return;
+        }
+        $table->saveOrFail($entity);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
@@ -519,6 +519,11 @@ class CustomPropertiesBehaviorTest extends TestCase
                 'Users',
                 ['another_username' => ['ne' => 'synapse']],
             ],
+            'filter operator null' => [
+                [1, 20],
+                'Users',
+                ['another_username' => null],
+            ],
             'filter integer' => [
                 [4],
                 'Profiles',
@@ -544,7 +549,11 @@ class CustomPropertiesBehaviorTest extends TestCase
                 'Profiles',
                 ['number_of_friends' => [12, 24, 42]],
             ],
-
+            'filter integer with array as string' => [
+                [4],
+                'Profiles',
+                ['number_of_friends' => '12,24,42'],
+            ],
             'filter bool true' => [
                 [10],
                 'Files',


### PR DESCRIPTION
This pull request refactors and enhances the custom properties filtering logic in the `CustomPropertiesBehavior` class, improving its flexibility and maintainability. The main changes include extracting filtering logic into a dedicated method, supporting additional filter operators, and updating tests for better coverage and reliability.

### Custom properties filtering improvements

* Refactored the custom properties filtering logic in `CustomPropertiesBehavior` by extracting condition setup into a new `setupConditions` method, allowing for easier extension and clearer code. This method now supports various filter operators (e.g., `eq`, `ne`, `gt`, `lt`, `in`, `notin`).
* Added the `QueryFilterTrait` to `CustomPropertiesBehavior`, enabling reuse of filtering logic and operator expressions. 
* Improved handling of property field and value expressions for both MySQL and PostgreSQL drivers, ensuring correct query generation for custom property filters.

### Query filter operator enhancements

* Changed the signature of `operatorExpression` in `QueryFilterTrait` to accept a generic field type (not just string), making it compatible with custom property expressions.

### Test suite improvements

* Expanded the test coverage for custom property filtering, adding cases for string, integer, and various operators (`ne`, `gt`, `lt`, `in`)
