### PR TITLE
version_bump in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
     with:
       main_branch: '5-salix'
       dist_branches: '["5-salix","4-cactus"]'
+      version_bump: ${{ inputs.releaseType }}
       version_ini_path: plugins/BEdita/Core/config/bedita.ini
       version_ini_prefix: "[BEdita]\nversion = "
 


### PR DESCRIPTION
This adds version_bump in release workflow, necessary for manual releases.