### PR TITLE
Endpoint sysinfo shows database vendor and version

### DIFF
--- a/plugins/BEdita/Core/src/Utility/System.php
+++ b/plugins/BEdita/Core/src/Utility/System.php
@@ -16,6 +16,7 @@ namespace BEdita\Core\Utility;
 
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
+use Cake\Utility\Hash;
 
 /**
  * Retrieve system information on service availability and general status
@@ -31,6 +32,8 @@ class System
      */
     public static function info(): array
     {
+        $db = Database::basicInfo();
+
         return [
             'Url' => Configure::read('App.fullBaseUrl'),
             'Version' => Configure::read('BEdita.version'),
@@ -43,6 +46,10 @@ class System
             'Memory limit' => ini_get('memory_limit'),
             'Post max size' => sprintf('%dM', intVal(substr(ini_get('post_max_size'), 0, -1))),
             'Upload max size' => sprintf('%dM', intVal(substr(ini_get('upload_max_filesize'), 0, -1))),
+            'Database' => [
+                'vendor' => (string)Hash::get($db, 'vendor'),
+                'version' => (string)Hash::get($db, 'version'),
+            ],
         ];
     }
 

--- a/plugins/BEdita/Core/tests/TestCase/Utility/SystemTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Utility/SystemTest.php
@@ -47,6 +47,7 @@ class SystemTest extends TestCase
             'Memory limit',
             'Post max size',
             'Upload max size',
+            'Database',
         ];
         foreach ($expectedKeys as $expectedKey) {
             $this->assertArrayHasKey($expectedKey, $actual);


### PR DESCRIPTION
This PR provides an update in `/sysinfo` endpoint: add `"Database"` key, with `"vendor"` and `"version"`.