### PR TITLE
Fix: make the thumb generator read exif data correctly

### DIFF
--- a/plugins/BEdita/Core/src/Filesystem/Thumbnail/GlideGenerator.php
+++ b/plugins/BEdita/Core/src/Filesystem/Thumbnail/GlideGenerator.php
@@ -104,10 +104,15 @@ class GlideGenerator extends ThumbnailGenerator
      */
     protected function makeThumbnail(Stream $stream, array $options = []): string
     {
-        $source = (string)$stream->contents;
+        $tmpfile = tempnam(sys_get_temp_dir(), 'bedita_thumb_');
+        file_put_contents($tmpfile, (string)$stream->contents);
 
-        return $this->getGlideApi()
-            ->run($source, $options);
+        try {
+            return $this->getGlideApi()
+                ->run($tmpfile, $options);
+        } finally {
+            unlink($tmpfile);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR fixes a bug where images with rotation information set in the `Orientation` field of the exif data would not have that rotation applied during thumbnail generation, resulting in a thumbnail different from the final image.
The bug was caused by the fact that exif information was not being read correctly from the file passed as a binary string but, for some reason, is read correctly from a temporary file.
