### PR TITLE
Upgrade to CakePHP 5.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,6 +113,8 @@ jobs:
             db: '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
           - php: '8.4'
             db: '{"vendor": "MySQL 8.4", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.4", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+          - php: '8.5'
+            db: '{"vendor": "MySQL 8.4", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.4", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
     env:
       PHP_VERSION: '${{ matrix.php }}'
       DB_VENDOR: '${{ fromJson(matrix.db).vendor }}'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,7 +112,7 @@ jobs:
           - php: '8.4'
             db: '{"vendor": "SQLite", "pdo": "sqlite", "dsn": "sqlite://tmp/test.sql", "image": "nginx:alpine", "options": "--health-cmd \"/bin/true\" --health-interval 1s --health-timeout 2s --health-retries 5"}'
           - php: '8.4'
-            db: '{"vendor": "MySQL 8.0", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.0", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
+            db: '{"vendor": "MySQL 8.4", "pdo": "mysql", "dsn": "mysql://bedita:bedita@127.0.0.1:3306/bedita", "image": "mysql:8.4", "options": "--health-cmd \"mysqladmin ping -h localhost\" --health-interval 10s --health-timeout 5s --health-retries 5"}'
     env:
       PHP_VERSION: '${{ matrix.php }}'
       DB_VENDOR: '${{ fromJson(matrix.db).vendor }}'

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "cakephp/cakephp": "~5.2.9",
+        "cakephp/cakephp": "~5.3.0",
         "cakephp/migrations": "^4.8.2",
         "cakephp/plugin-installer": "^2.0",
         "mobiledetect/mobiledetectlib": "^4.8.03",
@@ -32,10 +32,10 @@
     "require-dev": {
         "cakephp/bake": "^3.5.0",
         "cakephp/cakephp-codesniffer": "^5.3.0",
-        "cakephp/debug_kit": "^5.0.0",
+        "cakephp/debug_kit": "^5.2.0",
         "phpstan/phpdoc-parser": "^2.1",
         "cakephp/repl": "^2.0.1",
-        "phpunit/phpunit": "^11.5 || ^12.1",
+        "phpunit/phpunit": "^11.5.3 || ^12.1.3",
         "bedita/dev-tools": "^3.1.1",
         "phpstan/phpstan": "^1.7.1",
         "phpstan/extension-installer": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "cakephp/debug_kit": "^5.2.0",
         "phpstan/phpdoc-parser": "^2.1",
         "cakephp/repl": "^2.0.1",
-        "phpunit/phpunit": "^11.5.3 || ^12.1.3",
+        "phpunit/phpunit": "^12.5.1",
         "bedita/dev-tools": "^3.1.1",
         "phpstan/phpstan": "^1.7.1",
         "phpstan/extension-installer": "^1.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,6 @@
     >
     <php>
         <ini name="memory_limit" value="-1"/>
-        <ini name="apc.enable_cli" value="1"/>
         <const name="UNIT_TEST_RUN" value="1"/>
     </php>
   <!-- Add any additional test suites you want to run here -->

--- a/plugins/BEdita/API/composer.json
+++ b/plugins/BEdita/API/composer.json
@@ -24,12 +24,12 @@
         "php": ">=8.3",
         "cakephp/authentication": "^3.3.2",
         "cakephp/authorization": "^3.4.1",
-        "cakephp/cakephp": "~5.2.9",
+        "cakephp/cakephp": "~5.3.0",
         "firebase/php-jwt": "^6.11"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^5.3.0",
-        "phpunit/phpunit": "^11.5 || ^12.1"
+        "phpunit/phpunit": "^11.5.3 || ^12.1.3"
     },
     "autoload": {
         "psr-4": {

--- a/plugins/BEdita/API/composer.json
+++ b/plugins/BEdita/API/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^5.3.0",
-        "phpunit/phpunit": "^11.5.3 || ^12.1.3"
+        "phpunit/phpunit": "^12.5.1"
     },
     "autoload": {
         "psr-4": {

--- a/plugins/BEdita/API/src/Controller/Model/RelationsController.php
+++ b/plugins/BEdita/API/src/Controller/Model/RelationsController.php
@@ -58,13 +58,13 @@ class RelationsController extends ModelController
      */
     protected function getResourceId($id): string
     {
+        /** @var \BEdita\Core\Model\Behavior\ResourceNameBehavior $resourceNameBehavior */
+        $resourceNameBehavior = $this->Relations->getBehavior('ResourceName');
         try {
-            $id = $this->Relations->getId($id);
+            $id = $resourceNameBehavior->getId($id);
         } catch (RecordNotFoundException $ex) {
-            /** \BEdita\Core\Model\Behavior\ResourceNameBehavior $behavior */
-            $behavior = $this->Relations->behaviors()->get('ResourceName');
-            $behavior->setConfig('field', 'inverse_name');
-            $id = $this->Relations->getId($id);
+            $resourceNameBehavior->setConfig('field', 'inverse_name');
+            $id = $resourceNameBehavior->getId($id);
         }
 
         return (string)$id;

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -104,7 +104,7 @@ class ObjectsController extends ResourcesController
 
         $this->initObjectModel();
 
-        if ($this->Table->hasBehavior('objectType')) {
+        if ($this->Table->hasBehavior('ObjectType')) {
             /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $objectTypeBehavior */
             $objectTypeBehavior = $this->Table->getBehavior('ObjectType');
             /** @var \BEdita\Core\Model\Entity\ObjectType $objectType */

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -104,10 +104,11 @@ class ObjectsController extends ResourcesController
 
         $this->initObjectModel();
 
-        $behaviorRegistry = $this->Table->behaviors();
-        if ($behaviorRegistry->hasMethod('objectType')) {
+        if ($this->Table->hasBehavior('objectType')) {
+            /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $objectTypeBehavior */
+            $objectTypeBehavior = $this->Table->getBehavior('ObjectType');
             /** @var \BEdita\Core\Model\Entity\ObjectType $objectType */
-            $objectType = $behaviorRegistry->call('objectType');
+            $objectType = $objectTypeBehavior->objectType();
             $this->setConfig('allowedAssociations', array_fill_keys($objectType->relations, []));
         }
 
@@ -193,7 +194,9 @@ class ObjectsController extends ResourcesController
         if ($table === null) {
             $objectType = $this->objectType;
         } elseif ($table->hasBehavior('ObjectType')) {
-            $objectType = $table->objectType();
+            /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $behavior */
+            $behavior = $table->getBehavior('ObjectType');
+            $objectType = $behavior->objectType();
         }
 
         if ($objectType instanceof ObjectType && $objectType->hasAssoc('Permissions')) {
@@ -289,7 +292,10 @@ class ObjectsController extends ResourcesController
     {
         $this->request->allowMethod(['get', 'patch', 'delete']);
 
-        $id = TableRegistry::getTableLocator()->get('Objects')->getId($id);
+        $objectsTable = $this->fetchTable('Objects');
+        /** @var \BEdita\Core\Model\Behavior\ResourceNameBehavior $resourceNameBehavior */
+        $resourceNameBehavior = $objectsTable->getBehavior('ResourceName');
+        $id = $resourceNameBehavior->getId($id);
         $contain = $this->prepareInclude($this->request->getQuery('include'));
 
         $action = new GetObjectAction(['table' => $this->Table, 'objectType' => $this->objectType]);
@@ -425,7 +431,10 @@ class ObjectsController extends ResourcesController
         $this->request->allowMethod(['get']);
 
         $relationship = $this->request->getParam('relationship');
-        $relatedId = TableRegistry::getTableLocator()->get('Objects')->getId($this->request->getParam('related_id'));
+        $objectsTable = $this->fetchTable('Objects');
+        /** @var \BEdita\Core\Model\Behavior\ResourceNameBehavior $resourceNameBehavior */
+        $resourceNameBehavior = $objectsTable->getBehavior('ResourceName');
+        $relatedId = $resourceNameBehavior->getId($this->request->getParam('related_id'));
 
         $association = $this->findAssociation($relationship);
         $filter = $this->prepareFilter();
@@ -453,7 +462,10 @@ class ObjectsController extends ResourcesController
      */
     public function relationships(): ?Response
     {
-        $id = TableRegistry::getTableLocator()->get('Objects')->getId($this->request->getParam('id'));
+        $objectsTable = $this->fetchTable('Objects');
+        /** @var \BEdita\Core\Model\Behavior\ResourceNameBehavior $resourceNameBehavior */
+        $resourceNameBehavior = $objectsTable->getBehavior('ResourceName');
+        $id = $resourceNameBehavior->getId($this->request->getParam('id'));
         $relationship = $this->request->getParam('relationship');
 
         $association = $this->findAssociation($relationship);

--- a/plugins/BEdita/API/src/Controller/ResourcesController.php
+++ b/plugins/BEdita/API/src/Controller/ResourcesController.php
@@ -264,8 +264,12 @@ abstract class ResourcesController extends AppController
      */
     protected function getResourceId(string|int $id): string
     {
-        if ($this->fetchTable()->behaviors()->has('ResourceName')) {
-            return (string)$this->fetchTable()->getId($id);
+        $table = $this->fetchTable();
+        if ($table->hasBehavior('ResourceName')) {
+            /** @var \BEdita\Core\Model\Behavior\ResourceNameBehavior $resourceNameBehavior */
+            $resourceNameBehavior = $table->getBehavior('ResourceName');
+
+            return (string)$resourceNameBehavior->getId($id);
         }
 
         return (string)$id;

--- a/plugins/BEdita/API/src/View/JsonSchemaView.php
+++ b/plugins/BEdita/API/src/View/JsonSchemaView.php
@@ -17,7 +17,7 @@ namespace BEdita\API\View;
 use Cake\View\JsonView;
 
 /**
- * A view class that is used for API JSON sche,aresponse.
+ * A view class that is used for API JSON schema response.
  *
  * @since 6.0.0
  */

--- a/plugins/BEdita/API/tests/IntegrationTest/ExpiredTokenTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ExpiredTokenTest.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2026 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\API\Test\IntegrationTest;
+
+use BEdita\API\Exception\ExpiredTokenException;
+use BEdita\API\TestSuite\IntegrationTestCase;
+use Cake\Utility\Hash;
+use Cake\Utility\Security;
+use Firebase\JWT\JWT;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Tests for expired JWT token handling.
+ */
+#[CoversNothing]
+class ExpiredTokenTest extends IntegrationTestCase
+{
+    /**
+     * Provider for `testExpiredJwtToken`
+     *
+     * @return array
+     */
+    public static function expiredProvider(): array
+    {
+        return [
+            'json api' => [
+                '/roles',
+                'application/vnd.api+json',
+            ],
+            'plain json' => [
+                '/model/project',
+                'application/json',
+            ],
+        ];
+    }
+
+    /**
+     * Test API call with expired JWT bearer token.
+     *
+     * Verifies that an API request with an expired JWT token
+     * returns a 401 error response with code 'be_token_expired'.
+     *
+     * @return void
+     */
+    #[DataProvider('expiredProvider')]
+    public function testExpiredJwtToken(string $endoint, string $contentType): void
+    {
+        // Generate an expired JWT token (expired 10 seconds ago)
+        $expiredToken = JWT::encode(['exp' => time() - 10], Security::getSalt(), 'HS256');
+
+        $headers = [
+            'Host' => 'api.example.com',
+            'Accept' => $contentType,
+            'Content-Type' => 'application/json',
+            'Authorization' => 'Bearer ' . $expiredToken,
+        ];
+        $this->configRequestHeaders('GET', $headers);
+        $this->get($endoint);
+
+        $this->assertResponseCode(401);
+        $this->assertContentType($contentType);
+        $this->assertResponseNotEmpty();
+
+        $body = json_decode((string)$this->_response->getBody(), true);
+
+        static::assertArrayHasKey('error', $body);
+        static::assertEquals('401', $body['error']['status']);
+        static::assertEquals(ExpiredTokenException::BE_TOKEN_EXPIRED, Hash::get($body, 'error.code'));
+    }
+}

--- a/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
+++ b/plugins/BEdita/API/tests/IntegrationTest/ParentsRelationshipTest.php
@@ -80,9 +80,11 @@ class ParentsRelationshipTest extends IntegrationTestCase
 
         // POST: add 3 folders as parents relationships
         $foldersTable = TableRegistry::getTableLocator()->get('Folders');
+        /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $objectTypeBehavior */
+        $objectTypeBehavior = $foldersTable->getBehavior('ObjectType');
         $folders = $foldersTable
             ->find('list', keyField: 'uname', valueField: 'id')
-            ->where(['object_type_id' => $foldersTable->objectType()->id])
+            ->where(['object_type_id' => $objectTypeBehavior->objectType()->id])
             ->orderBy(['id' => 'ASC'])
             ->limit(3)
             ->toArray();

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -2438,10 +2438,10 @@ class ObjectsControllerTest extends IntegrationTestCase
         $request = new ServerRequest(compact('environment', 'params'));
         $request = $request->withAttribute('authentication', new AuthenticationService());
 
-        $controller = $this->getMockBuilder(ObjectsController::class)
+        $controller = $this->getStubBuilder(ObjectsController::class)
             ->setConstructorArgs([$request])
             ->onlyMethods(['getAvailableTypes'])
-            ->getMock();
+            ->getStub();
 
         $controller
             ->method('getAvailableTypes')

--- a/plugins/BEdita/API/tests/TestCase/Identifier/JwtSubjectIdentifierTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Identifier/JwtSubjectIdentifierTest.php
@@ -17,6 +17,7 @@ namespace BEdita\API\Test\TestCase\Identifier;
 use Authentication\Identifier\Resolver\ResolverInterface;
 use BEdita\API\Identifier\JwtSubjectIdentifier;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
@@ -32,9 +33,9 @@ class JwtSubjectIdentifierTest extends TestCase
      */
     public function testIdentify(): void
     {
-        $resolver = $this->getMockBuilder(ResolverInterface::class)
+        $resolver = $this->getStubBuilder(ResolverInterface::class)
             ->onlyMethods(['find'])
-            ->getMock();
+            ->getStub();
 
         $resolver->method('find')
             ->willReturn([]);

--- a/plugins/BEdita/API/tests/TestCase/Identifier/JwtSubjectIdentifierTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Identifier/JwtSubjectIdentifierTest.php
@@ -17,7 +17,6 @@ namespace BEdita\API\Test\TestCase\Identifier;
 use Authentication\Identifier\Resolver\ResolverInterface;
 use BEdita\API\Identifier\JwtSubjectIdentifier;
 use Cake\TestSuite\TestCase;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 /**

--- a/plugins/BEdita/API/tests/TestCase/Identifier/OAuth2IdentifierTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Identifier/OAuth2IdentifierTest.php
@@ -131,8 +131,8 @@ class OAuth2IdentifierTest extends TestCase
             ->firstOrFail();
         // Mock OAuth2 response
         $response = new Response([], json_encode($oauthResponse));
-        $mock = $this->getMockBuilder(Stream::class)
-            ->getMock();
+        $mock = $this->getStubBuilder(Stream::class)
+            ->getStub();
         $mock->method('send')
             ->willReturn([$response]);
 

--- a/plugins/BEdita/API/tests/TestCase/Middleware/ApplicationMiddlewareTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Middleware/ApplicationMiddlewareTest.php
@@ -103,8 +103,8 @@ class ApplicationMiddlewareTest extends TestCase
         static::assertNull(CurrentApplication::getApplication());
 
         $expected = $this->fetchTable('Applications')->find('apiKey', apiKey: API_KEY)->firstOrFail();
-        $serviceMock = $this->getMockForAuthenticationService(new Identity($expected));
-        $request = (new ServerRequest())->withAttribute('authentication', $serviceMock);
+        $serviceStub = $this->getStubForAuthenticationService(new Identity($expected));
+        $request = (new ServerRequest())->withAttribute('authentication', $serviceStub);
         $handler = new TestRequestHandler();
 
         $middleware = new ApplicationMiddleware();
@@ -174,8 +174,8 @@ class ApplicationMiddlewareTest extends TestCase
             $authProvider->authenticate($request); // decode jwt setting payload
         }
 
-        $serviceMock = $this->getMockForAuthenticationService(null, $authProvider);
-        $request = $request->withAttribute('authentication', $serviceMock);
+        $serviceStub = $this->getStubForAuthenticationService(null, $authProvider);
+        $request = $request->withAttribute('authentication', $serviceStub);
 
         $handler = new TestRequestHandler();
         $middleware = new ApplicationMiddleware();
@@ -206,9 +206,9 @@ class ApplicationMiddlewareTest extends TestCase
             ],
         ]);
 
-        $serviceMock = $this->getMockForAuthenticationService();
+        $serviceStub = $this->getStubForAuthenticationService();
         $request = $request->withData('grant_type', 'refresh_token')
-            ->withAttribute('authentication', $serviceMock);
+            ->withAttribute('authentication', $serviceStub);
 
         // before execute middleware disable the app
         $app->enabled = false;
@@ -235,8 +235,8 @@ class ApplicationMiddlewareTest extends TestCase
             ],
         ]);
 
-        $serviceMock = $this->getMockForAuthenticationService();
-        $request = $request->withAttribute('authentication', $serviceMock);
+        $serviceStub = $this->getStubForAuthenticationService();
+        $request = $request->withAttribute('authentication', $serviceStub);
 
         $handler = new TestRequestHandler();
         $middleware = new ApplicationMiddleware();
@@ -292,8 +292,8 @@ class ApplicationMiddlewareTest extends TestCase
 
         $middleware = new ApplicationMiddleware($config);
         $request = new ServerRequest();
-        $serviceMock = $this->getMockForAuthenticationService();
-        $request = $request->withAttribute('authentication', $serviceMock)
+        $serviceStub = $this->getStubForAuthenticationService();
+        $request = $request->withAttribute('authentication', $serviceStub)
             ->withAddedHeader($middleware->getConfig('apiKey.header'), $apiKey);
 
         $handler = new TestRequestHandler();

--- a/plugins/BEdita/API/tests/TestCase/Middleware/LoggedUserMiddlewareTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Middleware/LoggedUserMiddlewareTest.php
@@ -106,7 +106,7 @@ class LoggedUserMiddlewareTest extends TestCase
     public function testEmptyIdentity(): void
     {
         $request = new ServerRequest();
-        $request = $request->withAttribute('authentication', $this->getMockForAuthenticationService());
+        $request = $request->withAttribute('authentication', $this->getStubForAuthenticationService());
         $handler = new TestRequestHandler();
         $middleware = new LoggedUserMiddleware();
         $middleware->process($request, $handler);
@@ -141,7 +141,7 @@ class LoggedUserMiddlewareTest extends TestCase
         $request = new ServerRequest([
             'url' => '/auth',
         ]);
-        $request = $request->withAttribute('authentication', $this->getMockForAuthenticationService());
+        $request = $request->withAttribute('authentication', $this->getStubForAuthenticationService());
         $handler = new TestRequestHandler();
         $middleware = new LoggedUserMiddleware();
         $middleware->process($request, $handler);
@@ -194,7 +194,7 @@ class LoggedUserMiddlewareTest extends TestCase
     {
         $identity = new Identity($identityData);
         $request = new ServerRequest();
-        $request = $request->withAttribute('authentication', $this->getMockForAuthenticationService($identity));
+        $request = $request->withAttribute('authentication', $this->getStubForAuthenticationService($identity));
         $handler = new TestRequestHandler();
         $middleware = new LoggedUserMiddleware();
         $middleware->process($request, $handler);
@@ -229,7 +229,7 @@ class LoggedUserMiddlewareTest extends TestCase
         $authProvider = new JwtAuthenticator(new JwtSubjectIdentifier());
         $authProvider->authenticate($request); // it needs to decode and set payload
         $identity = new Identity($app);
-        $request = $request->withAttribute('authentication', $this->getMockForAuthenticationService($identity, $authProvider));
+        $request = $request->withAttribute('authentication', $this->getStubForAuthenticationService($identity, $authProvider));
 
         $handler = new TestRequestHandler();
         $middleware = new LoggedUserMiddleware();

--- a/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateAssociatedActionTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateAssociatedActionTest.php
@@ -243,15 +243,15 @@ class UpdateAssociatedActionTest extends TestCase
         }
 
         $request = new ServerRequest();
-        $identityMock = $this->getMockBuilder(Identity::class)
+        $identityStub = $this->getStubBuilder(Identity::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['can'])
-            ->getMock();
+            ->getStub();
 
-        $identityMock->method('can')->willReturn(true);
+        $identityStub->method('can')->willReturn(true);
 
         $request = $request->withParsedBody($data)
-            ->withAttribute('identity', $identityMock);
+            ->withAttribute('identity', $identityStub);
         $association = $this->fetchTable($table)->getAssociation($association);
         $parentAction = new SetAssociatedAction(compact('association'));
         $action = new UpdateAssociatedAction(['action' => $parentAction, 'request' => $request]);
@@ -294,15 +294,15 @@ class UpdateAssociatedActionTest extends TestCase
         $junction->saveOrFail($junctionEntity);
 
         $request = new ServerRequest();
-        $identityMock = $this->getMockBuilder(Identity::class)
+        $identityStub = $this->getStubBuilder(Identity::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['can'])
-            ->getMock();
+            ->getStub();
 
-        $identityMock->method('can')->willReturn(true);
+        $identityStub->method('can')->willReturn(true);
 
         $request = $request
-            ->withAttribute('identity', $identityMock)
+            ->withAttribute('identity', $identityStub)
             ->withParsedBody([
                 [
                     'id' => 1,
@@ -353,15 +353,15 @@ class UpdateAssociatedActionTest extends TestCase
             ['id' => 2],
         ];
         $request = new ServerRequest();
-        $identityMock = $this->getMockBuilder(Identity::class)
+        $identityStub = $this->getStubBuilder(Identity::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['can'])
-            ->getMock();
+            ->getStub();
 
-        $identityMock->method('can')->willReturn(false);
+        $identityStub->method('can')->willReturn(false);
 
         $request = $request->withParsedBody($data)
-            ->withAttribute('identity', $identityMock);
+            ->withAttribute('identity', $identityStub);
 
         $association = $this->fetchTable('FakeTags')->getAssociation('FakeArticles');
         $parentAction = new SetAssociatedAction(compact('association'));
@@ -384,26 +384,25 @@ class UpdateAssociatedActionTest extends TestCase
             ['id' => 2],
         ];
         $request = new ServerRequest();
-        $identityMock = $this->getMockBuilder(Identity::class)
+        $identityStub = $this->getStubBuilder(Identity::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['can'])
-            ->getMock();
+            ->getStub();
 
-        $identityMock->method('can')->with('updateParents')->willReturn(false);
+        $identityStub->method('can')->with('updateParents')->willReturn(false);
 
         $request = $request->withParsedBody($data)
             ->withMethod('PATCH')
-            ->withAttribute('identity', $identityMock);
-
-        $associationMock = $this->getMockBuilder(HasMany::class)
+            ->withAttribute('identity', $identityStub);
+        $associationStub = $this->getStubBuilder(HasMany::class)
             ->setConstructorArgs(['Parents'])
             ->onlyMethods(['getSource', 'getTarget'])
-            ->getMock();
+            ->getStub();
 
-        $associationMock->method('getSource')->willReturn($this->fetchTable('FakeAnimals'));
-        $associationMock->method('getTarget')->willReturn($this->fetchTable('FakeArticles'));
+        $associationStub->method('getSource')->willReturn($this->fetchTable('FakeAnimals'));
+        $associationStub->method('getTarget')->willReturn($this->fetchTable('FakeArticles'));
 
-        $parentAction = new SetAssociatedAction(['association' => $associationMock]);
+        $parentAction = new SetAssociatedAction(['association' => $associationStub]);
         $action = new UpdateAssociatedAction(['action' => $parentAction, 'request' => $request]);
 
         $action(['primaryKey' => 1]);
@@ -421,15 +420,15 @@ class UpdateAssociatedActionTest extends TestCase
             ['id' => 2],
         ];
         $request = new ServerRequest();
-        $identityMock = $this->getMockBuilder(Identity::class)
+        $identityStub = $this->getStubBuilder(Identity::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['can'])
-            ->getMock();
+            ->getStub();
 
-        $identityMock->method('can')->willThrowException(new MissingPolicyException('Missing policy'));
+        $identityStub->method('can')->willThrowException(new MissingPolicyException('Missing policy'));
 
         $request = $request->withParsedBody($data)
-            ->withAttribute('identity', $identityMock);
+            ->withAttribute('identity', $identityStub);
 
         $association = $this->fetchTable('FakeTags')->getAssociation('FakeArticles');
         $parentAction = new SetAssociatedAction(compact('association'));
@@ -639,13 +638,13 @@ class UpdateAssociatedActionTest extends TestCase
     {
         $Documents = $this->fetchTable('Documents');
         $association = $Documents->getAssociation($associationName);
-        $identityMock = $this->getMockBuilder(Identity::class)
+        $identityStub = $this->getStubBuilder(Identity::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['can'])
-            ->getMock();
-        $identityMock->method('can')->willReturn(true);
+            ->getStub();
+        $identityStub->method('can')->willReturn(true);
         $request = (new ServerRequest())->withParsedBody($body)
-            ->withAttribute('identity', $identityMock);
+            ->withAttribute('identity', $identityStub);
         $parentAction = new AddRelatedObjectsAction(compact('association'));
         $action = new UpdateAssociatedAction(['action' => $parentAction, 'request' => $request]);
         $result = $action(compact('primaryKey'));

--- a/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateAssociatedActionTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Model/Action/UpdateAssociatedActionTest.php
@@ -384,10 +384,10 @@ class UpdateAssociatedActionTest extends TestCase
             ['id' => 2],
         ];
         $request = new ServerRequest();
-        $identityStub = $this->getStubBuilder(Identity::class)
+        $identityStub = $this->getMockBuilder(Identity::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['can'])
-            ->getStub();
+            ->getMock();
 
         $identityStub->method('can')->with('updateParents')->willReturn(false);
 

--- a/plugins/BEdita/API/tests/Utility/TestAuthHelperTrait.php
+++ b/plugins/BEdita/API/tests/Utility/TestAuthHelperTrait.php
@@ -21,6 +21,7 @@ use BEdita\API\Utility\JWTHandler;
 use BEdita\Core\Model\Entity\Application;
 use BEdita\Core\State\CurrentApplication;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 
 /**
  * Collection of useful authentication related methods.
@@ -45,27 +46,27 @@ trait TestAuthHelperTrait
     }
 
     /**
-     * Helper class for get mock of AuthenticationService.
+     * Helper class for get stub of AuthenticationService.
      *
      * @param \Authentication\Identity|null $identity The identity
      * @param \Authentication\Authenticator\AbstractAuthenticator|null $authenticator The successful authenticator
-     * @return \PHPUnit\Framework\MockObject\MockObject
+     * @return \PHPUnit\Framework\MockObject\Stub
      */
-    protected function getMockForAuthenticationService(?Identity $identity = null, ?AbstractAuthenticator $authenticator = null): MockObject
+    protected function getStubForAuthenticationService(?Identity $identity = null, ?AbstractAuthenticator $authenticator = null): Stub
     {
-        $serviceMock = $this->getMockBuilder(AuthenticationService::class)
+        $serviceStub = $this->getStubBuilder(AuthenticationService::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getIdentity', 'getAuthenticationProvider'])
-            ->getMock();
+            ->getStub();
 
-         $serviceMock
+         $serviceStub
             ->method('getIdentity')
             ->willReturn($identity);
 
-        $serviceMock
+        $serviceStub
             ->method('getAuthenticationProvider')
             ->willReturn($authenticator);
 
-        return $serviceMock;
+        return $serviceStub;
     }
 }

--- a/plugins/BEdita/API/tests/Utility/TestAuthHelperTrait.php
+++ b/plugins/BEdita/API/tests/Utility/TestAuthHelperTrait.php
@@ -20,7 +20,6 @@ use Authentication\Identity;
 use BEdita\API\Utility\JWTHandler;
 use BEdita\Core\Model\Entity\Application;
 use BEdita\Core\State\CurrentApplication;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 
 /**

--- a/plugins/BEdita/Core/composer.json
+++ b/plugins/BEdita/Core/composer.json
@@ -33,7 +33,7 @@
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^5.3.0",
         "enqueue/fs": "^0.10.16",
-        "phpunit/phpunit": "^11.5.3 || ^12.1.3"
+        "phpunit/phpunit": "^12.5.1"
     },
     "autoload": {
         "psr-4": {

--- a/plugins/BEdita/Core/composer.json
+++ b/plugins/BEdita/Core/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "cakephp/cakephp": "~5.2.9",
+        "cakephp/cakephp": "~5.3.0",
         "cakephp/migrations": "^4.8.2",
         "cakephp/queue": "^2.2.0",
         "league/flysystem": "^3.30.2",
@@ -33,7 +33,7 @@
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^5.3.0",
         "enqueue/fs": "^0.10.16",
-        "phpunit/phpunit": "^11.5 || ^12.1"
+        "phpunit/phpunit": "^11.5.3 || ^12.1.3"
     },
     "autoload": {
         "psr-4": {

--- a/plugins/BEdita/Core/config/Migrations/20171005105447_ObjectTypesInheritance.php
+++ b/plugins/BEdita/Core/config/Migrations/20171005105447_ObjectTypesInheritance.php
@@ -142,7 +142,7 @@ class ObjectTypesInheritance extends BaseMigration
             'left' => 'tree_left',
             'right' => 'tree_right',
         ]);
-        /* @var \BEdita\Core\Model\Behavior\TreeBehavior $tree */
+        /** @var \BEdita\Core\Model\Behavior\TreeBehavior $tree */
         $tree = $table->behaviors()->get('Tree');
         $tree->nonAtomicRecover();
     }

--- a/plugins/BEdita/Core/config/Migrations/20171030185447_MediaTypesInheritance.php
+++ b/plugins/BEdita/Core/config/Migrations/20171030185447_MediaTypesInheritance.php
@@ -35,7 +35,7 @@ class MediaTypesInheritance extends BaseMigration
             'left' => 'tree_left',
             'right' => 'tree_right',
         ]);
-        /* @var \BEdita\Core\Model\Behavior\TreeBehavior $tree */
+        /** @var \BEdita\Core\Model\Behavior\TreeBehavior $tree */
         $tree = $table->behaviors()->get('Tree');
         $tree->nonAtomicRecover();
     }

--- a/plugins/BEdita/Core/config/Migrations/20171031155829_UsersInheritance.php
+++ b/plugins/BEdita/Core/config/Migrations/20171031155829_UsersInheritance.php
@@ -33,7 +33,7 @@ class UsersInheritance extends BaseMigration
             'left' => 'tree_left',
             'right' => 'tree_right',
         ]);
-        /* @var \BEdita\Core\Model\Behavior\TreeBehavior $tree */
+        /** @var \BEdita\Core\Model\Behavior\TreeBehavior $tree */
         $tree = $table->behaviors()->get('Tree');
         $tree->nonAtomicRecover();
     }

--- a/plugins/BEdita/Core/config/Migrations/20180131171902_FoldersType.php
+++ b/plugins/BEdita/Core/config/Migrations/20180131171902_FoldersType.php
@@ -54,7 +54,7 @@ class FoldersType extends BaseMigration
             'left' => 'tree_left',
             'right' => 'tree_right',
         ]);
-        /* @var \BEdita\Core\Model\Behavior\TreeBehavior $tree */
+        /** @var \BEdita\Core\Model\Behavior\TreeBehavior $tree */
         $tree = $table->behaviors()->get('Tree');
         $tree->nonAtomicRecover();
     }

--- a/plugins/BEdita/Core/config/Migrations/20200429070603_LinksTable.php
+++ b/plugins/BEdita/Core/config/Migrations/20200429070603_LinksTable.php
@@ -98,7 +98,7 @@ class LinksTable extends BaseMigration
             'left' => 'tree_left',
             'right' => 'tree_right',
         ]);
-        /* @var \BEdita\Core\Model\Behavior\TreeBehavior $tree */
+        /** @var \BEdita\Core\Model\Behavior\TreeBehavior $tree */
         $tree = $table->behaviors()->get('Tree');
         $tree->nonAtomicRecover();
     }

--- a/plugins/BEdita/Core/config/Migrations/20200505052558_PublicationsTable.php
+++ b/plugins/BEdita/Core/config/Migrations/20200505052558_PublicationsTable.php
@@ -104,7 +104,7 @@ class PublicationsTable extends BaseMigration
             'left' => 'tree_left',
             'right' => 'tree_right',
         ]);
-        /* @var \BEdita\Core\Model\Behavior\TreeBehavior $tree */
+        /** @var \BEdita\Core\Model\Behavior\TreeBehavior $tree */
         $tree = $table->behaviors()->get('Tree');
         $tree->nonAtomicRecover();
     }

--- a/plugins/BEdita/Core/src/Command/BuildSearchIndexCommand.php
+++ b/plugins/BEdita/Core/src/Command/BuildSearchIndexCommand.php
@@ -141,7 +141,9 @@ class BuildSearchIndexCommand extends Command
     {
         $indexed = 0;
         $table = $this->fetchTable($entity->getSource());
-        foreach ($table->getSearchAdapters() as $adapter) {
+        /** @var \BEdita\Core\Model\Behavior\SearchableBehavior $searchableBehavior */
+        $searchableBehavior = $table->getBehavior('Searchable');
+        foreach ($searchableBehavior->getSearchAdapters() as $adapter) {
             if (!empty($adapters) && !in_array($adapter->getAlias(), $adapters)) {
                 continue;
             }

--- a/plugins/BEdita/Core/src/Command/CheckSchemaCommand.php
+++ b/plugins/BEdita/Core/src/Command/CheckSchemaCommand.php
@@ -204,6 +204,9 @@ class CheckSchemaCommand extends Command
             if (is_array($value)) {
                 $value = new ArrayObject($value);
             }
+            if (!is_object($value) && !is_string($value)) {
+                continue;
+            }
             $validator->setProvider($key, $value);
         }
 

--- a/plugins/BEdita/Core/src/Command/FixHistoryCommand.php
+++ b/plugins/BEdita/Core/src/Command/FixHistoryCommand.php
@@ -255,7 +255,7 @@ class FixHistoryCommand extends Command
      * @param bool $created Created flag, if true look for `create` action in history
      * @param int $from From ID
      * @param int $to To ID
-     * @return \Cake\ORM\Query
+     * @return \Cake\ORM\Query\SelectQuery
      */
     protected function missingHistoryQuery(bool $created, int $from, int $to): SelectQuery
     {

--- a/plugins/BEdita/Core/src/Command/ResourcesCommand.php
+++ b/plugins/BEdita/Core/src/Command/ResourcesCommand.php
@@ -74,7 +74,7 @@ class ResourcesCommand extends Command
             ->addOption('filter', [
                 'help' => 'List entities filtered by comma separated key=value pairs',
                 'required' => false,
-                'short' => 'q',
+                'short' => 'e',
             ])
             ->addOption('field', [
                 'help' => 'Field name',

--- a/plugins/BEdita/Core/src/Command/TreeCheckCommand.php
+++ b/plugins/BEdita/Core/src/Command/TreeCheckCommand.php
@@ -98,7 +98,7 @@ class TreeCheckCommand extends Command
         if ($args->getOption('categories')) {
             /** @var \BEdita\Core\Model\Table\CategoriesTable $Categories */
             $Categories = $this->fetchTable('Categories');
-            $messages = $Categories->checkIntegrity();
+            $messages = $Categories->getBehavior('Tree')->checkIntegrity();
             if (!empty($messages)) {
                 $io->out('=====> <error>Categories tree is corrupt!</error>');
                 foreach ($messages as $msg) {

--- a/plugins/BEdita/Core/src/Model/Action/CloneObjectAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/CloneObjectAction.php
@@ -64,7 +64,9 @@ class CloneObjectAction extends BaseAction
         }, ARRAY_FILTER_USE_KEY);
 
         return $this->Table->getConnection()->transactional(function () use ($sourceId, $attributes, $include) {
-            $objectType = $this->Table->objectType();
+            /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $objectTypeBehavior */
+            $objectTypeBehavior = $this->Table->getBehavior('ObjectType');
+            $objectType = $objectTypeBehavior->objectType();
             $contain = $objectType->get('associations');
             $action = new GetObjectAction(['table' => $this->Table]);
             $source = $action(['primaryKey' => $sourceId, 'contain' => $contain]);

--- a/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
+++ b/plugins/BEdita/Core/src/Model/Action/ListRelatedObjectsAction.php
@@ -47,7 +47,9 @@ class ListRelatedObjectsAction extends ListAssociatedAction
             $objectType = null;
             if (count($objectTypes) === 1) {
                 $objectType = current($objectTypes);
-                $table->setupRelations($objectType);
+                /** @var \BEdita\Core\Model\Behavior\RelationsBehavior $relationsBehavior */
+                $relationsBehavior = $table->getBehavior('Relations');
+                $relationsBehavior->setupRelations($objectType);
             }
             $this->ListAction = new ListObjectsAction(array_filter(compact('table', 'objectType')));
         } elseif (

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -89,7 +89,10 @@ class CustomPropertiesBehavior extends Behavior
      */
     protected function objectType(array ...$args): ?ObjectType
     {
-        return $this->table()->behaviors()->call('objectType', $args);
+        /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $objectTypeBehavior */
+        $objectTypeBehavior = $this->table()->getBehavior('ObjectType');
+
+        return $objectTypeBehavior->objectType(...$args);
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/CustomPropertiesBehavior.php
@@ -352,7 +352,7 @@ class CustomPropertiesBehavior extends Behavior
                 $operator = key($operation);
                 $value = $operation[$operator];
 
-                return $this->operatorExpression($query->newExpr(), $operator, $fieldExp, $value);
+                return $this->operatorExpression($query->expr(), $operator, $fieldExp, $value);
             }, array_keys($conditions)));
         });
     }

--- a/plugins/BEdita/Core/src/Model/Behavior/DataCleanupBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/DataCleanupBehavior.php
@@ -60,8 +60,10 @@ class DataCleanupBehavior extends Behavior
         }
 
         $type = Inflector::underscore($this->_table->getAlias());
-        if ($this->_table->behaviors()->has('ObjectType') && $this->_table->objectType()) {
-             $type = $this->_table->objectType()->get('name');
+        if ($this->_table->behaviors()->has('ObjectType')) {
+            /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $objectModelBehavior */
+            $objectModelBehavior = $this->_table->getBehavior('ObjectType');
+            $type = $objectModelBehavior->objectType()?->get('name') ?? $type;
         }
         $fields = $this->defaultFields($type);
         foreach ($fields as $key => $value) {

--- a/plugins/BEdita/Core/src/Model/Behavior/ObjectModelBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/ObjectModelBehavior.php
@@ -49,7 +49,12 @@ class ObjectModelBehavior extends Behavior
         $table->addBehavior('BEdita/Core.CustomProperties');
         $table->addBehavior('BEdita/Core.UniqueName');
         $table->addBehavior('BEdita/Core.Relations');
-        $objectType = $this->table()->objectType();
+        $objectType = null;
+        if ($table->hasBehavior('ObjectType')) {
+            /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $objectTypeBehavior */
+            $objectTypeBehavior = $table->getBehavior('ObjectType');
+            $objectType = $objectTypeBehavior->objectType();
+        }
         $table->addBehavior('BEdita/Core.Searchable', [
             'operationName' => [
                 'Model.afterSave' => function (EventInterface $event, EntityInterface $entity): string {

--- a/plugins/BEdita/Core/src/Model/Behavior/QueryCacheBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/QueryCacheBehavior.php
@@ -56,9 +56,9 @@ class QueryCacheBehavior extends Behavior
     /**
      * Add query cache using configured cache config.
      *
-     * @param \Cake\ORM\SelectQuery $query Query object
+     * @param \Cake\ORM\Query\SelectQuery $query Query object
      * @param string $key Cache key
-     * @return \Cake\ORM\SelectQuery
+     * @return \Cake\ORM\Query\SelectQuery
      */
     public function queryCache(SelectQuery $query, string $key): SelectQuery
     {

--- a/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
+++ b/plugins/BEdita/Core/src/Model/Behavior/RelationsBehavior.php
@@ -60,7 +60,10 @@ class RelationsBehavior extends Behavior
      */
     protected function objectType(ObjectType|string|int|null $type = null): ObjectType
     {
-        return $this->table()->behaviors()->call('objectType', [$type]);
+        /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $objectTypeBehavior */
+        $objectTypeBehavior = $this->table()->getBehavior('ObjectType');
+
+        return $objectTypeBehavior->objectType($type);
     }
 
     /**
@@ -178,6 +181,7 @@ class RelationsBehavior extends Behavior
      *
      * @return array<\BEdita\Core\Model\Entity\Relation>
      * @deprecated Use `ObjectType::getRelations()` instead.
+     * @codeCoverageIgnore
      */
     public function getRelations(): array
     {

--- a/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
@@ -38,7 +38,7 @@ use Cake\Validation\Validator;
  * @method \BEdita\Core\Model\Entity\Application patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \BEdita\Core\Model\Entity\Application[] patchEntities(iterable $entities, array $data, array $options = [])
  * @method \BEdita\Core\Model\Entity\Application findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
- * @method \Cake\ORM\Query\SelectQuery queryCache(\Cake\ORM\Query $query, string $key)
+ * @method \Cake\ORM\Query\SelectQuery queryCache(\Cake\ORM\Query\SelectQuery $query, string $key)
  * @property \Cake\ORM\Table&\Cake\ORM\Association\HasMany $EndpointPermissions
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @method \BEdita\Core\Model\Entity\Application newEmptyEntity()

--- a/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ApplicationsTable.php
@@ -38,7 +38,6 @@ use Cake\Validation\Validator;
  * @method \BEdita\Core\Model\Entity\Application patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \BEdita\Core\Model\Entity\Application[] patchEntities(iterable $entities, array $data, array $options = [])
  * @method \BEdita\Core\Model\Entity\Application findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
- * @method \Cake\ORM\Query\SelectQuery queryCache(\Cake\ORM\Query\SelectQuery $query, string $key)
  * @property \Cake\ORM\Table&\Cake\ORM\Association\HasMany $EndpointPermissions
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @method \BEdita\Core\Model\Entity\Application newEmptyEntity()
@@ -177,7 +176,10 @@ class ApplicationsTable extends Table
             $this->aliasField('enabled') => true,
         ]);
 
-        return $this->queryCache($query, sprintf('app_%s', $apiKey));
+        /** @var \BEdita\Core\Model\Behavior\QueryCacheBehavior $queryCacheBehavior */
+        $queryCacheBehavior = $this->getBehavior('QueryCache');
+
+        return $queryCacheBehavior->queryCache($query, sprintf('app_%s', $apiKey));
     }
 
     /**

--- a/plugins/BEdita/Core/src/Model/Table/ConfigTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ConfigTable.php
@@ -33,7 +33,6 @@ use Cake\Validation\Validator;
  * @method \BEdita\Core\Model\Entity\Config patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \BEdita\Core\Model\Entity\Config[] patchEntities(iterable $entities, array $data, array $options = [])
  * @method \BEdita\Core\Model\Entity\Config findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
- * @method \Cake\ORM\Query\SelectQuery queryCache(\Cake\ORM\Query\SelectQuery $query, string $key)
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @method \BEdita\Core\Model\Entity\Config newEmptyEntity()
  * @method \BEdita\Core\Model\Entity\Config[]|\Cake\Datasource\ResultSetInterface<\BEdita\Core\Model\Entity\Config>|false saveMany(iterable $entities, array $options = [])
@@ -193,7 +192,10 @@ class ConfigTable extends Table
                 return $exp->isNull($this->aliasField('application_id'));
             });
 
-        return $this->queryCache(
+        /** @var \BEdita\Core\Model\Behavior\QueryCacheBehavior $queryCacheBehavior */
+        $queryCacheBehavior = $this->getBehavior('QueryCache');
+
+        return $queryCacheBehavior->queryCache(
             $query,
             sprintf('config_%s_%s', $applicationId ?: 'any', $context ?: 'any'),
         );

--- a/plugins/BEdita/Core/src/Model/Table/EndpointPermissionsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/EndpointPermissionsTable.php
@@ -30,7 +30,6 @@ use Cake\Validation\Validator;
  * @property \Cake\ORM\Table&\Cake\ORM\Association\BelongsTo $Endpoints
  * @property \Cake\ORM\Table&\Cake\ORM\Association\BelongsTo $Applications
  * @property \Cake\ORM\Table&\Cake\ORM\Association\BelongsTo $Roles
- * @method \Cake\ORM\Query\SelectQuery queryCache(\Cake\ORM\Query\SelectQuery $query, string $key)
  * @method \BEdita\Core\Model\Entity\EndpointPermission newEmptyEntity()
  * @method \BEdita\Core\Model\Entity\EndpointPermission newEntity(array $data, array $options = [])
  * @method \BEdita\Core\Model\Entity\EndpointPermission[] newEntities(array $data, array $options = [])
@@ -267,7 +266,10 @@ class EndpointPermissionsTable extends Table
         $query = $this->find('byApplication', applicationId: $applicationId)
             ->find('byEndpoint', endpointIds: $endpointIds);
 
-        return $this->queryCache($query, $key)
+        /** @var \BEdita\Core\Model\Behavior\QueryCacheBehavior $queryCacheBehavior */
+        $queryCacheBehavior = $this->getBehavior('QueryCache');
+
+        return $queryCacheBehavior->queryCache($query, $key)
             ->count();
     }
 
@@ -284,13 +286,15 @@ class EndpointPermissionsTable extends Table
         $applicationId = CurrentApplication::getApplicationId();
         $endpointIds = array_filter([$endpointId]);
         $key = sprintf('perms_%d_%s_%s', (int)$strict, $applicationId ?: 'any', $endpointId ?: 'any');
+        /** @var \BEdita\Core\Model\Behavior\QueryCacheBehavior $queryCacheBehavior */
+        $queryCacheBehavior = $this->getBehavior('QueryCache');
 
         // anonymous user
         if ($user === null) {
             $query = $this->find('byApplication', applicationId: $applicationId, strict: $strict)
                 ->find('byEndpoint', endpointIds: $endpointIds, strict: $strict);
 
-            return $this->queryCache($query, $key)
+            return $queryCacheBehavior->queryCache($query, $key)
                 ->toArray();
         }
 
@@ -302,7 +306,7 @@ class EndpointPermissionsTable extends Table
             ->find('byEndpoint', endpointIds: $endpointIds, strict: $strict)
             ->find('byRole', roleIds: $roleIds);
 
-        return $this->queryCache($query, $key)
+        return $queryCacheBehavior->queryCache($query, $key)
             ->toArray();
     }
 }

--- a/plugins/BEdita/Core/src/Model/Table/EndpointPermissionsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/EndpointPermissionsTable.php
@@ -30,7 +30,7 @@ use Cake\Validation\Validator;
  * @property \Cake\ORM\Table&\Cake\ORM\Association\BelongsTo $Endpoints
  * @property \Cake\ORM\Table&\Cake\ORM\Association\BelongsTo $Applications
  * @property \Cake\ORM\Table&\Cake\ORM\Association\BelongsTo $Roles
- * @method \Cake\ORM\Query queryCache(\Cake\ORM\Query $query, string $key)
+ * @method \Cake\ORM\Query\SelectQuery queryCache(\Cake\ORM\Query\SelectQuery $query, string $key)
  * @method \BEdita\Core\Model\Entity\EndpointPermission newEmptyEntity()
  * @method \BEdita\Core\Model\Entity\EndpointPermission newEntity(array $data, array $options = [])
  * @method \BEdita\Core\Model\Entity\EndpointPermission[] newEntities(array $data, array $options = [])

--- a/plugins/BEdita/Core/src/Model/Table/EndpointsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/EndpointsTable.php
@@ -31,7 +31,6 @@ use Cake\Validation\Validator;
  * @method \BEdita\Core\Model\Entity\Endpoint patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \BEdita\Core\Model\Entity\Endpoint[] patchEntities(iterable $entities, array $data, array $options = [])
  * @method \BEdita\Core\Model\Entity\Endpoint findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
- * @method \Cake\ORM\Query\SelectQuery queryCache(\Cake\ORM\Query\SelectQuery $query, string $key)
  * @property \Cake\ORM\Table&\Cake\ORM\Association\BelongsTo $ObjectTypes
  * @property \Cake\ORM\Table&\Cake\ORM\Association\HasMany $EndpointPermissions
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
@@ -123,7 +122,10 @@ class EndpointsTable extends Table
             ->disableHydration()
             ->where([$this->aliasField('name') => $name]);
 
-        $endpoint = (array)$this->queryCache($query, sprintf('enpoint_%s', $name))
+        /** @var \BEdita\Core\Model\Behavior\QueryCacheBehavior $queryCacheBehavior */
+        $queryCacheBehavior = $this->getBehavior('QueryCache');
+
+        $endpoint = (array)$queryCacheBehavior->queryCache($query, sprintf('endpoint_%s', $name))
             ->first();
 
         if (isset($endpoint['enabled']) && $endpoint['enabled'] === false) {

--- a/plugins/BEdita/Core/src/Model/Table/EndpointsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/EndpointsTable.php
@@ -31,7 +31,7 @@ use Cake\Validation\Validator;
  * @method \BEdita\Core\Model\Entity\Endpoint patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method \BEdita\Core\Model\Entity\Endpoint[] patchEntities(iterable $entities, array $data, array $options = [])
  * @method \BEdita\Core\Model\Entity\Endpoint findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
- * @method \Cake\ORM\Query queryCache(\Cake\ORM\Query $query, string $key)
+ * @method \Cake\ORM\Query\SelectQuery queryCache(\Cake\ORM\Query\SelectQuery $query, string $key)
  * @property \Cake\ORM\Table&\Cake\ORM\Association\BelongsTo $ObjectTypes
  * @property \Cake\ORM\Table&\Cake\ORM\Association\HasMany $EndpointPermissions
  * @mixin \Cake\ORM\Behavior\TimestampBehavior

--- a/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/FoldersTable.php
@@ -71,8 +71,12 @@ class FoldersTable extends ObjectsTable
 
         // Ensure to setup object type also when an alias different from `Folders` is used.
         // For example `Parents` association defined in `ObjectsTable`
-        if ($this->objectType() === null) {
-            $this->setupRelations('folders');
+        /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $objectTypeBehavior */
+        $objectTypeBehavior = $this->getBehavior('ObjectType');
+        if ($objectTypeBehavior->objectType() === null) {
+            /** @var \BEdita\Core\Model\Behavior\RelationsBehavior $relationsBehavior */
+            $relationsBehavior = $this->getBehavior('Relations');
+            $relationsBehavior->setupRelations('folders');
         }
     }
 
@@ -230,10 +234,12 @@ class FoldersTable extends ObjectsTable
             return;
         }
 
+        /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $objectTypeBehavior */
+        $objectTypeBehavior = $this->getBehavior('ObjectType');
         $options['descendants'] = $this
             ->find('ancestor', parent: $entity->get('id'))
             ->where([
-                $this->aliasField('object_type_id') => $this->objectType()->id,
+                $this->aliasField('object_type_id') => $objectTypeBehavior->objectType()?->id,
             ])
             ->toArray();
     }
@@ -305,15 +311,19 @@ class FoldersTable extends ObjectsTable
             });
 
         // Update deleted field of descendants
+        /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $objectTypeBehavior */
+        $objectTypeBehavior = $this->getBehavior('ObjectType');
+        /** @var \BEdita\Core\Model\Behavior\UserModifiedBehavior $userModifiedBehavior */
+        $userModifiedBehavior = $this->getBehavior('UserModified');
         $this->updateAll(
             [
                 'deleted' => $folder->deleted,
                 'modified' => $this->timestamp(null, true),
-                'modified_by' => $this->userId(),
+                'modified_by' => $userModifiedBehavior->userId(),
             ],
             [
                 'id IN' => $descendantsToUpdate,
-                'object_type_id' => $this->objectType()->id,
+                'object_type_id' => $objectTypeBehavior->objectType()?->id,
                 'deleted IS NOT' => $folder->deleted,
             ],
         );

--- a/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/ObjectsTable.php
@@ -201,7 +201,10 @@ class ObjectsTable extends Table
 
             return;
         }
-        $this->checkStatus($entity);
+
+        /** @var \BEdita\Core\Model\Behavior\StatusBehavior $statusBehavior */
+        $statusBehavior = $this->getBehavior('Status');
+        $statusBehavior->checkStatus($entity);
         $this->checkLangTag($entity);
         $this->checkLocked($entity);
 
@@ -404,7 +407,9 @@ class ObjectsTable extends Table
      */
     public function findAncestor(SelectQuery $query, string|int $parent): SelectQuery
     {
-        $parentId = $this->getId($parent);
+        /** @var \BEdita\Core\Model\Behavior\ResourceNameBehavior $resourceNameBehavior */
+        $resourceNameBehavior = $this->getBehavior('ResourceName');
+        $parentId = $resourceNameBehavior->getId($parent);
         $parentNode = $this->TreeNodes->find()
             ->where([
                 $this->TreeNodes->aliasField('object_id') => $parentId,
@@ -434,7 +439,9 @@ class ObjectsTable extends Table
      */
     public function findParent(SelectQuery $query, string|int $parent): SelectQuery
     {
-        $parentId = $this->getId($parent);
+        /** @var \BEdita\Core\Model\Behavior\ResourceNameBehavior $resourceNameBehavior */
+        $resourceNameBehavior = $this->getBehavior('ResourceName');
+        $parentId = $resourceNameBehavior->getId($parent);
 
         return $query
             ->innerJoinWith('TreeNodes', function (SelectQuery $query) use ($parentId) {

--- a/plugins/BEdita/Core/src/Model/Table/StreamsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/StreamsTable.php
@@ -204,7 +204,9 @@ class StreamsTable extends Table
 
         return $this->getConnection()->transactional(function () use ($clone, $stream): Stream {
             $clone = $this->saveOrFail($clone, ['atomic' => false]);
-            $this->copyFiles($stream, $clone);
+            /** @var \BEdita\Core\Model\Behavior\UploadableBehavior $uploadable */
+            $uploadable = $this->getBehavior('Uploadable');
+            $uploadable->copyFiles($stream, $clone);
 
             return $this->get($clone->get('uuid'));
         });

--- a/plugins/BEdita/Core/src/Model/Table/TreesTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/TreesTable.php
@@ -276,7 +276,9 @@ class TreesTable extends Table
     public function afterSave(EventInterface $event, Tree $entity): void
     {
         if ($entity->has('position')) {
-            if ($this->moveAt($entity, $entity->get('position')) === false) {
+            /** @var \BEdita\Core\Model\Behavior\TreeBehavior $treeBehavior */
+            $treeBehavior = $this->getBehavior('Tree');
+            if ($treeBehavior->moveAt($entity, $entity->get('position')) === false) {
                 throw new BadRequestException(__d('bedita', 'Invalid position'));
             }
         }

--- a/plugins/BEdita/Core/src/ORM/Association/RelatedTo.php
+++ b/plugins/BEdita/Core/src/ORM/Association/RelatedTo.php
@@ -102,9 +102,13 @@ class RelatedTo extends BelongsToMany
             return $target;
         }
 
-        $objectType = $target->objectType();
+        /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $objectTypeBehavior */
+        $objectTypeBehavior = $target->getBehavior('ObjectType');
+        $objectType = $objectTypeBehavior->objectType();
         if ($objectType === null || $objectType->id !== $targetOT->id) {
-            $target->setupRelations(
+            /** @var \BEdita\Core\Model\Behavior\RelationsBehavior $relationsBehavior */
+            $relationsBehavior = $target->getBehavior('Relations');
+            $relationsBehavior->setupRelations(
                 $this->getTableLocator()->get('ObjectTypes')
                     ->get($targetOT->id),
             );
@@ -224,8 +228,10 @@ class RelatedTo extends BelongsToMany
         if (!$table->behaviors()->has('ObjectType')) {
             return false;
         }
+        /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $objectTypeBehavior */
+        $objectTypeBehavior = $table->getBehavior('ObjectType');
 
-        return $table->objectType()->is_abstract;
+        return $objectTypeBehavior->objectType()->is_abstract;
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Command/CheckSchemaCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/CheckSchemaCommandTest.php
@@ -205,11 +205,9 @@ class CheckSchemaCommandTest extends TestCase
         $cmd->checkConventions($connection);
         $cmd->addMessages('phinxlog', ['foo' => 'bar']);
         $actual = $cmd->formatMessages();
-        $expected = true;
-        $info = Database::basicInfo();
-        if ($info['vendor'] === 'sqlite') {
-            $expected = false;
-        }
+        // On SQLite the check cannot run; on MariaDB/Aurora/etc we also treat it as unavailable
+        $expected = $this->checkAvailable($connection);
+
         static::assertSame($expected, $actual);
         $actual = array_keys($cmd->getMessages());
         $messages = $cmd->getMessages();

--- a/plugins/BEdita/Core/tests/TestCase/Command/CheckSchemaCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/CheckSchemaCommandTest.php
@@ -40,15 +40,6 @@ class CheckSchemaCommandTest extends TestCase
     use ConsoleIntegrationTestTrait;
 
     /**
-     * Fixtures
-     *
-     * @var array
-     */
-    protected array $fixtures = [
-        'plugin.BEdita/Core.FakeAnimals',
-    ];
-
-    /**
      * Test buildOptionParser method
      *
      * @return void

--- a/plugins/BEdita/Core/tests/TestCase/Command/CheckSchemaCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/CheckSchemaCommandTest.php
@@ -23,6 +23,7 @@ use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Core\Plugin;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Postgres;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\ConnectionHelper;
@@ -206,7 +207,7 @@ class CheckSchemaCommandTest extends TestCase
         $cmd->addMessages('phinxlog', ['foo' => 'bar']);
         $actual = $cmd->formatMessages();
         // On SQLite the check cannot run; on MariaDB/Aurora/etc we also treat it as unavailable
-        $expected = $this->checkAvailable($connection);
+        $expected = $this->checkAvailable($connection) || $connection->getDriver() instanceof Postgres ? true : false;
 
         static::assertSame($expected, $actual);
         $actual = array_keys($cmd->getMessages());

--- a/plugins/BEdita/Core/tests/TestCase/Command/JobsCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/JobsCommandTest.php
@@ -52,15 +52,15 @@ class JobsCommandTest extends TestCase
     }
 
     /**
-     * Get mock service.
+     * Get stub service.
      *
      * @param bool|\Exception $return Return value for `run()` method.
      * @return \BEdita\Core\Job\JobService|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getMockService($return = true)
+    protected function getStubService($return = true)
     {
-        $service = $this->getMockBuilder(JobService::class)
-            ->getMock();
+        $service = $this->getStubBuilder(JobService::class)
+            ->getStub();
 
         $method = $service->method('run');
         if ($return instanceof Exception) {
@@ -96,7 +96,7 @@ class JobsCommandTest extends TestCase
     public function testRetrocompatibility(): void
     {
         $uuid = 'd6bb8c84-6b29-432e-bb84-c3c4b2c1b99c';
-        ServiceRegistry::set('example', $this->getMockService());
+        ServiceRegistry::set('example', $this->getStubService());
         $this->exec(sprintf('jobs run %s', $uuid));
         $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContains('completed successfully');
@@ -111,7 +111,7 @@ class JobsCommandTest extends TestCase
     public function testProcess()
     {
         $uuid = 'd6bb8c84-6b29-432e-bb84-c3c4b2c1b99c';
-        ServiceRegistry::set('example', $this->getMockService());
+        ServiceRegistry::set('example', $this->getStubService());
         $this->exec(sprintf('jobs process %s', $uuid));
         $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContains('completed successfully');
@@ -126,7 +126,7 @@ class JobsCommandTest extends TestCase
     public function testProcessInvalid()
     {
         $uuid = Text::uuid(); // This UUID hopefully does not exist. :)
-        ServiceRegistry::set('example', $this->getMockService());
+        ServiceRegistry::set('example', $this->getStubService());
         $this->exec(sprintf('jobs process %s', $uuid));
         $this->assertExitCode(Command::CODE_ERROR);
         $this->assertOutputContains('Could not obtain lock');
@@ -142,7 +142,7 @@ class JobsCommandTest extends TestCase
     {
         $exception = new BadMethodCallException('example');
         $uuid = 'd6bb8c84-6b29-432e-bb84-c3c4b2c1b99c';
-        ServiceRegistry::set('example', $this->getMockService($exception));
+        ServiceRegistry::set('example', $this->getStubService($exception));
         $this->exec(sprintf('jobs process %s', $uuid));
         $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertErrorContains('BadMethodCallException with message "example"');
@@ -157,7 +157,7 @@ class JobsCommandTest extends TestCase
     public function testProcessFailSmooth()
     {
         $uuid = 'd6bb8c84-6b29-432e-bb84-c3c4b2c1b99c';
-        ServiceRegistry::set('example', $this->getMockService(false));
+        ServiceRegistry::set('example', $this->getStubService(false));
         $this->exec(sprintf('jobs process %s', $uuid));
         $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertErrorContains('failed');
@@ -171,7 +171,7 @@ class JobsCommandTest extends TestCase
     public function testProcessFailHard()
     {
         $uuid = 'd6bb8c84-6b29-432e-bb84-c3c4b2c1b99c';
-        ServiceRegistry::set('example', $this->getMockService(false));
+        ServiceRegistry::set('example', $this->getStubService(false));
         $this->exec(sprintf('jobs process -F %s', $uuid));
         $this->assertExitCode(Command::CODE_ERROR);
         $this->assertErrorContains('failed');
@@ -184,9 +184,9 @@ class JobsCommandTest extends TestCase
      */
     public function testPending()
     {
-        ServiceRegistry::set('example', $this->getMockService());
-        ServiceRegistry::set('example2', $this->getMockService());
-        ServiceRegistry::set('signup', $this->getMockService());
+        ServiceRegistry::set('example', $this->getStubService());
+        ServiceRegistry::set('example2', $this->getStubService());
+        ServiceRegistry::set('signup', $this->getStubService());
         $this->exec('jobs pending');
         $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContains('completed successfully');
@@ -201,7 +201,7 @@ class JobsCommandTest extends TestCase
      */
     public function testPendingEmpty()
     {
-        ServiceRegistry::set('example', $this->getMockService());
+        ServiceRegistry::set('example', $this->getStubService());
         $this->exec('jobs pending --limit 0');
         $this->assertExitCode(Command::CODE_SUCCESS);
         $this->assertOutputContains('Nothing to do');
@@ -215,7 +215,7 @@ class JobsCommandTest extends TestCase
      */
     public function testPendingFailHard()
     {
-        ServiceRegistry::set('example', $this->getMockService(false));
+        ServiceRegistry::set('example', $this->getStubService(false));
         $this->exec('jobs pending -F');
         $this->assertExitCode(Command::CODE_ERROR);
         $this->assertErrorContains('failed');

--- a/plugins/BEdita/Core/tests/TestCase/Command/ResourcesCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/ResourcesCommandTest.php
@@ -72,7 +72,7 @@ class ResourcesCommandTest extends TestCase
     {
         $this->exec('resources --help');
         $this->assertOutputContains('Resources management command. Available subcommands: add, edit, ls, rm');
-        $this->assertOutputContains('cake resources [-f api_key|description|enabled|name|unchangeable] [-q] [-h] [-q] [-t] [-v] [<add|edit|ls|rm>] [<name|id>]');
+        $this->assertOutputContains('cake resources [-f api_key|description|enabled|name|unchangeable] [-e] [-h] [-q] [-t] [-v] [<add|edit|ls|rm>] [<name|id>]');
         $this->assertOutputContains('Field name');
         $this->assertOutputContains('api_key|description|enabled|name|unchangeable)');
         $this->assertOutputContains('List entities filtered by comma separated key=value pairs');
@@ -91,7 +91,7 @@ class ResourcesCommandTest extends TestCase
     {
         $this->exec('resources add --help');
         $this->assertOutputContains('Resources management command. Available subcommands: add, edit, ls, rm');
-        $this->assertOutputContains('cake resources [-f api_key|description|enabled|name|unchangeable] [-q] [-h] [-q] [-t] [-v] [<add|edit|ls|rm>] [<name|id>]');
+        $this->assertOutputContains('cake resources [-f api_key|description|enabled|name|unchangeable] [-e] [-h] [-q] [-t] [-v] [<add|edit|ls|rm>] [<name|id>]');
         $this->assertOutputContains('Field name');
         $this->assertOutputContains('api_key|description|enabled|name|unchangeable)');
         $this->assertOutputContains('List entities filtered by comma separated key=value pairs');

--- a/plugins/BEdita/Core/tests/TestCase/Command/SetupConnectionCommandTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Command/SetupConnectionCommandTest.php
@@ -93,8 +93,8 @@ class SetupConnectionCommandTest extends TestCase
     public function testExecuteUnknownConnectionType(): void
     {
         // Setup temporary configuration.
-        $connection = $this->getMockBuilder(ConnectionInterface::class)
-            ->getMock();
+        $connection = $this->getStubBuilder(ConnectionInterface::class)
+            ->getStub();
         ConnectionManager::setConfig(static::TEMP_CONNECTION, $connection);
 
         $this->exec(sprintf('setup_connection --connection %s', static::TEMP_CONNECTION));

--- a/plugins/BEdita/Core/tests/TestCase/Event/ImageThumbsHandlerTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Event/ImageThumbsHandlerTest.php
@@ -72,7 +72,7 @@ class ImageThumbsHandlerTest extends TestCase
         return [
             'no presets' => [
                 [
-                    'entity' => static fn(self $testCase) => $testCase->getMockBuilder(Stream::class)->getMock(),
+                    'entity' => static fn(self $testCase) => $testCase->getStubBuilder(Stream::class)->getStub(),
                 ],
                 [],
                 false,
@@ -94,7 +94,7 @@ class ImageThumbsHandlerTest extends TestCase
             ],
             'presets, noImages' => [
                 [
-                    'entity' => static fn(self $testCase) => $testCase->getMockBuilder(Stream::class)->getMock(),
+                    'entity' => static fn(self $testCase) => $testCase->getStubBuilder(Stream::class)->getStub(),
                     'relatedEntities' => [],
                 ],
                 [
@@ -110,11 +110,11 @@ class ImageThumbsHandlerTest extends TestCase
             ],
             'presets, stream and images' => [
                 [
-                    'entity' => static fn(self $testCase) => $testCase->getMockBuilder(Stream::class)->getMock(),
+                    'entity' => static fn(self $testCase) => $testCase->getStubBuilder(Stream::class)->getStub(),
                     'relatedEntities' => static function (self $testCase) {
-                        $image = $testCase->getMockBuilder(ObjectEntity::class)
+                        $image = $testCase->getStubBuilder(ObjectEntity::class)
                             ->onlyMethods(['get'])
-                            ->getMock();
+                            ->getStub();
                         $image->method('get')->willReturn('images');
 
                         return [$image];
@@ -208,16 +208,11 @@ class ImageThumbsHandlerTest extends TestCase
      */
     public static function thumbnailsUpdateProvider(): array
     {
-        // $streamWithObjectId = $this->getMockBuilder(Stream::class)
-        //     ->onlyMethods(['get'])
-        //     ->getMock();
-        // $streamWithObjectId->method('get')->willReturn(999);
-
         return [
             'empty presets' => [
                 [
-                    'stream' => static fn(self $testCase) => $testCase->getMockBuilder(Stream::class)
-                        ->getMock()
+                    'stream' => static fn(self $testCase) => $testCase->getStubBuilder(Stream::class)
+                        ->getStub()
                         ->method('get')
                         ->willReturn(999),
                 ],
@@ -243,8 +238,8 @@ class ImageThumbsHandlerTest extends TestCase
             ],
             'presets, stream, no image' => [
                 [
-                    'stream' => static fn(self $testCase) => $testCase->getMockBuilder(Stream::class)
-                        ->getMock()
+                    'stream' => static fn(self $testCase) => $testCase->getStubBuilder(Stream::class)
+                        ->getStub()
                         ->method('get')
                         ->willReturn(999),
                 ],
@@ -262,8 +257,8 @@ class ImageThumbsHandlerTest extends TestCase
             ],
             'presets, stream, but image not found' => [
                 [
-                    'stream' => static fn(self $testCase) => $testCase->getMockBuilder(Stream::class)
-                        ->getMock()
+                    'stream' => static fn(self $testCase) => $testCase->getStubBuilder(Stream::class)
+                        ->getStub()
                         ->method('get')
                         ->willReturn(999),
                 ],

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/FilesystemAdapterTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/FilesystemAdapterTest.php
@@ -39,7 +39,7 @@ class FilesystemAdapterTest extends TestCase
             'key' => 'value',
         ];
 
-        $leagueAdapter = $this->getMockBuilder(LeagueFilesystemAdapter::class)->getMock();
+        $leagueAdapter = $this->getStubBuilder(LeagueFilesystemAdapter::class)->getStub();
         $adapter = new class ($leagueAdapter) extends FilesystemAdapter {
             protected LeagueFilesystemAdapter $leagueAdapter;
 
@@ -67,7 +67,7 @@ class FilesystemAdapterTest extends TestCase
      */
     public function testGetInnerAdapter(): void
     {
-        $innerAdapter = $this->getMockBuilder(LeagueFilesystemAdapter::class)->getMock();
+        $innerAdapter = $this->getStubBuilder(LeagueFilesystemAdapter::class)->getStub();
         $config = [
             'baseUrl' => 'http://example.org',
             'key' => 'value',
@@ -134,7 +134,7 @@ class FilesystemAdapterTest extends TestCase
     #[DataProvider('getPublicUrlProvider')]
     public function testGetPublicUrl($expected, $baseUrl, $path)
     {
-        $leagueAdapter = $this->getMockBuilder(LeagueFilesystemAdapter::class)->getMock();
+        $leagueAdapter = $this->getStubBuilder(LeagueFilesystemAdapter::class)->getStub();
         $adapter = new class ($leagueAdapter) extends FilesystemAdapter {
             protected LeagueFilesystemAdapter $leagueAdapter;
 
@@ -162,7 +162,7 @@ class FilesystemAdapterTest extends TestCase
      */
     public function testGetVisibility()
     {
-        $leagueAdapter = $this->getMockBuilder(LeagueFilesystemAdapter::class)->getMock();
+        $leagueAdapter = $this->getStubBuilder(LeagueFilesystemAdapter::class)->getStub();
         $adapter = new class ($leagueAdapter) extends FilesystemAdapter {
             protected LeagueFilesystemAdapter $leagueAdapter;
 

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/FilesystemRegistryTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/FilesystemRegistryTest.php
@@ -140,7 +140,7 @@ class FilesystemRegistryTest extends TestCase
      */
     public function testRegistryFailInitialize(): void
     {
-        $failedInitialization = $this->getMockBuilder(FilesystemAdapter::class)->getMock();
+        $failedInitialization = $this->getStubBuilder(FilesystemAdapter::class)->getStub();
         $failedInitialization
             ->method('initialize')
             ->willReturn(false);

--- a/plugins/BEdita/Core/tests/TestCase/Job/QueueJobTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/QueueJobTest.php
@@ -63,15 +63,15 @@ class QueueJobTest extends TestCase
     }
 
     /**
-     * Get mock service.
+     * Get stub service.
      *
      * @param bool|\Exception $return Return value for `run()` method.
-     * @return \BEdita\Core\Job\JobService|\PHPUnit\Framework\MockObject\MockObject
+     * @return \BEdita\Core\Job\JobService|\PHPUnit\Framework\MockObject\Stub
      */
-    protected function getMockService($return = true)
+    protected function getStubService($return = true)
     {
-        $service = $this->getMockBuilder(JobService::class)
-            ->getMock();
+        $service = $this->getStubBuilder(JobService::class)
+            ->getStub();
 
         $method = $service->method('run');
         if ($return instanceof Exception) {
@@ -147,7 +147,7 @@ class QueueJobTest extends TestCase
     #[DataProvider('executeProvider')]
     public function testExecute(string $expected, $return, string $uuid = self::TEST_UUID): void
     {
-        ServiceRegistry::set('example', $this->getMockService($return));
+        ServiceRegistry::set('example', $this->getStubService($return));
 
         $message = $this->createMessage(['data' => compact('uuid')]);
         $job = new QueueJob();
@@ -163,7 +163,7 @@ class QueueJobTest extends TestCase
      */
     public function testServiceFailsThenMissingAsyncJob(): void
     {
-        ServiceRegistry::set('example', $this->getMockService(false));
+        ServiceRegistry::set('example', $this->getStubService(false));
         $message = $this->createMessage(['data' => ['uuid' => self::TEST_UUID]]);
 
         $count = 0;

--- a/plugins/BEdita/Core/tests/TestCase/Job/ServiceRegistryTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Job/ServiceRegistryTest.php
@@ -42,10 +42,10 @@ class ServiceRegistryTest extends TestCase
      * @param bool $return Return value for `run()` method.
      * @return \BEdita\Core\Job\JobService
      */
-    protected function getMockService($return = true)
+    protected function getStubService($return = true)
     {
-        $service = $this->getMockBuilder(JobService::class)
-            ->getMock();
+        $service = $this->getStubBuilder(JobService::class)
+            ->getStub();
 
         $service->method('run')
             ->willReturn($return);
@@ -101,7 +101,7 @@ class ServiceRegistryTest extends TestCase
      */
     public function testSet()
     {
-        $service = $this->getMockService();
+        $service = $this->getStubService();
 
         ServiceRegistry::set('example', $service);
         static::assertEquals(['example'], ServiceRegistry::keys());
@@ -119,7 +119,7 @@ class ServiceRegistryTest extends TestCase
      */
     public function testReset()
     {
-        ServiceRegistry::set('example', $this->getMockService());
+        ServiceRegistry::set('example', $this->getStubService());
         static::assertNotEmpty(ServiceRegistry::keys());
 
         ServiceRegistry::reset();

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/CountRelatedObjectsActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/CountRelatedObjectsActionTest.php
@@ -496,9 +496,9 @@ class CountRelatedObjectsActionTest extends TestCase
             ],
         ];
 
-        $mock = $this->getMockBuilder(CountRelatedObjectsAction::class)
+        $mock = $this->getStubBuilder(CountRelatedObjectsAction::class)
             ->onlyMethods(['groupResultCountById'])
-            ->getMock();
+            ->getStub();
 
         $mock->method('groupResultCountById')
             ->willReturn($fakeResult);
@@ -529,9 +529,9 @@ class CountRelatedObjectsActionTest extends TestCase
             ],
         ];
 
-        $mock = $this->getMockBuilder(CountRelatedObjectsAction::class)
+        $mock = $this->getStubBuilder(CountRelatedObjectsAction::class)
             ->onlyMethods(['groupResultCountById'])
-            ->getMock();
+            ->getStub();
 
         $mock->method('groupResultCountById')
             ->willReturn($fakeResult);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SaveEntityActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SaveEntityActionTest.php
@@ -95,8 +95,8 @@ class SaveEntityActionTest extends TestCase
         $this->expectException(InternalErrorException::class);
         $entity = TableRegistry::getTableLocator()->get('FakeAnimals')->get(1);
 
-        $table = $this->getMockBuilder(Table::class)
-            ->getMock();
+        $table = $this->getStubBuilder(Table::class)
+            ->getStub();
 
         $table->method('patchEntity')
             ->willReturn($entity);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Action/SignupUserActionTest.php
@@ -341,9 +341,9 @@ class SignupUserActionTest extends TestCase
             static::assertInstanceOf(User::class, $arguments[1]);
         });
 
-        $action = $this->getMockBuilder(SignupUserAction::class)
+        $action = $this->getStubBuilder(SignupUserAction::class)
             ->onlyMethods(['getOAuth2Response'])
-            ->getMock();
+            ->getStub();
 
         $action
             ->method('getOAuth2Response')

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectModelBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectModelBehaviorTest.php
@@ -80,7 +80,9 @@ class ObjectModelBehaviorTest extends TestCase
         $this->Documents = $this->fetchTable('Documents');
         $entity = $this->Documents->get(3);
         $related = $this->Documents->get(2);
-        $this->Documents->addRelated($entity, 'test', [$related]);
+        /** @var \BEdita\Core\Model\Behavior\ObjectModelBehavior $objectModelBehavior */
+        $objectModelBehavior = $this->Documents->getBehavior('ObjectModel');
+        $objectModelBehavior->addRelated($entity, 'test', [$related]);
 
         $entity = $this->Documents->get(3, contain: 'Test');
         $ids = Hash::extract($entity->get('test'), '{n}.id');
@@ -98,7 +100,9 @@ class ObjectModelBehaviorTest extends TestCase
         $this->Documents = $this->fetchTable('Documents');
         $entity = $this->Documents->get(3);
         $related = $this->Documents->get(2);
-        $this->Documents->replaceRelated($entity, 'test', [$related]);
+        /** @var \BEdita\Core\Model\Behavior\ObjectModelBehavior $objectModelBehavior */
+        $objectModelBehavior = $this->Documents->getBehavior('ObjectModel');
+        $objectModelBehavior->replaceRelated($entity, 'test', [$related]);
 
         $entity = $this->Documents->get(3, contain: 'Test');
         $ids = Hash::extract($entity->get('test'), '{n}.id');
@@ -115,7 +119,9 @@ class ObjectModelBehaviorTest extends TestCase
         $this->Documents = $this->fetchTable('Documents');
         $entity = $this->Documents->get(3);
         $related = $this->Documents->get(4);
-        $this->Documents->removeRelated($entity, 'test', [$related]);
+        /** @var \BEdita\Core\Model\Behavior\ObjectModelBehavior $objectModelBehavior */
+        $objectModelBehavior = $this->Documents->getBehavior('ObjectModel');
+        $objectModelBehavior->removeRelated($entity, 'test', [$related]);
 
         $entity = $this->Documents->get(3, contain: 'Test');
         $ids = Hash::extract($entity->get('test'), '{n}.id');

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectTypeBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ObjectTypeBehaviorTest.php
@@ -80,9 +80,9 @@ class ObjectTypeBehaviorTest extends TestCase
             $table->addBehavior('BEdita/Core.ObjectType');
         }
 
-        static::assertTrue($table->behaviors()->hasMethod('objectType'));
-
-        $objectType = $table->behaviors()->call('objectType', [$objectType]);
+        /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $objectTypeBehavior */
+        $objectTypeBehavior = $table->getBehavior('ObjectType');
+        $objectType = $objectTypeBehavior->objectType($objectType);
 
         if ($expected === null) {
             static::assertNull($objectType);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/PriorityBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/PriorityBehaviorTest.php
@@ -323,7 +323,9 @@ class PriorityBehaviorTest extends TestCase
     {
         $table = TableRegistry::getTableLocator()->get('ObjectRelations');
         $entity = $table->newEntity($entityData);
-        $actual = $table->compactEntityField($entity, $field, $config);
+        /** @var \BEdita\Core\Model\Behavior\PriorityBehavior $behavior */
+        $behavior = $table->getBehavior('Priority');
+        $actual = $behavior->compactEntityField($entity, $field, $config);
         static::assertSame($expected, $actual);
     }
 
@@ -424,6 +426,8 @@ class PriorityBehaviorTest extends TestCase
         $entityData[$field] = $previousValue;
         $entity = $table->newEntity($entityData);
         $entity->set($field, $actualValue);
-        static::assertSame($expected, $table->updateEntityPriorities($entity, $field, $config));
+        /** @var \BEdita\Core\Model\Behavior\PriorityBehavior $behavior */
+        $behavior = $table->getBehavior('Priority');
+        static::assertSame($expected, $behavior->updateEntityPriorities($entity, $field, $config));
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/RelationsBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/RelationsBehaviorTest.php
@@ -58,8 +58,12 @@ class RelationsBehaviorTest extends TestCase
         static::assertTrue($Profiles->hasBehavior('ObjectType'));
         static::assertTrue($Locations->hasBehavior('ObjectType'));
 
-        static::assertSame(2, $Documents->objectType()->id);
-        static::assertSame(3, $Profiles->objectType()->id);
+        /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $docObjectTypeBehavior */
+        $docObjectTypeBehavior = $Documents->getBehavior('ObjectType');
+        /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $profileObjectTypeBehavior */
+        $profileObjectTypeBehavior = $Profiles->getBehavior('ObjectType');
+        static::assertSame(2, $docObjectTypeBehavior->objectType()?->id);
+        static::assertSame(3, $profileObjectTypeBehavior->objectType()?->id);
 
         static::assertInstanceOf(BelongsToMany::class, $Documents->getAssociation('Test'));
         static::assertSame('BEdita/Core.Objects', $Documents->getAssociation('Test')->getClassName());
@@ -100,7 +104,9 @@ class RelationsBehaviorTest extends TestCase
         ], $inverseAnotherTestRelation->params);
 
         $before = count($Profiles->associations()->keys());
-        $Profiles->setupRelations('profiles');
+        /** @var \BEdita\Core\Model\Behavior\RelationsBehavior $relationsBehavior */
+        $relationsBehavior = $Profiles->getBehavior('Relations');
+        $relationsBehavior->setupRelations('profiles');
         $after = count($Profiles->associations()->keys());
 
         static::assertSame($before, $after);
@@ -120,32 +126,5 @@ class RelationsBehaviorTest extends TestCase
         $after = count($FakeArticles->associations()->keys());
 
         static::assertSame($before, $after);
-    }
-
-    /**
-     * Test getter of relations.
-     *
-     * @return void
-     */
-    public function testGetRelations()
-    {
-        $expected = [
-            'test',
-            'test_simple',
-            'test_defaults',
-            'inverse_test',
-            'inverse_test_simple',
-            'inverse_test_defaults',
-        ];
-
-        $Documents = TableRegistry::getTableLocator()->get('Documents');
-
-        static::assertTrue($Documents->behaviors()->hasMethod('getRelations'));
-
-        $relations = $Documents->behaviors()->call('getRelations');
-        static::assertEquals($expected, array_keys($relations));
-        foreach ($relations as $relation) {
-            static::assertInstanceOf(Relation::class, $relation);
-        }
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ResourceNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/ResourceNameBehaviorTest.php
@@ -94,7 +94,9 @@ class ResourceNameBehaviorTest extends TestCase
             $this->expectExceptionMessage($expected->getMessage());
         }
 
-        $id = $Roles->getId($name);
+        /** @var \BEdita\Core\Model\Behavior\ResourceNameBehavior $resourceNameBehavior */
+        $resourceNameBehavior = $Roles->getBehavior('ResourceName');
+        $id = $resourceNameBehavior->getId($name);
         static::assertEquals($expected, $id);
     }
 }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -136,7 +136,9 @@ class TreeBehaviorTest extends TestCase
             ->where(compact('name'))
             ->firstOrFail();
 
-        $position = $this->Table->getCurrentPosition($node);
+        /** @var \BEdita\Core\Model\Behavior\TreeBehavior $treeBehavior */
+        $treeBehavior = $this->Table->getBehavior('Tree');
+        $position = $treeBehavior->getCurrentPosition($node);
 
         static::assertSame($expected, $position);
     }
@@ -217,11 +219,13 @@ class TreeBehaviorTest extends TestCase
             ->where(compact('name'))
             ->firstOrFail();
 
-        $previousPosition = $this->Table->getCurrentPosition($node);
+        /** @var \BEdita\Core\Model\Behavior\TreeBehavior $treeBehavior */
+        $treeBehavior = $this->Table->getBehavior('Tree');
+        $previousPosition = $treeBehavior->getCurrentPosition($node);
         $previousIndexes = [$node->get('left_idx'), $node->get('right_idx')];
 
-        $result = $this->Table->moveAt($node, $position);
-        $finalPosition = $this->Table->getCurrentPosition($node);
+        $result = $treeBehavior->moveAt($node, $position);
+        $finalPosition = $treeBehavior->getCurrentPosition($node);
 
         if ($expected === false) {
             static::assertFalse($result);
@@ -271,8 +275,10 @@ class TreeBehaviorTest extends TestCase
         $count = count($currentPositions);
         $expected = array_reverse($currentPositions);
 
+        /** @var \BEdita\Core\Model\Behavior\TreeBehavior $treeBehavior */
+        $treeBehavior = $this->Table->getBehavior('Tree');
         foreach ($children as $child) {
-            $this->Table->moveAt($child, $count--);
+            $treeBehavior->moveAt($child, $count--);
         }
 
         $actual = $this->Table
@@ -291,7 +297,9 @@ class TreeBehaviorTest extends TestCase
      */
     public function testCheckIntegritySuccess(): void
     {
-        $errors = $this->Table->checkIntegrity();
+        /** @var \BEdita\Core\Model\Behavior\TreeBehavior $treeBehavior */
+        $treeBehavior = $this->Table->getBehavior('Tree');
+        $errors = $treeBehavior->checkIntegrity();
 
         static::assertEmpty($errors);
     }
@@ -308,7 +316,9 @@ class TreeBehaviorTest extends TestCase
             'Found record where left_idx >= right_idx',
         ];
 
-        $errors = $this->Table->checkIntegrity();
+        /** @var \BEdita\Core\Model\Behavior\TreeBehavior $treeBehavior */
+        $treeBehavior = $this->Table->getBehavior('Tree');
+        $errors = $treeBehavior->checkIntegrity();
 
         static::assertSame($expected, $errors);
     }
@@ -327,7 +337,9 @@ class TreeBehaviorTest extends TestCase
             'Found record where parent.left_idx + 1 != MIN(children.left_idx)',
         ];
 
-        $errors = $this->Table->checkIntegrity();
+        /** @var \BEdita\Core\Model\Behavior\TreeBehavior $treeBehavior */
+        $treeBehavior = $this->Table->getBehavior('Tree');
+        $errors = $treeBehavior->checkIntegrity();
 
         static::assertSame($expected, $errors);
     }
@@ -346,7 +358,9 @@ class TreeBehaviorTest extends TestCase
             'Found record where parent.right_idx - 1 != MAX(children.right_idx)',
         ];
 
-        $errors = $this->Table->checkIntegrity();
+        /** @var \BEdita\Core\Model\Behavior\TreeBehavior $treeBehavior */
+        $treeBehavior = $this->Table->getBehavior('Tree');
+        $errors = $treeBehavior->checkIntegrity();
 
         static::assertSame($expected, $errors);
     }
@@ -364,7 +378,9 @@ class TreeBehaviorTest extends TestCase
             'Found record where left_idx - 1 != MAX(previousSiblings.right_idx)',
         ];
 
-        $errors = $this->Table->checkIntegrity();
+        /** @var \BEdita\Core\Model\Behavior\TreeBehavior $treeBehavior */
+        $treeBehavior = $this->Table->getBehavior('Tree');
+        $errors = $treeBehavior->checkIntegrity();
 
         static::assertSame($expected, $errors);
     }
@@ -382,7 +398,9 @@ class TreeBehaviorTest extends TestCase
             'Found record where left_idx - 1 != MAX(previousSiblings.right_idx)',
         ];
 
-        $errors = $this->Table->checkIntegrity();
+        /** @var \BEdita\Core\Model\Behavior\TreeBehavior $treeBehavior */
+        $treeBehavior = $this->Table->getBehavior('Tree');
+        $errors = $treeBehavior->checkIntegrity();
 
         static::assertSame($expected, $errors);
     }
@@ -404,7 +422,9 @@ class TreeBehaviorTest extends TestCase
             $parentNode->child_categories[2],
         ]);
 
-        $errors = $this->Table->checkIntegrity();
+        /** @var \BEdita\Core\Model\Behavior\TreeBehavior $treeBehavior */
+        $treeBehavior = $this->Table->getBehavior('Tree');
+        $errors = $treeBehavior->checkIntegrity();
 
         static::assertEmpty($errors);
     }

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UniqueNameBehaviorTest.php
@@ -110,7 +110,9 @@ class UniqueNameBehaviorTest extends TestCase
         $user = $Users->newEmptyEntity();
 
         $user = $Users->patchEntity($user, compact('username'));
-        $Users->uniqueName($user);
+        /** @var \BEdita\Core\Model\Behavior\UniqueNameBehavior $behavior */
+        $behavior = $Users->behaviors()->get('UniqueName');
+        $behavior->uniqueName($user);
         $user->type = 'users';
         $Users->save($user);
 
@@ -150,6 +152,7 @@ class UniqueNameBehaviorTest extends TestCase
     #[DataProvider('uniqueNameProvider')]
     public function testUniqueName($value, $expected)
     {
+        /** @var \BEdita\Core\Model\Behavior\UniqueNameBehavior $behavior */
         $behavior = TableRegistry::getTableLocator()->get('Objects')->behaviors()->get('UniqueName');
         $entity = new Entity(['uname' => $value]);
         $behavior->uniqueName($entity);
@@ -214,6 +217,7 @@ class UniqueNameBehaviorTest extends TestCase
         $Users = TableRegistry::getTableLocator()->get('Users');
         $user = $Users->newEmptyEntity();
         $Users->patchEntity($user, compact('username', 'name'));
+        /** @var \BEdita\Core\Model\Behavior\UniqueNameBehavior $behavior */
         $behavior = $Users->behaviors()->get('UniqueName');
         $uname1 = $behavior->generateUniqueName($user, false, $config);
         $uname2 = $behavior->generateUniqueName($user, true, $config);
@@ -232,7 +236,9 @@ class UniqueNameBehaviorTest extends TestCase
         $profile = $Profiles->newEmptyEntity();
         $Profiles->patchEntity($profile, ['title' => '12345']);
         $config = ['sourceField' => 'title'];
-        $generatedUname = $Profiles->behaviors()->get('UniqueName')->generateUniqueName($profile, false, $config);
+        /** @var \BEdita\Core\Model\Behavior\UniqueNameBehavior $behavior */
+        $behavior = $Profiles->behaviors()->get('UniqueName');
+        $generatedUname = $behavior->generateUniqueName($profile, false, $config);
         static::assertIsNotNumeric($generatedUname);
     }
 
@@ -272,6 +278,7 @@ class UniqueNameBehaviorTest extends TestCase
         $Folders = TableRegistry::getTableLocator()->get('Folders');
         $folder = $Folders->newEmptyEntity();
         $Folders->patchEntity($folder, compact('uname', 'title'));
+        /** @var \BEdita\Core\Model\Behavior\UniqueNameBehavior $behavior */
         $behavior = $Folders->behaviors()->get('UniqueName');
         $generated = $behavior->generateUniqueName($folder, true);
 
@@ -330,6 +337,7 @@ class UniqueNameBehaviorTest extends TestCase
     public function testUniqueNameExists($uname, $id, $expected)
     {
         $Users = TableRegistry::getTableLocator()->get('Users');
+        /** @var \BEdita\Core\Model\Behavior\UniqueNameBehavior $behavior */
         $behavior = $Users->behaviors()->get('UniqueName');
         $result = $behavior->uniqueNameExists($uname, $id);
 
@@ -389,6 +397,7 @@ class UniqueNameBehaviorTest extends TestCase
     #[DataProvider('uniqueFromValueProvider')]
     public function testUniqueNameFromValue($value, $expected, array $cfg, $regenerate)
     {
+        /** @var \BEdita\Core\Model\Behavior\UniqueNameBehavior $behavior */
         $behavior = TableRegistry::getTableLocator()->get('Objects')->behaviors()->get('UniqueName');
         $result = $behavior->uniqueNameFromValue($value, $regenerate, $cfg);
 
@@ -407,6 +416,7 @@ class UniqueNameBehaviorTest extends TestCase
     public function testUniqueNameMissing()
     {
         $Documents = TableRegistry::getTableLocator()->get('Documents');
+        /** @var \BEdita\Core\Model\Behavior\UniqueNameBehavior $behavior */
         $behavior = $Documents->behaviors()->get('UniqueName');
 
         $data = ['title' => 'Some data', 'uname' => 'some-data'];
@@ -434,6 +444,7 @@ class UniqueNameBehaviorTest extends TestCase
     public function testUniqueNameUnchanged(): void
     {
         $Documents = TableRegistry::getTableLocator()->get('Documents');
+        /** @var \BEdita\Core\Model\Behavior\UniqueNameBehavior $behavior */
         $behavior = $Documents->behaviors()->get('UniqueName');
         $document = $Documents->get(2);
         $behavior->uniqueName($document);
@@ -453,6 +464,7 @@ class UniqueNameBehaviorTest extends TestCase
         $document->set('title', 'a new title');
         unset($document['uname']);
 
+        /** @var \BEdita\Core\Model\Behavior\UniqueNameBehavior $behavior */
         $behavior = $Documents->behaviors()->get('UniqueName');
         $behavior->uniqueName($document);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
@@ -191,7 +191,9 @@ class UploadableBehaviorTest extends TestCase
         $copy = $this->Streams->newEmptyEntity();
         $copy->uri = $copy->filesystemPath();
 
-        $this->Streams->copyFiles($stream, $copy);
+        /** @var \BEdita\Core\Model\Behavior\UploadableBehavior $uploadable */
+        $uploadable = $this->Streams->getBehavior('Uploadable');
+        $uploadable->copyFiles($stream, $copy);
 
         static::assertTrue($manager->fileExists($copy->uri));
         static::assertSame($manager->read($stream->uri), $manager->read($copy->uri));

--- a/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UserModifiedBehaviorTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Behavior/UserModifiedBehaviorTest.php
@@ -106,10 +106,12 @@ class UserModifiedBehaviorTest extends TestCase
      */
     public function testUserId()
     {
-        static::assertSame(1, $this->Objects->userId());
+        /** @var \BEdita\Core\Model\Behavior\UserModifiedBehavior $behavior */
+        $behavior = $this->Objects->getBehavior('UserModified');
+        static::assertSame(1, $behavior->userId());
 
-        static::assertSame(99, $this->Objects->userId(99));
-        static::assertSame(99, $this->Objects->userId());
+        static::assertSame(99, $behavior->userId(99));
+        static::assertSame(99, $behavior->userId());
     }
 
     /**
@@ -174,8 +176,10 @@ class UserModifiedBehaviorTest extends TestCase
     #[Depends('testHandleEvent')]
     public function testTouchUser(ObjectEntity $object)
     {
-        $this->Objects->userId(99);
-        $this->Objects->touchUser($object);
+        /** @var \BEdita\Core\Model\Behavior\UserModifiedBehavior $behavior */
+        $behavior = $this->Objects->getBehavior('UserModified');
+        $behavior->userId(99);
+        $behavior->touchUser($object);
 
         static::assertSame(LoggedUser::id(), $object->created_by);
         static::assertSame(99, $object->modified_by);
@@ -191,8 +195,10 @@ class UserModifiedBehaviorTest extends TestCase
     {
         $object = $this->Objects->get(1);
 
-        $this->Objects->userId(99);
-        $this->Objects->touchUser($object, 'UnknownEvent');
+        /** @var \BEdita\Core\Model\Behavior\UserModifiedBehavior $behavior */
+        $behavior = $this->Objects->getBehavior('UserModified');
+        $behavior->userId(99);
+        $behavior->touchUser($object, 'UnknownEvent');
 
         static::assertSame(1, $object->created_by);
         static::assertSame(1, $object->modified_by);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/AsyncJobTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/AsyncJobTest.php
@@ -159,7 +159,7 @@ class AsyncJobTest extends TestCase
      */
     public function testRun()
     {
-        $service = $this->getMockBuilder(JobService::class)->getMock();
+        $service = $this->getStubBuilder(JobService::class)->getStub();
         $service->method('run')->willReturn(true);
         ServiceRegistry::set('example', $service);
 

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/FoldersTableTest.php
@@ -112,8 +112,10 @@ class FoldersTableTest extends TestCase
     public function testInitializeObjectType(): void
     {
         $Folders = $this->fetchTable('FolderAlias', ['className' => 'BEdita/Core.Folders']);
-        static::assertInstanceOf(ObjectType::class, $Folders->objectType());
-        static::assertEquals('folders', $Folders->objectType()->name);
+        /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $objectTypeBehavior */
+        $objectTypeBehavior = $Folders->getBehavior('ObjectType');
+        static::assertInstanceOf(ObjectType::class, $objectTypeBehavior->objectType());
+        static::assertEquals('folders', $objectTypeBehavior->objectType()->name);
     }
 
     /**
@@ -380,13 +382,16 @@ class FoldersTableTest extends TestCase
         $this->Folders->save($anotherSubfolder);
         $folderIds[] = $anotherSubfolder->id;
 
+        /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $objectTypeBehavior */
+        $objectTypeBehavior = $this->Folders->getBehavior('ObjectType');
+
         // get descendants not folders
         $notFoldersIds = $this->Folders
             ->find('ancestor', parent: $parentFolder->id)
             ->orderBy([$this->Folders->aliasField('id') => 'ASC'])
             ->find('list', keyField: 'id', valueField: 'id')
-            ->where(function (QueryExpression $exp) {
-                return $exp->not(['object_type_id' => $this->Folders->objectType()->id]);
+            ->where(function (QueryExpression $exp) use ($objectTypeBehavior) {
+                return $exp->not(['object_type_id' => $objectTypeBehavior->objectType()->id]);
             })
             ->toArray();
 
@@ -471,10 +476,12 @@ class FoldersTableTest extends TestCase
         $parent->deleted = true;
         $this->Folders->save($parent);
 
+        /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $objectTypeBehavior */
+        $objectTypeBehavior = $this->Folders->getBehavior('ObjectType');
         $children = $this->Folders
             ->find('ancestor', parent: 11)
             ->orderBy([$this->Folders->aliasField('id') => 'ASC'])
-            ->where(['object_type_id' => $this->Folders->objectType()->id])
+            ->where(['object_type_id' => $objectTypeBehavior->objectType()->id])
             ->toArray();
 
         static::assertNotEmpty($children);

--- a/plugins/BEdita/Core/tests/TestCase/Model/Table/TreesTableTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Table/TreesTableTest.php
@@ -475,7 +475,9 @@ class TreesTableTest extends TestCase
         $node->set('position', $position);
         $this->Trees->save($node);
 
-        $currentPosition = $this->Trees->getCurrentPosition($node);
+        /** @var \BEdita\Core\Model\Behavior\TreeBehavior $treeBehavior */
+        $treeBehavior = $this->Trees->getBehavior('Tree');
+        $currentPosition = $treeBehavior->getCurrentPosition($node);
 
         static::assertSame($expected, $currentPosition);
     }

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Association/RelatedToTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Association/RelatedToTest.php
@@ -326,7 +326,9 @@ class RelatedToTest extends TestCase
             static::assertContains($expectedAssoc, $actualAssociations);
         }
         if ($expectedOT !== null) {
-            $actualOT = $target->objectType();
+            /** @var \BEdita\Core\Model\Behavior\ObjectTypeBehavior $objectTypeBehavior */
+            $objectTypeBehavior = $target->getBehavior('ObjectType');
+            $actualOT = $objectTypeBehavior->objectType();
             static::assertInstanceOf(ObjectType::class, $actualOT);
             static::assertSame($expectedOT, $actualOT->name);
         }

--- a/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/AssociationCollectionTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/ORM/Inheritance/AssociationCollectionTest.php
@@ -286,15 +286,15 @@ class AssociationCollectionTest extends TestCase
     #[DataProvider('inheritedAssociationsRelatedToProvider')]
     public function testInheritedAssociationsRelatedTo($expected, $isAbstract)
     {
-        $relatedToMock = $this->getMockBuilder(RelatedTo::class)
+        $relatedToStub = $this->getStubBuilder(RelatedTo::class)
             ->setConstructorArgs(['TestRelatedTo'])
             ->onlyMethods(['isSourceAbstract'])
-            ->getMock();
+            ->getStub();
 
-        $relatedToMock->method('isSourceAbstract')
+        $relatedToStub->method('isSourceAbstract')
             ->willReturn($isAbstract);
 
-        $this->fakeAnimals->associations()->add($relatedToMock->getName(), $relatedToMock);
+        $this->fakeAnimals->associations()->add($relatedToStub->getName(), $relatedToStub);
         $collection = new AssociationCollection($this->fakeMammals);
 
         static::assertEquals($expected, $collection->keys());
@@ -313,15 +313,15 @@ class AssociationCollectionTest extends TestCase
         $this->fakeMammals->associations()->remove('FakeFelines');
         $this->fakeFelines->extensionOf('FakeMammals');
 
-        $relatedToMock = $this->getMockBuilder(RelatedTo::class)
+        $relatedToStub = $this->getStubBuilder(RelatedTo::class)
             ->setConstructorArgs(['TestRelatedTo'])
             ->onlyMethods(['isSourceAbstract'])
-            ->getMock();
+            ->getStub();
 
-        $relatedToMock->method('isSourceAbstract')
+        $relatedToStub->method('isSourceAbstract')
             ->willReturn(false);
 
-        $this->fakeAnimals->associations()->add($relatedToMock->getName(), $relatedToMock);
+        $this->fakeAnimals->associations()->add($relatedToStub->getName(), $relatedToStub);
         $collection = new AssociationCollection($this->fakeFelines);
 
         static::assertEquals(['FakeArticles'], $collection->keys());

--- a/plugins/BEdita/Core/tests/TestCase/Utility/DatabaseTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/DatabaseTest.php
@@ -43,8 +43,8 @@ class DatabaseTest extends TestCase
         }
 
         // test not valid Connection object
-        $mockConnection = $this->createMock('\Cake\Datasource\ConnectionInterface');
-        ConnectionManager::setConfig('__wrongConnection', $mockConnection);
+        $stubConnection = $this->createStub('\Cake\Datasource\ConnectionInterface');
+        ConnectionManager::setConfig('__wrongConnection', $stubConnection);
         $info = Database::basicInfo('__wrongConnection');
         static::assertEquals([], $info);
         ConnectionManager::drop('__wrongConnection');

--- a/plugins/BEdita/Core/tests/TestCase/Utility/OAuth2Test.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/OAuth2Test.php
@@ -58,13 +58,13 @@ class OAuth2Test extends TestCase
     public function testResponse(array $expected, string $body, array $options = []): void
     {
         $response = new Response([], $body);
-        $mock = $this->getMockBuilder(Stream::class)
-            ->getMock();
-        $mock->method('send')
+        $stub = $this->getStubBuilder(Stream::class)
+            ->getStub();
+        $stub->method('send')
             ->willReturn([$response]);
 
         $oauth2 = new OAuth2();
-        $oauth2->setConfig('client', ['adapter' => $mock]);
+        $oauth2->setConfig('client', ['adapter' => $stub]);
         $data = $oauth2->response('https://oauth2.example.com', 'token-example', $options);
 
         static::assertEquals($expected, $data);


### PR DESCRIPTION
This PR upgrades CakePHP to 5.3 version.

Rif. [Migration guide](https://book.cakephp.org/5.x/appendices/5-3-migration-guide.html)

**Bonus track**
All PHPUnit notice was removed using stub instead of mock when it's better.