### PR TITLE
fix: forward configured visibility as default for implicitly created folders

### DIFF
--- a/plugins/BEdita/Core/src/Filesystem/Adapter/LocalAdapter.php
+++ b/plugins/BEdita/Core/src/Filesystem/Adapter/LocalAdapter.php
@@ -18,6 +18,7 @@ use BEdita\Core\Filesystem\FilesystemAdapter;
 use Cake\Routing\Router;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 use League\Flysystem\UnixVisibility\PortableVisibilityConverter;
+use League\Flysystem\Visibility;
 
 /**
  * Adapter to store files on local filesystem.
@@ -63,7 +64,10 @@ class LocalAdapter extends FilesystemAdapter
     {
         return new LocalFilesystemAdapter(
             $this->getConfig('path'),
-            PortableVisibilityConverter::fromArray((array)$this->getConfig('permissions')),
+            PortableVisibilityConverter::fromArray(
+                (array)$this->getConfig('permissions'),
+                (string)$this->getConfig('visibility', Visibility::PUBLIC),
+            ),
             $this->getConfig('writeFlags'),
             $this->getConfig('linkHandling'),
         );

--- a/plugins/BEdita/Core/tests/TestCase/Filesystem/Adapter/LocalAdapterTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Filesystem/Adapter/LocalAdapterTest.php
@@ -17,6 +17,7 @@ namespace BEdita\Core\Test\TestCase\Filesystem\Adapter;
 use BEdita\Core\Filesystem\Adapter\LocalAdapter;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
+use League\Flysystem\Config;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -85,5 +86,34 @@ class LocalAdapterTest extends TestCase
         $innerAdapter = $adapter->getInnerAdapter();
 
         static::assertInstanceOf(LocalFilesystemAdapter::class, $innerAdapter);
+    }
+
+    /**
+     * Directories created implicitly while writing a file (e.g. nested thumbnail
+     * directories) must use the adapter's configured default visibility, not always
+     * fall back to "private", regardless of the `permissions` configuration.
+     *
+     * @return void
+     */
+    public function testWriteUsesDefaultVisibilityForImplicitDirectories()
+    {
+        $config = [
+            'path' => self::FILES_PATH,
+            'permissions' => [
+                'dir' => ['public' => 0755, 'private' => 0700],
+            ],
+        ];
+
+        $adapter = new LocalAdapter();
+        $adapter->initialize($config);
+
+        $innerAdapter = $adapter->getInnerAdapter();
+        $innerAdapter->write('nested/file.txt', 'content', new Config());
+
+        $permissions = fileperms(self::FILES_PATH . DS . 'nested') & 0777;
+        static::assertSame(0755, $permissions);
+
+        unlink(self::FILES_PATH . DS . 'nested' . DS . 'file.txt');
+        rmdir(self::FILES_PATH . DS . 'nested');
     }
 }


### PR DESCRIPTION
BEdita\Core\Filesystem\Adapter\LocalAdapter::buildAdapter() called PortableVisibilityConverter::fromArray() without its second argument, so Flysystem always fell back to its own default (Visibility::PRIVATE) when deciding the mode for directories created implicitly during a write (e.g. nested thumbnail directories), regardless of any permissions.dir.public value configured and of the adapter's own visibility setting (which defaults to public).

In practice, any directory auto-created by a write() call without an explicit directory_visibility option (e.g.
BEdita\Core\Filesystem\Thumbnail\GlideGenerator::generate()) ended up with 0700 permissions, unreadable by a webserver process running as a different user than the one generating the thumbnails.

