### PR TITLE
Support case insensitive simple search on Postgres

### DIFF
--- a/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/FilterQueryStringTest.php
@@ -15,8 +15,6 @@ declare(strict_types=1);
 namespace BEdita\API\Test\IntegrationTest;
 
 use BEdita\API\TestSuite\IntegrationTestCase;
-use Cake\Database\Driver\Postgres;
-use Cake\Datasource\ConnectionManager;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 use PHPUnit\Framework\Attributes\CoversNothing;
@@ -269,7 +267,12 @@ class FilterQueryStringTest extends IntegrationTestCase
                 [
                     '8',
                 ],
-                true,
+            ],
+            'case insensitive locations' => [
+                '/locations?filter[query]=BolOGna',
+                [
+                    '8',
+                ],
             ],
             'users' => [
                 '/users?filter[query]=second',
@@ -378,16 +381,11 @@ class FilterQueryStringTest extends IntegrationTestCase
      *
      * @param string $url Url string.
      * @param array $expected Expected result.
-     * @param bool $caseInsensitive Whether test case relies on case-insensitive comparison.
      * @return void
      */
     #[DataProvider('searchFilterProvider')]
-    public function testSearchFilter($url, $expected, bool $caseInsensitive = false)
+    public function testSearchFilter($url, $expected)
     {
-        if ($caseInsensitive && ConnectionManager::get('default')->getDriver() instanceof Postgres) {
-            static::markTestSkipped('Case-insensitive test cases are skipped on Postgres');
-        }
-
         $this->configRequestHeaders();
         $this->get($url);
         $result = json_decode((string)$this->_response->getBody(), true);

--- a/plugins/BEdita/Core/src/Search/Adapter/SimpleAdapter.php
+++ b/plugins/BEdita/Core/src/Search/Adapter/SimpleAdapter.php
@@ -17,7 +17,10 @@ namespace BEdita\Core\Search\Adapter;
 use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\ORM\Inheritance\Table as InheritanceTable;
 use BEdita\Core\Search\BaseAdapter;
+use Cake\Database\Driver\Postgres;
+use Cake\Database\Expression\ComparisonExpression;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\ExpressionInterface;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
@@ -174,16 +177,33 @@ class SimpleAdapter extends BaseAdapter
 
         // Build query conditions.
         return $query
-            ->where(function (QueryExpression $exp) use ($field, $words) {
+            ->where(function (QueryExpression $exp, SelectQuery $query) use ($field, $words) {
                 foreach ($words as $word) {
-                    $exp->like(
-                        $field,
-                        sprintf('%%%s%%', $word),
-                    );
+                    $exp->add($this->buildLikeExpression($query, $field, $word));
                 }
 
                 return $exp;
             });
+    }
+
+    /**
+     * Build a case insensitive LIKE expression for the given field and word.
+     *
+     * @param \Cake\ORM\Query\SelectQuery $query The query
+     * @param \Cake\Database\ExpressionInterface|string $field The field to search
+     * @param string $word The word to search
+     * @return \Cake\Database\Expression\QueryExpression
+     */
+    protected function buildLikeExpression(SelectQuery $query, ExpressionInterface|string $field, string $word): QueryExpression
+    {
+        $word = sprintf('%%%s%%', $word);
+        $driver = $query->getConnection()->getDriver();
+        $exp = $query->expr();
+        if ($driver instanceof Postgres) {
+            return $exp->add(new ComparisonExpression($field, $word, null, 'ILIKE'));
+        }
+
+        return $exp->like($field, $word);
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Search/Adapter/SimpleAdapterTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Search/Adapter/SimpleAdapterTest.php
@@ -17,8 +17,6 @@ namespace BEdita\Core\Test\TestCase\Search\Adapter;
 use BEdita\Core\Exception\BadFilterException;
 use BEdita\Core\ORM\Inheritance\Table as InheritanceTable;
 use BEdita\Core\Search\Adapter\SimpleAdapter;
-use Cake\Database\Driver\Postgres;
-use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use Exception;
@@ -221,7 +219,6 @@ class SimpleAdapterTest extends TestCase
                 [],
                 'FakeSearches',
                 [],
-                true,
             ],
             'exact false' => [
                 [
@@ -254,16 +251,11 @@ class SimpleAdapterTest extends TestCase
      * @param string $text Text to search
      * @param array $options Search options
      * @param string $tableName Table name
-     * @param bool $caseInsensitive Whether test case relies on case-insensitive comparison.
      * @return void
      */
     #[DataProvider('searchProvider')]
-    public function testSearch($expected, string $text, array $options = [], $tableName = 'FakeAnimals', array $fields = [], bool $caseInsensitive = false)
+    public function testSearch($expected, string $text, array $options = [], $tableName = 'FakeAnimals', array $fields = [])
     {
-        if ($caseInsensitive && ConnectionManager::get('default')->getDriver() instanceof Postgres) {
-            static::markTestSkipped('Case-insensitive test cases are skipped on Postgres');
-        }
-
         if ($expected instanceof Exception) {
             $this->expectExceptionObject($expected);
         }


### PR DESCRIPTION
This PR fixes a known issue we have using PostgresSQL and performing simple search via `LIKE`.

In fact in Postgres `LIKE` operator executes a case sensitive search. To make search operation case insensitive behaving as other datasource supported as MySQL/MariaDB and Sqlite the `ILIKE` operator is used.
