### PR TITLE
Project model configDiff + remove php 7.4 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: 'Setup PHP'
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.0'
           tools: 'composer'
           extensions: 'mbstring, intl'
           coverage: 'none'
@@ -67,7 +67,7 @@ jobs:
       - name: 'Setup PHP'
         uses: 'shivammathur/setup-php@v2'
         with:
-          php-version: '7.4'
+          php-version: '8.0'
           tools: 'composer'
           extensions: 'mbstring, intl'
           coverage: 'none'
@@ -100,7 +100,7 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '7.4'
+          - '8.0'
         db:
           - '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
           - '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
@@ -108,8 +108,6 @@ jobs:
           - '{"vendor": "MariaDB", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mariadb", "image": "mariadb:10", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
           - '{"vendor": "PostgreSQL", "pdo": "pgsql", "dsn": "postgres://bedita:bedita@127.0.0.1:5432/bedita", "image": "postgres:14", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
         include:
-          - php: '8.0'
-            db: '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
           - php: '8.0'
             db: '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
           - php: '8.1'
@@ -206,7 +204,7 @@ jobs:
       - name: 'Setup PHP'
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.0'
           tools: 'composer'
           extensions: 'mbstring, intl, pdo_sqlite'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,8 +108,6 @@ jobs:
           - '{"vendor": "MariaDB", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita?realVendor=mariadb", "image": "mariadb:10", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
           - '{"vendor": "PostgreSQL", "pdo": "pgsql", "dsn": "postgres://bedita:bedita@127.0.0.1:5432/bedita", "image": "postgres:14", "options": "--health-cmd \"pg_isready\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
         include:
-          - php: '8.0'
-            db: '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
           - php: '8.1'
             db: '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
           - php: '8.1'

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,6 @@
 build:
     environment:
-        php: "8.3"
+        php: 8.3.16
     nodes:
         analysis:
             tests:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,6 @@
 build:
     environment:
-        php: "7.4"
+        php: "8.3"
     nodes:
         analysis:
             tests:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The easiest and quickest way to try out BEdita4 is via [Docker](https://www.dock
 
 ## Prerequisites
 
-* PHP 7.4, 8.0, 8.1, 8.2 or 8.3 with extensions: `json`, `mbstring`, `fileinfo`, `intl`, `pdo`, `simplexml`
+* PHP 8.0, 8.1, 8.2 or 8.3 with extensions: `json`, `mbstring`, `fileinfo`, `intl`, `pdo`, `simplexml`
 * MySQL 8.0 (recommended) or MySQL 5.7, Postgres 11/12/13/14, MariaDB 10.2/10.3/10.4 or SQLite 3
 * [Composer](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx)
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "cakephp/cakephp": "~4.5.0",
         "cakephp/plugin-installer": "^1.3.1",
         "guzzlehttp/psr7": "^2.2.1",

--- a/config/requirements.php
+++ b/config/requirements.php
@@ -20,8 +20,8 @@
 /*
  * You can remove this if you are confident that your PHP version is sufficient.
  */
-if (version_compare(PHP_VERSION, '7.4.0') < 0) {
-    trigger_error('Your PHP version must be equal or higher than 7.4.0 to use BEdita.' . PHP_EOL, E_USER_ERROR);
+if (version_compare(PHP_VERSION, '8.0.0') < 0) {
+    trigger_error('Your PHP version must be equal or higher than 8.0.0 to use BEdita.' . PHP_EOL, E_USER_ERROR);
 }
 
 /*

--- a/plugins/BEdita/API/composer.json
+++ b/plugins/BEdita/API/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "cakephp/authentication": "^2.9",
         "cakephp/authorization": "^2.2",
         "cakephp/cakephp": "~4.5.0",

--- a/plugins/BEdita/Core/composer.json
+++ b/plugins/BEdita/Core/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.0",
         "cakephp/cakephp": "~4.5.0",
         "cakephp/migrations": "^3.5.2",
         "cakephp/queue": "^1.1",

--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -331,14 +331,27 @@ class ProjectModel
     protected static function configDiff(array $items, array $projectItems): array
     {
         $create = $update = $remove = $new = $current = [];
-        $current = Hash::combine($items, '{n}.application', '{n}');
-        $new = Hash::combine($projectItems, '{n}.application', '{n}');
+        $currentKeys = array_unique(array_column($items, 'name'));
+        foreach ($currentKeys as $key) {
+            $current[$key] = Hash::extract($items, sprintf('{n}[name=%s]', $key));
+        }
+        $newKeys = array_unique(array_column($projectItems, 'name'));
+        foreach ($newKeys as $key) {
+            $new[$key] = Hash::extract($projectItems, sprintf('{n}[name=%s]', $key));
+        }
         $currentKeys = array_unique(array_column($items, 'name'));
         $newKeys = array_unique(array_column($projectItems, 'name'));
         $allKeys = array_unique(array_merge($currentKeys, $newKeys));
         foreach ($allKeys as $key) {
             $newItems = (array)Hash::get($new, $key);
             $currItems = (array)Hash::get($current, $key);
+            // reorder items by name, context, application, content
+            usort($newItems, function ($a, $b) {
+                return strcmp($a['context'] . '|' . $a['application'] . '|' . $a['content'], $b['context'] . '|' . $b['application'] . '|' . $b['content']);
+            });
+            usort($currItems, function ($a, $b) {
+                return strcmp($a['context'] . '|' . $a['application'] . '|' . $a['content'], $b['context'] . '|' . $b['application'] . '|' . $b['content']);
+            });
             $create = array_merge($create, array_values(array_diff_key($newItems, $currItems)));
             $remove = array_merge($remove, array_values(array_diff_key($currItems, $newItems)));
             $update = array_merge($update, array_values(static::itemsToUpdate($currItems, $newItems)));

--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -340,7 +340,6 @@ class ProjectModel
                     if ($p['content'] !== $c['content']) {
                         $update[] = $p;
                     }
-                    break;
                 }
             }
             if (!$found) {

--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -331,29 +331,23 @@ class ProjectModel
     protected static function configDiff(array $items, array $projectItems): array
     {
         $create = $update = $remove = $new = $current = [];
-        $currentKeys = array_unique(array_column($items, 'name'));
-        foreach ($currentKeys as $key) {
-            $current[$key] = Hash::extract($items, sprintf('{n}[name=%s]', $key));
+        foreach ($projectItems as $p) {
+            $found = false;
+            foreach ($items as $index => $c) {
+                if ($p['name'] === $c['name'] && $p['context'] === $c['context'] && $p['application'] === $c['application']) {
+                    $found = true;
+                    unset($items[$index]);
+                    if ($p['content'] !== $c['content']) {
+                        $update[] = $p;
+                    }
+                    break;
+                }
+            }
+            if (!$found) {
+                $create[] = $p;
+            }
         }
-        $newKeys = array_unique(array_column($projectItems, 'name'));
-        foreach ($newKeys as $key) {
-            $new[$key] = Hash::extract($projectItems, sprintf('{n}[name=%s]', $key));
-        }
-        $allKeys = array_unique(array_merge($currentKeys, $newKeys));
-        foreach ($allKeys as $key) {
-            $newItems = (array)Hash::get($new, $key);
-            $currItems = (array)Hash::get($current, $key);
-            // reorder items by name, context, application, content
-            usort($newItems, function ($a, $b) {
-                return strcmp($a['context'] . '|' . $a['application'] . '|' . $a['content'], $b['context'] . '|' . $b['application'] . '|' . $b['content']);
-            });
-            usort($currItems, function ($a, $b) {
-                return strcmp($a['context'] . '|' . $a['application'] . '|' . $a['content'], $b['context'] . '|' . $b['application'] . '|' . $b['content']);
-            });
-            $create = array_merge($create, array_values(array_diff_key($newItems, $currItems)));
-            $remove = array_merge($remove, array_values(array_diff_key($currItems, $newItems)));
-            $update = array_merge($update, array_values(static::itemsToUpdate($currItems, $newItems)));
-        }
+        $remove = array_values($items);
 
         return compact('create', 'update', 'remove');
     }

--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -339,8 +339,6 @@ class ProjectModel
         foreach ($newKeys as $key) {
             $new[$key] = Hash::extract($projectItems, sprintf('{n}[name=%s]', $key));
         }
-        $currentKeys = array_unique(array_column($items, 'name'));
-        $newKeys = array_unique(array_column($projectItems, 'name'));
         $allKeys = array_unique(array_merge($currentKeys, $newKeys));
         foreach ($allKeys as $key) {
             $newItems = (array)Hash::get($new, $key);

--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -330,7 +330,7 @@ class ProjectModel
      */
     protected static function configDiff(array $items, array $projectItems): array
     {
-        $create = $update = $remove = $new = $current = [];
+        $create = $update = $remove = [];
         foreach ($projectItems as $p) {
             $found = false;
             foreach ($items as $index => $c) {

--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -331,14 +331,10 @@ class ProjectModel
     protected static function configDiff(array $items, array $projectItems): array
     {
         $create = $update = $remove = $new = $current = [];
+        $current = Hash::combine($items, '{n}.application', '{n}');
+        $new = Hash::combine($projectItems, '{n}.application', '{n}');
         $currentKeys = array_unique(array_column($items, 'name'));
-        foreach ($currentKeys as $key) {
-            $current[$key] = Hash::extract($items, sprintf('{n}[name=%s]', $key));
-        }
         $newKeys = array_unique(array_column($projectItems, 'name'));
-        foreach ($newKeys as $key) {
-            $new[$key] = Hash::extract($projectItems, sprintf('{n}[name=%s]', $key));
-        }
         $allKeys = array_unique(array_merge($currentKeys, $newKeys));
         foreach ($allKeys as $key) {
             $newItems = (array)Hash::get($new, $key);

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -673,8 +673,8 @@ class ProjectModelTest extends TestCase
             ],
             'no changes' => [
                 [
-                    ['name' => 'Status', 'context' => 'core', 'content' => '{"level":"draft"}', 'application' => 'first-app'],
                     ['name' => 'Status', 'context' => 'core', 'content' => '{"level":"on"}', 'application' => 'second-app'],
+                    ['name' => 'Status', 'context' => 'core', 'content' => '{"level":"draft"}', 'application' => 'first-app'],
                 ],
                 [
                     ['name' => 'Status', 'context' => 'core', 'content' => '{"level":"draft"}', 'application' => 'first-app'],


### PR DESCRIPTION
This PR fixes an unexpected behaviour when launching `bin/cake project_model` and config data is saved on db with a different order than set in project_model.json file.

Due to dependencies issues, we remove php 7.4 compatibility