### PR TITLE
feat: Async job options

### DIFF
--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/AsyncJobsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/AsyncJobsControllerTest.php
@@ -61,6 +61,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
+                        'options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -86,6 +87,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
+                        'options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -111,6 +113,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
+                        'options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -136,6 +139,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'signup',
                         'priority' => 20,
+                        'options' => null,
                         'payload' => [
                             'user_id' => '99999',
                         ],
@@ -161,6 +165,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
+                        'options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -186,6 +191,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
+                        'options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -211,6 +217,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
+                        'options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -236,6 +243,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example2',
                         'priority' => 10,
+                        'options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -324,6 +332,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                 'attributes' => [
                     'service' => 'example',
                     'priority' => 1,
+                    'options' => null,
                     'payload' => [
                         'key' => 'value',
                     ],

--- a/plugins/BEdita/API/tests/TestCase/Controller/Admin/AsyncJobsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/Admin/AsyncJobsControllerTest.php
@@ -61,7 +61,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
-                        'options' => null,
+                        'job_options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -87,7 +87,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
-                        'options' => null,
+                        'job_options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -113,7 +113,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
-                        'options' => null,
+                        'job_options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -139,7 +139,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'signup',
                         'priority' => 20,
-                        'options' => null,
+                        'job_options' => null,
                         'payload' => [
                             'user_id' => '99999',
                         ],
@@ -165,7 +165,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
-                        'options' => null,
+                        'job_options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -191,7 +191,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
-                        'options' => null,
+                        'job_options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -217,7 +217,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
-                        'options' => null,
+                        'job_options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -243,7 +243,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example2',
                         'priority' => 10,
-                        'options' => null,
+                        'job_options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -332,7 +332,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                 'attributes' => [
                     'service' => 'example',
                     'priority' => 1,
-                    'options' => null,
+                    'job_options' => null,
                     'payload' => [
                         'key' => 'value',
                     ],

--- a/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
@@ -61,7 +61,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
-                        'options' => null,
+                        'job_options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -87,7 +87,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
-                        'options' => null,
+                        'job_options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -113,7 +113,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
-                        'options' => null,
+                        'job_options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -139,7 +139,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'signup',
                         'priority' => 20,
-                        'options' => null,
+                        'job_options' => null,
                         'payload' => [
                             'user_id' => '99999',
                         ],
@@ -165,7 +165,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
-                        'options' => null,
+                        'job_options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -191,7 +191,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
-                        'options' => null,
+                        'job_options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -217,7 +217,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
-                        'options' => null,
+                        'job_options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -243,7 +243,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example2',
                         'priority' => 10,
-                        'options' => null,
+                        'job_options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],

--- a/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
+++ b/plugins/BEdita/API/tests/TestCase/Controller/AsyncJobsControllerTest.php
@@ -61,6 +61,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
+                        'options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -86,6 +87,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
+                        'options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -111,6 +113,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
+                        'options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -136,6 +139,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'signup',
                         'priority' => 20,
+                        'options' => null,
                         'payload' => [
                             'user_id' => '99999',
                         ],
@@ -161,6 +165,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
+                        'options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -186,6 +191,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
+                        'options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -211,6 +217,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example',
                         'priority' => 1,
+                        'options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],
@@ -236,6 +243,7 @@ class AsyncJobsControllerTest extends IntegrationTestCase
                     'attributes' => [
                         'service' => 'example2',
                         'priority' => 10,
+                        'options' => null,
                         'payload' => [
                             'key' => 'value',
                         ],

--- a/plugins/BEdita/Core/config/Migrations/20260910080418_AsyncJobsAddColumnOptions.php
+++ b/plugins/BEdita/Core/config/Migrations/20260910080418_AsyncJobsAddColumnOptions.php
@@ -10,8 +10,12 @@ class AsyncJobsAddColumnOptions extends BaseMigration
      */
     public function up()
     {
+        $adapterType = $this->getAdapter()->getAdapterType();
         $columnTypes = $this->getAdapter()->getColumnTypes();
         $json = in_array('json', $columnTypes) ? 'json' : 'text';
+        if ($adapterType === 'pgsql' && in_array('jsonb', $columnTypes)) {
+            $json = 'jsonb';
+        }
         $this->table('async_jobs')
             ->addColumn('job_options', $json, [
                 'after' => 'priority',

--- a/plugins/BEdita/Core/config/Migrations/20260910080418_AsyncJobsAddColumnOptions.php
+++ b/plugins/BEdita/Core/config/Migrations/20260910080418_AsyncJobsAddColumnOptions.php
@@ -13,7 +13,7 @@ class AsyncJobsAddColumnOptions extends BaseMigration
         $columnTypes = $this->getAdapter()->getColumnTypes();
         $json = in_array('json', $columnTypes) ? 'json' : 'text';
         $this->table('async_jobs')
-            ->addColumn('options', $json, [
+            ->addColumn('job_options', $json, [
                 'after' => 'priority',
                 'comment' => 'Job options (JSON)',
                 'default' => null,
@@ -29,7 +29,7 @@ class AsyncJobsAddColumnOptions extends BaseMigration
     public function down()
     {
         $this->table('async_jobs')
-            ->removeColumn('options')
+            ->removeColumn('job_options')
             ->update();
     }
 }

--- a/plugins/BEdita/Core/config/Migrations/20260910080418_AsyncJobsAddColumnOptions.php
+++ b/plugins/BEdita/Core/config/Migrations/20260910080418_AsyncJobsAddColumnOptions.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\BaseMigration;
+
+class AsyncJobsAddColumnOptions extends BaseMigration
+{
+    /**
+     * @inheritDoc
+     */
+    public function up()
+    {
+        $columnTypes = $this->getAdapter()->getColumnTypes();
+        $json = in_array('json', $columnTypes) ? 'json' : 'text';
+        $this->table('async_jobs')
+            ->addColumn('options', $json, [
+                'after' => 'priority',
+                'comment' => 'Job options (JSON)',
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->update();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function down()
+    {
+        $this->table('async_jobs')
+            ->removeColumn('options')
+            ->update();
+    }
+}

--- a/plugins/BEdita/Core/src/Command/JobsCommand.php
+++ b/plugins/BEdita/Core/src/Command/JobsCommand.php
@@ -113,7 +113,7 @@ class JobsCommand extends Command
         $success = false;
         $messages = [];
         try {
-            $result = $asyncJob->run();
+            $result = $asyncJob->run($asyncJob->options ?? []);
             $success = is_bool($result) ? $result : (bool)Hash::get((array)$result, 'success');
             $messages = is_array($result) ? (array)Hash::get($result, 'messages') : [];
         } catch (Exception $e) {

--- a/plugins/BEdita/Core/src/Command/JobsCommand.php
+++ b/plugins/BEdita/Core/src/Command/JobsCommand.php
@@ -113,7 +113,7 @@ class JobsCommand extends Command
         $success = false;
         $messages = [];
         try {
-            $result = $asyncJob->run($asyncJob->options ?? []);
+            $result = $asyncJob->run($asyncJob->job_options ?? []);
             $success = is_bool($result) ? $result : (bool)Hash::get((array)$result, 'success');
             $messages = is_array($result) ? (array)Hash::get($result, 'messages') : [];
         } catch (Exception $e) {

--- a/plugins/BEdita/Core/src/Command/JobsCommand.php
+++ b/plugins/BEdita/Core/src/Command/JobsCommand.php
@@ -113,7 +113,7 @@ class JobsCommand extends Command
         $success = false;
         $messages = [];
         try {
-            $result = $asyncJob->run($asyncJob->job_options ?? []);
+            $result = $asyncJob->run();
             $success = is_bool($result) ? $result : (bool)Hash::get((array)$result, 'success');
             $messages = is_array($result) ? (array)Hash::get($result, 'messages') : [];
         } catch (Exception $e) {

--- a/plugins/BEdita/Core/src/Mailer/Transport/AsyncJobsTransport.php
+++ b/plugins/BEdita/Core/src/Mailer/Transport/AsyncJobsTransport.php
@@ -34,6 +34,7 @@ class AsyncJobsTransport extends AbstractTransport
     protected array $_defaultConfig = [
         'service' => 'mail',
         'max_attempts' => 3,
+        'job_options' => null,
     ];
 
     /**
@@ -50,6 +51,7 @@ class AsyncJobsTransport extends AbstractTransport
         if ($this->getConfig('priority') !== null) {
             $asyncJob->priority = $this->getConfig('priority');
         }
+        $asyncJob->job_options = $this->getConfig('job_options');
 
         $payload = $message->jsonSerialize();
         // Remove unnecessary attributes from payload since templates have already been rendered

--- a/plugins/BEdita/Core/src/Model/Entity/AsyncJob.php
+++ b/plugins/BEdita/Core/src/Model/Entity/AsyncJob.php
@@ -28,6 +28,7 @@ use Cake\ORM\Entity;
  * @property string $uuid
  * @property string $service
  * @property int $priority
+ * @property array|null $options
  * @property array|null $payload
  * @property \Cake\I18n\DateTime|null $scheduled_from
  * @property \Cake\I18n\DateTime|null $expires
@@ -52,6 +53,7 @@ class AsyncJob extends Entity implements JsonApiSerializable, EventDispatcherInt
         'uuid' => true,
         'service' => true,
         'priority' => true,
+        'options' => true,
         'payload' => true,
         'scheduled_from' => true,
         'expires' => true,

--- a/plugins/BEdita/Core/src/Model/Entity/AsyncJob.php
+++ b/plugins/BEdita/Core/src/Model/Entity/AsyncJob.php
@@ -28,7 +28,7 @@ use Cake\ORM\Entity;
  * @property string $uuid
  * @property string $service
  * @property int $priority
- * @property array|null $options
+ * @property array|null $job_options
  * @property array|null $payload
  * @property \Cake\I18n\DateTime|null $scheduled_from
  * @property \Cake\I18n\DateTime|null $expires
@@ -53,7 +53,7 @@ class AsyncJob extends Entity implements JsonApiSerializable, EventDispatcherInt
         'uuid' => true,
         'service' => true,
         'priority' => true,
-        'options' => true,
+        'job_options' => true,
         'payload' => true,
         'scheduled_from' => true,
         'expires' => true,

--- a/plugins/BEdita/Core/src/Model/Entity/AsyncJob.php
+++ b/plugins/BEdita/Core/src/Model/Entity/AsyncJob.php
@@ -105,7 +105,7 @@ class AsyncJob extends Entity implements JsonApiSerializable, EventDispatcherInt
         if ($this->status !== 'locked') {
             throw new BadMethodCallException('Only locked jobs can be run');
         }
-
+        $options += $this->job_options ?? [];
         $service = ServiceRegistry::get($this->service);
         $entity = $this;
         $this->dispatchEvent('AsyncJob.beforeRun', compact('entity', 'options'), $service);

--- a/plugins/BEdita/Core/src/Model/Table/AsyncJobsTable.php
+++ b/plugins/BEdita/Core/src/Model/Table/AsyncJobsTable.php
@@ -74,6 +74,7 @@ class AsyncJobsTable extends Table
         $this->setPrimaryKey('uuid');
         $this->setDisplayField('payload');
         $this->getSchema()
+            ->setColumnType('job_options', 'json')
             ->setColumnType('payload', 'json')
             ->setColumnType('uuid', 'uuid')
             ->setColumnType('results', 'json');


### PR DESCRIPTION
This PR add a column `job_options` (`options` is a reserved word) to `async_jobs` table. 

When scheduling the job, if available the job options are saved (to specific use in job process).
