### PR TITLE
Add custom properties sorting support

### DIFF
--- a/plugins/BEdita/API/src/Datasource/JsonApiPaginator.php
+++ b/plugins/BEdita/API/src/Datasource/JsonApiPaginator.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 namespace BEdita\API\Datasource;
 
 use BEdita\Core\Model\Enum\DateRangesSortField;
+use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Postgres;
 use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Datasource\Paging\NumericPaginator;
@@ -24,8 +26,6 @@ use Cake\Datasource\RepositoryInterface;
 use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
-use Cake\Database\Driver\Mysql;
-use Cake\Database\Driver\Postgres;
 
 /**
  * Handle model pagination using JSON API conventions.

--- a/plugins/BEdita/API/src/Datasource/JsonApiPaginator.php
+++ b/plugins/BEdita/API/src/Datasource/JsonApiPaginator.php
@@ -23,6 +23,9 @@ use Cake\Datasource\QueryInterface;
 use Cake\Datasource\RepositoryInterface;
 use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\Query\SelectQuery;
+use Cake\ORM\Table;
+use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Postgres;
 
 /**
  * Handle model pagination using JSON API conventions.
@@ -113,6 +116,29 @@ class JsonApiPaginator extends NumericPaginator
                     $options['direction'] ?? 'asc',
                 );
                 unset($options['sort'], $options['direction']);
+            }
+
+            if (
+                !empty($options['sort'])
+                && empty($options['order'])
+                && $object instanceof Table
+                && $object->behaviors()->has('CustomProperties')
+            ) {
+                /** @var \BEdita\Core\Model\Behavior\CustomPropertiesBehavior $behavior */
+                $behavior = $object->behaviors()->get('CustomProperties');
+                $available = $behavior->getAvailable();
+                $sortField = (string)$options['sort'];
+                if ($sortField !== '' && array_key_exists($sortField, $available)) {
+                    $driver = $object->getConnection()->getDriver();
+                    if ($driver instanceof Mysql || $driver instanceof Postgres) {
+                        $options['order'] = $behavior->customPropOrderClause(
+                            $sortField,
+                            (string)($options['direction'] ?? 'asc'),
+                            $driver,
+                        );
+                        unset($options['sort'], $options['direction']);
+                    }
+                }
             }
         }
 

--- a/plugins/BEdita/API/src/Datasource/JsonApiPaginator.php
+++ b/plugins/BEdita/API/src/Datasource/JsonApiPaginator.php
@@ -100,46 +100,8 @@ class JsonApiPaginator extends NumericPaginator
                 $options['sortableFields'] = [$options['sort']];
             }
 
-            $sortableFields = $options['sortableFields'] ?? null;
-            $canSortField = fn(string $field): bool => $sortableFields === null || in_array($field, $sortableFields, true);
-            if ($options['sort'] === 'published' && $canSortField('publish_start')) {
-                $options['order'] = new OrderClauseExpression(
-                    new FunctionExpression(
-                        'COALESCE',
-                        [
-                            $object->getAlias() . '.publish_start' => 'identifier',
-                            $object->getAlias() . '.created' => 'identifier',
-                        ],
-                        ['timestamp', 'timestamp'],
-                        'timestamp',
-                    ),
-                    $options['direction'] ?? 'asc',
-                );
-                unset($options['sort'], $options['direction']);
-            }
-
-            if (
-                !empty($options['sort'])
-                && empty($options['order'])
-                && $object instanceof Table
-                && $object->behaviors()->has('CustomProperties')
-            ) {
-                /** @var \BEdita\Core\Model\Behavior\CustomPropertiesBehavior $behavior */
-                $behavior = $object->behaviors()->get('CustomProperties');
-                $available = $behavior->getAvailable();
-                $sortField = (string)$options['sort'];
-                if ($sortField !== '' && array_key_exists($sortField, $available)) {
-                    $driver = $object->getConnection()->getDriver();
-                    if ($driver instanceof Mysql || $driver instanceof Postgres) {
-                        $options['order'] = $behavior->customPropOrderClause(
-                            $sortField,
-                            (string)($options['direction'] ?? 'asc'),
-                            $driver,
-                        );
-                        unset($options['sort'], $options['direction']);
-                    }
-                }
-            }
+            $this->handlePublishedSort($options, $object);
+            $this->handleCustomPropertiesSort($options, $object);
         }
 
         $options = parent::validateSort($object, $options);
@@ -149,5 +111,67 @@ class JsonApiPaginator extends NumericPaginator
         }
 
         return $options;
+    }
+
+    /**
+     * Handle 'published' sort field.
+     *
+     * @param array $options
+     * @param \Cake\Datasource\RepositoryInterface $object
+     * @return void
+     */
+    protected function handlePublishedSort(array &$options, RepositoryInterface $object): void
+    {
+        $sortableFields = $options['sortableFields'] ?? null;
+        $canSortField = fn(string $field): bool => $sortableFields === null || in_array($field, $sortableFields, true);
+
+        if ($options['sort'] === 'published' && $canSortField('publish_start')) {
+            $options['order'] = new OrderClauseExpression(
+                new FunctionExpression(
+                    'COALESCE',
+                    [
+                        $object->getAlias() . '.publish_start' => 'identifier',
+                        $object->getAlias() . '.created' => 'identifier',
+                    ],
+                    ['timestamp', 'timestamp'],
+                    'timestamp',
+                ),
+                $options['direction'] ?? 'asc',
+            );
+            unset($options['sort'], $options['direction']);
+        }
+    }
+
+    /**
+     * Handle custom properties sort field.
+     *
+     * @param array $options
+     * @param \Cake\Datasource\RepositoryInterface $object
+     * @return void
+     */
+    protected function handleCustomPropertiesSort(array &$options, RepositoryInterface $object): void
+    {
+        if (
+            !empty($options['sort'])
+            && empty($options['order'])
+            && $object instanceof Table
+            && $object->behaviors()->has('CustomProperties')
+        ) {
+            /** @var \BEdita\Core\Model\Behavior\CustomPropertiesBehavior $behavior */
+            $behavior = $object->behaviors()->get('CustomProperties');
+            $available = $behavior->getAvailable();
+            $sortField = (string)$options['sort'];
+            if ($sortField !== '' && array_key_exists($sortField, $available)) {
+                $driver = $object->getConnection()->getDriver();
+                if ($driver instanceof Mysql || $driver instanceof Postgres) {
+                    $options['order'] = $behavior->customPropOrderClause(
+                        $sortField,
+                        (string)($options['direction'] ?? 'asc'),
+                        $driver,
+                    );
+                    unset($options['sort'], $options['direction']);
+                }
+            }
+        }
     }
 }

--- a/plugins/BEdita/API/tests/IntegrationTest/SortQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/SortQueryStringTest.php
@@ -15,6 +15,9 @@ declare(strict_types=1);
 namespace BEdita\API\Test\IntegrationTest;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
+use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Postgres;
+use Cake\Datasource\ConnectionManager;
 use Cake\Utility\Hash;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -72,6 +75,12 @@ class SortQueryStringTest extends IntegrationTestCase
                 '/events',
                 'date_ranges_max_end_date',
             ],
+            'customPropSort' => [
+                200,
+                '/files',
+                'media_property',
+                true
+            ],
         ];
     }
 
@@ -81,13 +90,17 @@ class SortQueryStringTest extends IntegrationTestCase
      * @param int $expected The HTTP status code expected
      * @param string $endpoint The object type
      * @param string $sort The field on which sort
+     * @param bool $customProps Whether there's a custom properties sort
      * @return void
      */
     #[DataProvider('sortProvider')]
-    public function testSort($expected, $endpoint, $sort)
+    public function testSort($expected, $endpoint, $sort, $customProps = false): void
     {
         $sortedFields = [];
-
+        if ($customProps) {
+            $driver = ConnectionManager::get('default')->getDriver();
+            $this->skipUnless(($driver instanceof Mysql) || ($driver instanceof Postgres));
+        }
         // sort asc
         $this->configRequestHeaders();
         $url = sprintf('%s?sort=%s', $endpoint, $sort);

--- a/plugins/BEdita/API/tests/IntegrationTest/SortQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/SortQueryStringTest.php
@@ -79,7 +79,7 @@ class SortQueryStringTest extends IntegrationTestCase
                 200,
                 '/files',
                 'media_property',
-                true
+                true,
             ],
         ];
     }

--- a/plugins/BEdita/API/tests/IntegrationTest/SortQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/SortQueryStringTest.php
@@ -81,6 +81,12 @@ class SortQueryStringTest extends IntegrationTestCase
                 'media_property',
                 true,
             ],
+            'numberCustomProp' => [
+                200,
+                '/profiles',
+                'number_of_friends',
+                true,
+            ],
         ];
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Datasource/JsonApiPaginatorTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Datasource/JsonApiPaginatorTest.php
@@ -198,7 +198,7 @@ class JsonApiPaginatorTest extends TestCase
      *
      * @return void
      */
-    public function testValidateSortCustomProperty()
+    public function testValidateSortCustomProperty(): void
     {
         $paginator = new JsonApiPaginator();
         $repository = TableRegistry::getTableLocator()->get('Profiles')->find()->getRepository();

--- a/plugins/BEdita/API/tests/TestCase/Datasource/JsonApiPaginatorTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Datasource/JsonApiPaginatorTest.php
@@ -15,10 +15,10 @@ declare(strict_types=1);
 namespace BEdita\API\Test\TestCase\Datasource;
 
 use BEdita\API\Datasource\JsonApiPaginator;
-use Cake\Database\Expression\FunctionExpression;
-use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Postgres;
+use Cake\Database\Expression\FunctionExpression;
+use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;

--- a/plugins/BEdita/API/tests/TestCase/Datasource/JsonApiPaginatorTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Datasource/JsonApiPaginatorTest.php
@@ -17,6 +17,8 @@ namespace BEdita\API\Test\TestCase\Datasource;
 use BEdita\API\Datasource\JsonApiPaginator;
 use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\Expression\OrderClauseExpression;
+use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Postgres;
 use Cake\Http\Exception\BadRequestException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -41,6 +43,10 @@ class JsonApiPaginatorTest extends TestCase
         'plugin.BEdita/Core.Relations',
         'plugin.BEdita/Core.RelationTypes',
         'plugin.BEdita/Core.Roles',
+        'plugin.BEdita/Core.Objects',
+        'plugin.BEdita/Core.Profiles',
+        'plugin.BEdita/Core.Properties',
+        'plugin.BEdita/Core.PropertyTypes',
     ];
 
     /**
@@ -185,6 +191,27 @@ class JsonApiPaginatorTest extends TestCase
         $options = $paginator->validateSort($repository, compact('sort'));
 
         static::assertEquals($expected, $options['order']);
+    }
+
+    /**
+     * Test `validateSort()` method with a CustomProperties key.
+     *
+     * @return void
+     */
+    public function testValidateSortCustomProperty()
+    {
+        $paginator = new JsonApiPaginator();
+        $repository = TableRegistry::getTableLocator()->get('Profiles')->find()->getRepository();
+
+        $driver = $repository->getConnection()->getDriver();
+        if (!($driver instanceof Mysql) && !($driver instanceof Postgres)) {
+            $this->expectException(BadRequestException::class);
+            $this->expectExceptionMessage('Unsupported sorting field');
+        }
+
+        $options = $paginator->validateSort($repository, ['sort' => 'another_surname']);
+
+        static::assertInstanceOf(OrderClauseExpression::class, $options['order']);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -23,6 +23,7 @@ use Cake\Collection\CollectionInterface;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Postgres;
 use Cake\Database\Expression\FunctionExpression;
+use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
@@ -52,6 +53,7 @@ class CustomPropertiesBehavior extends Behavior
         ],
         'implementedFinders' => [
             'customProp' => 'findCustomProp',
+            // 'customPropSort' => 'findCustomPropSort',
         ],
         'implementedMethods' => [
             'getCustomPropsAvailable' => 'getAvailable',
@@ -448,6 +450,47 @@ class CustomPropertiesBehavior extends Behavior
     }
 
     /**
+     * Finder for sorting on a custom property.
+     *
+     * The following are equivalent:
+     *
+     * ```
+     * $table->find('customPropSort', field: 'prop_name', direction: 'asc');
+     * $table->find('customPropSort', value: ['field' => 'prop_name', 'direction' => 'asc']);
+     * ```
+     *
+     * @param \Cake\ORM\Query\SelectQuery $query Query object instance.
+     * @param mixed $args Named arguments. If `value` is present it will be used.
+     * @return \Cake\ORM\Query\SelectQuery
+     * @throws \BEdita\Core\Exception\BadFilterException
+     */
+    // public function findCustomPropSort(SelectQuery $query, mixed ...$args): SelectQuery
+    // {
+    //     $options = (array)($args['value'] ?? $args);
+    //     $field = (string)Hash::get($options, 'field');
+    //     $direction = strtolower((string)Hash::get($options, 'direction', 'asc'));
+
+    //     if ($field === '') {
+    //         throw new BadFilterException(__d('bedita', 'Invalid data'));
+    //     }
+    //     if (!in_array($direction, ['asc', 'desc'], true)) {
+    //         throw new BadFilterException(__d('bedita', 'Invalid data'));
+    //     }
+
+    //     $available = $this->getAvailable();
+    //     if (!array_key_exists($field, $available)) {
+    //         throw new BadFilterException(__d('bedita', 'Invalid data'));
+    //     }
+
+    //     $driver = $query->getConnection()->getDriver();
+    //     if (!($driver instanceof Mysql) && !($driver instanceof Postgres)) {
+    //         throw new BadFilterException(__d('bedita', 'customPropSort finder isn\'t supported for this datasource'));
+    //     }
+
+    //     return $query->orderBy($this->customPropOrderClause($field, $direction, $driver));
+    // }
+
+    /**
      * Get expression value for a property value.
      *
      * @param mixed $value Property value.
@@ -464,5 +507,25 @@ class CustomPropertiesBehavior extends Behavior
         }
 
         return $value;
+    }
+
+    /**
+     * Get order clause expression for a custom property sorting.
+     *
+     * @param string $sortField Property name.
+     * @param string $direction Sort direction.
+     * @param object $driver Database driver.
+     * @return \Cake\Database\Expression\OrderClauseExpression
+     * @throws \BEdita\Core\Exception\BadFilterException
+     */
+    public function customPropOrderClause(string $sortField, string $direction, object $driver): OrderClauseExpression
+    {
+        if (!($driver instanceof Mysql) && !($driver instanceof Postgres)) {
+            throw new BadFilterException(__d('bedita', 'customPropSort finder isn\'t supported for this datasource'));
+        }
+        $field = $this->table()->aliasField($this->getConfig('field'));
+        $fieldExp = $this->expressionField($field, $sortField, $driver);
+
+        return new OrderClauseExpression($fieldExp,  strtoupper($direction));
     }
 }

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -53,7 +53,6 @@ class CustomPropertiesBehavior extends Behavior
         ],
         'implementedFinders' => [
             'customProp' => 'findCustomProp',
-            // 'customPropSort' => 'findCustomPropSort',
         ],
         'implementedMethods' => [
             'getCustomPropsAvailable' => 'getAvailable',
@@ -450,47 +449,6 @@ class CustomPropertiesBehavior extends Behavior
     }
 
     /**
-     * Finder for sorting on a custom property.
-     *
-     * The following are equivalent:
-     *
-     * ```
-     * $table->find('customPropSort', field: 'prop_name', direction: 'asc');
-     * $table->find('customPropSort', value: ['field' => 'prop_name', 'direction' => 'asc']);
-     * ```
-     *
-     * @param \Cake\ORM\Query\SelectQuery $query Query object instance.
-     * @param mixed $args Named arguments. If `value` is present it will be used.
-     * @return \Cake\ORM\Query\SelectQuery
-     * @throws \BEdita\Core\Exception\BadFilterException
-     */
-    // public function findCustomPropSort(SelectQuery $query, mixed ...$args): SelectQuery
-    // {
-    //     $options = (array)($args['value'] ?? $args);
-    //     $field = (string)Hash::get($options, 'field');
-    //     $direction = strtolower((string)Hash::get($options, 'direction', 'asc'));
-
-    //     if ($field === '') {
-    //         throw new BadFilterException(__d('bedita', 'Invalid data'));
-    //     }
-    //     if (!in_array($direction, ['asc', 'desc'], true)) {
-    //         throw new BadFilterException(__d('bedita', 'Invalid data'));
-    //     }
-
-    //     $available = $this->getAvailable();
-    //     if (!array_key_exists($field, $available)) {
-    //         throw new BadFilterException(__d('bedita', 'Invalid data'));
-    //     }
-
-    //     $driver = $query->getConnection()->getDriver();
-    //     if (!($driver instanceof Mysql) && !($driver instanceof Postgres)) {
-    //         throw new BadFilterException(__d('bedita', 'customPropSort finder isn\'t supported for this datasource'));
-    //     }
-
-    //     return $query->orderBy($this->customPropOrderClause($field, $direction, $driver));
-    // }
-
-    /**
      * Get expression value for a property value.
      *
      * @param mixed $value Property value.
@@ -521,11 +479,11 @@ class CustomPropertiesBehavior extends Behavior
     public function customPropOrderClause(string $sortField, string $direction, object $driver): OrderClauseExpression
     {
         if (!($driver instanceof Mysql) && !($driver instanceof Postgres)) {
-            throw new BadFilterException(__d('bedita', 'customPropSort finder isn\'t supported for this datasource'));
+            throw new BadFilterException(__d('bedita', 'Custom property sorting is not supported for this datasource'));
         }
         $field = $this->table()->aliasField($this->getConfig('field'));
         $fieldExp = $this->expressionField($field, $sortField, $driver);
 
-        return new OrderClauseExpression($fieldExp,  strtoupper($direction));
+        return new OrderClauseExpression($fieldExp, strtoupper($direction));
     }
 }

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -445,7 +445,7 @@ class CustomPropertiesBehavior extends Behavior
         }
 
         // Postgres field
-        return sprintf('%s->>%s', $field, $driver->quote($key));
+        return sprintf('CAST(%s AS JSONB)->>%s', $field, $driver->quote($key));
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/CustomPropertiesBehaviorTest.php
@@ -20,6 +20,7 @@ use BEdita\Core\Test\Utility\TestFilesystemTrait;
 use Cake\Collection\CollectionInterface;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Postgres;
+use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -639,5 +640,28 @@ class CustomPropertiesBehaviorTest extends TestCase
             return;
         }
         $table->saveOrFail($entity);
+    }
+
+    /**
+     * Test `customPropOrderClause()` method.
+     *
+     * @throws \BEdita\Core\Exception\BadFilterException
+     * @return void
+     */
+    public function testCustomPropOrderClause(): void
+    {
+        $table = $this->getTableLocator()->get('Profiles');
+        /** @var CustomPropertiesBehavior $behavior */
+        $behavior = $table->behaviors()->get('CustomProperties');
+
+        $connection = ConnectionManager::get('default');
+        $driver = $connection->getDriver();
+        if (!($driver instanceof Mysql) && !($driver instanceof Postgres)) {
+            $this->expectException(BadFilterException::class);
+            $this->expectExceptionMessage('Custom property sorting is not supported for this datasource');
+        }
+
+        $orderClause = $behavior->customPropOrderClause('another_surname', 'asc', $driver);
+        static::assertInstanceOf(OrderClauseExpression::class, $orderClause);
     }
 }


### PR DESCRIPTION
This pull request adds support for sorting on custom properties in API pagination, specifically for tables using the `CustomProperties` behavior and compatible with MySQL or PostgreSQL. It introduces a new method to generate database order clauses for custom property fields and extends the paginator and its tests to handle this feature. The most important changes are:

### Feature: Custom Properties Sorting Support

* Added logic in `JsonApiPaginator::validateSort()` to detect when sorting is requested on a custom property and, if so, generate an appropriate order clause using the new `customPropOrderClause()` method from the `CustomPropertiesBehavior` class. This only applies for MySQL and PostgreSQL drivers.
* Introduced the `customPropOrderClause()` method in `CustomPropertiesBehavior` to create a database order clause expression for a given custom property and direction, ensuring compatibility with MySQL and PostgreSQL.
* Updated imports and dependencies to include the necessary database driver and expression classes in relevant files. 

### Testing Improvements

* Enhanced integration and unit tests to cover sorting on custom properties, including driver checks to ensure tests only run for supported databases. Added new test cases and fixtures for profiles and properties. 

