### PR TITLE
feat: display created by user on streams

### DIFF
--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -206,8 +206,7 @@ class ObjectsController extends ResourcesController
         if ($savedByReferences) {
             $contain['CreatedByUsers'] = ['strategy' => 'select'];
             $contain['ModifiedByUsers'] = ['strategy' => 'select'];
-            $currTable = $table ?? $this->Table;
-            if ($currTable->hasAssociation('Streams')) {
+            if ($objectType instanceof ObjectType && $objectType->hasAssoc('Streams')) {
                 $contain['Streams'] = ['CreatedByUsers' => ['strategy' => 'select']];
             }
         }

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -206,6 +206,10 @@ class ObjectsController extends ResourcesController
         if ($savedByReferences) {
             $contain['CreatedByUsers'] = ['strategy' => 'select'];
             $contain['ModifiedByUsers'] = ['strategy' => 'select'];
+            $streamsTable = $table ?? $this->Table;
+            if ($streamsTable->hasAssociation('Streams')) {
+                $contain['Streams'] = ['CreatedByUsers' => ['strategy' => 'select']];
+            }
         }
 
         return $contain;

--- a/plugins/BEdita/API/src/Controller/ObjectsController.php
+++ b/plugins/BEdita/API/src/Controller/ObjectsController.php
@@ -206,8 +206,8 @@ class ObjectsController extends ResourcesController
         if ($savedByReferences) {
             $contain['CreatedByUsers'] = ['strategy' => 'select'];
             $contain['ModifiedByUsers'] = ['strategy' => 'select'];
-            $streamsTable = $table ?? $this->Table;
-            if ($streamsTable->hasAssociation('Streams')) {
+            $currTable = $table ?? $this->Table;
+            if ($currTable->hasAssociation('Streams')) {
                 $contain['Streams'] = ['CreatedByUsers' => ['strategy' => 'select']];
             }
         }

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/ApplicationsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/ApplicationsControllerTest.php
@@ -204,7 +204,7 @@ class ApplicationsControllerTest extends IntegrationTestCase
     public function testSingleName()
     {
         $this->configRequestHeaders('GET', $this->getUserAuthHeader());
-        $this->get(sprintf('/admin/applications/%s', urlencode('First app')));
+        $this->get(sprintf('/admin/applications/%s', rawurlencode('First app')));
         $this->assertResponseCode(200);
     }
 

--- a/plugins/BEdita/API/tests/TestCase/Controller/MediaControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/MediaControllerTest.php
@@ -21,6 +21,7 @@ use BEdita\API\TestSuite\IntegrationTestCase;
 use BEdita\Core\Filesystem\Thumbnail;
 use BEdita\Core\Test\Utility\TestFilesystemTrait;
 use Cake\Core\Configure;
+use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -1116,5 +1117,28 @@ class MediaControllerTest extends IntegrationTestCase
         $this->assertResponseCode(200);
         $this->assertContentType('application/vnd.api+json');
         static::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test that `saved_by_refs` adds `created_by_user` fullname to included streams' `meta`.
+     *
+     * @return void
+     */
+    public function testSingleViewSavedByRefsStreams()
+    {
+        $streams = TableRegistry::getTableLocator()->get('Streams');
+        $stream = $streams->get('6aceb0eb-bd30-4f60-ac74-273083b921b6');
+        $stream->set('created_by', 1, ['guard' => false]);
+        $streams->saveOrFail($stream, ['checkRules' => false]);
+
+        $this->configRequestHeaders();
+        $this->get('/files/14?saved_by_refs=1');
+        $result = json_decode((string)$this->_response->getBody(), true);
+
+        $this->assertResponseCode(200);
+        $this->assertContentType('application/vnd.api+json');
+        static::assertSame('First User', $result['data']['meta']['created_by_user']);
+        static::assertSame(1, $result['included'][0]['meta']['created_by']);
+        static::assertSame('First User', $result['included'][0]['meta']['created_by_user']);
     }
 }

--- a/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/RolesControllerTest.php
@@ -224,7 +224,7 @@ class RolesControllerTest extends IntegrationTestCase
     public function testSingleName()
     {
         $this->configRequestHeaders('GET', $this->getUserAuthHeader());
-        $this->get(sprintf('/roles/%s', urlencode('first role')));
+        $this->get(sprintf('/roles/%s', rawurlencode('first role')));
         $this->assertResponseCode(200);
     }
 

--- a/plugins/BEdita/Core/src/Model/Entity/Property.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Property.php
@@ -149,7 +149,7 @@ class Property extends Entity implements JsonApiSerializable
             ObjectTypesTable::CACHE_CONFIG,
         );
 
-        if (empty($propertyTypes[$propertyType])) {
+        if (empty($propertyTypes[(string)$propertyType])) {
             // Unknown property type.
             $this->property_type = null;
             $this->property_type_id = null;
@@ -157,7 +157,7 @@ class Property extends Entity implements JsonApiSerializable
             return null;
         }
 
-        $this->property_type = $propertyTypes[$propertyType];
+        $this->property_type = $propertyTypes[(string)$propertyType];
         $this->property_type_id = $this->property_type->id;
 
         return $this->property_type->name;

--- a/plugins/BEdita/Core/src/Model/Entity/Stream.php
+++ b/plugins/BEdita/Core/src/Model/Entity/Stream.php
@@ -50,11 +50,14 @@ use Psr\Http\Message\StreamInterface;
  * @property \Cake\I18n\DateTime $created
  * @property \Cake\I18n\DateTime $modified
  * @property \BEdita\Core\Model\Entity\ObjectEntity|null $object
+ * @property \BEdita\Core\Model\Entity\User|null $created_by_user
  */
 class Stream extends Entity implements JsonApiSerializable
 {
     use EventDispatcherTrait;
-    use JsonApiTrait;
+    use JsonApiTrait {
+        getMeta as protected jsonApiGetMeta;
+    }
     use LogTrait;
 
     public const FILE_PROPERTIES = [
@@ -150,6 +153,19 @@ class Stream extends Entity implements JsonApiSerializable
             $prefix, // Prefix.
             $fileName, // File name.
         );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getMeta(): array
+    {
+        $meta = $this->jsonApiGetMeta();
+        if ($this->created_by_user) {
+            $meta['created_by_user'] = $this->created_by_user->get('fullname');
+        }
+
+        return $meta;
     }
 
     /**

--- a/plugins/BEdita/Core/tests/TestCase/Model/Entity/StreamTest.php
+++ b/plugins/BEdita/Core/tests/TestCase/Model/Entity/StreamTest.php
@@ -28,6 +28,7 @@ use Laminas\Diactoros\Stream;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Http\Message\StreamInterface;
+use ReflectionMethod;
 use stdClass;
 
 /**
@@ -148,6 +149,27 @@ class StreamTest extends TestCase
         $path = $stream->filesystemPath($filesystem, $subLevels);
 
         static::assertSame($expected, $path);
+    }
+
+    /**
+     * Test that `created_by_user` fullname is added to `meta` when the association is loaded.
+     *
+     * @return void
+     */
+    public function testGetMetaCreatedByUser()
+    {
+        $stream = $this->Streams->get('9e58fa47-db64-4479-a0ab-88a706180d59');
+        $getMeta = new ReflectionMethod($stream, 'getMeta');
+
+        static::assertArrayNotHasKey('created_by_user', $getMeta->invoke($stream));
+
+        $user = TableRegistry::getTableLocator()->get('Users')->newEntity(
+            ['name' => 'First', 'surname' => 'User'],
+            ['guard' => false],
+        );
+        $stream->set('created_by_user', $user, ['guard' => false]);
+
+        static::assertSame('First User', $getMeta->invoke($stream)['created_by_user']);
     }
 
     /**


### PR DESCRIPTION
This PR enhances JSON:API metadata for stream resources by exposing the creator’s full name (`created_by_user`) when the related user association is loaded, and wires API-side eager-loading for streams’ creator users when `saved_by_refs` is requested.

**Changes:**
- Extend `Stream` JSON:API `meta` to include `created_by_user` (fullname) when the association is present.
- Update API include preparation so `saved_by_refs` can load creator users for streams.
- Add/adjust tests covering the new `created_by_user` meta behavior; minor robustness tweak in `Property` entity type lookup.