### PR TITLE
Project model config diff

### DIFF
--- a/plugins/BEdita/Core/src/Utility/ProjectModel.php
+++ b/plugins/BEdita/Core/src/Utility/ProjectModel.php
@@ -329,23 +329,23 @@ class ProjectModel
      */
     protected static function configDiff(array $items, array $projectItems): array
     {
-        $create = $update = $remove = $new = $current = [];
-        $currentKeys = array_unique(array_column($items, 'name'));
-        foreach ($currentKeys as $key) {
-            $current[$key] = Hash::extract($items, sprintf('{n}[name=%s]', $key));
+        $create = $update = $remove = [];
+        foreach ($projectItems as $p) {
+            $found = false;
+            foreach ($items as $index => $c) {
+                if ($p['name'] === $c['name'] && $p['context'] === $c['context'] && $p['application'] === $c['application']) {
+                    $found = true;
+                    unset($items[$index]);
+                    if ($p['content'] !== $c['content']) {
+                        $update[] = $p;
+                    }
+                }
+            }
+            if (!$found) {
+                $create[] = $p;
+            }
         }
-        $newKeys = array_unique(array_column($projectItems, 'name'));
-        foreach ($newKeys as $key) {
-            $new[$key] = Hash::extract($projectItems, sprintf('{n}[name=%s]', $key));
-        }
-        $allKeys = array_unique(array_merge($currentKeys, $newKeys));
-        foreach ($allKeys as $key) {
-            $newItems = (array)Hash::get($new, $key);
-            $currItems = (array)Hash::get($current, $key);
-            $create = array_merge($create, array_values(array_diff_key($newItems, $currItems)));
-            $remove = array_merge($remove, array_values(array_diff_key($currItems, $newItems)));
-            $update = array_merge($update, array_values(static::itemsToUpdate($currItems, $newItems)));
-        }
+        $remove = array_values($items);
 
         return compact('create', 'update', 'remove');
     }

--- a/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/ProjectModelTest.php
@@ -659,8 +659,8 @@ class ProjectModelTest extends TestCase
                     ['name' => 'Status', 'context' => 'core', 'content' => '{"level":"on"}', 'application' => 'second-app'],
                 ],
                 [
-                    ['name' => 'Status', 'context' => 'core', 'content' => '{"level":"draft"}', 'application' => 'first-app'],
                     ['name' => 'Status', 'context' => 'core', 'content' => '{"level":"on"}', 'application' => 'second-app'],
+                    ['name' => 'Status', 'context' => 'core', 'content' => '{"level":"draft"}', 'application' => 'first-app'],
                 ],
                 ['create' => [], 'update' => [], 'remove' => []],
             ],


### PR DESCRIPTION
This PR fixes an unexpected behaviour when launching bin/cake project_model and config data is saved on db with a different order than set in project_model.json file.

Same logic of https://github.com/bedita/bedita/pull/2164