### PR TITLE
Remove hardcoded ID from default application migration

### DIFF
--- a/plugins/BEdita/Core/config/Migrations/20171027164507_DefaultApplication.php
+++ b/plugins/BEdita/Core/config/Migrations/20171027164507_DefaultApplication.php
@@ -34,7 +34,6 @@ class DefaultApplication extends BaseMigration
         $this->table('applications')
             ->insert([
                 [
-                    'id' => 1,
                     'name' => 'manager',
                     'api_key' => ApplicationsTable::generateApiKey(),
                     'description' => 'Manager application',


### PR DESCRIPTION
This pull request makes a minor adjustment to the applications table migration by removing the explicit setting of the `id` field for the manager application. This change likely allows the database to handle the `id` assignment automatically, improving flexibility and consistency.

- Migration update:
  * Removed the explicit `'id' => 1` assignment from the inserted manager application record in `20171027164507_DefaultApplication.php` to let the database auto-assign the primary key.