### PR TITLE
Include created by user and modified user

### DIFF
--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -75,6 +75,8 @@ class ObjectsController extends ResourcesController
     protected $_defaultConfig = [
         'allowedAssociations' => [
             'parents' => ['folders'],
+            'created_by_user' => ['users'],
+            'modified_by_user' => ['users'],
         ],
     ];
 
@@ -108,6 +110,8 @@ class ObjectsController extends ResourcesController
             $objectType = $behaviorRegistry->call('objectType');
             $this->setConfig('allowedAssociations', array_fill_keys($objectType->relations, []));
         }
+        $this->setConfig('allowedAssociations.created_by_user', ['users']);
+        $this->setConfig('allowedAssociations.modified_by_user', ['users']);
 
         // Requested object type endpoint MUST be `enabled`
         if (!$this->objectType->get('enabled')) {

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -3713,6 +3713,25 @@ class ObjectsControllerTest extends IntegrationTestCase
     }
 
     /**
+     * Test creator/modifier users meta on objects endpoint without include parameter.
+     *
+     * @return void
+     * @covers ::prepareInclude()
+     */
+    public function testHistoryUsersWithoutInclude(): void
+    {
+        $this->configRequestHeaders();
+        $this->get('/documents/3');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        static::assertNull(Hash::get($result, 'data.meta.created_by_user'));
+        static::assertNull(Hash::get($result, 'data.meta.modified_by_user'));
+    }
+
+    /**
      * Test listing streams for an object.
      *
      * @return void

--- a/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/ObjectsControllerTest.php
@@ -3687,6 +3687,32 @@ class ObjectsControllerTest extends IntegrationTestCase
     }
 
     /**
+     * Test creator/modifier users include on objects endpoint.
+     *
+     * @return void
+     * @covers ::prepareInclude()
+     */
+    public function testIncludeHistoryUsers(): void
+    {
+        $this->configRequestHeaders();
+        $this->get('/documents/3?include=created_by_user,modified_by_user');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+
+        static::assertSame(1, Hash::get($result, 'data.meta.created_by'));
+        static::assertSame(5, Hash::get($result, 'data.meta.modified_by'));
+
+        static::assertSame(1, Hash::get($result, 'data.meta.created_by_user.id'));
+        static::assertSame(5, Hash::get($result, 'data.meta.modified_by_user.id'));
+        static::assertNotNull(Hash::get($result, 'data.meta.created_by_user.name'));
+        static::assertNotNull(Hash::get($result, 'data.meta.created_by_user.surname'));
+        static::assertNotNull(Hash::get($result, 'data.meta.modified_by_user.name'));
+        static::assertNotNull(Hash::get($result, 'data.meta.modified_by_user.surname'));
+    }
+
+    /**
      * Test listing streams for an object.
      *
      * @return void

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
@@ -177,7 +177,55 @@ class ObjectEntity extends Entity implements JsonApiSerializable
      */
     protected function getMeta()
     {
-        return array_diff_key($this->jsonApiGetMeta(), array_flip(['type']));
+        $meta = array_diff_key($this->jsonApiGetMeta(), array_flip(['type']));
+        $meta['created_by_user'] = $this->getHistoryUserMeta('created_by_user');
+        $meta['modified_by_user'] = $this->getHistoryUserMeta('modified_by_user');
+
+        return $meta;
+    }
+
+    /**
+     * Extract compact user info for history metadata.
+     *
+     * @param string $property Association property name
+     * @return array
+     */
+    protected function getHistoryUserMeta(string $property): array
+    {
+        $user = $this->get($property);
+        $user = $this->loadHistoryUser((int)$user->id);
+
+        return [
+            'id' => $user->id,
+            'name' => $user->name,
+            'surname' => $user->surname,
+            'username' => $user->username,
+            'title' => $user->title,
+        ];
+    }
+
+    /**
+     * Load user data including inherited profile fields.
+     *
+     * @param int $id User ID
+     * @return \BEdita\Core\Model\Entity\User|null
+     */
+    protected function loadHistoryUser(int $id): ?User
+    {
+        static $cache = [];
+        if (array_key_exists($id, $cache)) {
+            return $cache[$id];
+        }
+
+        try {
+            /** @var \BEdita\Core\Model\Entity\User $user */
+            $user = TableRegistry::getTableLocator()->get('Users')->get($id);
+            $cache[$id] = $user;
+        } catch (RecordNotFoundException $e) {
+            $cache[$id] = null;
+        }
+
+        return $cache[$id];
     }
 
     /**
@@ -241,6 +289,13 @@ class ObjectEntity extends Entity implements JsonApiSerializable
         }
 
         $associations = $entity::listAssociations($table, $entity->getHidden());
+        // Keep these relationships hidden by default, but expose them when explicitly contained.
+        foreach (['created_by_user', 'modified_by_user'] as $association) {
+            if ($this->has($association)) {
+                $associations[] = $association;
+            }
+        }
+        $associations = array_values(array_unique($associations));
         foreach ($associations as $relationship) {
             $self = Router::url(
                 [

--- a/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
+++ b/plugins/BEdita/Core/src/Model/Entity/ObjectEntity.php
@@ -190,10 +190,21 @@ class ObjectEntity extends Entity implements JsonApiSerializable
      * @param string $property Association property name
      * @return array
      */
-    protected function getHistoryUserMeta(string $property): array
+    protected function getHistoryUserMeta(string $property): ?array
     {
+        if (!$this->has($property)) {
+            return null;
+        }
+
         $user = $this->get($property);
+        if (!$user instanceof User || empty($user->id)) {
+            return null;
+        }
+
         $user = $this->loadHistoryUser((int)$user->id);
+        if (!$user instanceof User) {
+            return null;
+        }
 
         return [
             'id' => $user->id,


### PR DESCRIPTION
This PR fixes https://github.com/bedita/bedita/issues/1793

`GET /:type?include=created_by_user,modified_by_user` will return creator and modifier data in meta, i.e.:

```
meta": {
    "locked": false,
    "created": "2025-02-20T12:20:51+00:00",
    "modified": "2025-02-20T12:20:51+00:00",
    "published": null,
    "created_by": 12345,
    "modified_by": 12346,
    -"created_by_user": {
        "id": 12345,
        "name": "Gustavo",
        "surname": "Rossi",
        "username": "gustavorossi@example.com",
        "title": "Gustavo Rossi"
    },
    -"modified_by_user": {
        "id": 12346,
        "name": "Gustavo",
        "surname": "Bianchi",
        "username": "gustavobianchi@example.com",
        "title": "Gustavo Bianchi"
    }
},
```